### PR TITLE
Draft - example of request driven audio API

### DIFF
--- a/module-apps/application-music-player/ApplicationMusicPlayer.cpp
+++ b/module-apps/application-music-player/ApplicationMusicPlayer.cpp
@@ -24,6 +24,9 @@ namespace app
 
     sys::Message_t ApplicationMusicPlayer::DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp)
     {
+        if (auto r = dynamic_cast<AudioResponseMessage *>(resp)) {
+            LOG_INFO("[HUBERT] HERE ! %f", r->val);
+        }
         return Application::DataReceivedHandler(msgl);
     }
 
@@ -92,10 +95,13 @@ namespace app
 
     bool ApplicationMusicPlayer::play(const std::string &fileName)
     {
-        auto handle = AudioServiceAPI::PlaybackStart(this, audio::PlaybackType::Multimedia, fileName);
-        if (handle.GetLastRetCode() != audio::RetCode::Success) {
-            LOG_ERROR("play failed with %s", audio::c_str(handle.GetLastRetCode()));
-            return false;
+        // this is how we send async
+        auto a = AudioServiceAPI::PlaybackStartRequest(fileName, audio::PlaybackType::Multimedia);
+        a->SendAsync(this);
+        // this is how we send sync
+        auto ret = AudioServiceAPI::PlaybackStartRequest(fileName, audio::PlaybackType::Multimedia)->SendSync(this);
+        if (ret.GetLastRetCode() == audio::RetCode::Success) {
+            // do something
         }
         return true;
     }

--- a/module-services/service-audio/CMakeLists.txt
+++ b/module-services/service-audio/CMakeLists.txt
@@ -17,5 +17,6 @@ target_sources( ${PROJECT_NAME}
 	PRIVATE
 		"${CMAKE_CURRENT_LIST_DIR}/ServiceAudio.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/api/AudioServiceAPI.cpp"
+		"${CMAKE_CURRENT_LIST_DIR}/messages/AudioMessage.cpp"
 )
 

--- a/module-services/service-audio/ServiceAudio.cpp
+++ b/module-services/service-audio/ServiceAudio.cpp
@@ -23,6 +23,14 @@ ServiceAudio::ServiceAudio()
 {
     busChannels.push_back(sys::BusChannels::ServiceAudioNotifications);
     LOG_INFO("[ServiceAudio] Initializing");
+
+    // this is just a test
+    connect(PlaybackStartReq("", PlaybackType::None), [&](sys::DataMessage *req, sys::ResponseMessage *response) {
+        if (auto *audioReq = dynamic_cast<PlaybackStartReq *>(req)) {
+            LOG_ERROR("Play %s", audioReq->fileName.c_str());
+        }
+        return std::make_shared<AudioResponseMessage>(audio::RetCode::Success, 1.55);
+    });
 }
 
 ServiceAudio::~ServiceAudio()

--- a/module-services/service-audio/api/AudioServiceAPI.cpp
+++ b/module-services/service-audio/api/AudioServiceAPI.cpp
@@ -43,6 +43,12 @@ namespace AudioServiceAPI
         return Handle(ret->retCode, ret->token);
     }
 
+    std::shared_ptr<AudioRequest> PlaybackStartRequest(const std::string fileName,
+                                                       const audio::PlaybackType playbackType)
+    {
+        return std::make_shared<PlaybackStartReq>(fileName, playbackType);
+    }
+
     Handle RecordingStart(sys::Service *serv, const std::string &fileName)
     {
         auto msg      = std::make_shared<AudioRequestMessage>(MessageType::AudioRecorderStart);

--- a/module-services/service-audio/api/AudioServiceAPI.hpp
+++ b/module-services/service-audio/api/AudioServiceAPI.hpp
@@ -23,6 +23,9 @@ namespace AudioServiceAPI
     audio::Handle PlaybackStart(sys::Service *serv,
                                 const audio::PlaybackType &playbackType,
                                 const std::string &fileName);
+
+    std::shared_ptr<AudioRequest> PlaybackStartRequest(const std::string fileName,
+                                                       const audio::PlaybackType playbackType);
     /**
      * @brief Starts recording.
      *

--- a/module-services/service-audio/messages/AudioMessage.cpp
+++ b/module-services/service-audio/messages/AudioMessage.cpp
@@ -1,0 +1,18 @@
+#include "AudioMessage.hpp"
+#include "../ServiceAudio.hpp"
+
+audio::Handle AudioRequestSync::SendSync(sys::Service *serv)
+{
+    auto ret = sys::Bus::SendUnicast(shared_from_this(), ServiceAudio::serviceName, serv, sys::defaultCmdTimeout);
+    if (ret.first == sys::ReturnCodes::Success) {
+        if (auto resp = std::dynamic_pointer_cast<AudioResponseMessage>(ret.second)) {
+            return audio::Handle(resp->retCode, resp->token);
+        }
+    }
+    return audio::Handle(audio::RetCode::Failed, audio::Token::MakeBadToken());
+}
+
+bool AudioRequestAsync::SendAsync(sys::Service *serv)
+{
+    return sys::Bus::SendUnicast(shared_from_this(), ServiceAudio::serviceName, serv);
+}


### PR DESCRIPTION
THIS IS DRAFT - NOT TO BE MERGED 
Possible way of exposing both sync and async calls for audio API.
(this POC is done on old revision but currently when we have class per request it is even easier to introduce)

In short:
- each Request class can inherit after AudioRequestSync, AudioRequestAsync or AudioRequest (which provides both sync and async)
- calls to audio API internally create instances of specialized Requests but return one of following: AudioRequest or AudioRequestSync or AudioRequestAsync
- depending on the need user calls SendSync or SendAsync on the request