### PR TITLE
[EGD-3606] fix speed dial on contact merge

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 * `[listview]` List returning to previously focused element on CRUD notifications (Messages and Phonebook).
 * `[phonebook]` Change alternative/other number to second number.
 * `[database]` Fixed boot error caused by new settings table.
+* `[phonebook]` Fix speed dial number conflict resolution.
 
 ### Other
 * `[desktopApp]` Added functional tests.

--- a/module-apps/windows/Dialog.cpp
+++ b/module-apps/windows/Dialog.cpp
@@ -163,7 +163,7 @@ DialogYesNoIconTxt::DialogYesNoIconTxt(app::Application *app, const std::string 
 
 void DialogYesNoIconTxt::update(const Meta &meta)
 {
-    Dialog::update(meta);
+    DialogYesNo::update(meta);
     iconText->setText(textStr);
     topBar->setActive(TopBar::Elements::BATTERY, false);
     topBar->setActive(TopBar::Elements::SIM, false);


### PR DESCRIPTION
When there is a conflict on a speed dial user is promptod if he/she
wants to move speed dial number to the updated contact. Currently this
does not work because of invalid meta update in the DialogYesNoIconTxt.

Fix meta update in the above mentioned class to enable proper speed dial
moving to the updated contact.