### PR TITLE
[EGD-3116] battery: show on linux, fix levels and position

### DIFF
--- a/module-bsp/board/linux/battery-charger/battery_charger.cpp
+++ b/module-bsp/board/linux/battery-charger/battery_charger.cpp
@@ -15,6 +15,7 @@ extern "C"
 
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <module-utils/common_data/EventStore.hpp>
 
 #include "board.h"
 #include "bsp/battery-charger/battery_charger.hpp"
@@ -50,6 +51,7 @@ namespace bsp
     void battery_getBatteryLevel(uint8_t &levelPercent)
     {
         levelPercent = battLevel;
+        Store::Battery::modify().level = levelPercent;
     }
 
     void battery_getChargeStatus(bool &status)
@@ -96,7 +98,7 @@ namespace bsp
                     break;
                 case '[':
                     notification = 0x01;
-                    if (battLevel > 1)
+                    if (battLevel >= 1)
                         battLevel--;
                     break;
                 }

--- a/module-gui/gui/widgets/TopBar.cpp
+++ b/module-gui/gui/widgets/TopBar.cpp
@@ -21,7 +21,7 @@ namespace gui
 {
 
     const uint32_t TopBar::signalOffset    = 35;
-    const uint32_t TopBar::batteryOffset   = 415;
+    const uint32_t TopBar::batteryOffset   = 413;
     gui::TopBar::TimeMode TopBar::timeMode = TimeMode::TIME_24H;
     uint32_t TopBar::time                  = 0;
 
@@ -56,7 +56,7 @@ namespace gui
             val = battery.size();
         }
         for (unsigned int i = 0; i < battery.size(); ++i) {
-            battery[i]->setVisible(val > i);
+            battery[i]->setVisible(val >= i);
         }
     }
 
@@ -73,16 +73,16 @@ namespace gui
 
         // icons for battery
         battery = {
-            new gui::Image(this, batteryOffset, 17, 0, 0, "battery0"),
-            new gui::Image(this, batteryOffset, 17, 0, 0, "battery1"),
-            new gui::Image(this, batteryOffset, 17, 0, 0, "battery2"),
-            new gui::Image(this, batteryOffset, 17, 0, 0, "battery3"),
-            new gui::Image(this, batteryOffset, 17, 0, 0, "battery4"),
-            new gui::Image(this, batteryOffset, 17, 0, 0, "battery5"),
+            new gui::Image(this, batteryOffset, 15, 0, 0, "battery0"),
+            new gui::Image(this, batteryOffset, 15, 0, 0, "battery1"),
+            new gui::Image(this, batteryOffset, 15, 0, 0, "battery2"),
+            new gui::Image(this, batteryOffset, 15, 0, 0, "battery3"),
+            new gui::Image(this, batteryOffset, 15, 0, 0, "battery4"),
+            new gui::Image(this, batteryOffset, 15, 0, 0, "battery5"),
         };
         batteryShowBars(0);
 
-        charging = new Label(this, batteryOffset, 17, 30, this->drawArea.h);
+        charging = new Label(this, batteryOffset, 15, 30, this->drawArea.h);
         charging->setFilled(false);
         charging->setBorderColor(gui::ColorNoColor);
         charging->setFont(style::header::font::title);


### PR DESCRIPTION
## to change the "_battery_" level on linux, press `[` or `]`.

TODO:
there should be an initial, polled message for `MessageType::EVMBatteryLevel`. somehow rt1051 manages to get IRQ from charger and send that message before the first render, and therefore populate `Store::Battery` with relevant value. Linux does not manage to do it magically, so there is `level == 0` until you change it.

![image](https://user-images.githubusercontent.com/56958031/79285569-3ec1dd80-7ebe-11ea-954d-018bdd6a2054.png)
