### PR TITLE
[EGD-4093] fix crash on simulator exit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 
 * `[audio]` Fix parsing audio meta tags during playback
 * `[settings]` Removed the border around the settings menu.
+* `[simulator]` Fix crash on exit.
 
 ## [0.42.1 2020-10-12]
 

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -264,6 +264,9 @@ sys::ReturnCodes EventManager::InitHandler()
 sys::ReturnCodes EventManager::DeinitHandler()
 {
     EventWorker->close();
+    EventWorker.reset();
+    EventWorker = nullptr;
+
     return sys::ReturnCodes::Success;
 }
 


### PR DESCRIPTION
The event worker was closed twice by the Event Manager which resulted
in crash.
