### PR TITLE
[EGD-3797] change default country to unknown

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 ### Changed
 
 * `[antenna-app]` Added parameter history window.
+* `[phonenumber]` Change default country to unknown.
 
 ### Fixed
 

--- a/module-db/tests/CalllogRecord_tests.cpp
+++ b/module-db/tests/CalllogRecord_tests.cpp
@@ -72,7 +72,7 @@ TEST_CASE("Calllog Record tests")
         REQUIRE_FALSE(call.contactId == testRec.contactId);
         REQUIRE(call.contactId == 1);
         REQUIRE_FALSE(call.name == testRec.name);
-        REQUIRE(call.name == "600 123 456");
+        REQUIRE(call.name == "600123456");
     }
 
     SECTION("Entry update")

--- a/module-services/service-desktop/tests/unittest.cpp
+++ b/module-services/service-desktop/tests/unittest.cpp
@@ -141,7 +141,7 @@ TEST_CASE("DB Helpers test - json decoding")
         REQUIRE(contact.alternativeName == "Cic");
         REQUIRE(contact.isOnBlocked() == true);
         REQUIRE(contact.isOnFavourites() == true);
-        REQUIRE(contact.numbers.at(0).number.getFormatted() == "724 842 187");
+        REQUIRE(contact.numbers.at(0).number.getEntered() == "724842187");
         REQUIRE(contact.primaryName == "Baatek");
     }
     SECTION("incorrect json")
@@ -151,7 +151,7 @@ TEST_CASE("DB Helpers test - json decoding")
         auto contactJson = json11::Json::parse(recordPayload, err);
         REQUIRE(err.empty());
 
-        auto helper = std::make_unique<ContactHelper>(nullptr);
+        auto helper  = std::make_unique<ContactHelper>(nullptr);
         auto contact = helper->from_json(contactJson);
         REQUIRE(contact.address == "");
         REQUIRE(contact.alternativeName == "Cic");

--- a/module-utils/country.hpp
+++ b/module-utils/country.hpp
@@ -260,7 +260,7 @@ namespace utils::country
     };
 
     constexpr std::size_t count = static_cast<std::size_t>(Id::UNKNOWN) + 1;
-    constexpr Id defaultCountry = Id::POLAND;
+    constexpr Id defaultCountry = Id::UNKNOWN;
 
     struct Data
     {

--- a/module-utils/test/unittest_phonenumber.cpp
+++ b/module-utils/test/unittest_phonenumber.cpp
@@ -109,7 +109,7 @@ TEST_CASE("PhoneNumber - views")
         const std::string dummyNumber = "12345";
 
         auto invalid_view = PhoneNumber::parse(dummyNumber);
-        auto valid_view   = PhoneNumber::parse(pl_entered);
+        auto valid_view   = PhoneNumber::parse(pl_e164);
 
         REQUIRE_FALSE(invalid_view.isValid());
         REQUIRE(valid_view.isValid());


### PR DESCRIPTION
Can't assume that user is in Poland if number origin is unknown.