### PR TITLE
[EGD-2595] do not use string numbers in messaging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 * `[notifications]` Added bottom bar action indicators.
 
 ### Changed
-* `[phonebook]` Improved contact matching by phone number.
+* `[phonebook]``[sms]` Improved contact matching by phone number.
 * `[sms]` Contact Add/Contact details option.
 
 ### Fixed

--- a/module-apps/application-messages/ApplicationMessages.cpp
+++ b/module-apps/application-messages/ApplicationMessages.cpp
@@ -220,9 +220,9 @@ namespace app
         return true;
     }
 
-    bool ApplicationMessages::sendSms(const UTF8 &number, const UTF8 &body)
+    bool ApplicationMessages::sendSms(const utils::PhoneNumber::View &number, const UTF8 &body)
     {
-        if (number.length() == 0 || body.length() == 0) {
+        if (number.getEntered().size() == 0 || body.length() == 0) {
             LOG_WARN("Number or sms body is empty");
             return false;
         }
@@ -244,7 +244,7 @@ namespace app
         return DBServiceAPI::SMSUpdate(this, resendRecord) != DB_ID_NONE;
     }
 
-    bool ApplicationMessages::handleSendSmsFromThread(const UTF8 &number, const UTF8 &body)
+    bool ApplicationMessages::handleSendSmsFromThread(const utils::PhoneNumber::View &number, const UTF8 &body)
     {
         if (!sendSms(number, body)) {
             return false;

--- a/module-apps/application-messages/ApplicationMessages.hpp
+++ b/module-apps/application-messages/ApplicationMessages.hpp
@@ -4,6 +4,7 @@
 #include <Interface/ThreadRecord.hpp>
 #include <Interface/SMSTemplateRecord.hpp>
 #include <Interface/SMSRecord.hpp>
+#include <PhoneNumber.hpp>
 
 namespace gui
 {
@@ -56,11 +57,11 @@ namespace app
         /// show dialog with big search icon and text which was used for query
         bool searchEmpty(const std::string &query = "");
         bool showSearchResults(const UTF8 &title, const UTF8 &search_text);
-        bool sendSms(const UTF8 &number, const UTF8 &body);
+        bool sendSms(const utils::PhoneNumber::View &number, const UTF8 &body);
         bool resendSms(const SMSRecord &record);
         bool newMessageOptions(const std::string &requestingWindow, gui::Text *text);
         bool showNotification(std::function<bool()> action, bool ignoreCurrentWindowOnStack = false);
-        bool handleSendSmsFromThread(const UTF8 &number, const UTF8 &body);
+        bool handleSendSmsFromThread(const utils::PhoneNumber::View &number, const UTF8 &body);
 
         // used by sms template items
         std::function<bool(std::shared_ptr<SMSTemplateRecord> templ)> templatesCallback;

--- a/module-apps/application-messages/windows/NewMessage.hpp
+++ b/module-apps/application-messages/windows/NewMessage.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AppWindow.hpp>
+#include <PhoneNumber.hpp>
 #include <widgets/Text.hpp>
 #include <service-db/api/DBServiceAPI.hpp>
 
@@ -18,7 +19,7 @@ namespace gui
 
         bool selectContact();
         bool sendSms();
-        bool switchToThreadWindow(UTF8 number);
+        bool switchToThreadWindow(const utils::PhoneNumber::View &number);
         void updateBottomBar();
 
       public:

--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -76,9 +76,9 @@ namespace gui
         auto app = dynamic_cast<app::ApplicationMessages *>(application);
         assert(app != nullptr);
 
-        auto phoneNumber       = switchData->getPhoneNumber().getEntered();
+        auto phoneNumber       = switchData->getPhoneNumber();
         app->templatesCallback = [=](std::shared_ptr<SMSTemplateRecord> templ) {
-            LOG_DEBUG("SMS template id = %" PRIu32 "sent to %s", templ->ID, phoneNumber.c_str());
+            LOG_DEBUG("SMS template id = %" PRIu32 "sent to %s", templ->ID, phoneNumber.getFormatted().c_str());
             app->sendSms(phoneNumber, templ->text);
             sapm::ApplicationManager::messageSwitchPreviousApplication(
                 app,

--- a/module-apps/application-messages/windows/ThreadViewWindow.cpp
+++ b/module-apps/application-messages/windows/ThreadViewWindow.cpp
@@ -89,7 +89,7 @@ namespace gui
         text->activatedCallback = [&](gui::Item &item) {
             auto app = dynamic_cast<app::ApplicationMessages *>(application);
             assert(app != nullptr);
-            if (app->handleSendSmsFromThread(contact->numbers[0].number.getE164().c_str(), text->getText())) {
+            if (app->handleSendSmsFromThread(contact->numbers[0].number, text->getText())) {
                 LOG_ERROR("handleSendSmsFromThread failed");
             }
             text->clear();
@@ -346,7 +346,7 @@ namespace gui
 
         body->addWidget(new gui::Span(Axis::Y, style::window::messages::sms_vertical_spacer));
 
-        LOG_INFO("Add sms: %s %s", smsRecord.body.c_str(), smsRecord.number.c_str());
+        LOG_INFO("Add sms: %s %s", smsRecord.body.c_str(), smsRecord.number.getFormatted().c_str());
         body->addWidget(labelSpan);
         return labelSpan->visible;
     }

--- a/module-db/Interface/ContactRecord.hpp
+++ b/module-db/Interface/ContactRecord.hpp
@@ -153,9 +153,6 @@ class ContactRecordInterface : public RecordInterface<ContactRecord, ContactReco
 
   private:
     ContactsDB *contactDB;
-    bool numbersDirty = true;
-    utils::NumberHolderMatcher<std::vector, ContactNumberHolder> numberMatcher;
-    std::vector<ContactNumberHolder> contactNumberHolders;
 
     /// get multiple numbers by split numbers_id
     std::vector<ContactRecord::Number> getNumbers(const std::string &numbers_id);

--- a/module-db/Interface/SMSRecord.hpp
+++ b/module-db/Interface/SMSRecord.hpp
@@ -16,20 +16,22 @@
 #include "utf8/UTF8.hpp"
 #include "../Common/Common.hpp"
 
+#include <PhoneNumber.hpp>
+
 struct SMSRecord : public Record
 {
     uint32_t date      = 0;
     uint32_t dateSent  = 0;
     uint32_t errorCode = 0;
-    UTF8 number        = "";
     UTF8 body          = "";
     bool isRead        = false;
     SMSType type       = SMSType::ALL;
     uint32_t threadID  = 0;
     uint32_t contactID = 0;
+    utils::PhoneNumber::View number;
 
     SMSRecord() = default;
-    SMSRecord(const SMSTableRow &, const UTF8 & = "");
+    SMSRecord(const SMSTableRow &, const utils::PhoneNumber::View &);
 };
 
 enum class SMSRecordField

--- a/module-db/tests/SMSRecord_tests.cpp
+++ b/module-db/tests/SMSRecord_tests.cpp
@@ -1,30 +1,21 @@
-
-/*
- * @file SMSRecord_tests.cpp
- * @author Mateusz Piesta (mateusz.piesta@mudita.com)
- * @date 05.06.19
- * @brief
- * @copyright Copyright (C) 2019 mudita.com
- * @details
- */
-
-#include "vfs.hpp"
-
 #include "catch.hpp"
 
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
+#include <Database/Database.hpp>
+#include <Databases/ContactsDB.hpp>
+#include <Databases/SmsDB.hpp>
+#include <Interface/ContactRecord.hpp>
+#include <Interface/SMSRecord.hpp>
+#include <Interface/ThreadRecord.hpp>
+
+#include <country.hpp>
+#include <PhoneNumber.hpp>
+#include <vfs.hpp>
+
 #include <algorithm>
 
-#include <iostream>
-#include <Interface/ContactRecord.hpp>
-
-#include "../Database/Database.hpp"
-#include "../Databases/ContactsDB.hpp"
-#include "../Databases/SmsDB.hpp"
-#include "../Interface/SMSRecord.hpp"
-#include "../Interface/ThreadRecord.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
 
 struct test
 {
@@ -45,8 +36,8 @@ TEST_CASE("SMS Record tests")
     const uint32_t dateTest      = 123456789;
     const uint32_t dateSentTest  = 987654321;
     const uint32_t errorCodeTest = 555;
-    const char *numberTest       = "+48600123456";
-    const char *numberTest2      = "222333444";
+    auto numberTest              = utils::PhoneNumber("+48600123456", utils::country::Id::UNKNOWN).getView();
+    auto numberTest2             = utils::PhoneNumber("222333444", utils::country::Id::UNKNOWN).getView();
     const char *bodyTest         = "Test SMS Body";
     const char *bodyTest2        = "Test SMS Body2";
     const bool isReadTest        = true;


### PR DESCRIPTION
Use `PhoneNumber::View` instead.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>