### PR TITLE
utils: fix various minor bugs in phonenumber

### DIFF
--- a/module-utils/PhoneNumber.cpp
+++ b/module-utils/PhoneNumber.cpp
@@ -12,15 +12,14 @@
 using namespace utils;
 
 PhoneNumber::PhoneNumber(const std::string &phoneNumber, country::Id defaultCountryCode)
-    : valid(false), countryCode(defaultCountryCode), util(*phn_util::GetInstance()), rawInput(phoneNumber)
+    : countryCode(defaultCountryCode), util(*phn_util::GetInstance()), rawInput(phoneNumber)
 {
-    valid = util.ParseAndKeepRawInput(phoneNumber, country::getAlpha2Code(countryCode), &pbNumber) ==
-            errCode::NO_PARSING_ERROR;
+    util.ParseAndKeepRawInput(phoneNumber, country::getAlpha2Code(countryCode), &pbNumber);
 }
 
 bool PhoneNumber::isValid() const
 {
-    return valid;
+    return util.IsValidNumber(pbNumber);
 }
 
 const std::string &PhoneNumber::get() const
@@ -34,7 +33,7 @@ const std::string &PhoneNumber::get() const
 
 std::string PhoneNumber::getFormatted() const
 {
-    if (!valid) {
+    if (!isValid()) {
         return rawInput;
     }
 
@@ -45,7 +44,7 @@ std::string PhoneNumber::getFormatted() const
 
 std::string PhoneNumber::toE164() const
 {
-    if (!valid) {
+    if (!isValid()) {
         throw std::runtime_error("Can't create E164 format from an invalid number.");
     }
 
@@ -55,12 +54,12 @@ std::string PhoneNumber::toE164() const
     return e164number;
 }
 
-bool PhoneNumber::operator==(const PhoneNumber &right)
+bool PhoneNumber::operator==(const PhoneNumber &right) const
 {
     return util.IsNumberMatch(pbNumber, right.pbNumber) == phn_util::EXACT_MATCH;
 }
 
-bool PhoneNumber::operator==(const View &view)
+bool PhoneNumber::operator==(const View &view) const
 {
     if (isValid() != view.isValid()) {
         return false;
@@ -167,3 +166,8 @@ PhoneNumber::View::View(const std::string &enteredNumber,
                         bool valid)
     : entered(enteredNumber), formatted(formattedNumber), e164(e164Number), valid(valid)
 {}
+
+bool PhoneNumber::View::operator==(const View &rhs) const
+{
+    return valid == rhs.valid && e164 == rhs.e164;
+}

--- a/module-utils/PhoneNumber.hpp
+++ b/module-utils/PhoneNumber.hpp
@@ -115,6 +115,15 @@ namespace utils
              */
             bool isValid() const;
 
+            /**
+             * @brief Compares two View objects
+             *
+             * @param rhs - instance of a VIew to compare to.
+             * @return true if objects are equal.
+             * @return false if objects are different (not equal).
+             */
+            bool operator==(const View &rhs) const;
+
           private:
             View(const std::string &enteredNumber,
                  const std::string &formattedNumber,
@@ -202,7 +211,7 @@ namespace utils
          * @return true if objects are equal.
          * @return false if objects are different (not equal).
          */
-        bool operator==(const PhoneNumber &right);
+        bool operator==(const PhoneNumber &right) const;
 
         /**
          * @brief Compares PhoneNumber with number represented by View.
@@ -211,7 +220,7 @@ namespace utils
          * @return true if objects are equal.
          * @return false if objects are different (not equal).
          */
-        bool operator==(const View &view);
+        bool operator==(const View &view) const;
 
         /**
          * @brief Convenience wrapper for E164 number formatting.
@@ -248,7 +257,6 @@ namespace utils
         static View viewFromE164(const std::string &e164);
 
       private:
-        bool valid;
         const country::Id countryCode;
         phn_util &util;
         gnumber pbNumber;

--- a/module-utils/test/CMakeLists.txt
+++ b/module-utils/test/CMakeLists.txt
@@ -127,3 +127,19 @@ add_test(NAME ${PROJECT_NAME}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 add_dependencies(check ${PROJECT_NAME})
+
+###########################################
+#Utils unit tests project
+project(unittest_module-utils_phonenumber VERSION 1.0
+       DESCRIPTION "Module-utils phonenumber unit tests")
+add_executable( ${PROJECT_NAME} EXCLUDE_FROM_ALL
+    unittest_phonenumber.cpp
+)
+target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/..")
+target_link_libraries(${PROJECT_NAME} PRIVATE module-utils module-vfs)
+add_test(NAME ${PROJECT_NAME}
+    COMMAND ${PROJECT_NAME}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+add_dependencies(check ${PROJECT_NAME})
+

--- a/module-utils/test/unittest_phonenumber.cpp
+++ b/module-utils/test/unittest_phonenumber.cpp
@@ -1,0 +1,119 @@
+#include "PhoneNumber.hpp"
+#include "country.hpp"
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include <string>
+
+using namespace utils;
+
+static const std::string pl_entered       = "600123456";
+static const std::string pl_e164          = "+48600123456";
+static const std::string pl_formatted     = "600 123 456";
+static const std::string pl_formatted_int = "+48 600 123 456";
+
+TEST_CASE("PhoneNumber - parsing")
+{
+    SECTION("PL - valid")
+    {
+        PhoneNumber number(pl_entered, country::Id::POLAND);
+        REQUIRE(number.isValid());
+    }
+
+    SECTION("Wrong country")
+    {
+        PhoneNumber number(pl_entered, country::Id::UNITED_KINGDOM);
+        REQUIRE_FALSE(number.isValid());
+    }
+
+    SECTION("From E164")
+    {
+        PhoneNumber number(pl_e164, country::Id::UNKNOWN);
+        REQUIRE(number.isValid());
+    }
+
+    SECTION("Invalid input")
+    {
+        PhoneNumber number1("foobar");
+        REQUIRE_FALSE(number1.isValid());
+
+        PhoneNumber number2("-1");
+        REQUIRE_FALSE(number2.isValid());
+
+        PhoneNumber number3("");
+        REQUIRE_FALSE(number3.isValid());
+    }
+}
+
+TEST_CASE("PhoneNumber - formatting")
+{
+    SECTION("From national")
+    {
+        PhoneNumber number(pl_entered, country::Id::POLAND);
+        REQUIRE(number.getFormatted() == pl_formatted);
+    }
+
+    SECTION("From international")
+    {
+        PhoneNumber number(pl_e164, country::Id::UNKNOWN);
+        REQUIRE(number.getFormatted() == pl_formatted_int);
+    }
+}
+
+TEST_CASE("PhoneNumber - views")
+{
+    SECTION("Invalid")
+    {
+        const std::string dummyNumber = "12345";
+        PhoneNumber number(dummyNumber);
+        REQUIRE_FALSE(number.isValid());
+
+        auto view = number.makeView();
+        REQUIRE(view.getEntered() == dummyNumber);
+        REQUIRE(view.getFormatted() == dummyNumber);
+        REQUIRE(view.getE164() == "");
+    }
+
+    SECTION("Valid")
+    {
+        PhoneNumber number(pl_entered, country::Id::POLAND);
+        REQUIRE(number.isValid());
+
+        auto view = number.makeView();
+        REQUIRE(view.getEntered() == pl_entered);
+        REQUIRE(view.getE164() == pl_e164);
+        REQUIRE(view.getFormatted() == pl_formatted);
+    }
+}
+
+TEST_CASE("PhoneNumber - equality")
+{
+    PhoneNumber number1(pl_entered, country::Id::POLAND);
+    PhoneNumber number2(pl_e164, country::Id::UNKNOWN);
+
+    REQUIRE(number1 == number1);
+    REQUIRE(number2 == number2);
+
+    REQUIRE(number1 == number2);
+
+    REQUIRE(number1 == number2.makeView());
+    REQUIRE(number2 == number1.makeView());
+    REQUIRE(number1.makeView() == number2.makeView());
+}
+
+TEST_CASE("PhoneNumber - record validation")
+{
+    SECTION("Valid")
+    {
+        auto view = PhoneNumber::validateNumber(pl_e164, pl_entered);
+        REQUIRE(view.isValid());
+        REQUIRE(view.getFormatted() == pl_formatted);
+    }
+
+    SECTION("Invalid")
+    {
+        auto view = PhoneNumber::validateNumber("+44600123456", pl_entered);
+        REQUIRE_FALSE(view.isValid());
+    }
+}


### PR DESCRIPTION
Bugs:
 - invalid number validation
 - no `const` qualifier in comparison operators
 - lack of comparison operator for PhoneNumber::View

Add appropriate unit tests.