### PR TITLE
[EGD-3462] SMS conversation view - filer db triggers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 * `[utilities]` Fix for UTF8 by character copies
 * `[gui]` Fix crash in font glyph rendering on screen
 * `[sms]` When opening a thread show it from the newest message  
+* `[sms]` Fixed superfluous refreshes (causing delay/screen flashing) on entering conversation view 
 
 ### Other
 

--- a/module-apps/application-messages/windows/MessagesMainWindow.cpp
+++ b/module-apps/application-messages/windows/MessagesMainWindow.cpp
@@ -182,12 +182,18 @@ namespace gui
 
         auto *msgNotification = dynamic_cast<db::NotificationMessage *>(msgl);
         if (msgNotification != nullptr) {
-            // whatever notification had happened, rebuild
-            this->rebuild();
-            if (this == application->getCurrentWindow()) {
-                application->refreshWindow(gui::RefreshModes::GUI_REFRESH_FAST);
+            if ((msgNotification->interface == db::Interface::Name::SMSThread ||
+                 msgNotification->interface == db::Interface::Name::SMS)) {
+                if (msgNotification->type == db::Query::Type::Create ||
+                    msgNotification->type == db::Query::Type::Update ||
+                    msgNotification->type == db::Query::Type::Delete) {
+                    this->rebuild();
+                    if (this == application->getCurrentWindow()) {
+                        application->refreshWindow(gui::RefreshModes::GUI_REFRESH_FAST);
+                    }
+                    return true;
+                }
             }
-            return true;
         }
         return false;
     } // namespace gui


### PR DESCRIPTION
Limit rebuilding only to SMS related db notifications.

---

This filter is way too broad, because there is a underlying issue:
_We cannot trust db notification: it's db operation and db interface._

db operations, which sendUnicast in the end, sometimes do more than Unicast says (e.g. delete whole Thread on top of requested SMS)
Please consider if interface methods should return a collection of actually performed operations, for windows to react precisely.