### PR TITLE
bsp: make HF handler naked

### DIFF
--- a/module-bsp/board/rt1051/common/startup_mimxrt1052.cpp
+++ b/module-bsp/board/rt1051/common/startup_mimxrt1052.cpp
@@ -1116,9 +1116,8 @@ WEAK_AV void MemManage_Handler(void)
 #endif
 }
 
-WEAK_AV void HardFault_Handler(void)
+[[gnu::naked]] WEAK_AV void HardFault_Handler(void)
 {
-#if 1
     asm volatile(" tst lr,#4       \n"
                  " ite eq          \n"
                  " mrseq r0,msp    \n"
@@ -1131,7 +1130,6 @@ WEAK_AV void HardFault_Handler(void)
                  : /* Inputs */
                  : /* Clobbers */
     );
-#endif
 }
 
 WEAK_AV void BusFault_Handler(void)


### PR DESCRIPTION
Add "naked" attribute to the HF handler in order to:
1. print properly stack frame when HF occures in the Handler Mode
2. not overwrite frame pointer register and be able to determine stack
trace more easily.