### PR TITLE
EGD-3276: fix plus sign input

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Mudita PurePhone changelog
 
+## **11-06-2020**
+
+* [EGD-3276] Fix plus sign input on a 0 key longpress.
+
 ## **04-06-2020**
 * Initial changelog file created

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -223,7 +223,7 @@ namespace gui
             }
             // long press of '0' key is translated to '+'
             else if (inputEvent.keyCode == KeyCode::KEY_0) {
-                return app::prepare_call(application, std::to_string('+'));
+                return app::prepare_call(application, "+");
             }
         }
 


### PR DESCRIPTION
"42" was showing on a 0 key longpress instead of a plus sign.