### PR TITLE
[EGD-4038] handling incoming calls and sms in sleep mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Added
 
 * `[meditation]` Added basic meditation functionalities and settings
+* `[cellular]` Handling incoming calls and sms in sleep mode
 
 ### Fixed
 * `[audio]` Fix headphones autodetection.

--- a/module-bsp/board/linux/cellular/linux_cellular.cpp
+++ b/module-bsp/board/linux/cellular/linux_cellular.cpp
@@ -271,5 +271,12 @@ namespace bsp
             void sim_sel()
             {}
         } // namespace sim
+        namespace ringIndicator
+        {
+            auto riIRQ_handler() -> BaseType_t
+            {
+                return BaseType_t();
+            }
+        } // namespace ringIndicator
     }     // namespace cellular
 } // namespace bsp

--- a/module-bsp/board/rt1051/common/irq/irq_gpio.cpp
+++ b/module-bsp/board/rt1051/common/irq/irq_gpio.cpp
@@ -127,7 +127,7 @@ namespace bsp
             }
 
             if (irq_mask & (1 << BSP_CELLULAR_RI_PIN)) {
-                // TODO:M.P BSP_CellularUartRingIndicatorIrqHandler();
+                bsp::cellular::ringIndicator::riIRQ_handler();
             }
 
             // Clear all IRQs

--- a/module-bsp/bsp/cellular/bsp_cellular.hpp
+++ b/module-bsp/bsp/cellular/bsp_cellular.hpp
@@ -74,6 +74,7 @@ namespace cellular
         enum IRQsource{
             statusPin,
             trayPin,
+			ringIndicatorPin,
         };
 
         /// initialize SIM queue directed to EventWorker
@@ -119,6 +120,13 @@ namespace cellular
             void hotswap_trigger();
             void sim_sel();
         } // namespace sim
+
+        namespace ringIndicator
+		{
+        	// handling incoming calls and sms - RI pin
+        	BaseType_t riIRQ_handler();
+		} // namespace RingIndicator
+
     }     // namespace cellular
 };        // namespace bsp
 

--- a/module-cellular/Modem/TS0710/TS0710.cpp
+++ b/module-cellular/Modem/TS0710/TS0710.cpp
@@ -539,3 +539,18 @@ void TS0710::ResetModem(void)
 {
     return pv_cellular->Restart();
 }
+
+void TS0710::TurnOffModem(void)
+{
+    return pv_cellular->PowerDown();
+}
+
+void TS0710::EnterSleepMode(void)
+{
+    return pv_cellular->EnterSleep();
+}
+
+void TS0710::ExitSleepMode(void)
+{
+    return pv_cellular->ExitSleep();
+}

--- a/module-cellular/Modem/TS0710/TS0710.h
+++ b/module-cellular/Modem/TS0710/TS0710.h
@@ -444,6 +444,9 @@ class TS0710
     bool IsModemActive(void);
     void TurnOnModem(void);
     void ResetModem(void);
+    void TurnOffModem(void);
+    void EnterSleepMode(void);
+    void ExitSleepMode(void);
 };
 
 #endif //_TS0710_H

--- a/module-cellular/at/Commands.hpp
+++ b/module-cellular/at/Commands.hpp
@@ -57,8 +57,12 @@ namespace at
         FLOW_CTRL_ON,
         FLOW_CTRL_OFF,
         URC_NOTIF_CHANNEL,          /// Route URCs to second (Notifications) MUX channel
+        RI_PIN_AUTO_CALL,           /// Turn on RI pin for incoming calls
         RI_PIN_OFF_CALL,            /// Turn off RI pin for incoming calls
+        RI_PIN_PULSE_SMS,           /// Turn on RI pin for incoming sms
         RI_PIN_OFF_SMS,             /// Turn off RI pin for incoming sms
+        RI_PIN_OFF_OTHER,           /// Turn off RI pin for other URCs
+        URC_DELAY_ON,               /// Enable delay the output of URC indication until ring indicator pulse ends
         URC_UART1,                  /// Route URCs to UART1
         AT_PIN_READY_LOGIC,         /// Configure AP_Ready pin logic ( enable, logic level 1, 200ms )
         URC_NOTIF_SIGNAL,           /// Turn on signal strength change URC
@@ -126,8 +130,12 @@ namespace at
             {AT::FLOW_CTRL_ON, {"AT+IFC=2,2\r\n", 500}},
             {AT::FLOW_CTRL_OFF, {"AT+IFC=0,0\r", 500}},
             {AT::URC_NOTIF_CHANNEL, {"AT+QCFG=\"cmux/urcport\",1\r"}},
