### PR TITLE
rt1051: merge text sections

### DIFF
--- a/board/rt1051/ldscripts/sections.ld
+++ b/board/rt1051/ldscripts/sections.ld
@@ -78,7 +78,7 @@ SECTIONS
 
     .text : ALIGN(4)    
     {
-       /**(.text*)*/
+       *(.text*)
        *(.rodata .rodata.* .constdata .constdata.*)
        . = ALIGN(4);
             /* C++ constructors etc */


### PR DESCRIPTION
Having one .text sections results in faster loading speed (currently 21
vs 44 seconds).