### PR TITLE
[EGD-3457] sys: improve workers destroying

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## [Current release]
 
 ### Added
+
 * `[desktop][gui]` Added SIM and PUK lock-related windows
 * `[GUI]` Added rich text parsing for full text styling needs
 * `[calendar]` Add notifications from database handling.
@@ -20,7 +21,7 @@
 
 ### Other
 * `[audio]` Audio service and api cleanup/refactor.
-
+* `[system]` Improved destroying of worker threads.
 
 
 ## [0.39.1 2020-09-25]

--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -15,9 +15,6 @@ ServiceDesktop::ServiceDesktop() : sys::Service(service::name::service_desktop, 
 ServiceDesktop::~ServiceDesktop()
 {
     LOG_INFO("[ServiceDesktop] Cleaning resources");
-    if (desktopWorker != nullptr) {
-        desktopWorker->deinit();
-    }
 }
 
 sys::ReturnCodes ServiceDesktop::InitHandler()
@@ -75,6 +72,7 @@ sys::ReturnCodes ServiceDesktop::InitHandler()
 
 sys::ReturnCodes ServiceDesktop::DeinitHandler()
 {
+    desktopWorker->close();
     return sys::ReturnCodes::Success;
 }
 

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -33,6 +33,8 @@
 #include "bsp/cellular/bsp_cellular.hpp"
 #include "bsp/common.hpp"
 
+#include <cassert>
+
 EventManager::EventManager(const std::string &name) : sys::Service(name)
 {
     LOG_INFO("[%s] Initializing", name.c_str());
@@ -44,9 +46,6 @@ EventManager::EventManager(const std::string &name) : sys::Service(name)
 EventManager::~EventManager()
 {
     LOG_INFO("[%s] Cleaning resources", GetName().c_str());
-    if (EventWorker != nullptr) {
-        EventWorker->deinit();
-    }
 }
 
 // Invoked upon receiving data message
@@ -253,9 +252,7 @@ sys::ReturnCodes EventManager::InitHandler()
 
 sys::ReturnCodes EventManager::DeinitHandler()
 {
-
-    EventWorker->deinit();
-    EventWorker.reset();
+    EventWorker->close();
     return sys::ReturnCodes::Success;
 }
 

--- a/module-services/service-evtmgr/WorkerEvent.hpp
+++ b/module-services/service-evtmgr/WorkerEvent.hpp
@@ -27,6 +27,7 @@ struct KeyState
 enum class WorkerEventQueues
 {
     queueService = 0,
+    queueControl = 1,
     queueKeyboardIRQ,
     queueHeadsetIRQ,
     queueBattery,

--- a/module-services/service-gui/ServiceGUI.cpp
+++ b/module-services/service-gui/ServiceGUI.cpp
@@ -63,8 +63,6 @@ namespace sgui
             delete renderContext;
         if (transferContext)
             delete transferContext;
-
-        worker->deinit();
     }
 
     void ServiceGUI::sendBuffer()
@@ -96,7 +94,7 @@ namespace sgui
     }
 
     // Invoked upon receiving data message
-    sys::Message_t ServiceGUI::DataReceivedHandler(sys::DataMessage * msgl, sys::ResponseMessage * resp)
+    sys::Message_t ServiceGUI::DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp)
     {
 
         sgui::GUIMessage *msg = static_cast<sgui::GUIMessage *>(msgl);
@@ -262,6 +260,10 @@ namespace sgui
         if (semCommands != NULL)
             vSemaphoreDelete(semCommands);
         semCommands = NULL;
+
+        worker->stop();
+        worker->join();
+        worker->deinit();
 
         return sys::ReturnCodes::Success;
     }


### PR DESCRIPTION
    Implement termination of worker threads. To achieve the goal so called
    control queue has been introduced which is handled in Worker base class.
    Once worker thread receives stop message it tries to kill itself. It is
    possible to join a worker thread before deinit know thanks to a
    semaphore given before thread termination.
    
    Some improvements to the interface and implementation has been made
    including state sanity checks. It is assumed that only service that owns
    the worker is allowed to stop it, which allows not to consider code
    reentrancy.
    
    Worker destroying procedure has been updated in services that already
    own workers.
