### PR TITLE
[EGD-3097] Add storing audio settings in database

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Added
 * `[phonebook]` NoName contacts at the end of contacts list.
 * `[calllog]` Added new queries to the DB
+* `[audio]` Add storing and updating audio settings in database.
 
 ### Changed
 

--- a/module-apps/Application.cpp
+++ b/module-apps/Application.cpp
@@ -492,12 +492,13 @@ namespace app
         acceptInput = true;
     }
 
-    bool Application::adjustCurrentVolume(const audio::Volume step)
+    bool Application::adjustCurrentVolume(const int step)
     {
         audio::Volume vol;
         auto ret = AudioServiceAPI::GetOutputVolume(this, vol);
-        if (ret == audio::RetCode::Success && vol != audio::invalidVolume) {
-            ret = AudioServiceAPI::SetOutputVolume(this, vol + step);
+        if (ret == audio::RetCode::Success) {
+            ret = ((static_cast<int>(vol) + step) < 0) ? audio::RetCode::Success
+                                                       : AudioServiceAPI::SetOutputVolume(this, vol + step);
         }
         return ret == audio::RetCode::Success;
     }

--- a/module-apps/Application.hpp
+++ b/module-apps/Application.hpp
@@ -228,7 +228,7 @@ namespace app
             shutdownInProgress = true;
         };
 
-        bool adjustCurrentVolume(const audio::Volume step);
+        bool adjustCurrentVolume(const int step);
         bool increaseCurrentVolume(const audio::Volume step = audio::defaultVolumeStep)
         {
             return adjustCurrentVolume(step);

--- a/module-apps/application-music-player/windows/MusicPlayerMainWindow.cpp
+++ b/module-apps/application-music-player/windows/MusicPlayerMainWindow.cpp
@@ -26,7 +26,7 @@ namespace gui
     {
         audio::Volume volume;
         const auto ret = application->getCurrentVolume(volume);
-        if (ret == audio::RetCode::Success && volume != audio::invalidVolume) {
+        if (ret == audio::RetCode::Success) {
             if (successCallback != nullptr) {
                 successCallback(volume);
             }

--- a/module-audio/Audio/Audio.hpp
+++ b/module-audio/Audio/Audio.hpp
@@ -22,7 +22,8 @@ namespace audio
             Routing,
         };
 
-        Audio(std::function<int32_t(AudioEvents event)> asyncCallback);
+        Audio(std::function<int32_t(AudioEvents event)> asyncCallback,
+              std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback);
 
         // Events
         audio::RetCode SendEvent(const Operation::Event evt, const EventData *data = nullptr);
@@ -53,6 +54,11 @@ namespace audio
             return currentOperation->GetInputGain();
         }
 
+        const Operation *GetCurrentOperation() const
+        {
+            return currentOperation.get();
+        }
+
         // TODO:M.P Set/Get inputGain/outputVolume for each profile
 
         // Operations
@@ -70,6 +76,7 @@ namespace audio
         std::unique_ptr<Operation> currentOperation;
 
         std::function<int32_t(AudioEvents event)> asyncCallback = nullptr;
+        std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback = nullptr;
     };
 
 } // namespace audio

--- a/module-audio/Audio/AudioCommon.cpp
+++ b/module-audio/Audio/AudioCommon.cpp
@@ -44,10 +44,15 @@ namespace audio
         return "";
     }
 
+    const std::string str(const Profile::Type &type, const ProfileSetup &setup)
+    {
+        std::stringstream ss;
+        ss << "audio/" << str(type) << ((setup == ProfileSetup::Volume) ? "/volume" : "/gain");
+        return ss.str();
+    }
+
     auto GetVolumeText(const audio::Volume &volume) -> const std::string
     {
-        auto roundedVolume = static_cast<uint8_t>(std::round(volume * 10)); // Converts 0-1 volume to 0 - 10
-        return (static_cast<std::ostringstream &&>(std::ostringstream() << "Vol: " << std::to_string(roundedVolume)))
-            .str();
+        return (static_cast<std::ostringstream &&>(std::ostringstream() << "Vol: " << std::to_string(volume))).str();
     }
 } // namespace audio

