### PR TITLE
EGD-3197 fix empty calllog list item

### DIFF
--- a/module-apps/UiCommonActions.cpp
+++ b/module-apps/UiCommonActions.cpp
@@ -46,7 +46,7 @@ namespace app
 
     bool call(Application *app, const std::string &e164number)
     {
-        return call(app, utils::PhoneNumber::viewFromE164(e164number));
+        return call(app, utils::PhoneNumber::parse(e164number));
     }
 
     bool prepare_call(Application *app, const std::string &number)

--- a/module-db/Interface/CalllogRecord.cpp
+++ b/module-db/Interface/CalllogRecord.cpp
@@ -58,9 +58,9 @@ bool CalllogRecordInterface::Add(const CalllogRecord &rec)
 {
     ContactRecordInterface contactInterface(contactsDB);
     auto contactRec =
-        contactInterface.GetByNumber(rec.phoneNumber.getE164(), ContactRecordInterface::CreateTempContact::True);
+        contactInterface.GetByNumber(rec.phoneNumber.getNonEmpty(), ContactRecordInterface::CreateTempContact::True);
     if (contactRec->size() == 0) {
-        LOG_ERROR("Cannot get contact, for number %s", rec.phoneNumber.getE164().c_str());
+        LOG_ERROR("Cannot get contact, for number %s", rec.phoneNumber.getNonEmpty().c_str());
         return false;
     }
     auto localRec      = rec;

--- a/module-services/service-cellular/messages/CellularMessage.hpp
+++ b/module-services/service-cellular/messages/CellularMessage.hpp
@@ -45,7 +45,7 @@ class CellularCallMessage : public CellularMessage
         : CellularMessage(MessageType::CellularCall), type(type), number(number.makeView())
     {}
     CellularCallMessage(Type type, const std::string &e164number)
-        : CellularMessage(MessageType::CellularCall), type(type), number(utils::PhoneNumber::viewFromE164(e164number))
+        : CellularMessage(MessageType::CellularCall), type(type), number(utils::PhoneNumber::parse(e164number))
     {}
 
     Type type;

--- a/module-utils/PhoneNumber.cpp
+++ b/module-utils/PhoneNumber.cpp
@@ -134,9 +134,9 @@ void PhoneNumber::View::clear()
     this->operator=(View());
 }
 
-PhoneNumber::View PhoneNumber::viewFromE164(const std::string &e164)
+PhoneNumber::View PhoneNumber::parse(const std::string &inputNumber)
 {
-    PhoneNumber number(e164, country::Id::UNKNOWN);
+    PhoneNumber number(inputNumber);
     return number.makeView();
 }
 
@@ -170,4 +170,9 @@ PhoneNumber::View::View(const std::string &enteredNumber,
 bool PhoneNumber::View::operator==(const View &rhs) const
 {
     return valid == rhs.valid && e164 == rhs.e164;
+}
+
+const std::string &PhoneNumber::View::getNonEmpty() const
+{
+    return valid ? e164 : entered;
 }

--- a/module-utils/PhoneNumber.hpp
+++ b/module-utils/PhoneNumber.hpp
@@ -80,6 +80,13 @@ namespace utils
             void clear();
 
             /**
+             * @brief A convenience method to get a non empty number.
+             *
+             * @return E164 number if it has one, entered number otherwise.
+             */
+            const std::string &getNonEmpty() const;
+
+            /**
              * @brief Getter for the entered number - number parsed from.
              *
              * @return const std::string& - reference to entered number
@@ -251,10 +258,10 @@ namespace utils
         /**
          * @brief Create instance of View directly from the E164 format.
          *
-         * @param e164 - number in the E164 format to create View from
+         * @param inputNumber - a string represenation of a number to create View from
          * @return View - phone number representation
          */
-        static View viewFromE164(const std::string &e164);
+        static View parse(const std::string &inputNumber);
 
       private:
         const country::Id countryCode;

--- a/module-utils/test/unittest_phonenumber.cpp
+++ b/module-utils/test/unittest_phonenumber.cpp
@@ -44,6 +44,21 @@ TEST_CASE("PhoneNumber - parsing")
         PhoneNumber number3("");
         REQUIRE_FALSE(number3.isValid());
     }
+
+    SECTION("Wrapper")
+    {
+        const std::string dummy = "12345";
+
+        auto view         = PhoneNumber::parse(pl_e164);
+        auto invalid_view = PhoneNumber::parse(dummy);
+
+        REQUIRE(view.isValid());
+        REQUIRE(view.getE164() == pl_e164);
+
+        REQUIRE_FALSE(invalid_view.isValid());
+        REQUIRE(invalid_view.getE164() == "");
+        REQUIRE(invalid_view.getEntered() == dummy);
+    }
 }
 
 TEST_CASE("PhoneNumber - formatting")
@@ -84,6 +99,23 @@ TEST_CASE("PhoneNumber - views")
         REQUIRE(view.getEntered() == pl_entered);
         REQUIRE(view.getE164() == pl_e164);
         REQUIRE(view.getFormatted() == pl_formatted);
+    }
+
+    SECTION("Safe get non empty number")
+    {
+        const std::string dummyNumber = "12345";
+
+        auto invalid_view = PhoneNumber::parse(dummyNumber);
+        auto valid_view   = PhoneNumber::parse(pl_entered);
+
+        REQUIRE_FALSE(invalid_view.isValid());
+        REQUIRE(valid_view.isValid());
+
+        REQUIRE(invalid_view.getNonEmpty() != "");
+        REQUIRE(valid_view.getNonEmpty() != "");
+
+        REQUIRE(invalid_view.getNonEmpty() == dummyNumber);
+        REQUIRE(valid_view.getNonEmpty() == pl_e164);
     }
 }
 


### PR DESCRIPTION
Fix empty calllog title when number comes in national format. The
problem was caused by:
 1. making assumption that every number from cellular network comes in
 e164 format which is not true,
 2. using e164 number when looking for contact matching calllog entry
 without checking if e164 exists for calllog entry.
Fix problem by:
a.d.1 - replacing `PhoneNumber::viewFromE164` with less strict
`PhoneNumber::Parse` method which basically is a convenience method
which creates `PhoneNumber` entity and uses it to create a `View`.
a.d.2 - instead of fetching e164 directly introduce `getNonEmpty` method
of a View, which returns e164 number if it is present and entered number
otherwise.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>