### PR TITLE
os: add system heap integrity check fields

### DIFF
--- a/module-os/CMakeLists.txt
+++ b/module-os/CMakeLists.txt
@@ -72,6 +72,10 @@ target_compile_definitions(${PROJECT_NAME}
         CPP_FREERTOS_CONDITION_VARIABLES
 )
 
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+	target_compile_definitions(${PROJECT_NAME} PRIVATE DEBUG_FREERTOS)
+endif ()
+
 target_include_directories(${PROJECT_NAME}
 
         PUBLIC

--- a/module-os/FreeRTOS/heap_4.c
+++ b/module-os/FreeRTOS/heap_4.c
@@ -64,13 +64,37 @@ task.h is included from an application file. */
 	static uint8_t ucHeap[ configTOTAL_HEAP_SIZE ];
 #endif /* configAPPLICATION_ALLOCATED_HEAP */
 
+/* Additional heap settings default values */
+#if !defined(configSYSTEM_HEAP_INTEGRITY_CHECK)
+#define configSYSTEM_HEAP_INTEGRITY_CHECK (0)
+#endif
+#if !defined(configSYSTEM_HEAP_STATS)
+#define configSYSTEM_HEAP_STATS (0)
+#endif
+
 /* Define the linked list structure.  This is used to link free blocks in order
 of their memory address. */
 typedef struct A_BLOCK_LINK
 {
 	struct A_BLOCK_LINK *pxNextFreeBlock;	/*<< The next free block in the list. */
 	size_t xBlockSize;						/*<< The size of the free block. */
+#if (configSYSTEM_HEAP_INTEGRITY_CHECK == 1)
+	uint32_t ulMarker;
+#endif
+#if (configSYSTEM_HEAP_STATS == 1)
+	TaskHandle_t xAllocatingTask;
+	TickType_t xTimeAllocated;
+	struct A_BLOCK_LINK *pxNextTakenBlock, *pxPrevTakenBlock;
+#endif
 } BlockLink_t;
+
+/* Heap integrity markers */
+#if (configSYSTEM_HEAP_INTEGRITY_CHECK == 1)
+static const uint32_t ulMarkerAllocated   = 0xabababab;
+static const uint32_t ulMarkerUnallocated = 0xcdcdcdcd;
+static const uint32_t ulMarkerFreed       = 0xdddddddd;
+static const uint32_t ulMarkerSpecial     = 0xbaadc0de;
+#endif
 
 /*-----------------------------------------------------------*/
 
@@ -96,6 +120,11 @@ static const size_t xHeapStructSize	= ( sizeof( BlockLink_t ) + ( ( size_t ) ( p
 
 /* Create a couple of list links to mark the start and end of the list. */
 static BlockLink_t xStart, *pxEnd = NULL;
+
+/* Start/end of used blocks list */
+#if (configSYSTEM_HEAP_STATS == 1)
+static BlockLink_t xTakenEnd;
+#endif
 
 /* Keeps track of the number of free bytes remaining, but says nothing about
 fragmentation. */
@@ -174,6 +203,10 @@ void *pvReturn = NULL;
 				was	not found. */
 				if( pxBlock != pxEnd )
 				{
+					/* check block integrity */
+#if (configSYSTEM_HEAP_INTEGRITY_CHECK == 1)
+					configASSERT((pxBlock->ulMarker == ulMarkerUnallocated) || (pxBlock->ulMarker == ulMarkerFreed));
+#endif
 					/* Return the memory space pointed to - jumping over the
 					BlockLink_t structure at its start. */
 					pvReturn = ( void * ) ( ( ( uint8_t * ) pxPreviousBlock->pxNextFreeBlock ) + xHeapStructSize );
@@ -192,6 +225,11 @@ void *pvReturn = NULL;
 						compiler. */
 						pxNewBlockLink = ( void * ) ( ( ( uint8_t * ) pxBlock ) + xWantedSize );
 						configASSERT( ( ( ( size_t ) pxNewBlockLink ) & portBYTE_ALIGNMENT_MASK ) == 0 );
+
+						/* mark new block as unallocated */
+#if (configSYSTEM_HEAP_INTEGRITY_CHECK == 1)
+						pxNewBlockLink->ulMarker = ulMarkerUnallocated;
+#endif
 
 						/* Calculate the sizes of two blocks split from the
 						single block. */
@@ -216,6 +254,21 @@ void *pvReturn = NULL;
 					{
 						mtCOVERAGE_TEST_MARKER();
 					}
+
+#if (configSYSTEM_HEAP_INTEGRITY_CHECK == 1)
+					pxBlock->ulMarker = ulMarkerAllocated;
+#endif
+#if (configSYSTEM_HEAP_STATS == 1)
+					/* Push taken block at the end of the taken list */
+					xTakenEnd.pxPrevTakenBlock->pxNextTakenBlock = pxBlock;
+					pxBlock->pxPrevTakenBlock                    = xTakenEnd.pxPrevTakenBlock;
+					pxBlock->pxNextTakenBlock                    = &xTakenEnd;
+					xTakenEnd.pxPrevTakenBlock                   = pxBlock;
+
+					/* Update block stats */
+					pxBlock->xTimeAllocated  = xTaskGetTickCount();
+					pxBlock->xAllocatingTask = xTaskGetCurrentTaskHandle();
+#endif
 
 					/* The block is being returned - it is allocated and owned
 					by the application and has no "next" block. */
@@ -274,6 +327,11 @@ BlockLink_t *pxLink;
 		/* This casting is to keep the compiler from issuing warnings. */
 		pxLink = ( void * ) puc;
 
+		/* integrity check */
+#if (configSYSTEM_HEAP_INTEGRITY_CHECK == 1)
+		configASSERT(pxLink->ulMarker == ulMarkerAllocated);
+#endif
+
 		/* Check the block is actually allocated. */
 		configASSERT( ( pxLink->xBlockSize & xBlockAllocatedBit ) != 0 );
 		configASSERT( pxLink->pxNextFreeBlock == NULL );
@@ -285,6 +343,9 @@ BlockLink_t *pxLink;
 				/* The block is being returned to the heap - it is no longer
 				allocated. */
 				pxLink->xBlockSize &= ~xBlockAllocatedBit;
+#if configSYSTEM_HEAP_INTEGRITY_CHECK == 1
+				pxLink->ulMarker = ulMarkerFreed;
+#endif
 
 				vTaskSuspendAll();
 				{
@@ -292,6 +353,14 @@ BlockLink_t *pxLink;
 					xFreeBytesRemaining += pxLink->xBlockSize;
 					traceFREE( pv, pxLink->xBlockSize );
 					prvInsertBlockIntoFreeList( ( ( BlockLink_t * ) pxLink ) );
+
+#if (configSYSTEM_HEAP_STATS == 1)
+					/* Update taken list */
+					pxLink->pxPrevTakenBlock                   = pxLink->pxNextTakenBlock;
+					pxLink->pxNextTakenBlock->pxPrevTakenBlock = pxLink->pxPrevTakenBlock;
+					pxLink->pxPrevTakenBlock                   = NULL;
+					pxLink->pxNextTakenBlock                   = NULL;
+#endif
 				}
 				( void ) xTaskResumeAll();
 			}
@@ -349,6 +418,29 @@ size_t xTotalHeapSize = configTOTAL_HEAP_SIZE;
 	blocks.  The void cast is used to prevent compiler warnings. */
 	xStart.pxNextFreeBlock = ( void * ) pucAlignedHeap;
 	xStart.xBlockSize = ( size_t ) 0;
+#if (configSYSTEM_HEAP_INTEGRITY_CHECK == 1)
+	xStart.ulMarker = ulMarkerSpecial;
+#endif
+
+#if (configSYSTEM_HEAP_STATS == 1)
+	/* Initialize start of list of taken blocks */
+	xStart.pxNextTakenBlock = &xTakenEnd;
+	xStart.pxPrevTakenBlock = NULL;
+	xStart.xTimeAllocated   = 0;
+	xStart.xAllocatingTask  = 0;
+
+	/* Initialize end of list of taken blocks */
+	xTakenEnd.pxNextFreeBlock  = NULL;
+	xTakenEnd.xBlockSize	   = 0;
+	xTakenEnd.pxNextTakenBlock = NULL;
+	xTakenEnd.pxPrevTakenBlock = &xStart;
+	xTakenEnd.xTimeAllocated   = 0;
+	xTakenEnd.xAllocatingTask  = 0;
+
+#if (configSYSTEM_HEAP_INTEGRITY_CHECK == 1)
+	xTakenEnd.ulMarker = ulMarkerSpecial;
+#endif
+#endif
 
 	/* pxEnd is used to mark the end of the list of free blocks and is inserted
 	at the end of the heap space. */
@@ -364,6 +456,9 @@ size_t xTotalHeapSize = configTOTAL_HEAP_SIZE;
 	pxFirstFreeBlock = ( void * ) pucAlignedHeap;
 	pxFirstFreeBlock->xBlockSize = uxAddress - ( size_t ) pxFirstFreeBlock;
 	pxFirstFreeBlock->pxNextFreeBlock = pxEnd;
+#if (configSYSTEM_HEAP_INTEGRITY_CHECK == 1)
+	pxFirstFreeBlock->ulMarker = ulMarkerUnallocated;
+#endif
 
 	/* Only one block exists - and it covers the entire usable heap space. */
 	xMinimumEverFreeBytesRemaining = pxFirstFreeBlock->xBlockSize;

--- a/module-os/FreeRTOS/include/FreeRTOSConfig.h
+++ b/module-os/FreeRTOS/include/FreeRTOSConfig.h
@@ -162,4 +162,10 @@ standard names. */
 /* Low power Tickless idle. Low power timer (GPT) is initialized in application code. */
 #define configGPT_CLOCK_HZ                    (32768U)
 
+/* system heap integrity check */
+#ifdef DEBUG_FREERTOS
+#define configSYSTEM_HEAP_STATS           (1)
+#define configSYSTEM_HEAP_INTEGRITY_CHECK (1)
+#endif
+
 #endif /* FREERTOS_CONFIG_H */


### PR DESCRIPTION
Add fields to system heap which are needed to do an integrity check
and harvest some additional usage stats. Add only for Debug build type.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>