### PR TITLE
renderer: disable address sanitizer

### DIFF
--- a/module-services/service-eink/board/linux/renderer/CMakeLists.txt
+++ b/module-services/service-eink/board/linux/renderer/CMakeLists.txt
@@ -4,11 +4,11 @@ project( service_renderer VERSION 1.0
 	DESCRIPTION "GTK application for showing draw buffer."
 	LANGUAGES CXX )
 
-find_package(PkgConfig REQUIRED)               
+find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
 
-add_executable( ${PROJECT_NAME} 
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/gui_renderer.cpp 
+add_executable( ${PROJECT_NAME}
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/gui_renderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/RArea.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/RWindow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/RArea.hpp
@@ -18,10 +18,23 @@ target_link_libraries( ${PROJECT_NAME}  ${GTKMM_LIBRARIES}  )
 target_include_directories(${PROJECT_NAME} PUBLIC ${GTKMM_LIBRARY_DIRS} )
 target_include_directories( ${PROJECT_NAME}  PUBLIC ${GTKMM_INCLUDE_DIRS}  )
 target_link_libraries( ${PROJECT_NAME} ${LIBRT} rt pthread )
-   
+
 #key_code
 target_include_directories( ${PROJECT_NAME}  PUBLIC "${CMAKE_SOURCE_DIR}/"  )
 target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-deprecated-declarations")
 target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-unused-result")
 message(WARNING "Please restore -Wno-error and -Wall flags with docker with gtk3 >= 3.24")
 target_compile_options(${PROJECT_NAME} PRIVATE -Wno-error -Wno-all)
+
+# disable sanitizier for target, due to bug in sigc
+# https://github.com/libsigcplusplus/libsigcplusplus/issues/10
+get_target_property(_target_cxx_flags ${PROJECT_NAME} COMPILE_OPTIONS)
+if(_target_cxx_flags)
+	list(REMOVE_ITEM _target_cxx_flags -fsanitize=address)
+	set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_OPTIONS "${_target_cxx_flags}")
+endif()
+get_target_property(_target_link_flags ${PROJECT_NAME} LINK_OPTIONS)
+if(_target_link_flags)
+	list(REMOVE_ITEM _target_link_flags -fsanitize=address)
+	set_target_properties(${PROJECT_NAME} PROPERTIES LINK_OPTIONS "${_target_link_flags}")
+endif()


### PR DESCRIPTION
Disable address sanitizier due to a bug in sigc library which results in
false positive report in the PurePhone process.