### PR TITLE
[EGD-3714] rt1051: dtcm ld cleanup

### DIFF
--- a/board/rt1051/ldscripts/memory.ld
+++ b/board/rt1051/ldscripts/memory.ld
@@ -1,19 +1,19 @@
 /*
- * GENERATED FILE - DO NOT EDIT
  * (c) Code Red Technologies Ltd, 2008-2013
  * (c) NXP Semiconductors 2013-2018
  * Generated linker script file for MIMXRT1052xxxxB
  * Created from memory.ldt by FMCreateLinkMemory
  * Using Freemarker v2.3.23
  * MCUXpresso IDE v10.2.0 [Build 759] [2018-05-15]  on 2018-07-30 10:43:20
+ *
+ * Modified by Mudita
  */
 MEMORY
 {
 	/* Define each memory region */
 	SRAM_OC (rwx) : ORIGIN = 0x20200000, LENGTH = 0x10000 /* 64K bytes (alias RAM) */
 	/*SRAM_ITC (rwx) : ORIGIN = 0x0, LENGTH = 0x0*/ /* 0K bytes (alias RAM2) */
-	SRAM_DTC_TEXT (rwx) : ORIGIN = 0x20000000, LENGTH = 0x6000 /* 24K bytes (alias RAM3) */
-	SRAM_DTC (rwx) : ORIGIN = 0x20006000, LENGTH = 0x6A000 /* 434K bytes (alias RAM3) */
+	SRAM_DTC (rwx) : ORIGIN = 0x20000000, LENGTH = 0x70000 /* 448K bytes (alias RAM3) */
 	BOARD_SDRAM_TEXT (rx) : ORIGIN = 0x80000000, LENGTH = 0x0600000 /* 6M bytes for application code */
 	BOARD_SDRAM_HEAP (rwx) : ORIGIN = 0x80600000, LENGTH = 0x0A00000 /* 10M bytes for heap (alias RAM4) */
 }

--- a/board/rt1051/ldscripts/sections.ld
+++ b/board/rt1051/ldscripts/sections.ld
@@ -1,19 +1,15 @@
 /*
- * GENERATED FILE - DO NOT EDIT
  * (c) Code Red Technologies Ltd, 2008-2013
  * (c) NXP Semiconductors 2013-2018
  * Generated linker script file for MIMXRT1052xxxxB
  * Created from linkscript.ldt by FMCreateLinkLibraries
  * Using Freemarker v2.3.23
  * MCUXpresso IDE v10.2.0 [Build 759] [2018-05-15]  on 2018-07-30 10:43:20
+ *
+ * Modified by Mudita
  */
 
 ENTRY(ResetISR)
-
-/*
-__sdram_non_cached_start = ORIGIN(BOARD_SDRAM_NOCACHE);
-__sdram_non_cached_end = ORIGIN(BOARD_SDRAM_NOCACHE) + LENGTH(BOARD_SDRAM_NOCACHE);
-*/
 
 __ocram_noncached_start = ORIGIN(SRAM_OC);
 __ocram_noncached_end = ORIGIN(SRAM_OC) + LENGTH(SRAM_OC);
