### PR TITLE
vscode: use cmake tools' intellisense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ doc/docs-gui/
 
 build-*/
 .vscode/ipch
-.vscode/settings.json
 
 lib/
 

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,22 +1,11 @@
 {
     "configurations": [
         {
-            "name": "Win32",
-            "includePath": [
-                "${workspaceFolder}/**"
-            ],
-            "defines": [
-                "_DEBUG",
-                "UNICODE",
-                "_UNICODE",
-                "CPU_MIMXRT1051DVL6B"
-            ],
-            "compilerPath": "c:/Program Files (x86)/GNU Tools ARM Embedded/8 2018-q4-major/bin/arm-none-eabi-g++",
+            "name": "CMake configuration",
             "cStandard": "c11",
             "cppStandard": "c++17",
-            "intelliSenseMode": "clang-x64",
-            "configurationProvider": "vector-of-bool.cmake-tools",
-            "compileCommands": "${workspaceFolder}/build/compile_commands.json" 
+            "intelliSenseMode": "${default}",
+            "configurationProvider": "vector-of-bool.cmake-tools"
         }
     ],
     "version": 4

--- a/.vscode/cmake-kits.json
+++ b/.vscode/cmake-kits.json
@@ -1,14 +1,14 @@
 [
   {
-    "name": "RT1051",
+    "name": "rt1051",
     "toolchainFile": "Target_RT1051.cmake"
   },
   {
-    "name": "Linux",
+    "name": "linux",
     "toolchainFile": "Target_Linux.cmake"
   },
   {
     "name": "Unittests",
     "toolchainFile": "Target_Unittests.cmake"
   }
-  ]
+]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "cmake.sourceDirectory": "${workspaceFolder}",
+    "cmake.buildDirectory": "${workspaceFolder}/build-${buildKit}-${buildType}"
+}


### PR DESCRIPTION
Improve VSCode config:
 - automatically use proper build directory
 - use intellisense from cmake.tools plugin
 - don't use OS dependent paths