### PR TITLE
[EGD-3426] Audio buffers handling fix and call start noise fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+* `[audio]` Fixed audio buffers handling to eliminate sending uninitialized data and making loud noise on start of a call.
 * `[music player]` Fixed songs list building and song name font size.
 * `[gui]` Added bootloader version information 
 


### PR DESCRIPTION
This PR introduces audio buffers handling fixes to eliminate sending uninitialized data. This eliminates loud noise on start of a call.