@@ -27,7 +23,6 @@ __sdram_cached_end = ORIGIN(BOARD_SDRAM_HEAP) + LENGTH(BOARD_SDRAM_HEAP);
 SECTIONS
 {
     /* Image Vector Table and Boot Data for booting from external flash */
-    
     .boot_hdr : ALIGN(4)
     {
         FILL(0x00)
@@ -43,7 +38,7 @@ SECTIONS
         . = 0x2000 ;
     } > BOARD_SDRAM_TEXT
 
-    /* MAIN TEXT SECTION */
+    /* Data sections descriptors for startup initialization */
     .text : ALIGN(4)
     {
         FILL(0x00)
@@ -53,85 +48,97 @@ SECTIONS
         . = ALIGN(4) ;
         __section_table_start = .;
         __data_section_table = .;
+        /* System data */
+        LONG(LOADADDR(.sysdata));
+        LONG(    ADDR(.sysdata));
+        LONG(  SIZEOF(.sysdata));
+        /* User data */
         LONG(LOADADDR(.data));
         LONG(    ADDR(.data));
         LONG(  SIZEOF(.data));
         __data_section_table_end = .;
         __bss_section_table = .;
+        /* System bss */
+        LONG(    ADDR(.sysbss));
+        LONG(  SIZEOF(.sysbss));
+        /* User bss */
         LONG(    ADDR(.bss));
         LONG(  SIZEOF(.bss));
         __bss_section_table_end = .;
         __section_table_end = . ;
         /* End of Global Section Table */
+    } > BOARD_SDRAM_TEXT
 
+    /* Init code */
+    .text : ALIGN(4)
+    {
         *(.after_vectors*)
-
     } > BOARD_SDRAM_TEXT
 
-    /* Put FreeRTOS code into internal DTC RAM */
-    /*
-    .freeRTOS : ALIGN(4)
+    /* System uninitialized data */
+    .sysbss : ALIGN(4)
     {
-        *module-os/FreeRTOS/*.c.obj (.text .text*)
-    }  > SRAM_DTC_TEXT AT>BOARD_SDRAM_TEXT
-    */
+        *(NonCacheable)
+        *(COMMON)
+        lib/libmodule-os.a:*(.bss*)
+        lib/libmodule-sys.a:*(.bss*)
+        lib/libmodule-bsp.a:*(.bss*)
+    } > SRAM_DTC
 
-    .text : ALIGN(4)    
+    /* System initialized data */
+    .sysdata : ALIGN(4)
     {
-       *(.text*)
-       *(.rodata .rodata.* .constdata .constdata.*)
-       . = ALIGN(4);
-            /* C++ constructors etc */
-            . = ALIGN(4);
-            KEEP(*(.init))
-            
-            . = ALIGN(4);
-            __preinit_array_start = .;
-            KEEP (*(.preinit_array))
-            __preinit_array_end = .;
-            
-            . = ALIGN(4);
-            __init_array_start = .;
-            KEEP (*(SORT(.init_array.*)))
-            KEEP (*(.init_array))
-            __init_array_end = .;
-            
-            KEEP(*(.fini));
-            
-            . = ALIGN(4);
-            KEEP (*crtbegin.o(.ctors))
-            KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
-            KEEP (*(SORT(.ctors.*)))
-            KEEP (*crtend.o(.ctors))
-            
-            . = ALIGN(4);
-            KEEP (*crtbegin.o(.dtors))
-            KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
-            KEEP (*(SORT(.dtors.*)))
-            KEEP (*crtend.o(.dtors))
-            . = ALIGN(4);
-            /* End C++ */
+        *(NonCacheable.init)
+        *(.ramfunc*)
+        lib/libmodule-os.a:*(.data*)
+        lib/libmodule-sys.a:*(.data*)
+        lib/libmodule-bsp.a:*(.data*)
+    } > SRAM_DTC AT > BOARD_SDRAM_TEXT
+
+    /* MAIN TEXT SECTION */
+    .text : ALIGN(4)
+    {
+        *(.text*)
+        *(.rodata .rodata.* .constdata .constdata.*)
+        . = ALIGN(4);
+
+        /* C++ constructors etc */
+        . = ALIGN(4);
+        KEEP(*(.init))
+
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        KEEP(*(.fini));
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+        . = ALIGN(4);
+        /* End of C++ support */
     } > BOARD_SDRAM_TEXT
 
-    .intfoo : ALIGN(4)
-    {
-        *(.intfoo)
-        *(.intfoo.*)
-    } >SRAM_DTC_TEXT
-
-
-    
-    /*
-     * for exception handling/unwind - some Newlib functions (in common
-     * with C++ and STDC++) use this. 
-     */
-    .ARM.extab : ALIGN(4) 
+    /* Exception handling */
+    .ARM.extab : ALIGN(4)
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
     } > BOARD_SDRAM_TEXT
