### PR TITLE
[EGD-3057] text quick fix

### DIFF
--- a/module-gui/gui/core/Font.cpp
+++ b/module-gui/gui/core/Font.cpp
@@ -274,13 +274,11 @@ namespace gui
             }
 
             if (availableSpace - (glyph->xadvance + kern_value) < 0) {
-                if (spaceConsumed) {
-                    spaceConsumed = space - availableSpace; // unreachable
-                }
+                spaceConsumed = space - availableSpace;
                 return stringChars;
             }
 
-            availableSpace -= glyph->xadvance + kern_value;
+            availableSpace -= (glyph->xadvance + kern_value);
 
             idLast = idCurrent;
             ++stringChars;


### PR DESCRIPTION
fix this:

![image](https://user-images.githubusercontent.com/56958031/78178204-8dec2500-745f-11ea-97c8-0dc95fcd0416.png)

introduced by me in [EGD-2952]


[EGD-2952]: https://appnroll.atlassian.net/browse/EGD-2952