### PR TITLE
[EGD-2778] deleting conversation thread: abset phonenumber fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,11 +18,12 @@
 
 ### Fixed
 
+* `[GUI][messages]` Fixed not showing number on deleting temporary contact
 * `[GUI]` Fixed filling Label with color
 
 ## [0.44.1 2020-10-30]
 
-### Added
+### Addedgit 
 
 * `[settings][bluetooth]` Add "Phone name" window.
 * `[cellular]` Add support for modem reset.

--- a/module-apps/application-messages/ApplicationMessages.cpp
+++ b/module-apps/application-messages/ApplicationMessages.cpp
@@ -185,16 +185,16 @@ namespace app
         }
         LOG_DEBUG("Removing thread: %" PRIu32, record->ID);
 
-        auto query = std::make_unique<ContactGetByID>(record->contactID);
+        auto query = std::make_unique<ContactGetByID>(record->contactID, true);
         query->setQueryListener(db::QueryCallback::fromFunction([this, record](auto response) {
             auto result = dynamic_cast<ContactGetByIDResult *>(response);
             if (result != nullptr) {
                 const auto &contact = result->getResult();
                 gui::DialogMetadata meta;
-                meta.action         = [this, record]() { return onRemoveSmsThreadConfirmed(*record); };
-                meta.text           = utils::localize.get("app_messages_thread_delete_confirmation");
-                meta.title          = contact.getFormattedName();
-                meta.icon           = "phonebook_contact_delete_trashcan";
+                meta.action = [this, record]() { return onRemoveSmsThreadConfirmed(*record); };
+                meta.text   = utils::localize.get("app_messages_thread_delete_confirmation");
+                meta.title  = contact.getFormattedName();
+                meta.icon   = "phonebook_contact_delete_trashcan";
                 switchWindow(gui::name::window::dialog_yes_no, std::make_unique<gui::DialogMetadataMessage>(meta));
                 return true;
             }


### PR DESCRIPTION
This PR completes EGD-2778 story. The missing component fixed here was: On deleting thread with number absent in PhoneBook  the title of dialog_box was empty instead of showing phone number.