-
-    
-
     .ARM.exidx : ALIGN(4)
     {
         __exidx_start = .;
@@ -139,104 +146,47 @@ SECTIONS
         __exidx_end = .;
     } > BOARD_SDRAM_TEXT
 
-    _etext = .;
-
-    /* MAIN DATA SECTION */
-    .uninit_RESERVED : ALIGN(4)
-    {
-        KEEP(*(.bss.$RESERVED*))
-        . = ALIGN(4) ;
-        _end_uninit_RESERVED = .;
-    } > SRAM_DTC AT>BOARD_SDRAM_TEXT
-
-    /* Main DATA section (SRAM_OC) */
+    /* Main DATA section (SDRAM) */
     .data : ALIGN(4)
     {
-       FILL(0xff)
-       _data = . ;
-       *(vtable)
-       *(.ramfunc*)
-       *(NonCacheable.init)
-       *(.data*)
-       . = ALIGN(4) ;
-       _edata = . ;
-    } > SRAM_DTC AT>BOARD_SDRAM_TEXT
+        FILL(0xff)
+        _data = . ;
+        *(vtable)
+        *(.data*)
+        . = ALIGN(4) ;
+        _edata = . ;
+    } > BOARD_SDRAM_TEXT
 
     /* MAIN BSS SECTION */
     .bss : ALIGN(4)
     {
         _bss = .;
-        *(NonCacheable)
         *(.bss*)
-        *(COMMON)
         . = ALIGN(4) ;
         _ebss = .;
         PROVIDE(end = .);
-    } > SRAM_DTC
+    } > BOARD_SDRAM_TEXT
 
-    /* DEFAULT NOINIT SECTION */
-    .noinit (NOLOAD): ALIGN(4)
-    {
-        _noinit = .;
-        *(.noinit*) 
-         . = ALIGN(4) ;
-        _end_noinit = .;
-    } > SRAM_DTC
-    
-    
     /* ext SDRAM */
     .sdram (NOLOAD) : ALIGN(4)
     {
         *(.sdram)
         *(.sdram.*)
     } >BOARD_SDRAM_HEAP
-    
-    /* No cacheable region in ext SDRAM */
-    /*
-    .sdramnoncacheable (NOLOAD) : ALIGN(4)
-    {
-        *(.sdramnoncacheable)
-        *(.sdramnoncacheable.*)
-    } >BOARD_SDRAM_NOCACHE
-    */
 
+    /* DMA buffers */
     .intramnoncacheable (NOLOAD) : ALIGN(4)
     {
         *(.intramnoncacheable)
         *(.intramnoncacheable.*)
-    } >SRAM_OC
+    } > SRAM_OC
 
-    /* Reserve and place Heap within memory map */
-    _HeapSize = 0x1000;
-    .heap :  ALIGN(4)
-    {
-        _pvHeapStart = .;
-        . += _HeapSize;
-        . = ALIGN(4);
-        _pvHeapLimit = .;
-    } > SRAM_DTC
-
-     _StackSize = 0x1000;
-     /* Reserve space in memory for Stack */
-    .heap2stackfill  :
-    {
-        . += _StackSize;
-    } > SRAM_DTC
-    
-    /* Locate actual Stack in memory map */
-    .stack ORIGIN(SRAM_DTC) + LENGTH(SRAM_DTC) - _StackSize - 0:  ALIGN(4)
+    /* Place system stack at the very end of DTCM */
+    _StackSize = 0x1000;
+    .stack ORIGIN(SRAM_DTC) + LENGTH(SRAM_DTC) - _StackSize - 0 : ALIGN(4)
     {
         _vStackBase = .;
         . = ALIGN(4);
         _vStackTop = . + _StackSize;
     } > SRAM_DTC
-
-    /* Provide basic symbols giving location and size of main text
-     * block, including initial values of RW data sections. Note that
-     * these will need extending to give a complete picture with
-     * complex images (e.g multiple Flash banks).
-     */
-    _image_start = LOADADDR(.text);
-    _image_end = LOADADDR(.data) + SIZEOF(.data);
-    _image_size = _image_end - _image_start;
 }

