### PR TITLE
[EGD-3384] remove .at from TS0710

### DIFF
--- a/module-cellular/Modem/TS0710/TS0710.h
+++ b/module-cellular/Modem/TS0710/TS0710.h
@@ -314,17 +314,21 @@ class TS0710
         return channels.back();
     }
 
-    void CloseChannel(int index)
+    void CloseChannel(unsigned index)
     {
-        delete channels.at(index);
+        if (index >= channels.size()) {
+            LOG_ERROR("Wrong channel index");
+            return;
+        }
+        delete channels[index];
         channels.erase(channels.begin() + index);
     }
 
     void CloseChannel(const std::string &name)
     {
         for (size_t i = 0; i < channels.size(); i++) {
-            if (channels.at(i)->getName() == name) {
-                delete channels.at(i);
+            if (channels[i]->getName() == name) {
+                delete channels[i];
                 channels.erase(channels.begin() + 1);
             }
         }

--- a/module-cellular/Modem/TS0710/TS0710_Frame.h
+++ b/module-cellular/Modem/TS0710/TS0710_Frame.h
@@ -69,8 +69,9 @@ class TS0710_Frame
                 //     len += 1;
             }
             /*len is the number of bytes in the message, p points to message*/
+
             while (len--) {
-                FCS = crctable[FCS ^ ret.at(i++)];
+                FCS = crctable[FCS ^ ret[i++]];
             }
             /*Ones complement*/
             FCS = 0xFF - FCS;
@@ -102,7 +103,7 @@ class TS0710_Frame
                 }
             }
 
-            if ((serData[0] != TS0710_FLAG) || (serData.at(myLen - 1) != TS0710_FLAG)) {
+            if ((serData[0] != TS0710_FLAG) || (serData[myLen - 1] != TS0710_FLAG)) {
                 Address = 0;
                 Control = 0;
                 LOG_ERROR("Received frame has incorrect leading/trailing flags. Dropping.");


### PR DESCRIPTION
remove .at from TS0710 as it can throw.
Instead, check size of vector before dereferencing