+            {AT::RI_PIN_AUTO_CALL, {"AT+QCFG=\"urc/ri/ring\",\"auto\"\r"}},
             {AT::RI_PIN_OFF_CALL, {"AT+QCFG=\"urc/ri/ring\",\"off\"\r"}},
+            {AT::RI_PIN_PULSE_SMS, {"AT+QCFG=\"urc/ri/smsincoming\",\"pulse\",200\r"}},
             {AT::RI_PIN_OFF_SMS, {"AT+QCFG=\"urc/ri/smsincoming\",\"off\"\r"}},
+            {AT::RI_PIN_OFF_OTHER, {"AT+QCFG=\"urc/ri/other\",\"off\"\r"}},
+            {AT::URC_DELAY_ON, {"AT+QCFG=\"urc/delay\",1\r"}},
             {AT::URC_UART1, {"AT+QURCCFG=\"urcport\",\"uart1\"\r"}},
             {AT::AT_PIN_READY_LOGIC, {"AT+QCFG=\"apready\",1,1,200\r"}},
             {AT::URC_NOTIF_SIGNAL, {"AT+QINDCFG=\"csq\",1\r"}},

--- a/module-cellular/at/src/Commands.cpp
+++ b/module-cellular/at/src/Commands.cpp
@@ -11,8 +11,10 @@ namespace at
         switch (set) {
         case commadsSet::modemInit:
             ret.push_back(AT::URC_NOTIF_CHANNEL);
-            ret.push_back(AT::RI_PIN_OFF_CALL);
-            ret.push_back(AT::RI_PIN_OFF_SMS);
+            ret.push_back(AT::RI_PIN_AUTO_CALL);
+            ret.push_back(AT::RI_PIN_PULSE_SMS);
+            ret.push_back(AT::RI_PIN_OFF_OTHER);
+            ret.push_back(AT::URC_DELAY_ON);
             ret.push_back(AT::URC_UART1);
             ret.push_back(AT::AT_PIN_READY_LOGIC);
             ret.push_back(AT::URC_NOTIF_SIGNAL);

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -224,12 +224,11 @@ sys::ReturnCodes ServiceCellular::SwitchPowerModeHandler(const sys::ServicePower
 
     switch (mode) {
     case sys::ServicePowerMode ::Active:
-        // muxdaemon->ExitSleepMode();
+        cmux->ExitSleepMode();
         break;
     case sys::ServicePowerMode ::SuspendToRAM:
     case sys::ServicePowerMode ::SuspendToNVM:
-        LOG_FATAL("TEMPORARY DISABLED!!!!! UNCOMMENT WHEN READY.");
-        //            muxdaemon->EnterSleepMode();
+        cmux->EnterSleepMode();
         break;
     }
 

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -213,6 +213,10 @@ sys::Message_t EventManager::DataReceivedHandler(sys::DataMessage *msgl, sys::Re
             sys::Bus::SendMulticast(notification, sys::BusChannels::ServiceEvtmgrNotifications, this);
         }
     }
+    else if (msgl->messageType == MessageType::EVMRingIndicator) {
+        sys::SystemManager::ResumeSystem(this);
+    }
+
     if (handled)
         return std::make_shared<sys::ResponseMessage>();
     else

--- a/module-services/service-evtmgr/WorkerEvent.cpp
+++ b/module-services/service-evtmgr/WorkerEvent.cpp
@@ -163,6 +163,11 @@ bool WorkerEvent::handleMessage(uint32_t queueID)
             LOG_DEBUG("SIM state change: %d", static_cast<int>(pinstate));
             bsp::cellular::sim::hotswap_trigger();
         }
+
+        if (notification == bsp::cellular::ringIndicatorPin) {
+            auto message = std::make_shared<sevm::StatusStateMessage>(MessageType::EVMRingIndicator);
+            sys::Bus::SendUnicast(message, "EventManager", this->service);
+        }
     }
 
     return true;

--- a/source/MessageType.hpp
+++ b/source/MessageType.hpp
@@ -178,6 +178,7 @@ enum class MessageType
     // cellular messages
     EVMGetBoard,
     EVMModemStatus,
+    EVMRingIndicator,
 
     // bluetooth messages
     BluetoothRequest,


### PR DESCRIPTION
added wake-up of the system on an event - interrupt from the RI cellular pin - which allows to handle incoming calls and text messages in sleep mode