### PR TITLE
[EGD-4144] Put each third party in its own library

### DIFF
--- a/config/thirdparty.cmake
+++ b/config/thirdparty.cmake
@@ -1,8 +1,20 @@
 option (THIRD_PARTY_DEBUG_OPTIMIZE "Optimize third party in debug" ON)
 
 # optimize third party sources in debug by setting source file properties
-macro(third_party_source_optimization)
-    if (${THIRD_PARTY_DEBUG_OPTIMIZE} AND (${CMAKE_BUILD_TYPE} STREQUAL "Debug"))
+macro (third_party_source_optimization)
+    if (${THIRD_PARTY_DEBUG_OPTIMIZE} AND (${CMAKE_BUILD_TYPE} STREQUAL "Debug") AND NOT (${PROJECT_TARGET} STREQUAL "TARGET_Linux"))
         set_property(SOURCE ${ARGV} APPEND_STRING PROPERTY COMPILE_FLAGS " -Os")
-    endif()
-endmacro()
+    endif ()
+endmacro ()
+
+# setup flags for a third party target
+macro (third_party_target_setup TARGET_NAME)
+    target_compile_definitions(${TARGET_NAME} PUBLIC ${PROJECT_CONFIG_DEFINITIONS})
+    target_compile_definitions(${TARGET_NAME} PUBLIC ${PROJECT_TARGET})
+    target_compile_definitions(${TARGET_NAME} PUBLIC ${TARGET_COMPILE_DEFINITIONS})
+    target_include_directories(${TARGET_NAME} PUBLIC ${BOARD_DIR_INCLUDES} )
+    target_include_directories(${TARGET_NAME} PUBLIC ${PROJECT_INCLUDES})
+    target_compile_features(${TARGET_NAME} PUBLIC ${TARGET_COMPILE_FEATURES})
+    target_compile_options(${TARGET_NAME} PUBLIC ${TARGET_COMPILE_OPTIONS})
+    target_link_options(${TARGET_NAME} PUBLIC ${TARGET_LINK_OPTIONS})
+endmacro ()

--- a/module-utils/CMakeLists.txt
+++ b/module-utils/CMakeLists.txt
@@ -44,8 +44,10 @@ include(third-party/re2.cmake)
 include(third-party/protobuf-lite.cmake)
 include(third-party/libphonenumber.cmake)
 include(third-party/tinyexpr.cmake)
+include(third-party/pugixml.cmake)
 
