### PR TITLE
[EGD-3798] remove utf8 test output

### DIFF
--- a/module-utils/test/unittest_utf8.cpp
+++ b/module-utils/test/unittest_utf8.cpp
@@ -331,8 +331,6 @@ TEST_CASE("UTF8: insert whole string which doesn't work")
             uint32_t code;
         } tmp;
         tmp.code = fin[i];
-
-        printf("insert: 0x%x    which is: >%s<: ", tmp.code, std::string(tmp.ch).c_str());
         lol.insertCode(tmp.code);
     }
     REQUIRE(lol == fin);


### PR DESCRIPTION
Test result parsers are failing due to excessive output of one of utf8's
tests.
