### PR TITLE
fix gtk & FileAttributes

### DIFF
--- a/module-os/CMakeLists.txt
+++ b/module-os/CMakeLists.txt
@@ -102,3 +102,8 @@ message(WARNING "Tests for ${PROJECT_NAME} need update")
 if(DEFINED BUILD_UNIT_TESTS)
     target_compile_definitions(${PROJECT_NAME} PUBLIC LINUX_PORT_DEBUG)
 endif()
+
+if(${PROJECT_TARGET} STREQUAL "TARGET_Linux")
+    message(WARNING "For linux release port.c needs Wall and Werror disabled")
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wno-error)
+endif()

--- a/module-services/service-eink/board/linux/renderer/CMakeLists.txt
+++ b/module-services/service-eink/board/linux/renderer/CMakeLists.txt
@@ -6,7 +6,7 @@ project( service_renderer VERSION 1.0
 
 find_package(PkgConfig REQUIRED)               
 pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
-                   
+
 add_executable( ${PROJECT_NAME} 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/gui_renderer.cpp 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/RArea.cpp
@@ -23,4 +23,5 @@ target_link_libraries( ${PROJECT_NAME} ${LIBRT} rt pthread )
 target_include_directories( ${PROJECT_NAME}  PUBLIC "${CMAKE_SOURCE_DIR}/"  )
 target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-deprecated-declarations")
 target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-unused-result")
-
+message(WARNING "Please restore -Wno-error and -Wall flags with docker with gtk3 >= 3.24")
+target_compile_options(${PROJECT_NAME} PRIVATE -Wno-error -Wno-all)

--- a/module-vfs/board/linux/vfs.cpp
+++ b/module-vfs/board/linux/vfs.cpp
@@ -113,7 +113,7 @@ static inline bool hasEnding(std::string const &fullString, std::string const &e
 std::vector<vfs::DirectoryEntry> vfs::listdir(const char *path, const std::string &ext)
 {
     std::vector<DirectoryEntry> dir_list;
-    FileAttributes attribute;
+    FileAttributes attribute = FileAttributes::ReadOnly;
     size_t fileSize = 0;
 
     for (auto &p : fs::directory_iterator(path)) {


### PR DESCRIPTION
TL;DR: 
- Wall and Werror disabled for just linux renderer code
- Fixes for linux release (relase doesn't have assert, and forces few more checks)


Long: 
With Werror & Wall working on whole project it stopped working for Ubuntu 18.04
This is because gtklib in ubuntu 18.04 has libgtk3 in version 3.22, on the other hand it works fine with libgtk3.24 (for most team :) )