### PR TITLE
[EGD-4004] audio: fix routing synchronization

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
 ### Other
 
 * `[appmgr]` Application manager documentation added.
+* `[audio]` Improve synchronization during calls.
 
 ## [0.43.1 2020-10-23]
 


### PR DESCRIPTION
Protect copying to buffers with mutex locks. Fix C style copying.

Add sanity checks to detect synchronization issues when routing.
