### PR TITLE
[EGD-3300] allow empty e164 on parsing

### DIFF
--- a/module-utils/PhoneNumber.hpp
+++ b/module-utils/PhoneNumber.hpp
@@ -218,9 +218,13 @@ namespace utils
         PhoneNumber(const std::string &phoneNumber, country::Id defaultCountryCode = country::defaultCountry);
 
         /**
-         * @brief Construct a new Phone Number object from its e164
-         * representation checking if it matches entered number in the proces.
-         * Country code is retrieved from E164 number format.
+         * @brief Construct a new Phone Number object from its raw and e164
+         * representations checking if they match in the process.
+         *
+         * If e164 is empty PhoneNumber is constructed based on entered number
+         * only.
+         *
+         * Country code is retrieved from E164 number format if possible.
          *
          * @param phoneNumber - phone number provided by the user
          * @param e164number - E164 number representation

--- a/module-utils/test/unittest_phonenumber.cpp
+++ b/module-utils/test/unittest_phonenumber.cpp
@@ -217,4 +217,22 @@ TEST_CASE("PhoneNumber - record validation")
         REQUIRE_THROWS_AS(PhoneNumber(pl_entered, "+44600123456"), utils::PhoneNumber::Error);
         REQUIRE_THROWS_AS(PhoneNumber(pl_entered, pl_entered), utils::PhoneNumber::Error);
     }
+
+    SECTION("Empty E164")
+    {
+        REQUIRE_NOTHROW(PhoneNumber(pl_entered, ""));
+        auto number = PhoneNumber(pl_entered, "");
+        REQUIRE(number.get() == pl_entered);
+        REQUIRE(number.getFormatted() == pl_entered);
+        REQUIRE_FALSE(number.isValid());
+    }
+
+    SECTION("Entered single e164")
+    {
+        REQUIRE_NOTHROW(PhoneNumber(pl_e164, ""));
+        auto number = PhoneNumber(pl_e164, pl_e164);
+        REQUIRE(number.isValid());
+        REQUIRE(number.getFormatted() == pl_formatted_int);
+        REQUIRE(number.getCountryCode() == country::Id::POLAND);
+    }
 }


### PR DESCRIPTION
Do not throw on empty e164 while parsing number records.

**No changelog entry - this is a fix for a bug introduced in the current unreleased version**

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>