### PR TITLE
ccache fixup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/config")
+include(CCacheConfig)
+
 project(PurePhone)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/config")
-
 include(Colours)
-include(CCacheConfig)
 include(ProjectConfig)
 include(ModuleConfig)
 include(SerialPort)

--- a/config/CCacheConfig.cmake
+++ b/config/CCacheConfig.cmake
@@ -1,5 +1,11 @@
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+    message("ccache found ${CCACHE_FOUND}")
+    set(CMAKE_C_COMPILER_LAUNCHER   "${CCACHE_FOUND}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_FOUND}")
 endif(CCACHE_FOUND)
+
+# To show how much time we spend compiling - with ccache it should take close less then 1s per file
+if(COMPILATION_TIMINGS)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
+endif(COMPILATION_TIMINGS)


### PR DESCRIPTION
There is something seriously wrong with current ccache config - this is: it doesn't use ccache.
This is proposed fixup which works, I don't feel good enough to tell that it's right from cmake perspective - therefore draft @mpsm please see it kk?

I don't know why but https://cmake.org/cmake/help/v3.14/prop_tgt/LANG_COMPILER_LAUNCHER.html doesn't work without:
1. setting it prior to project
2. setting it with CMAKE_... ( which I understand is set as default then)

To reproduce:
1. ./configure.sh project (which will remove your actual build) 
2. run make

or:
just check `ccache -s` if you started to use it recently

or:

use flag for check for compilation time ( COMPILATION_TIMINGS added here ) to see how long compiler takes to compile files. 