--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,8 @@
 
 ### Other
 
-
+* `[build]` Move user data to SDRAM during linking.
+* `[build]` RT1051's linker script cleanup.
 
 ## [0.38.1 2020-09-18]
 

--- a/module-bsp/board/rt1051/common/startup_mimxrt1052.cpp
+++ b/module-bsp/board/rt1051/common/startup_mimxrt1052.cpp
@@ -730,7 +730,9 @@ __attribute__((section(".after_vectors.reset"))) void ResetISR(void)
         LoadAddr   = *SectionTableAddr++;
         ExeAddr    = *SectionTableAddr++;
         SectionLen = *SectionTableAddr++;
-        data_init(LoadAddr, ExeAddr, SectionLen);
+        if (LoadAddr != ExeAddr) {
+            data_init(LoadAddr, ExeAddr, SectionLen);
+        }
     }
 
     // Initialize BSS section
@@ -1076,24 +1078,6 @@ extern "C"
     {
         abort();
     }
-
-    /*    extern void failure_exit(syslog_exception_stack_frame_t* frame,syslog_exception_source_t source);
-
-
-
-
-
-        WEAK_AV void BusFault_Handler_C (syslog_exception_stack_frame_t* frame __attribute__((unused)),
-                            uint32_t lr __attribute__((unused)))
-        {
-            failure_exit(frame,SyslogExceptionSource_BusFault);
-        }
-
-        WEAK_AV void UsageFault_Handler_C (syslog_exception_stack_frame_t* frame __attribute__((unused)),
-                            uint32_t lr __attribute__((unused)))
-        {
-            failure_exit(frame,SyslogExceptionSource_UsageFault);
-        }*/
 
 #if defined(__cplusplus)
 }

--- a/module-bsp/board/rt1051/rt1051-memory.md
+++ b/module-bsp/board/rt1051/rt1051-memory.md
@@ -1,0 +1,30 @@
+# Memory configuration for the RT1051 platform
+
+## Memory interfaces
+
+There are 4 memory interfaces available for the platform. Three of them connect to FlexRAM inside the MCU, fourth is an external SDRAM.
+Inside the chip there are:
+* OCRAM - clocked with peripheral clock.
+* TCM - clocked with CPU clock. TCM is a high speed memory interface which allows to access data via two 32bit DTCM interfaces and/or instructions via a single 64 bit interface.
+
+Currently RT1051 offers:
+* 64 kB of OCRAM memory;
+* 448 kB of DTCM memory;
+* 16 MB of SDRAM memory.
+
+## Firmware in the memory
+
+During linking firmware is split between memory regions. Data that
+need to be accessed fast is placed inside the chip (system code and
+data mostly), 
+* data that cannot be cached (`NonCacheable*`),
+* system data, including system heap in (see `heap_4.c`),
+* common symbols (e.g. `errno` variable),
+* system stack (used before starting scheduler and by scheduler itself),
+* relocated "fast" functions (`.ramfunc`)
+
+The rest is placed in the SDRAM split between two regions:
+* user code, including exception handling (`BOARD_SDRAM_TEXT`),
+* big buffers, including user heap (see `usermem.c`, region `BOARD_SDRAM_HEAP`)
+
+Currently there is no data in the OCRAM region, though it could be used for DMA buffers.


### PR DESCRIPTION
There is a memory shortage in the DTCM region. In order to be able to
add new features linker script for the rt1051 needs to be cleanup.

A couple of issues has been fixed:
* double stack definition blocking 4kB
* excessive heap definition blocking 4kB
* a part of DTCM had not been used blocking 24 kB.

Data has been split to user and system part, user data has been moved to
the SDRAM, therefore new data will be placed there. To place it inside
the MCU an explicit statement has to be used.

Added a basic description of memory layout and a couple of comments.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>