--- a/module-audio/Audio/AudioCommon.hpp
+++ b/module-audio/Audio/AudioCommon.hpp
@@ -1,19 +1,36 @@
 #pragma once
 
+#include <map>
+
+#include "Profiles/Profile.hpp"
 #include "bsp_audio.hpp"
 
 namespace audio
 {
     using Position = float;
-    using Volume   = float;
-    using Gain     = float;
+    using Volume   = uint32_t;
+    using Gain     = uint32_t;
 
-    constexpr Volume defaultVolumeStep = 0.1;
-    constexpr Gain defaultGainStep     = 1.0;
-    constexpr Volume invalidVolume     = -1.0;
-    constexpr Gain invalidGain         = -1.0;
-    constexpr Volume defaultVolume     = 0.5;
-    constexpr Gain defaultGain         = 0.5;
+    constexpr Volume defaultVolumeStep = 1;
+    constexpr Gain defaultGainStep     = 10;
+    constexpr Volume defaultVolume     = 5;
+    constexpr Gain defaultGain         = 5;
+
+    constexpr Volume maxVolume = 10;
+    constexpr Volume minVolume = 0;
+
+    constexpr Gain maxGain = 100;
+    constexpr Gain minGain = 0;
+
+    constexpr uint32_t audioOperationTimeout = 1000;
+
+    enum class ProfileSetup
+    {
+        Volume,
+        Gain
+    };
+
+    [[nodiscard]] const std::string str(const Profile::Type &type, const ProfileSetup &setup);
 
     enum class RetCode
     {

--- a/module-audio/Audio/Operation/Operation.cpp
+++ b/module-audio/Audio/Operation/Operation.cpp
@@ -12,8 +12,10 @@
 
 namespace audio
 {
-
-    std::optional<std::unique_ptr<Operation>> Operation::Create(const Operation::Type &t, const char *fileName)
+    std::optional<std::unique_ptr<Operation>> Operation::Create(
+        Operation::Type t,
+        const char *fileName,
+        std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback)
     {
         std::unique_ptr<Operation> inst;
 
@@ -22,13 +24,13 @@ namespace audio
             inst = std::make_unique<IdleOperation>(fileName);
             break;
         case Type::Playback:
-            inst = std::make_unique<PlaybackOperation>(fileName);
+            inst = std::make_unique<PlaybackOperation>(fileName, dbCallback);
             break;
         case Type::Router:
-            inst = std::make_unique<RouterOperation>(fileName);
+            inst = std::make_unique<RouterOperation>(fileName, dbCallback);
             break;
         case Type::Recorder:
-            inst = std::make_unique<RecorderOperation>(fileName);
+            inst = std::make_unique<RecorderOperation>(fileName, dbCallback);
             break;
         }
 

--- a/module-audio/Audio/Operation/Operation.hpp
+++ b/module-audio/Audio/Operation/Operation.hpp
@@ -11,7 +11,6 @@
 
 namespace audio
 {
-
     class EventData
     {
       public:
@@ -73,7 +72,10 @@ namespace audio
 
         virtual ~Operation() = default;
 
-        static std::optional<std::unique_ptr<Operation>> Create(const Type &t, const char *fileName);
+        static std::optional<std::unique_ptr<Operation>> Create(
+            Type t,
+            const char *fileName                                                                      = "",
+            std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback = nullptr);
 
         virtual audio::RetCode Start(std::function<int32_t(AudioEvents event)> callback) = 0;
 
@@ -91,22 +93,22 @@ namespace audio
 
         virtual Position GetPosition() = 0;
 
-        Volume GetOutputVolume()
+        Volume GetOutputVolume() const
         {
-            return currentProfile != nullptr ? currentProfile->GetOutputVolume() : invalidVolume;
+            return (currentProfile != nullptr) ? currentProfile->GetOutputVolume() : Volume{};
         }
 
-        Gain GetInputGain()
+        Gain GetInputGain() const
         {
-            return currentProfile != nullptr ? currentProfile->GetInputGain() : invalidGain;
+            return currentProfile->GetInputGain();
         }
 
-        State GetState()
+        State GetState() const
         {
             return state;
         }
 
-        const Profile *GetProfile()
+        const Profile *GetProfile() const
         {
             return currentProfile;
         }

--- a/module-audio/Audio/Operation/PlaybackOperation.hpp
+++ b/module-audio/Audio/Operation/PlaybackOperation.hpp
@@ -11,7 +11,9 @@ namespace audio
     class PlaybackOperation : public Operation
     {
       public:
-        PlaybackOperation(const char *file);
+        PlaybackOperation(
+            const char *file,
+            std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback = nullptr);
 
         audio::RetCode Start(std::function<int32_t(AudioEvents event)> callback) override final;
 

--- a/module-audio/Audio/Operation/RecorderOperation.hpp
+++ b/module-audio/Audio/Operation/RecorderOperation.hpp
@@ -20,7 +20,8 @@ namespace audio
     class RecorderOperation : public Operation
     {
       public:
-        RecorderOperation(const char *file);
+        RecorderOperation(const char *file,
+                          std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback);
 
         audio::RetCode Start(std::function<int32_t(AudioEvents event)> callback) override final;
 

--- a/module-audio/Audio/Operation/RouterOperation.cpp
+++ b/module-audio/Audio/Operation/RouterOperation.cpp
@@ -18,7 +18,9 @@
 namespace audio
 {
 
-    RouterOperation::RouterOperation([[maybe_unused]] const char *file)
+    RouterOperation::RouterOperation(
+        [[maybe_unused]] const char *file,
+        std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback)
     {
 
         audioDeviceCallback =
@@ -79,10 +81,39 @@ namespace audio
         audioDeviceBuffer.resize(1024, 0);
         audioDeviceCellularBuffer.resize(1024, 0);
 
-        // TODO:M.P should be fetched from DB
-        availableProfiles.push_back(std::make_unique<ProfileRoutingEarspeaker>(nullptr, 1, 2));
-        availableProfiles.push_back(std::make_unique<ProfileRoutingSpeakerphone>(nullptr, 1, 2));
-        availableProfiles.push_back(std::make_unique<ProfileRoutingHeadset>(nullptr, 1, 5));
+        constexpr audio::Gain defaultRoutingEarspeakerGain       = 20;
+        constexpr audio::Volume defaultRoutingEarspeakerVolume   = 10;
+        constexpr audio::Gain defaultRoutingSpeakerphoneGain     = 20;
+        constexpr audio::Volume defaultRoutingSpeakerphoneVolume = 10;
+        constexpr audio::Gain defaultRoutingHeadsetGain          = 50;
+        constexpr audio::Volume defaultRoutingHeadsetVolume      = 10;
+
+        const auto dbRoutingEarspeakerGainPath =
+            audio::str(audio::Profile::Type::RoutingEarspeaker, audio::ProfileSetup::Gain);
+        const auto routingEarspeakerGain = dbCallback(dbRoutingEarspeakerGainPath, defaultRoutingEarspeakerGain);
+        const auto dbRoutingEarspeakerVolumePath =
+            audio::str(audio::Profile::Type::RoutingEarspeaker, audio::ProfileSetup::Volume);
+        const auto routingEarspeakerVolume = dbCallback(dbRoutingEarspeakerVolumePath, defaultRoutingEarspeakerVolume);
+        const auto dbRoutingSpeakerphoneGainPath =
+            audio::str(audio::Profile::Type::RoutingSpeakerphone, audio::ProfileSetup::Gain);
+        const auto routingSpeakerphoneGain = dbCallback(dbRoutingSpeakerphoneGainPath, defaultRoutingSpeakerphoneGain);
+        const auto dbRoutingSpeakerphoneVolumePath =
+            audio::str(audio::Profile::Type::RoutingSpeakerphone, audio::ProfileSetup::Volume);
+        const auto routingSpeakerphoneVolume =
+            dbCallback(dbRoutingSpeakerphoneVolumePath, defaultRoutingSpeakerphoneVolume);
+        const auto dbRoutingHeadsetGainPath =
+            audio::str(audio::Profile::Type::RoutingHeadset, audio::ProfileSetup::Gain);
+        const auto routingHeadsetGain = dbCallback(dbRoutingHeadsetGainPath, defaultRoutingHeadsetGain);
+        const auto dbRoutingHeadsetVolumePath =
+            audio::str(audio::Profile::Type::RoutingHeadset, audio::ProfileSetup::Volume);
+        const auto routingHeadsetVolume = dbCallback(dbRoutingHeadsetVolumePath, defaultRoutingHeadsetVolume);
+
+        availableProfiles.push_back(
+            std::make_unique<ProfileRoutingEarspeaker>(nullptr, routingEarspeakerVolume, routingEarspeakerGain));
+        availableProfiles.push_back(
+            std::make_unique<ProfileRoutingSpeakerphone>(nullptr, routingSpeakerphoneVolume, routingSpeakerphoneGain));
+        availableProfiles.push_back(
+            std::make_unique<ProfileRoutingHeadset>(nullptr, routingHeadsetVolume, routingHeadsetGain));
 
         currentProfile = availableProfiles[0].get();
 

--- a/module-audio/Audio/Operation/RouterOperation.hpp
+++ b/module-audio/Audio/Operation/RouterOperation.hpp
@@ -33,7 +33,8 @@ namespace audio
         friend void recorderWorker(void *pvp);
 
       public:
-        RouterOperation(const char *file);
+        RouterOperation(const char *file,
+                        std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback);
 
         ~RouterOperation();
 

--- a/module-audio/Audio/Profiles/Profile.cpp
+++ b/module-audio/Audio/Profiles/Profile.cpp
@@ -96,4 +96,55 @@ namespace audio
         audioFormat.sampleRate_Hz = samplerate;
     }
 
+    const std::string str(const Profile::Type &profileType)
+    {
+        switch (profileType) {
+        case Profile::Type::RoutingSpeakerphone: {
+            return "RoutingSpeakerphone";
+        }
+        case Profile::Type::RoutingHeadset: {
+            return "RoutingHeadset";
+        }
+        case Profile::Type::RoutingBTHeadset: {
+            return "RoutingBTHeadset";
+        }
+        case Profile::Type::RoutingHeadphones: {
+            return "RoutingHeadphones";
+        }
+        case Profile::Type::RoutingEarspeaker: {
+            return "RoutingEarspeaker";
+        }
+        case Profile::Type::RecordingBuiltInMic: {
+            return "RecordingBuiltInMic";
+        }
+        case Profile::Type::RecordingHeadset: {
+            return "RecordingHeadset";
+        }
+        case Profile::Type::RecordingBTHeadset: {
+            return "RecordingBTHeadset";
+        }
+        case Profile::Type::PlaybackLoudspeaker: {
+            return "PlaybackLoudspeaker";
+        }
+        case Profile::Type::PlaybackHeadphones: {
+            return "PlaybackHeadphones";
+        }
+        case Profile::Type::PlaybackBTA2DP: {
+            return "PlaybackBTA2DP";
+        }
+        case Profile::Type::SystemSoundLoudspeaker: {
+            return "SystemSoundLoudspeaker";
+        }
+        case Profile::Type::SystemSoundHeadphones: {
+            return "SystemSoundHeadphones";
+        }
+        case Profile::Type::SystemSoundBTA2DP: {
+            return "SystemSoundBTA2DP";
+        }
+        case Profile::Type::Idle: {
+            return "Idle";
+        }
+        }
+        return "";
+    }
 } // namespace audio

--- a/module-audio/Audio/Profiles/Profile.hpp
+++ b/module-audio/Audio/Profiles/Profile.hpp
@@ -111,13 +111,13 @@ namespace audio
             return name;
         }
 
-        Type GetType()
+        Type GetType() const
         {
             return type;
         }
 
       protected:
-        bsp::AudioDevice::Format audioFormat;
+        bsp::AudioDevice::Format audioFormat{};
         bsp::AudioDevice::Type audioDeviceType = bsp::AudioDevice::Type::Audiocodec;
 
         std::string name;
@@ -126,4 +126,5 @@ namespace audio
         std::function<int32_t()> dbAccessCallback = nullptr;
     };
 
+    [[nodiscard]] const std::string str(const Profile::Type &profileType);
 } // namespace audio

--- a/module-bsp/board/linux/audio/LinuxCellularAudio.cpp
+++ b/module-bsp/board/linux/audio/LinuxCellularAudio.cpp
@@ -102,8 +102,9 @@ namespace bsp
 
         if (inputBuffer) {
             int16_t *pBuff = reinterpret_cast<int16_t *>(const_cast<void *>(inputBuffer));
-            std::transform(pBuff, pBuff + framesToFetch, pBuff, [ptr](int16_t c) -> int16_t {
-                return (float)c * ptr->currentFormat.inputGain;
+            constexpr float scaleFactor = .1f;
+            std::transform(pBuff, pBuff + framesToFetch, pBuff, [ptr, &scaleFactor](int16_t c) -> int16_t {
+                return static_cast<float>(c * ptr->currentFormat.inputGain * scaleFactor);
             });
         }
 
@@ -117,8 +118,9 @@ namespace bsp
             // Scale output buffer
             if (outputBuffer) {
                 int16_t *pBuff = reinterpret_cast<int16_t *>(outputBuffer);
+                constexpr float scaleFactor = .1f;
                 std::transform(pBuff, pBuff + framesToFetch, pBuff, [ptr](int16_t c) -> int16_t {
-                    return (float)c * ptr->currentFormat.outputVolume;
+                    return static_cast<float>(c * ptr->currentFormat.outputVolume / 10.f);
                 });
             }
             return paContinue;

--- a/module-bsp/board/linux/audio/linux_audiocodec.cpp
+++ b/module-bsp/board/linux/audio/linux_audiocodec.cpp
@@ -100,8 +100,9 @@ namespace bsp
 
         if (inputBuffer) {
             int16_t *pBuff = reinterpret_cast<int16_t *>(const_cast<void *>(inputBuffer));
-            std::transform(pBuff, pBuff + framesToFetch, pBuff, [ptr](int16_t c) -> int16_t {
-                return (float)c * ptr->currentFormat.inputGain;
+            constexpr float scaleFactor = .1f;
+            std::transform(pBuff, pBuff + framesToFetch, pBuff, [ptr, &scaleFactor](int16_t c) -> int16_t {
+                return static_cast<float>(c * ptr->currentFormat.inputGain * scaleFactor);
             });
         }
 
@@ -115,8 +116,9 @@ namespace bsp
             // Scale output buffer
             if (outputBuffer) {
                 int16_t *pBuff = reinterpret_cast<int16_t *>(outputBuffer);
-                std::transform(pBuff, pBuff + framesToFetch, pBuff, [ptr](int16_t c) -> int16_t {
-                    return (float)c * ptr->currentFormat.outputVolume;
+                constexpr float scaleFactor = .1f;
+                std::transform(pBuff, pBuff + framesToFetch, pBuff, [ptr, &scaleFactor](int16_t c) -> int16_t {
+                    return static_cast<float>(c * ptr->currentFormat.outputVolume * scaleFactor);
                 });
             }
             return paContinue;

--- a/module-bsp/board/rt1051/bsp/audio/CodecMAX98090.cpp
+++ b/module-bsp/board/rt1051/bsp/audio/CodecMAX98090.cpp
@@ -393,8 +393,8 @@ CodecRetCode CodecMAX98090::SetOutputVolume(const float vol)
     case CodecParamsMAX98090::OutputPath::Headphones:
     case CodecParamsMAX98090::OutputPath::HeadphonesMono: {
         // Scale input volume(range 0 - 100) to MAX98090 range(decibels hardcoded as specific hex values)
-        float scale_factor               = 0.31;
-        uint8_t volume                   = (float)(vol * 100 * scale_factor);
+        constexpr float scale_factor     = .31f * 10.f;
+        uint8_t volume                   = static_cast<float>(vol * scale_factor);
         max98090_reg_lhp_vol_ctrl_t lvol = {0};
         max98090_reg_rhp_vol_ctrl_t rvol = {0};
 
@@ -412,8 +412,8 @@ CodecRetCode CodecMAX98090::SetOutputVolume(const float vol)
 
     case CodecParamsMAX98090::OutputPath::Earspeaker: {
         // Scale input volume(range 0 - 100) to MAX98090 range(decibels hardcoded as specific hex values)
-        float scale_factor               = 0.31;
-        uint8_t volume                   = (float)(vol * 100 * scale_factor);
+        constexpr float scale_factor     = .31f * 10.f;
+        uint8_t volume                   = static_cast<float>(vol * scale_factor);
         max98090_reg_recv_vol_ctrl_t vol = {0};
 
         vol.rcvlm   = mute;
@@ -425,8 +425,8 @@ CodecRetCode CodecMAX98090::SetOutputVolume(const float vol)
 
     case CodecParamsMAX98090::OutputPath::Loudspeaker: {
         // Scale input volume(range 0 - 100) to MAX98090 range(decibels hardcoded as specific hex values)
-        float scale_factor = 0.39;
-        uint8_t volume     = (float)(vol * 100 * scale_factor) + 0x18;
+        constexpr float scale_factor = .39f * 10.f;
+        uint8_t volume               = static_cast<float>(vol * scale_factor) + 0x18;
 
         max98090_reg_lspk_vol_ctrl_t lvol = {0};
         max98090_reg_rspk_vol_ctrl_t rvol = {0};
@@ -453,7 +453,8 @@ CodecRetCode CodecMAX98090::SetOutputVolume(const float vol)
 
 CodecRetCode CodecMAX98090::SetInputGain(const float gain)
 {
-    float gainToSet = gain;
+    constexpr float scaleFactor = .1f;
+    float gainToSet             = gain * scaleFactor;
 
     if (gain > 10) {
         gainToSet = 10;

--- a/module-bsp/bsp/audio/bsp_audio.hpp
+++ b/module-bsp/bsp/audio/bsp_audio.hpp
@@ -57,9 +57,9 @@ namespace bsp {
         };
 
         using Format = struct {
-            uint32_t sampleRate_Hz;   /*!< Sample rate of audio data */
-            uint32_t bitWidth;        /*!< Data length of audio data, usually 8/16/24/32 bits */
-            uint32_t flags;             /*!< In/Out configuration flags */
+            uint32_t sampleRate_Hz{};   /*!< Sample rate of audio data */
+            uint32_t bitWidth{};        /*!< Data length of audio data, usually 8/16/24/32 bits */
+            uint32_t flags{};             /*!< In/Out configuration flags */
             float outputVolume=0.0;
             float inputGain=0.0;
             InputPath inputPath=InputPath ::None;

--- a/module-db/CMakeLists.txt
+++ b/module-db/CMakeLists.txt
@@ -100,6 +100,8 @@ set(SOURCES
         queries/calendar/QueryEventsGetFiltered.hpp
         queries/calendar/QueryEventsGetFiltered.cpp
         queries/settings/QuerySettingsGet_v2.cpp
+        queries/settings/QuerySettingsUpdate_v2.cpp
+        queries/settings/QuerySettingsAddOrIgnore_v2.cpp
 )
 
 if(NOT ${PROJECT_TARGET} STREQUAL "TARGET_Linux")

--- a/module-db/Interface/SettingsRecord_v2.hpp
+++ b/module-db/Interface/SettingsRecord_v2.hpp
@@ -12,6 +12,10 @@ namespace db::query::settings
 {
     class SettingsQuery;
     class SettingsResult;
+    class AddOrIgnoreQuery;
+    class AddOrIgnoreResult;
+    class UpdateQuery;
+    class UpdateResult;
 } // namespace db::query::settings
 
 class SettingsRecord_v2 : public Record
@@ -28,8 +32,11 @@ class SettingsRecord_v2 : public Record
         return path;
     }
 
-    template <typename T>[[nodiscard]] auto getValue() const -> T
+    template <typename T>[[nodiscard]] auto getValue(const T &defaultValue = {}) const -> T
     {
+        if (value.empty()) {
+            return defaultValue;
+        }
         T ret;
         std::istringstream(value) >> ret;
         return ret;
@@ -59,6 +66,7 @@ class SettingsRecordInterface_v2 : public RecordInterface<SettingsRecord_v2, Set
     uint32_t GetCount() override final;
     bool RemoveByID(uint32_t id) override final;
     bool Update(const SettingsRecord_v2 &recUpdated) override final;
+    bool Update(const std::string &path, const std::string &value) noexcept;
     std::unique_ptr<db::QueryResult> runQuery(std::shared_ptr<db::Query> query) override;
 
   private:

--- a/module-db/queries/settings/QuerySettingsAddOrIgnore_v2.cpp
+++ b/module-db/queries/settings/QuerySettingsAddOrIgnore_v2.cpp
@@ -1,0 +1,30 @@
+#include "QuerySettingsAddOrIgnore_v2.hpp"
+
+namespace db::query::settings
+{
+    AddOrIgnoreQuery::AddOrIgnoreQuery(const SettingsRecord_v2 &record) : Query{Query::Type::Update}, record{record}
+    {}
+
+    auto AddOrIgnoreQuery::debugInfo() const -> std::string
+    {
+        return "Update";
+    }
+
+    auto AddOrIgnoreQuery::getRecord() const noexcept -> const SettingsRecord_v2 &
+    {
+        return record;
+    }
+
+    AddOrIgnoreResult::AddOrIgnoreResult(const bool &value) : value{value}
+    {}
+
+    auto AddOrIgnoreResult::getValue() const -> bool
+    {
+        return value;
+    }
+
+    auto AddOrIgnoreResult::debugInfo() const -> std::string
+    {
+        return "AddOrIgnoreResult";
+    }
+} // namespace db::query::settings

--- a/module-db/queries/settings/QuerySettingsAddOrIgnore_v2.hpp
+++ b/module-db/queries/settings/QuerySettingsAddOrIgnore_v2.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "module-db/Interface/SettingsRecord_v2.hpp"
+#include <Common/Query.hpp>
+
+namespace db::query::settings
+{
+    class AddOrIgnoreQuery : public Query
+    {
+        const SettingsRecord_v2 record;
+
+      public:
+        AddOrIgnoreQuery(const SettingsRecord_v2 &record);
+
+        [[nodiscard]] auto getRecord() const noexcept -> const SettingsRecord_v2 &;
+        [[nodiscard]] auto debugInfo() const -> std::string override;
+    };
+
+    class AddOrIgnoreResult : public QueryResult
+    {
+        bool value = false;
+
+      public:
+        AddOrIgnoreResult(const bool &value);
+
+        [[nodiscard]] auto getValue() const -> bool;
+        [[nodiscard]] auto debugInfo() const -> std::string override;
+    };
+
+} // namespace db::query::settings

--- a/module-db/queries/settings/QuerySettingsUpdate_v2.cpp
+++ b/module-db/queries/settings/QuerySettingsUpdate_v2.cpp
@@ -1,0 +1,30 @@
+#include "QuerySettingsUpdate_v2.hpp"
+
+namespace db::query::settings
+{
+    UpdateQuery::UpdateQuery(const SettingsRecord_v2 &record) : Query{Query::Type::Update}, record{record}
+    {}
+
+    auto UpdateQuery::debugInfo() const -> std::string
+    {
+        return "Update";
+    }
+
+    auto UpdateQuery::getRecord() const -> const SettingsRecord_v2 &
+    {
+        return record;
+    }
+
+    UpdateResult::UpdateResult(const bool &value) : value{value}
+    {}
+
+    auto UpdateResult::getValue() const -> bool
+    {
+        return value;
+    }
+
+    auto UpdateResult::debugInfo() const -> std::string
+    {
+        return "UpdateResult";
+    }
+} // namespace db::query::settings

--- a/module-db/queries/settings/QuerySettingsUpdate_v2.hpp
+++ b/module-db/queries/settings/QuerySettingsUpdate_v2.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "module-db/Interface/SettingsRecord_v2.hpp"
+#include <Common/Query.hpp>
+
+namespace db::query::settings
+{
+    class UpdateQuery : public Query
+    {
+        const SettingsRecord_v2 record;
+
+      public:
+        UpdateQuery(const SettingsRecord_v2 &record);
+
+        [[nodiscard]] auto debugInfo() const -> std::string override;
+        [[nodiscard]] auto getRecord() const -> const SettingsRecord_v2 &;
+    };
+
+    class UpdateResult : public QueryResult
+    {
+        bool value = false;
+
+      public:
+        UpdateResult(const bool &value);
+
+        [[nodiscard]] auto getValue() const -> bool;
+        [[nodiscard]] auto debugInfo() const -> std::string override;
+    };
+} // namespace db::query::settings

--- a/module-services/service-audio/ServiceAudio.hpp
+++ b/module-services/service-audio/ServiceAudio.hpp
@@ -15,6 +15,13 @@
 #include "Audio/Audio.hpp"
 #include "MessageType.hpp"
 
+#include <service-db/api/DBServiceAPI.hpp>
+#include <queries/settings/QuerySettingsGet_v2.hpp>
+#include <queries/settings/QuerySettingsAddOrIgnore_v2.hpp>
+#include <queries/settings/QuerySettingsUpdate_v2.hpp>
+#include <service-db/messages/QueryMessage.hpp>
+#include <Utils.hpp>
+
 class ServiceAudio : public sys::Service
 {
 
@@ -40,6 +47,49 @@ class ServiceAudio : public sys::Service
   private:
     audio::Audio audio;
     std::function<uint32_t(audio::AudioEvents event)> audioCallback = nullptr;
+
+    template <typename T> void addOrIgnoreEntry(const std::string &profilePath, const T &defaultValue)
+    {
+        auto [code, msg] = DBServiceAPI::GetQueryWithReply(
+            this,
+            db::Interface::Name::Settings_v2,
+            std::make_unique<db::query::settings::AddOrIgnoreQuery>(
+                SettingsRecord_v2{SettingsTableRow_v2{{.ID = DB_ID_NONE},
+                                                      .path  = profilePath,
+                                                      .value = std::to_string(static_cast<uint32_t>(defaultValue))}}),
+            audio::audioOperationTimeout);
+
+        if (code == sys::ReturnCodes::Success && msg != nullptr) {
+            auto queryResponse = dynamic_cast<db::QueryResponse *>(msg.get());
+            assert(queryResponse != nullptr);
+
+            auto settingsResultResponse = queryResponse->getResult();
+            auto settingsResult = dynamic_cast<db::query::settings::AddOrIgnoreResult *>(settingsResultResponse.get());
+            assert(settingsResult != nullptr);
+        }
+    }
+
+    template <typename T>[[nodiscard]] T fetchAudioSettingFromDb(const std::string &profilePath, const T &defaultValue)
+    {
+        auto [code, msg] =
+            DBServiceAPI::GetQueryWithReply(this,
+                                            db::Interface::Name::Settings_v2,
+                                            std::make_unique<db::query::settings::SettingsQuery>(profilePath),
+                                            audio::audioOperationTimeout);
+
+        if (code == sys::ReturnCodes::Success && msg != nullptr) {
+            auto queryResponse = dynamic_cast<db::QueryResponse *>(msg.get());
+            assert(queryResponse != nullptr);
+
+            auto settingsResultResponse = queryResponse->getResult();
+            auto settingsResult = dynamic_cast<db::query::settings::SettingsResult *>(settingsResultResponse.get());
+            assert(settingsResult != nullptr);
+
+            return settingsResult->getResult().getValue<T>({});
+        }
+        return defaultValue;
+    }
+    void updateDbValue(const audio::Operation *currentOperation, const audio::ProfileSetup &profileSetup);
 };
 
 #endif // PUREPHONE_SERVICEAUDIO_HPP

--- a/module-services/service-audio/api/AudioServiceAPI.cpp
+++ b/module-services/service-audio/api/AudioServiceAPI.cpp
@@ -153,7 +153,9 @@ namespace AudioServiceAPI
             std::make_shared<AudioRequestMessage>(MessageType::AudioGetOutputVolume);
 
         auto resp = SendAudioRequest(serv, msg);
-        vol       = resp->retCode == audio::RetCode::Success ? resp->val : invalidVolume;
+        if (resp->retCode == RetCode::Success) {
+            vol = resp->val;
+        }
 
         return resp->retCode;
     }


### PR DESCRIPTION
Integrating new settings with an audio. It allows to store audio profiles values in database, get and update them. If only audio service can't communicate with database or there is no requested entries default values are taken.  