-add_subdirectory(pugixml)
+# link against libphonenumber
+target_link_libraries (${PROJECT_NAME} PUBLIC ${LIBPHONENUMBER_TARGET})
 
 add_subdirectory(taglib EXCLUDE_FROM_ALL)
 set( TAGLIB_INCLUDE_DIRS
@@ -55,7 +57,13 @@ set( TAGLIB_INCLUDE_DIRS
 	 PARENT_SCOPE
 )
 
-target_link_libraries(${PROJECT_NAME} PUBLIC module-os module-vfs pugixml)
+# link against tinyexpr
+target_link_libraries (${PROJECT_NAME} PUBLIC ${TINYEXPR_TARGET})
+
+# link against pugixml
+target_link_libraries (${PROJECT_NAME} PUBLIC ${PUGIXML_TARGET})
+
+target_link_libraries(${PROJECT_NAME} PUBLIC module-os module-vfs)
 
 # Board specific compilation definitions,options,include directories and features
 target_compile_definitions(${PROJECT_NAME} PUBLIC ${PROJECT_CONFIG_DEFINITIONS})

--- a/module-utils/third-party/protobuf-lite.cmake
+++ b/module-utils/third-party/protobuf-lite.cmake
@@ -1,9 +1,9 @@
 include (thirdparty)
 
 # add sources
-set(PROTOBUF_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/src)
-set(PROTOBUF ${PROTOBUF_SRCDIR}/google/protobuf)
-set(PROTOBUF_SOURCES
+set (PROTOBUF_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/src)
+set (PROTOBUF ${PROTOBUF_SRCDIR}/google/protobuf)
+set (PROTOBUF_SOURCES
         ${PROTOBUF}/any_lite.cc
         ${PROTOBUF}/arena.cc
         ${PROTOBUF}/extension_set.cc
@@ -32,13 +32,19 @@ set(PROTOBUF_SOURCES
         ${PROTOBUF}/stubs/time.cc
         ${PROTOBUF}/wire_format_lite.cc
 )
-target_sources(${PROJECT_NAME} PRIVATE ${PROTOBUF_SOURCES})
+
+# create static library for the third party
+set (PROTOBUF_TARGET protobuf)
+add_library (${PROTOBUF_TARGET} STATIC ${PROTOBUF_SOURCES})
+
+# setup flags for the third party
+third_party_target_setup (${PROTOBUF_TARGET})
 
 # set compile definitions for third party libraries
-target_compile_definitions(${PROJECT_NAME} PUBLIC GOOGLE_PROTOBUF_NO_THREADS)
+target_compile_definitions (${PROTOBUF_TARGET} PUBLIC GOOGLE_PROTOBUF_NO_THREADS)
 
-# supress warning for protobuf
-set_source_files_properties(${PROTOBUF_SOURCES}
+# supress warnings for protobuf
+set_source_files_properties (${PROTOBUF_SOURCES}
         PROPERTIES COMPILE_FLAGS
 	"-Wno-stringop-truncation \
         -Wno-stringop-overflow \
@@ -49,6 +55,10 @@ set_source_files_properties(${PROTOBUF_SOURCES}
 )
 
 # add include dir
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROTOBUF_SRCDIR})
+target_include_directories (${PROTOBUF_TARGET} PUBLIC ${PROTOBUF_SRCDIR})
 
-third_party_source_optimization(${PROTOBUF_SOURCES})
+# module-os dependency (locking support)
+target_link_libraries (${RE2_TARGET} PUBLIC module-os)
+
+# turn on optimization in debug
+third_party_source_optimization (${PROTOBUF_SOURCES})

--- a/module-utils/third-party/pugixml.cmake
+++ b/module-utils/third-party/pugixml.cmake
@@ -1,0 +1,21 @@
+include (thirdparty)
+
+set (PUGIXML_TARGET pugixml)
+
+# setup pufixml path and source list
+set (PUGIXML_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/pugixml/src)
+set (PUGIXML_SOURCES
+    ${PUGIXML_SRCDIR}/pugixml.cpp
+)
+
+# create static library for the third party
+add_library (${PUGIXML_TARGET} STATIC ${PUGIXML_SOURCES})
+
+# setup flags for the third party
+third_party_target_setup (${PUGIXML_TARGET})
+
+# add include directory path
+target_include_directories (${PUGIXML_TARGET} PUBLIC ${PUGIXML_SRCDIR})
+
+# turn on optimization in debug
+third_party_source_optimization (${PUGIXML_SOURCES})

--- a/module-utils/third-party/re2.cmake
+++ b/module-utils/third-party/re2.cmake
@@ -1,8 +1,8 @@
-include(thirdparty)
+include (thirdparty)
 
 # add re2 library sources
-set(RE2_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/re2)
-set(RE2_SOURCES
+set (RE2_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/re2)
+set (RE2_SOURCES
         ${RE2_SRCDIR}/re2/bitstate.cc
         ${RE2_SRCDIR}/re2/compile.cc
         ${RE2_SRCDIR}/re2/dfa.cc
@@ -26,19 +26,31 @@ set(RE2_SOURCES
         ${RE2_SRCDIR}/util/rune.cc
         ${RE2_SRCDIR}/util/strutil.cc
 )
-target_sources(${PROJECT_NAME} PRIVATE ${RE2_SOURCES})
+
+# create static library for the third party
+set (RE2_TARGET re2)
+add_library (${RE2_TARGET} STATIC ${RE2_SOURCES})
+
+# setup flags for the third party
+third_party_target_setup (${RE2_TARGET})
 
 # use FreeRTOS cpp wrapper to provide thread safety
-target_compile_definitions(${PROJECT_NAME}
+target_compile_definitions (${RE2_TARGET}
 	PUBLIC
 	RE2_USE_RTOS_WRAPPER
 )
 
 # suppress warning for RE2 to avoid big changes in the original library
-set_source_files_properties(${RE2_SRCDIR}/re2/perl_groups.cc
+set_source_files_properties (${RE2_SRCDIR}/re2/perl_groups.cc
         PROPERTIES COMPILE_FLAGS
         -Wno-missing-field-initializers
 )
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${RE2_SRCDIR})
+# add include directory path
+target_include_directories(${RE2_TARGET} PUBLIC ${RE2_SRCDIR})
+
+# module-os dependency (locking support)
+target_link_libraries (${RE2_TARGET} PUBLIC module-os)
+
+# optimize thirdy party sources in dbeug
 third_party_source_optimization(${RE2_SOURCES})

--- a/module-utils/third-party/tinyexpr.cmake
+++ b/module-utils/third-party/tinyexpr.cmake
@@ -1,11 +1,20 @@
-include(thirdparty)
+include (thirdparty)
 
 # add tinyexpr library sources
-set(TINYEXPR_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/tinyexpr)
-set(TINYEXPR_SOURCES
+set (TINYEXPR_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/tinyexpr)
+set (TINYEXPR_SOURCES
         ${TINYEXPR_SRCDIR}/tinyexpr.c
-        )
-target_sources(${PROJECT_NAME} PRIVATE ${TINYEXPR_SOURCES})
+)
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${TINYEXPR_SRCDIR})
-third_party_source_optimization(${TINYEXPR_SOURCES})
+# create static library for the third party
+set (TINYEXPR_TARGET tinyexpr)
+add_library (${TINYEXPR_TARGET} STATIC ${TINYEXPR_SOURCES})
+
+# setup flags for the third party
+third_party_target_setup (${TINYEXPR_TARGET})
+
+# add include directory path
+target_include_directories (${TINYEXPR_TARGET} PUBLIC ${TINYEXPR_SRCDIR})
+
+# optimize thirdy party sources in dbeug
+third_party_source_optimization (${TINYEXPR_SOURCES})


### PR DESCRIPTION
    [EGD-4144] build: individual libs for 3rdparty
    
    Create individual library for each of third party project to be able to
    determine memory usage of each of project's components.
    
    Disable third party optimization for linux platform.


[EGD-4144]: https://appnroll.atlassian.net/browse/EGD-4144