### PR TITLE
[EGD-2910] quick fix time + flash eMMC

### DIFF
--- a/flash_eMMC.sh
+++ b/flash_eMMC.sh
@@ -35,8 +35,11 @@ cp -v $BUILD_PATH/sys/* "$PURE_PATH"/ -r  # | sed 's/'-\>'/'→'/g'
 echo -e "PurePhone copied\n"
 
 PURE_PARTITION=$(lsblk -nlp /dev/sda | tail +2 | awk '{print $1}')
+if [ -z $PURE_PARTITION ]; then
+       PURE_PARTITION=$PURE_DISK # it is formatted like so apparently
+fi
 # unmount the partition (sdX1), but eject the whole disk (sdX). then the PurePhone will detect it's been removed (=ejected)
-if $(udisksctl unmount -b "$PURE_PARTITION" > /dev/null ) || ! $(umount "$PURE_PARTITION" > /dev/null ); then
+if $(udisksctl unmount -b "$PURE_PARTITION" > /dev/null ) || $(umount "$PURE_PARTITION" > /dev/null ); then
 	echo "PurePhone unmouted"
 	timeout --signal=SIGINT 1 udisksctl power-off -b $PURE_DISK # timeout because there is known error, that this command hangs up.
 	echo "PurePhone ejected"

--- a/module-utils/time/time_locale.hpp
+++ b/module-utils/time/time_locale.hpp
@@ -49,7 +49,6 @@ class Locale {
     {
         FormatTime12H = 0,     // H:M in 12h format
         FormatTime24H,         // H:M in 24h format
-        FormatLocaleTime,      // H:M [AM/PM] locale specified format
         FormatLocaleDateFull,  // format locale specified format
         FormatLocaleDateShort, // format locale specified format
     };


### PR DESCRIPTION
ad1. failed futureproofing. let's wait for ICU with all locale related.
ad2. sometimes pure is formatted as partition on a disk and sometimes as disk == parition 
