### PR TITLE
[EGD-3199] new menu icons - afterthough

### DIFF
--- a/module-apps/application-desktop/windows/MenuWindow.cpp
+++ b/module-apps/application-desktop/windows/MenuWindow.cpp
@@ -239,7 +239,7 @@ namespace gui
 
         setTitle(page->title);
         setFocusItem(page);
-        application->refreshWindow(gui::RefreshModes::GUI_REFRESH_FAST);
+        application->refreshWindow(gui::RefreshModes::GUI_REFRESH_DEEP);
     }
 
 } /* namespace gui */


### PR DESCRIPTION
I realised menu windows **aren't** refreshed deeply between transitions.
Note: sometimes (~10%) deep refersh doesn't work. It is known error.