### PR TITLE
build: fix linux build on 18.04

### DIFF
--- a/module-services/service-eink/board/linux/renderer/CMakeLists.txt
+++ b/module-services/service-eink/board/linux/renderer/CMakeLists.txt
@@ -25,6 +25,8 @@ target_link_libraries( ${PROJECT_NAME} ${LIBRT} rt pthread )
 target_include_directories( ${PROJECT_NAME}  PUBLIC "${CMAKE_SOURCE_DIR}/"  )
 target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-deprecated-declarations")
 target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-unused-result")
+target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-parentheses")
+target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-cast-function-type")
 
 # disable sanitizier for target, due to bug in sigc
 # https://github.com/libsigcplusplus/libsigcplusplus/issues/10


### PR DESCRIPTION
Due to an old version of gtkmm there are some warnings which we are
escalating to errors globally. Turning them off.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>