### PR TITLE
Software commit, tag & branch in LOG on systemstart

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(env.cmake)
 project(PurePhone)
 
 include(config/ProjectConfig.cmake)
+include(config/Version.cmake)
 include(module-lwip/lwip-includes.cmake)
 
 message("PROJECT_TARGET: ${PROJECT_TARGET}")

--- a/config/Version.cmake
+++ b/config/Version.cmake
@@ -1,0 +1,45 @@
+# from: https://www.mattkeeter.com/blog/2018-01-06-versioning/
+
+execute_process(COMMAND git log --pretty=format:'%h' -n 1
+                OUTPUT_VARIABLE GIT_REV
+                ERROR_QUIET)
+
+# Check whether we got any revision (which isn't
+# always the case, e.g. when someone downloaded a zip
+# file from Github instead of a checkout)
+if ("${GIT_REV}" STREQUAL "")
+    set(GIT_REV "N/A")
+    set(GIT_DIFF "")
+    set(GIT_TAG "N/A")
+    set(GIT_BRANCH "N/A")
+else()
+    execute_process(
+        COMMAND bash -c "git diff --quiet --exit-code || echo +"
+        OUTPUT_VARIABLE GIT_DIFF)
+    execute_process(
+        COMMAND git describe --exact-match --tags
+        OUTPUT_VARIABLE GIT_TAG ERROR_QUIET)
+    execute_process(
+        COMMAND git rev-parse --abbrev-ref HEAD
+        OUTPUT_VARIABLE GIT_BRANCH)
+
+    string(STRIP "${GIT_REV}" GIT_REV)
+    string(SUBSTRING "${GIT_REV}" 1 7 GIT_REV)
+    string(STRIP "${GIT_DIFF}" GIT_DIFF)
+    string(STRIP "${GIT_TAG}" GIT_TAG)
+    string(STRIP "${GIT_BRANCH}" GIT_BRANCH)
+endif()
+
+set(VERSION "inline const char* GIT_REV=\"${GIT_REV}${GIT_DIFF}\";
+inline const char* GIT_TAG=\"${GIT_TAG}\";
+inline const char* GIT_BRANCH=\"${GIT_BRANCH}\";")
+
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/source/version.hpp)
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/source/version.hpp VERSION_)
+else()
+    set(VERSION_ "")
+endif()
+
+if (NOT "${VERSION}" STREQUAL "${VERSION_}")
+    file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/source/version.hpp "${VERSION}")
+endif()

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -6,6 +6,7 @@
 #include "log/log.hpp"
 #include "memory/usermem.h"
 #include "ticks.hpp"
+#include "version.hpp"
 
 //module-applications
 #include "application-clock/ApplicationClock.hpp"
@@ -132,7 +133,8 @@ int main() {
 
     bsp::BoardInit();
 
-    LOG_PRINTF("Launching PurePhone..\n");
+    LOG_PRINTF("Launching PurePhone \n");
+    LOG_PRINTF("commit: %s tag: %s branch: %s\n", GIT_REV, GIT_TAG, GIT_BRANCH);
 
 #if 1
     auto sysmgr = std::make_shared<sys::SystemManager>(5000);


### PR DESCRIPTION
stupid simple git hash on start of system in log (copied from web)
it doesn't check on every make, but on every cmake execution, so it's not perfect yet  - better than nothing.