### PR TITLE
[EGD-3098] Add audio volume control per functionality.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 
 * `[build]` Move user data to SDRAM during linking.
 * `[build]` RT1051's linker script cleanup.
+* `[audio]` Add audio volume control per functionality.
 
 ## [0.38.1 2020-09-18]
 

--- a/module-apps/Application.cpp
+++ b/module-apps/Application.cpp
@@ -492,6 +492,14 @@ namespace app
         acceptInput = true;
     }
 
+    bool Application::setVolume(const audio::Volume &value,
+                                const audio::Profile::Type &profileType,
+                                const audio::PlaybackType &playbackType)
+    {
+        const auto ret = AudioServiceAPI::SetVolume(this, value, profileType, playbackType);
+        return ret == audio::RetCode::Success;
+    }
+
     bool Application::adjustCurrentVolume(const int step)
     {
         audio::Volume vol;

--- a/module-apps/Application.hpp
+++ b/module-apps/Application.hpp
@@ -228,6 +228,17 @@ namespace app
             shutdownInProgress = true;
         };
 
+        bool setVolume(const audio::Volume &value,
+                       const audio::Profile::Type &profileType,
+                       const audio::PlaybackType &playbackType);
+
+        auto getVolume(audio::Volume &volume,
+                       const audio::Profile::Type &profileType,
+                       const audio::PlaybackType &playbackType)
+        {
+            return AudioServiceAPI::GetVolume(this, volume, profileType, playbackType);
+        }
+
         bool adjustCurrentVolume(const int step);
         bool increaseCurrentVolume(const audio::Volume step = audio::defaultVolumeStep)
         {

--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -98,7 +98,7 @@ namespace app
             LOG_INFO("ignoring call incoming");
         }
         else {
-            AudioServiceAPI::PlaybackStart(this, ringtone_path);
+            AudioServiceAPI::PlaybackStart(this, audio::PlaybackType::CallRingtone, ringtone_path);
             runCallTimer();
             std::unique_ptr<gui::SwitchData> data = std::make_unique<app::IncomingCallData>(msg->number);
             // send to itself message to switch (run) call application

--- a/module-apps/application-music-player/ApplicationMusicPlayer.cpp
+++ b/module-apps/application-music-player/ApplicationMusicPlayer.cpp
@@ -92,7 +92,7 @@ namespace app
 
     bool ApplicationMusicPlayer::play(const std::string &fileName)
     {
-        auto ret = AudioServiceAPI::PlaybackStart(this, fileName);
+        auto ret = AudioServiceAPI::PlaybackStart(this, audio::PlaybackType::Multimedia, fileName);
         if (ret != audio::RetCode::Success) {
             LOG_ERROR("play failed with %s", audio::c_str(ret));
             return false;

--- a/module-audio/Audio/Audio.cpp
+++ b/module-audio/Audio/Audio.cpp
@@ -11,7 +11,7 @@ namespace audio
         : currentOperation(), asyncCallback(asyncCallback), dbCallback(dbCallback)
     {
 
-        auto ret = Operation::Create(Operation::Type::Idle, "", dbCallback);
+        auto ret = Operation::Create(Operation::Type::Idle, "", audio::PlaybackType::None, dbCallback);
         if (ret) {
             currentOperation = std::move(ret.value());
         }
@@ -74,10 +74,10 @@ namespace audio
         return currentOperation->SetInputGain(gainToSet);
     }
 
-    audio::RetCode Audio::Start(Operation::Type op, const char *fileName)
+    audio::RetCode Audio::Start(Operation::Type op, const char *fileName, const audio::PlaybackType &playbackType)
     {
 
-        auto ret = Operation::Create(op, fileName, dbCallback);
+        auto ret = Operation::Create(op, fileName, playbackType, dbCallback);
         if (ret) {
 
             switch (op) {

--- a/module-audio/Audio/Audio.hpp
+++ b/module-audio/Audio/Audio.hpp
@@ -59,10 +59,15 @@ namespace audio
             return currentOperation.get();
         }
 
-        // TODO:M.P Set/Get inputGain/outputVolume for each profile
+        [[nodiscard]] inline bool GetHeadphonesInserted() const
+        {
+            return headphonesInserted;
+        }
 
         // Operations
-        audio::RetCode Start(Operation::Type op, const char *fileName = "");
+        audio::RetCode Start(Operation::Type op,
+                             const char *fileName                    = "",
+                             const audio::PlaybackType &playbackType = audio::PlaybackType::None);
 
         audio::RetCode Stop();
 

--- a/module-audio/Audio/AudioCommon.cpp
+++ b/module-audio/Audio/AudioCommon.cpp
@@ -44,11 +44,86 @@ namespace audio
         return "";
     }
 
-    const std::string str(const Profile::Type &type, const ProfileSetup &setup)
+    const std::string str(const PlaybackType &playbackType) noexcept
+    {
+        switch (playbackType) {
+        case PlaybackType::None: {
+            return "";
+        }
+        case PlaybackType::Multimedia: {
+            return "Multimedia";
+        }
+        case PlaybackType::Notifications: {
+            return "Notifications";
+        }
+        case PlaybackType::KeypadSound: {
+            return "KeypadSound";
+        }
+        case PlaybackType::CallRingtone: {
+            return "CallRingtone";
+        }
+        case PlaybackType::TextMessageRingtone: {
+            return "TextMessageRingtone";
+        }
+        }
+        return "";
+    }
+
+    const std::string str(const Setting &setting) noexcept
+    {
+        switch (setting) {
+        case Setting::Volume:
+            return "volume";
+            break;
+        case Setting::Gain:
+            return "gain";
+            break;
+        }
+        return "";
+    }
+
+    const std::string str(const Profile::Type &profileType, const Setting &setup, const PlaybackType &playbackType)
     {
         std::stringstream ss;
-        ss << "audio/" << str(type) << ((setup == ProfileSetup::Volume) ? "/volume" : "/gain");
+        const auto typeStr = str(profileType);
+        if (typeStr.empty()) {
+            return "";
+        }
+        const auto op = str(playbackType);
+        if (op.empty()) {
+            ss << "audio/" << str(profileType) << "/" << str(setup);
+        }
+        else {
+            ss << "audio/" << str(profileType) << "/" << str(playbackType) << "/" << str(setup);
+        }
         return ss.str();
+    }
+
+    const std::string str(const PlaybackType &playbackType, const Setting &setup, const bool headphonesInserted)
+    {
+        const auto playbackCall = (headphonesInserted) ? str(Profile::Type::PlaybackHeadphones, setup, playbackType)
+                                                       : str(Profile::Type::PlaybackLoudspeaker, setup, playbackType);
+        switch (playbackType) {
+        case PlaybackType::None: {
+            return "";
+        }
+        case PlaybackType::Multimedia: {
+            return playbackCall;
+        }
+        case PlaybackType::Notifications: {
+            return playbackCall;
+        }
+        case PlaybackType::KeypadSound: {
+            return playbackCall;
+        }
+        case PlaybackType::CallRingtone: {
+            return playbackCall;
+        }
+        case PlaybackType::TextMessageRingtone: {
+            return playbackCall;
+        }
+        }
+        return "";
     }
 
     auto GetVolumeText(const audio::Volume &volume) -> const std::string

--- a/module-audio/Audio/AudioCommon.hpp
+++ b/module-audio/Audio/AudioCommon.hpp
@@ -24,13 +24,33 @@ namespace audio
 
     constexpr uint32_t audioOperationTimeout = 1000;
 
-    enum class ProfileSetup
+    enum class Setting
     {
         Volume,
         Gain
     };
 
-    [[nodiscard]] const std::string str(const Profile::Type &type, const ProfileSetup &setup);
+    enum class PlaybackType
+    {
+        None,
+        Multimedia,
+        Notifications,
+        KeypadSound,
+        CallRingtone,
+        TextMessageRingtone
+    };
+
+    [[nodiscard]] const std::string str(const PlaybackType &playbackType) noexcept;
+
+    [[nodiscard]] const std::string str(const Setting &setting) noexcept;
+
+    [[nodiscard]] const std::string str(const Profile::Type &profileType,
+                                        const Setting &setup,
+                                        const PlaybackType &playbackType = PlaybackType::None);
+
+    [[nodiscard]] const std::string str(const PlaybackType &playbackType,
+                                        const Setting &setup,
+                                        const bool headphonesInserted = false);
 
     enum class RetCode
     {

--- a/module-audio/Audio/Operation/Operation.cpp
+++ b/module-audio/Audio/Operation/Operation.cpp
@@ -15,6 +15,7 @@ namespace audio
     std::optional<std::unique_ptr<Operation>> Operation::Create(
         Operation::Type t,
         const char *fileName,
+        const audio::PlaybackType &playbackType,
         std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback)
     {
         std::unique_ptr<Operation> inst;
@@ -24,7 +25,7 @@ namespace audio
             inst = std::make_unique<IdleOperation>(fileName);
             break;
         case Type::Playback:
-            inst = std::make_unique<PlaybackOperation>(fileName, dbCallback);
+            inst = std::make_unique<PlaybackOperation>(fileName, playbackType, dbCallback);
             break;
         case Type::Router:
             inst = std::make_unique<RouterOperation>(fileName, dbCallback);

--- a/module-audio/Audio/Operation/Operation.hpp
+++ b/module-audio/Audio/Operation/Operation.hpp
@@ -21,7 +21,9 @@ namespace audio
     class Operation
     {
       public:
-        Operation(const bool &isInitialized = false) : isInitialized{isInitialized}
+        Operation(const bool &isInitialized               = false,
+                  const audio::PlaybackType &playbackType = audio::PlaybackType::None)
+            : isInitialized{isInitialized}, playbackType{playbackType}
         {}
 
         enum class State
@@ -74,7 +76,8 @@ namespace audio
 
         static std::optional<std::unique_ptr<Operation>> Create(
             Type t,
-            const char *fileName                                                                      = "",
+            const char *fileName                  = "",
+            const audio::PlaybackType &operations = audio::PlaybackType::None,
             std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback = nullptr);
 
         virtual audio::RetCode Start(std::function<int32_t(AudioEvents event)> callback) = 0;
@@ -113,6 +116,11 @@ namespace audio
             return currentProfile;
         }
 
+        audio::PlaybackType GetplaybackType() const noexcept
+        {
+            return playbackType;
+        }
+
       protected:
         Profile *currentProfile = nullptr;
         std::vector<std::unique_ptr<Profile>> availableProfiles;
@@ -120,6 +128,7 @@ namespace audio
         std::function<int32_t(AudioEvents event)> eventCallback = nullptr;
 
         bool isInitialized = false;
+        audio::PlaybackType playbackType = audio::PlaybackType::None;
 
         virtual audio::RetCode SwitchProfile(const Profile::Type type) = 0;
 

--- a/module-audio/Audio/Operation/PlaybackOperation.cpp
+++ b/module-audio/Audio/Operation/PlaybackOperation.cpp
@@ -17,8 +17,10 @@ namespace audio
 #define PERF_STATS_ON 0
 
     PlaybackOperation::PlaybackOperation(
-        const char *file, std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback)
-        : dec(nullptr)
+        const char *file,
+        const audio::PlaybackType &playbackType,
+        std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback)
+        : Operation(false, playbackType), dec(nullptr)
     {
 
         audioCallback = [this](const void *inputBuffer, void *outputBuffer, unsigned long framesPerBuffer) -> int32_t {
@@ -43,11 +45,11 @@ namespace audio
         constexpr audio::Volume defaultHeadphonesVolume  = 2;
 
         const auto dbLoudspeakerVolumePath =
-            audio::str(audio::Profile::Type::PlaybackLoudspeaker, audio::ProfileSetup::Volume);
+            audio::str(audio::Profile::Type::PlaybackLoudspeaker, audio::Setting::Volume, playbackType);
         const auto loudspeakerVolume = dbCallback(dbLoudspeakerVolumePath, defaultLoudspeakerVolume);
 
         const auto dbHeadphonesVolumePath =
-            audio::str(audio::Profile::Type::PlaybackHeadphones, audio::ProfileSetup::Volume);
+            audio::str(audio::Profile::Type::PlaybackHeadphones, audio::Setting::Volume, playbackType);
         const auto headphonesVolume = dbCallback(dbHeadphonesVolumePath, defaultHeadphonesVolume);
 
         availableProfiles.push_back(std::make_unique<ProfilePlaybackLoudspeaker>(nullptr, loudspeakerVolume));

--- a/module-audio/Audio/Operation/PlaybackOperation.hpp
+++ b/module-audio/Audio/Operation/PlaybackOperation.hpp
@@ -13,6 +13,7 @@ namespace audio
       public:
         PlaybackOperation(
             const char *file,
+            const audio::PlaybackType &playbackType,
             std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback = nullptr);
 
         audio::RetCode Start(std::function<int32_t(AudioEvents event)> callback) override final;

--- a/module-audio/Audio/Operation/RecorderOperation.cpp
+++ b/module-audio/Audio/Operation/RecorderOperation.cpp
@@ -52,11 +52,11 @@ namespace audio
         constexpr audio::Gain defaultRecordingHeadsetGain    = 100;
 
         const auto dbRecordingOnBoardMicGainPath =
-            audio::str(audio::Profile::Type::RecordingBuiltInMic, audio::ProfileSetup::Gain);
+            audio::str(audio::Profile::Type::RecordingBuiltInMic, audio::Setting::Gain);
         const auto recordingOnBoardMicGain = dbCallback(dbRecordingOnBoardMicGainPath, defaultRecordingOnBoardMicGain);
 
         const auto dbRecordingHeadsetGainPath =
-            audio::str(audio::Profile::Type::RecordingHeadset, audio::ProfileSetup::Gain);
+            audio::str(audio::Profile::Type::RecordingHeadset, audio::Setting::Gain);
         const auto recordingHeadsetGain = dbCallback(dbRecordingHeadsetGainPath, defaultRecordingHeadsetGain);
 
         availableProfiles.push_back(std::make_unique<ProfileRecordingOnBoardMic>(nullptr, recordingOnBoardMicGain));

--- a/module-audio/Audio/Operation/RouterOperation.cpp
+++ b/module-audio/Audio/Operation/RouterOperation.cpp
@@ -89,23 +89,22 @@ namespace audio
         constexpr audio::Volume defaultRoutingHeadsetVolume      = 10;
 
         const auto dbRoutingEarspeakerGainPath =
-            audio::str(audio::Profile::Type::RoutingEarspeaker, audio::ProfileSetup::Gain);
+            audio::str(audio::Profile::Type::RoutingEarspeaker, audio::Setting::Gain);
         const auto routingEarspeakerGain = dbCallback(dbRoutingEarspeakerGainPath, defaultRoutingEarspeakerGain);
         const auto dbRoutingEarspeakerVolumePath =
-            audio::str(audio::Profile::Type::RoutingEarspeaker, audio::ProfileSetup::Volume);
+            audio::str(audio::Profile::Type::RoutingEarspeaker, audio::Setting::Volume);
         const auto routingEarspeakerVolume = dbCallback(dbRoutingEarspeakerVolumePath, defaultRoutingEarspeakerVolume);
         const auto dbRoutingSpeakerphoneGainPath =
-            audio::str(audio::Profile::Type::RoutingSpeakerphone, audio::ProfileSetup::Gain);
+            audio::str(audio::Profile::Type::RoutingSpeakerphone, audio::Setting::Gain);
         const auto routingSpeakerphoneGain = dbCallback(dbRoutingSpeakerphoneGainPath, defaultRoutingSpeakerphoneGain);
         const auto dbRoutingSpeakerphoneVolumePath =
-            audio::str(audio::Profile::Type::RoutingSpeakerphone, audio::ProfileSetup::Volume);
+            audio::str(audio::Profile::Type::RoutingSpeakerphone, audio::Setting::Volume);
         const auto routingSpeakerphoneVolume =
             dbCallback(dbRoutingSpeakerphoneVolumePath, defaultRoutingSpeakerphoneVolume);
-        const auto dbRoutingHeadsetGainPath =
-            audio::str(audio::Profile::Type::RoutingHeadset, audio::ProfileSetup::Gain);
+        const auto dbRoutingHeadsetGainPath = audio::str(audio::Profile::Type::RoutingHeadset, audio::Setting::Gain);
         const auto routingHeadsetGain = dbCallback(dbRoutingHeadsetGainPath, defaultRoutingHeadsetGain);
         const auto dbRoutingHeadsetVolumePath =
-            audio::str(audio::Profile::Type::RoutingHeadset, audio::ProfileSetup::Volume);
+            audio::str(audio::Profile::Type::RoutingHeadset, audio::Setting::Volume);
         const auto routingHeadsetVolume = dbCallback(dbRoutingHeadsetVolumePath, defaultRoutingHeadsetVolume);
 
         availableProfiles.push_back(

--- a/module-audio/Audio/Profiles/Profile.cpp
+++ b/module-audio/Audio/Profiles/Profile.cpp
@@ -142,7 +142,7 @@ namespace audio
             return "SystemSoundBTA2DP";
         }
         case Profile::Type::Idle: {
-            return "Idle";
+            return "";
         }
         }
         return "";

--- a/module-audio/Audio/test/unittest_audio.cpp
+++ b/module-audio/Audio/test/unittest_audio.cpp
@@ -15,6 +15,8 @@
 #include "Audio/decoder/decoderFLAC.hpp"
 #include "Audio/decoder/decoderWAV.hpp"
 
+#include "Audio/AudioCommon.hpp"
+
 class vfs vfs;
 
 TEST_CASE("Test audio tags")
@@ -29,5 +31,36 @@ TEST_CASE("Test audio tags")
         REQUIRE(tags->artist == ext + " Test artist name");
         REQUIRE(tags->album == ext + " Test album title");
         REQUIRE(tags->year == "2020");
+    }
+}
+
+TEST_CASE("Audio settings string creation")
+{
+    SECTION("Create volume string for playback loudspeaker, multimedia")
+    {
+        const auto str = audio::str(
+            audio::Profile::Type::PlaybackLoudspeaker, audio::Setting::Volume, audio::PlaybackType::Multimedia);
+        REQUIRE_FALSE(str.empty());
+        REQUIRE(str == "audio/PlaybackLoudspeaker/Multimedia/volume");
+    }
+
+    SECTION("Create volume string for routing speakerphone")
+    {
+        const auto str = audio::str(audio::Profile::Type::RoutingSpeakerphone, audio::Setting::Volume);
+        REQUIRE_FALSE(str.empty());
+        REQUIRE(str == "audio/RoutingSpeakerphone/volume");
+    }
+
+    SECTION("Create gain string for recording built-in microphone")
+    {
+        const auto str = audio::str(audio::Profile::Type::RecordingBuiltInMic, audio::Setting::Gain);
+        REQUIRE_FALSE(str.empty());
+        REQUIRE(str == "audio/RecordingBuiltInMic/gain");
+    }
+
+    SECTION("Create empty volume string when Idle")
+    {
+        const auto str = audio::str(audio::Profile::Type::Idle, audio::Setting::Volume);
+        REQUIRE(str.empty());
     }
 }

--- a/module-services/service-audio/ServiceAudio.hpp
+++ b/module-services/service-audio/ServiceAudio.hpp
@@ -88,7 +88,9 @@ class ServiceAudio : public sys::Service
         }
         return defaultValue;
     }
-    void updateDbValue(const audio::Operation *currentOperation, const audio::ProfileSetup &profileSetup);
+
+    void updateDbValue(const std::string &path, const audio::Setting &setting, const uint32_t &value);
+    void updateDbValue(const audio::Operation *currentOperation, const audio::Setting &setting, const uint32_t &value);
 };
 
 #endif // PUREPHONE_SERVICEAUDIO_HPP

--- a/module-services/service-audio/api/AudioServiceAPI.cpp
+++ b/module-services/service-audio/api/AudioServiceAPI.cpp
@@ -16,7 +16,7 @@ namespace AudioServiceAPI
 {
     namespace
     {
-        auto SendAudioRequest(sys::Service *serv, std::shared_ptr<AudioRequestMessage> msg)
+        auto SendAudioRequest(sys::Service *serv, std::shared_ptr<AudioMessage> msg)
         {
             auto msgType = static_cast<int>(msg->type);
             LOG_DEBUG("Msg type %d", msgType);
@@ -34,11 +34,12 @@ namespace AudioServiceAPI
         }
     } // namespace
 
-    RetCode PlaybackStart(sys::Service *serv, const std::string &fileName)
+    RetCode PlaybackStart(sys::Service *serv, const audio::PlaybackType &playbackType, const std::string &fileName)
     {
         std::shared_ptr<AudioRequestMessage> msg =
             std::make_shared<AudioRequestMessage>(MessageType::AudioPlaybackStart);
         msg->fileName = fileName;
+        msg->playbackType = playbackType;
 
         return SendAudioRequest(serv, msg)->retCode;
     }
@@ -145,6 +146,30 @@ namespace AudioServiceAPI
         msg->val = vol;
 
         return SendAudioRequest(serv, msg)->retCode;
+    }
+
+    audio::RetCode SetVolume(sys::Service *serv,
+                             const audio::Volume &vol,
+                             const Profile::Type &profileType,
+                             const audio::PlaybackType &playbackType)
+    {
+        auto msg = std::make_shared<AudioSetSetting>(profileType, playbackType, vol);
+
+        return SendAudioRequest(serv, msg)->retCode;
+    }
+
+    audio::RetCode GetVolume(sys::Service *serv,
+                             audio::Volume &vol,
+                             const Profile::Type &profileType,
+                             const audio::PlaybackType &playbackType)
+    {
+        auto msg  = std::make_shared<AudioGetSetting>(profileType, playbackType);
+        auto resp = SendAudioRequest(serv, msg);
+        if (resp->retCode == RetCode::Success) {
+            vol = resp->val;
+        }
+
+        return resp->retCode;
     }
 
     RetCode GetOutputVolume(sys::Service *serv, Volume &vol)

--- a/module-services/service-audio/api/AudioServiceAPI.hpp
+++ b/module-services/service-audio/api/AudioServiceAPI.hpp
@@ -9,7 +9,17 @@ class Service;
 
 namespace AudioServiceAPI
 {
-    audio::RetCode PlaybackStart(sys::Service *serv, const std::string &fileName);
+    /*! @brief Starts playback operation.
+     *
+     * @param serv - requesting service.
+     * @param playbackType - type of playback.
+     * If none, request would still be valid and default volume would be used.
+     * @param fileName - name of the file.
+     * @return           Standard service-api return code. Success if suitable.
+     */
+    audio::RetCode PlaybackStart(sys::Service *serv,
+                                 const audio::PlaybackType &playbackType,
+                                 const std::string &fileName);
     audio::RetCode RecordingStart(sys::Service *serv, const std::string &fileName);
     audio::RetCode RoutingStart(sys::Service *serv);
     audio::RetCode RoutingRecordCtrl(sys::Service *serv, bool enable);
@@ -21,6 +31,30 @@ namespace AudioServiceAPI
     audio::RetCode Resume(sys::Service *serv);
     std::optional<audio::Tags> GetFileTags(sys::Service *serv, const std::string &fileName);
     audio::RetCode SetOutputVolume(sys::Service *serv, const audio::Volume vol);
+    /*! @brief Sets volume.
+     *
+     * @param serv - requesting service.
+     * @param vol - volume to be set.
+     * @param profileType - selected profile type.
+     * @param playbackType -  type of playback. Not used when profileType is different than playback.
+     * @return           Standard service-api return code. Success if suitable.
+     */
+    audio::RetCode SetVolume(sys::Service *serv,
+                             const audio::Volume &vol,
+                             const audio::Profile::Type &profileType,
+                             const audio::PlaybackType &playbackType = audio::PlaybackType::None);
+    /*! @brief Gets volume.
+     *
+     * @param serv - requesting service.
+     * @param vol - requested volume.
+     * @param profileType - selected profile type.
+     * @param playbackType - type of playback. Not used when profileType is different than playback.
+     * @return           Standard service-api return code. Success if suitable.
+     */
+    audio::RetCode GetVolume(sys::Service *serv,
+                             audio::Volume &vol,
+                             const audio::Profile::Type &profileType,
+                             const audio::PlaybackType &playbackType = audio::PlaybackType::None);
     audio::RetCode GetOutputVolume(sys::Service *serv, audio::Volume &vol);
     audio::RetCode SetInputGain(sys::Service *serv, const audio::Gain gain);
     audio::RetCode GetInputGain(sys::Service *serv, audio::Gain &gain);

--- a/module-services/service-audio/messages/AudioMessage.hpp
+++ b/module-services/service-audio/messages/AudioMessage.hpp
@@ -20,11 +20,15 @@
 class AudioMessage : public sys::DataMessage
 {
   public:
-    AudioMessage(MessageType messageType) : sys::DataMessage(messageType), type(messageType){};
+    AudioMessage(MessageType messageType) : sys::DataMessage(messageType), type(messageType)
+    {}
 
-    virtual ~AudioMessage(){};
+    AudioMessage() : sys::DataMessage(MessageType::MessageTypeUninitialized)
+    {}
 
-    MessageType type;
+    virtual ~AudioMessage() = default;
+
+    MessageType type = MessageType::MessageTypeUninitialized;
 };
 
 class AudioNotificationMessage : public AudioMessage
@@ -46,6 +50,44 @@ class AudioNotificationMessage : public AudioMessage
     Type type;
 };
 
+class AudioSettingsMessage : public AudioMessage
+{
+  public:
+    AudioSettingsMessage(const audio::Profile::Type &profileType,
+                         const audio::PlaybackType &playbackType,
+                         const uint32_t &val = 0)
+        : AudioMessage{}, profileType{profileType}, playbackType{playbackType}, val{val}
+    {}
+
+    ~AudioSettingsMessage() override = default;
+
+    audio::Profile::Type profileType = audio::Profile::Type::Idle;
+    audio::PlaybackType playbackType = audio::PlaybackType::None;
+    uint32_t val{};
+};
+
+class AudioGetSetting : public AudioSettingsMessage
+{
+  public:
+    AudioGetSetting(const audio::Profile::Type &profileType, const audio::PlaybackType &playbackType)
+        : AudioSettingsMessage{profileType, playbackType}
+    {}
+
+    ~AudioGetSetting() override = default;
+};
+
+class AudioSetSetting : public AudioSettingsMessage
+{
+  public:
+    AudioSetSetting(const audio::Profile::Type &profileType,
+                    const audio::PlaybackType &playbackType,
+                    const uint32_t &val)
+        : AudioSettingsMessage{profileType, playbackType, val}
+    {}
+
+    ~AudioSetSetting() override = default;
+};
+
 class AudioRequestMessage : public AudioMessage
 {
   public:
@@ -57,6 +99,7 @@ class AudioRequestMessage : public AudioMessage
     std::string fileName;
     float val;
     bool enable;
+    audio::PlaybackType playbackType = audio::PlaybackType::None;
 };
 
 class AudioResponseMessage : public sys::ResponseMessage

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -1200,7 +1200,7 @@ bool ServiceCellular::receiveSMS(std::string messageNumber)
                             db::Interface::Name::Notifications,
                             std::make_unique<db::query::notifications::Increment>(NotificationsRecord::Key::Sms));
                         const std::string ringtone_path = "assets/audio/sms_transformer.wav";
-                        AudioServiceAPI::PlaybackStart(this, ringtone_path);
+                        AudioServiceAPI::PlaybackStart(this, audio::PlaybackType::TextMessageRingtone, ringtone_path);
                     }
                     else {
                         LOG_ERROR("Failed to add text message to db");


### PR DESCRIPTION
According to design requirements there is need to divide audio operations into smaller pieces (eg. Multimedia, ringtone etc). These changes applies an API to do that and allows user to change not active operation values.
Change request for operation that is not currently active calls database queries, audio module in that case is not used at all.