### PR TITLE
build: optimize third party in debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Following CMake options can be used:
  * `BUILD_DOC_WITH_ALL` - enable/disable building code documentation with the `all` target (disabled by default).
  * `ENABLE_TEST_LOGS` - enable/disable test log output (disabled by default).
  * `LINUX_ENABLE_SANITIZER` - enable/disable building with address sanitizer for Linux (enabled by default). This option is handy when you need to run the app with valgrind.
+* `THIRD_PARTY_DEBUG_OPTIMIZE` - enable/disable third party size optimization for debug build type (enabled by default)
 
 # Linux Bluetooth device
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 * `[sms]` Fix selecting contact for a new message after searching in phonebook.
 
 ### Other
+* `[build]` Optimize third party libraries in debug configuration to lower the size footprint for the RT1051 platform
 
 ## [0.30.1] - 2020-07-24
 

--- a/config/thirdparty.cmake
+++ b/config/thirdparty.cmake
@@ -1,0 +1,8 @@
+option (THIRD_PARTY_DEBUG_OPTIMIZE "Optimize third party in debug" ON)
+
+# optimize third party sources in debug by setting source file properties
+macro(third_party_source_optimization)
+    if (${THIRD_PARTY_DEBUG_OPTIMIZE} AND (${CMAKE_BUILD_TYPE} STREQUAL "Debug"))
+        set_property(SOURCE ${ARGV} APPEND_STRING PROPERTY COMPILE_FLAGS " -Os")
+    endif()
+endmacro()

--- a/module-db/CMakeLists.txt
+++ b/module-db/CMakeLists.txt
@@ -3,12 +3,16 @@ cmake_minimum_required(VERSION 3.12)
 project(module-db VERSION 1.0
         DESCRIPTION "Database module library")
 
+include(thirdparty)
+
+set (SQLITE3_SOURCE Database/sqlite3.c)
+
 set(SOURCES
         Database/Field.cpp
         Database/QueryResult.cpp
         Database/Database.cpp
-        Database/sqlite3.c
         Database/sqlite3vfs.cpp
+        ${SQLITE3_SOURCE}
 
         Databases/ContactsDB.cpp
         Databases/SmsDB.cpp
@@ -93,9 +97,9 @@ target_include_directories(${PROJECT_NAME}
 
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/Interface
-        
+
         PRIVATE
-        
+
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/Interface
         ${CMAKE_CURRENT_SOURCE_DIR}/Tables
@@ -114,3 +118,5 @@ target_link_libraries(${PROJECT_NAME} module-utils module-vfs )
 if (${ENABLE_TESTS})
     add_subdirectory(tests)
 endif ()
+
+third_party_source_optimization(${SQLITE3_SOURCE})

--- a/module-utils/third-party/libphonenumber.cmake
+++ b/module-utils/third-party/libphonenumber.cmake
@@ -1,3 +1,5 @@
+include (thirdparty)
+
 # add sources
 set (LIBPHONENUMBER_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/libphonenumber/cpp/src)
 set (LIBPHONENUMBER ${LIBPHONENUMBER_SRCDIR}/phonenumbers)
@@ -41,3 +43,5 @@ set_source_files_properties(${LIBPHONENUMBER}/asyoutypeformatter.cc
 
 # add include directory
 target_include_directories(${PROJECT_NAME} PUBLIC ${LIBPHONENUMBER_SRCDIR})
+
+third_party_source_optimization(${LIBPHONENUMBER_SOURCES})

--- a/module-utils/third-party/protobuf-lite.cmake
+++ b/module-utils/third-party/protobuf-lite.cmake
@@ -1,3 +1,5 @@
+include (thirdparty)
+
 # add sources
 set(PROTOBUF_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/src)
 set(PROTOBUF ${PROTOBUF_SRCDIR}/google/protobuf)
@@ -42,8 +44,11 @@ set_source_files_properties(${PROTOBUF_SOURCES}
         -Wno-stringop-overflow \
         -Wno-sign-compare \
         -Wno-type-limits  \
-        -Wno-redundant-move"
+        -Wno-redundant-move \
+        -Wno-maybe-uninitialized"
 )
 
 # add include dir
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROTOBUF_SRCDIR})
+
+third_party_source_optimization(${PROTOBUF_SOURCES})

--- a/module-utils/third-party/re2.cmake
+++ b/module-utils/third-party/re2.cmake
@@ -1,3 +1,5 @@
+include(thirdparty)
+
 # add re2 library sources
 set(RE2_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/re2)
 set(RE2_SOURCES
@@ -38,5 +40,5 @@ set_source_files_properties(${RE2_SRCDIR}/re2/perl_groups.cc
         -Wno-missing-field-initializers
 )
 
-
 target_include_directories(${PROJECT_NAME} PUBLIC ${RE2_SRCDIR})
+third_party_source_optimization(${RE2_SOURCES})

--- a/module-utils/third-party/sbini.cmake
+++ b/module-utils/third-party/sbini.cmake
@@ -1,3 +1,5 @@
+include(thirdparty)
+
 # add sources
 set(SBINI ${CMAKE_CURRENT_SOURCE_DIR}/sbini)
 set(SBINI_SOURCES
@@ -16,3 +18,5 @@ set_source_files_properties(${SBINI_SOURCES}
 
 # add include dir
 target_include_directories(${PROJECT_NAME} PUBLIC ${SBINI})
+
+third_party_source_optimization(${SBINI_SOURCES})


### PR DESCRIPTION
To minimize size footprint and to be able to fit in the RT1051 target,
add optimization options in debug configuration for third party modules
which are directly added to the sources.

This behaviour is controlled by the `THIRD_PARTY_DEBUG_OPTIMIZE` boolean
option.

Results: from 95.91 to 87.29 percentage usage of text section in the external RAM (saved ~530 kB).