### PR TITLE
[EGD-4288] refactor global data

### DIFF
--- a/module-apps/application-antenna/ApplicationAntenna.hpp
+++ b/module-apps/application-antenna/ApplicationAntenna.hpp
@@ -18,7 +18,7 @@
 namespace app
 {
 
-    inline const std::string name_antenna = "ApplicationAntenna";
+    inline constexpr auto name_antenna = "ApplicationAntenna";
     namespace antenna
     {
         class StoreParams

--- a/module-apps/application-antenna/windows/AlgoParamsWindow.hpp
+++ b/module-apps/application-antenna/windows/AlgoParamsWindow.hpp
@@ -14,7 +14,7 @@ namespace gui
     {
         namespace window
         {
-            const std::string algo_window("AlgoParamsWindow");
+            inline constexpr auto algo_window = "AlgoParamsWindow";
         }
     } // namespace name
     class AlgoParamsWindow : public AppWindow

--- a/module-apps/application-antenna/windows/ScanModesWindow.hpp
+++ b/module-apps/application-antenna/windows/ScanModesWindow.hpp
@@ -13,7 +13,7 @@ namespace gui
     {
         namespace window
         {
-            const std::string scan_window("AntennaScanWindow");
+            inline constexpr auto scan_window = "AntennaScanWindow";
         }
     } // namespace name
     class ScanModesWindow : public AppWindow

--- a/module-apps/application-calculator/ApplicationCalculator.hpp
+++ b/module-apps/application-calculator/ApplicationCalculator.hpp
@@ -7,8 +7,8 @@
 
 namespace app
 {
-    const inline std::string name_calculator = "ApplicationCalculator";
-    constexpr std::uint16_t stack_size       = 4096;
+    inline constexpr auto name_calculator     = "ApplicationCalculator";
+    inline constexpr std::uint16_t stack_size = 4096;
 
     class ApplicationCalculator : public Application
     {

--- a/module-apps/application-calculator/data/CalculatorUtility.cpp
+++ b/module-apps/application-calculator/data/CalculatorUtility.cpp
@@ -17,7 +17,7 @@ Result Calculator::calculate(std::string source)
         auto output = utils::to_string(result);
         if (utils::localize.get("app_calculator_decimal_separator") == style::calculator::symbols::strings::comma) {
             output.replace(output.find(style::calculator::symbols::strings::full_stop),
-                           style::calculator::symbols::strings::full_stop.length(),
+                           std::size(std::string_view(style::calculator::symbols::strings::full_stop)),
                            style::calculator::symbols::strings::comma);
         }
         return Result{source, output, false};

--- a/module-apps/application-calculator/widgets/CalculatorStyle.hpp
+++ b/module-apps/application-calculator/widgets/CalculatorStyle.hpp
@@ -2,51 +2,51 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
-#include <string>
+
 #include <module-gui/gui/widgets/Style.hpp>
 
 namespace style::calculator
 {
-    const inline int grid_cells                = 9;
-    const inline std::string equals            = "app_calculator_equals";
-    const inline std::string decimal_separator = "app_calculator_decimal_separator";
+    inline constexpr auto grid_cells        = 9;
+    inline constexpr auto equals            = "app_calculator_equals";
+    inline constexpr auto decimal_separator = "app_calculator_decimal_separator";
 
     namespace window
     {
-        const inline int math_box_height      = 240;
-        const inline int math_box_offset_top  = style::header::height + 200;
-        const inline int math_box_cell_height = 80;
-        const inline int math_box_cell_width  = style::window::default_body_width / 3;
-        const inline int input_offset_top     = style::header::height + 20;
-        const inline int input_height         = 100;
-        const inline int input_width          = 380;
-        const inline int input_margin         = 50;
+        inline constexpr auto math_box_height      = 240;
+        inline constexpr auto math_box_offset_top  = style::header::height + 200;
+        inline constexpr auto math_box_cell_height = 80;
+        inline constexpr auto math_box_cell_width  = style::window::default_body_width / 3;
+        inline constexpr auto input_offset_top     = style::header::height + 20;
+        inline constexpr auto input_height         = 100;
+        inline constexpr auto input_width          = 380;
+        inline constexpr auto input_margin         = 50;
     } // namespace window
 
     namespace symbols
     {
         namespace codes
         {
-            const inline int plus           = 0x002B;
-            const inline int minus          = 0x002D;
-            const inline int division       = 0x00F7;
-            const inline int multiplication = 0x00D7;
-            const inline int full_stop      = 0x002E;
-            const inline int comma          = 0x002C;
-            const inline int equals         = 0x003D;
+            inline constexpr auto plus           = 0x002B;
+            inline constexpr auto minus          = 0x002D;
+            inline constexpr auto division       = 0x00F7;
+            inline constexpr auto multiplication = 0x00D7;
+            inline constexpr auto full_stop      = 0x002E;
+            inline constexpr auto comma          = 0x002C;
+            inline constexpr auto equals         = 0x003D;
         } // namespace codes
 
         namespace strings
         {
-            const inline std::string plus           = "\u002B";
-            const inline std::string minus          = "\u002D";
-            const inline std::string division       = "\u00F7";
-            const inline std::string multiplication = "\u00D7";
-            const inline std::string equals         = "\u003D";
-            const inline std::string full_stop      = "\u002E";
-            const inline std::string comma          = "\u002C";
-            const inline std::string asterisk       = "\u002A";
-            const inline std::string solidus        = "\u002F";
+            inline constexpr auto plus           = "\u002B";
+            inline constexpr auto minus          = "\u002D";
+            inline constexpr auto division       = "\u00F7";
+            inline constexpr auto multiplication = "\u00D7";
+            inline constexpr auto equals         = "\u003D";
+            inline constexpr auto full_stop      = "\u002E";
+            inline constexpr auto comma          = "\u002C";
+            inline constexpr auto asterisk       = "\u002A";
+            inline constexpr auto solidus        = "\u002F";
         } // namespace strings
     }     // namespace symbols
 } // namespace style::calculator

--- a/module-apps/application-calendar/ApplicationCalendar.hpp
+++ b/module-apps/application-calendar/ApplicationCalendar.hpp
@@ -14,11 +14,11 @@
 namespace app
 {
 
-    inline const std::string name_calendar = "ApplicationCalendar";
+    inline constexpr auto name_calendar = "ApplicationCalendar";
 
     class ApplicationCalendar : public Application
     {
-        time_t applicationStartTime = 0;
+        time_t applicationStartTime       = 0;
         int eventShift                    = 0;
         EquivalentWindow equivalentWindow = EquivalentWindow::EmptyWindow;
 

--- a/module-apps/application-calendar/data/dateCommon.hpp
+++ b/module-apps/application-calendar/data/dateCommon.hpp
@@ -15,7 +15,7 @@ using TimePoint        = time_point<Clock>;
 using YearMonthDay     = date::year_month_day;
 using YearMonthDayLast = date::year_month_day_last;
 
-const inline int max_month_day = 48;
+inline constexpr auto max_month_day = 48;
 
 enum class Reminder
 {
@@ -42,7 +42,7 @@ enum class Repeat
     custom
 };
 
-constexpr TimePoint TIME_POINT_INVALID = date::sys_days{date::January / 1 / 1970};
+inline constexpr TimePoint TIME_POINT_INVALID = date::sys_days{date::January / 1 / 1970};
 
 inline std::tm CreateTmStruct(int year, int month, int day, int hour, int minutes, int seconds)
 {

--- a/module-apps/application-calendar/widgets/CalendarStyle.hpp
+++ b/module-apps/application-calendar/widgets/CalendarStyle.hpp
@@ -13,128 +13,128 @@ namespace style
         {
             namespace imageCircleTop
             {
-                constexpr uint32_t x = 116;
-                constexpr uint32_t y = 59;
-                constexpr auto name  = "circle_top";
+                inline constexpr auto x    = 116U;
+                inline constexpr auto y    = 59U;
+                inline constexpr auto name = "circle_top";
             } // namespace imageCircleTop
             namespace imageCircleBottom
             {
-                constexpr uint32_t x = 106;
-                constexpr uint32_t y = 240;
-                constexpr auto name  = "circle_bottom";
+                inline constexpr auto x    = 106U;
+                inline constexpr auto y    = 240U;
+                inline constexpr auto name = "circle_bottom";
             } // namespace imageCircleBottom
 
             namespace name
             {
-                const inline std::string day_events_window    = "DayEventsWindow";
-                const inline std::string no_events_window     = "NoEventsWindow";
-                const inline std::string events_options       = "Options";
-                const inline std::string dialog_yes_no        = "DialogYesNo";
-                const inline std::string all_events_window    = "AllEventsWindow";
-                const inline std::string details_window       = "DetailsWindow";
-                const inline std::string new_edit_event       = "NewEditEvent";
-                const inline std::string custom_repeat_window = "CustomRepeat";
-                const inline std::string event_reminder_window = "EventReminderWindow";
+                inline constexpr auto day_events_window     = "DayEventsWindow";
+                inline constexpr auto no_events_window      = "NoEventsWindow";
+                inline constexpr auto events_options        = "Options";
+                inline constexpr auto dialog_yes_no         = "DialogYesNo";
+                inline constexpr auto all_events_window     = "AllEventsWindow";
+                inline constexpr auto details_window        = "DetailsWindow";
+                inline constexpr auto new_edit_event        = "NewEditEvent";
+                inline constexpr auto custom_repeat_window  = "CustomRepeat";
+                inline constexpr auto event_reminder_window = "EventReminderWindow";
             } // namespace name
 
-            const inline std::string new_event  = "New";
-            const inline std::string edit_event = "Edit";
-            const inline int day_cell_width    = 60;
-            const inline int day_cell_height   = 55;
-            const inline int month_year_height = 60;
-            const inline int week_days_number  = 7;
-            const inline int max_weeks_number  = 6;
+            inline constexpr auto new_event         = "New";
+            inline constexpr auto edit_event        = "Edit";
+            inline constexpr auto day_cell_width    = 60;
+            inline constexpr auto day_cell_height   = 55;
+            inline constexpr auto month_year_height = 60;
+            inline constexpr auto week_days_number  = 7;
+            inline constexpr auto max_weeks_number  = 6;
 
-            const inline int cross_x    = 48;
-            const inline int cross_y    = 55;
-            const inline int arrow_x    = 30;
-            const inline int arrow_y    = 62;
-            const inline int listView_x = style::window::default_left_margin;
-            const inline int listView_y = style::header::height;
-            const inline int listView_w = style::listview::body_width_with_scroll;
-            const inline int listView_h = style::window_height - listView_y - style::footer::height;
+            inline constexpr auto cross_x    = 48;
+            inline constexpr auto cross_y    = 55;
+            inline constexpr auto arrow_x    = 30;
+            inline constexpr auto arrow_y    = 62;
+            inline constexpr auto listView_x = style::window::default_left_margin;
+            inline constexpr auto listView_y = style::header::height;
+            inline constexpr auto listView_w = style::listview::body_width_with_scroll;
+            inline constexpr auto listView_h = style::window_height - listView_y - style::footer::height;
 
             namespace test
             {
-                const inline int prev_month_id       = 1;
-                const inline int month_id            = 2;
-                const inline int next_month_id       = 3;
-                const inline std::string date_text_1 = "January 2019";
-                const inline std::string date_text_2 = "February 2019";
-                const inline std::string date_text_3 = "March 2019";
+                inline constexpr auto prev_month_id = 1;
+                inline constexpr auto month_id      = 2;
+                inline constexpr auto next_month_id = 3;
+                inline constexpr auto date_text_1   = "January 2019";
+                inline constexpr auto date_text_2   = "February 2019";
+                inline constexpr auto date_text_3   = "March 2019";
             } // namespace test
 
             namespace time
             {
-                const inline int max_time_length   = 2;
-                const inline int max_hour_24H_mode = 23;
-                const inline int max_hour_12H_mode = 12;
-                const inline int max_minutes       = 59;
+                inline constexpr auto max_time_length   = 2;
+                inline constexpr auto max_hour_24H_mode = 23;
+                inline constexpr auto max_hour_12H_mode = 12;
+                inline constexpr auto max_minutes       = 59;
             } // namespace time
 
             namespace item
             {
                 namespace dayEvents
                 {
-                    const inline int title_w    = 255;
-                    const inline int box_height = style::window::label::small_h;
-                    const inline int height     = 100;
+                    inline constexpr auto title_w    = 255;
+                    inline constexpr auto box_height = style::window::label::small_h;
+                    inline constexpr auto height     = 100;
                 } // namespace dayEvents
 
                 namespace allEvents
                 {
-                    const inline int description_w    = 310;
-                    const inline int start_time_min_w = 60;
+                    inline constexpr auto description_w    = 310;
+                    inline constexpr auto start_time_min_w = 60;
                 } // namespace allEvents
 
                 namespace repeatAndReminder
                 {
-                    const inline int height             = 150;
-                    const inline int title_label_h      = 45;
-                    const inline int title_label_margin = 15;
-                    const inline int description_w      = style::window::default_body_width / 2 - 30;
-                    const inline int description_h      = 30;
+                    inline constexpr auto height             = 150;
+                    inline constexpr auto title_label_h      = 45;
+                    inline constexpr auto title_label_margin = 15;
+                    inline constexpr auto description_w      = style::window::default_body_width / 2 - 30;
+                    inline constexpr auto description_h      = 30;
                 } // namespace repeatAndReminder
 
                 namespace eventDetail
                 {
-                    const inline int height_min        = 90;
-                    const inline int height_max        = 155;
-                    const inline int margin_top        = 2 * style::margins::big;
-                    const inline int event_time_margin = 25;
-                    const inline int title_h           = 20;
-                    const inline int label_h           = 35;
+                    inline constexpr auto height_min        = 90;
+                    inline constexpr auto height_max        = 155;
+                    inline constexpr auto margin_top        = 2 * style::margins::big;
+                    inline constexpr auto event_time_margin = 25;
+                    inline constexpr auto title_h           = 20;
+                    inline constexpr auto label_h           = 35;
                 } // namespace eventDetail
 
                 namespace eventTime
                 {
-                    const inline int height           = 106;
-                    const inline int margin           = 21;
-                    const inline int separator        = 30;
-                    const inline int time_input_12h_w = 120;
-                    const inline int time_input_24h_w = 195;
+                    inline constexpr auto height           = 106;
+                    inline constexpr auto margin           = 21;
+                    inline constexpr auto separator        = 30;
+                    inline constexpr auto time_input_12h_w = 120;
+                    inline constexpr auto time_input_24h_w = 195;
                 } // namespace eventTime
 
                 namespace checkBox
                 {
-                    const inline int height              = 44;
-                    const inline int margin_top          = 18;
-                    const inline int input_box_label_w   = style::window::label::big_h;
-                    const inline int description_label_w = 280;
+                    inline constexpr auto height              = 44;
+                    inline constexpr auto margin_top          = 18;
+                    inline constexpr auto input_box_label_w   = style::window::label::big_h;
+                    inline constexpr auto description_label_w = 280;
                 } // namespace checkBox
 
                 namespace severalOptions
                 {
-                    const inline int height    = 63;
-                    const inline int label_h   = 30;
-                    const inline int arrow_w_h = 20;
+                    inline constexpr auto height    = 63;
+                    inline constexpr auto label_h   = 30;
+                    inline constexpr auto arrow_w_h = 20;
                 } // namespace severalOptions
 
                 namespace textWithLabel
                 {
-                    const inline int height        = 80;
-                    const inline int description_h = 30;
-                    const inline int text_input_h  = 40;
+                    inline constexpr auto height        = 80;
+                    inline constexpr auto description_h = 30;
+                    inline constexpr auto text_input_h  = 40;
                 } // namespace textWithLabel
             }     // namespace item
         };        // namespace calendar

--- a/module-apps/application-calendar/widgets/EventTimeItem.hpp
+++ b/module-apps/application-calendar/widgets/EventTimeItem.hpp
@@ -11,19 +11,19 @@ namespace gui
 {
     namespace timeConstants
     {
-        const inline std::string before_noon = "AM";
-        const inline std::string after_noon  = "PM";
+        inline constexpr auto before_noon = "AM";
+        inline constexpr auto after_noon  = "PM";
     } // namespace timeConstants
     class EventTimeItem : public CalendarListItem
     {
-        gui::VBox *vBox              = nullptr;
-        gui::HBox *hBox              = nullptr;
-        gui::Label *colonLabel       = nullptr;
-        gui::Label *descriptionLabel = nullptr;
-        gui::Text *hourInput         = nullptr;
-        gui::Text *minuteInput       = nullptr;
-        gui::Label *mode12hInput     = nullptr;
-        bool mode24H                 = false;
+        gui::VBox *vBox                = nullptr;
+        gui::HBox *hBox                = nullptr;
+        gui::Label *colonLabel         = nullptr;
+        gui::Label *descriptionLabel   = nullptr;
+        gui::Text *hourInput           = nullptr;
+        gui::Text *minuteInput         = nullptr;
+        gui::Label *mode12hInput       = nullptr;
+        bool mode24H                   = false;
         gui::EventTimeItem *secondItem = nullptr;
 
         std::function<void(const UTF8 &text)> bottomBarTemporaryMode = nullptr;

--- a/module-apps/application-call/ApplicationCall.hpp
+++ b/module-apps/application-call/ApplicationCall.hpp
@@ -12,19 +12,19 @@
 
 namespace app
 {
-    inline const std::string name_call      = "ApplicationCall";
-    constexpr std::uint16_t call_stack_size = 8192;
+    inline constexpr auto name_call       = "ApplicationCall";
+    inline constexpr auto call_stack_size = 8192U;
 
     namespace window
     {
-        inline const std::string name_call              = "CallWindow";
-        inline const std::string name_enterNumber       = "EnterNumberWindow";
-        inline const std::string name_emergencyCall     = "EmergencyCallWindow";
-        inline const std::string name_duplicatedContact = "DuplicatedContactWindow";
-        inline const std::string name_dialogConfirm     = "DialogConfirm";
+        inline constexpr auto name_call              = "CallWindow";
+        inline constexpr auto name_enterNumber       = "EnterNumberWindow";
+        inline constexpr auto name_emergencyCall     = "EmergencyCallWindow";
+        inline constexpr auto name_duplicatedContact = "DuplicatedContactWindow";
+        inline constexpr auto name_dialogConfirm     = "DialogConfirm";
     } // namespace window
 
-    inline const std::string ringtone_path = "assets/audio/Ringtone-drum2.mp3"; // Should bo moved to database
+    inline constexpr auto ringtone_path = "assets/audio/Ringtone-drum2.mp3"; // Should bo moved to database
 
     class ApplicationCall : public Application
     {

--- a/module-apps/application-call/data/CallAppStyle.hpp
+++ b/module-apps/application-call/data/CallAppStyle.hpp
@@ -9,36 +9,36 @@ namespace callAppStyle
 {
     namespace strings
     {
-        const inline std::string call      = "app_call_call";
-        const inline std::string clear     = "app_call_clear";
-        const inline std::string reject    = "app_call_reject";
-        const inline std::string answer    = "app_call_answer";
-        const inline std::string message   = "app_call_message";
-        const inline std::string endcall   = "app_call_end_call";
-        const inline std::string emergency = "app_call_emergency";
-        const inline std::string iscalling = "app_call_is_calling";
-        const inline std::string calling   = "app_call_calling";
-        const inline std::string callended = "app_call_call_ended";
-        const inline std::string contact   = "app_call_contact";
-        const inline std::string mute      = "app_call_mute";
-        const inline std::string MUTED     = "app_call_muted";
-        const inline std::string speaker   = "app_call_speaker";
-        const inline std::string speakeron = "app_call_speaker_on";
-        const inline std::string bluetooth = "app_call_bluetooth";
+        inline constexpr auto call      = "app_call_call";
+        inline constexpr auto clear     = "app_call_clear";
+        inline constexpr auto reject    = "app_call_reject";
+        inline constexpr auto answer    = "app_call_answer";
+        inline constexpr auto message   = "app_call_message";
+        inline constexpr auto endcall   = "app_call_end_call";
+        inline constexpr auto emergency = "app_call_emergency";
+        inline constexpr auto iscalling = "app_call_is_calling";
+        inline constexpr auto calling   = "app_call_calling";
+        inline constexpr auto callended = "app_call_call_ended";
+        inline constexpr auto contact   = "app_call_contact";
+        inline constexpr auto mute      = "app_call_mute";
+        inline constexpr auto MUTED     = "app_call_muted";
+        inline constexpr auto speaker   = "app_call_speaker";
+        inline constexpr auto speakeron = "app_call_speaker_on";
+        inline constexpr auto bluetooth = "app_call_bluetooth";
     } // namespace strings
 
     namespace numberLabel
     {
-        constexpr uint32_t x       = 60;
-        constexpr uint32_t y       = 157;
-        constexpr uint32_t w       = style::window_width - 2 * x;
-        constexpr uint32_t h       = 51 + 16;
-        constexpr uint32_t borderW = 1;
+        inline constexpr auto x       = 60U;
+        inline constexpr auto y       = 157U;
+        inline constexpr auto w       = style::window_width - 2 * x;
+        inline constexpr auto h       = 51U + 16U;
+        inline constexpr auto borderW = 1U;
     } // namespace numberLabel
 
     namespace icon
     {
-        constexpr uint32_t x_margin = 20;
+        inline constexpr auto x_margin = 20U;
     }
 
     // ENTER NUMBER WINDOW
@@ -46,8 +46,8 @@ namespace callAppStyle
     {
         namespace newContactIcon
         {
-            constexpr uint32_t x = 190 - icon::x_margin;
-            constexpr uint32_t y = 411;
+            inline constexpr auto x = 190U - icon::x_margin;
+            inline constexpr auto y = 411U;
         } // namespace newContactIcon
     }     // namespace enterNumberWindow
 
@@ -56,37 +56,37 @@ namespace callAppStyle
     {
         namespace imageCircleTop
         {
-            constexpr uint32_t x = 116; // TODO: should be 104 with final image
-            constexpr uint32_t y = 59;
-            constexpr auto name  = "circle_top";
+            inline constexpr auto x    = 116U; // TODO: should be 104 with final image
+            inline constexpr auto y    = 59U;
+            inline constexpr auto name = "circle_top";
         } // namespace imageCircleTop
         namespace imageCircleBottom
         {
-            constexpr uint32_t x = 106; // TODO: should be 104 with final image
-            constexpr uint32_t y = 240;
-            constexpr auto name  = "circle_bottom";
+            inline constexpr auto x    = 106U; // TODO: should be 104 with final image
+            inline constexpr auto y    = 240U;
+            inline constexpr auto name = "circle_bottom";
         } // namespace imageCircleBottom
         namespace durationLabel
         {
-            constexpr uint32_t x = 120;
-            constexpr uint32_t y = 223;
-            constexpr uint32_t w = 240;
-            constexpr uint32_t h = 20;
+            inline constexpr auto x = 120U;
+            inline constexpr auto y = 223U;
+            inline constexpr auto w = 240U;
+            inline constexpr auto h = 20U;
         } // namespace durationLabel
         namespace speakerIcon
         {
-            constexpr uint32_t x = 260 - icon::x_margin;
-            constexpr uint32_t y = 411;
+            inline constexpr auto x = 260U - icon::x_margin;
+            inline constexpr auto y = 411U;
         } // namespace speakerIcon
         namespace microphoneIcon
         {
-            constexpr uint32_t x = 120 - icon::x_margin;
-            constexpr uint32_t y = 411;
+            inline constexpr auto x = 120U - icon::x_margin;
+            inline constexpr auto y = 411U;
         } // namespace microphoneIcon
         namespace sendMessageIcon
         {
-            constexpr uint32_t x = 190 - icon::x_margin;
-            constexpr uint32_t y = 411;
+            inline constexpr auto x = 190U - icon::x_margin;
+            inline constexpr auto y = 411U;
         } // namespace sendMessageIcon
     }     // namespace callWindow
 } // namespace callAppStyle

--- a/module-apps/application-call/data/CallSwitchData.hpp
+++ b/module-apps/application-call/data/CallSwitchData.hpp
@@ -21,7 +21,7 @@ namespace app
             INCOMING_CALL,
             EXECUTE_CALL
         };
-        static const inline std::string descriptionStr = "CallSwitchData";
+        static constexpr auto descriptionStr = "CallSwitchData";
 
       protected:
         Type type = Type::UNDEFINED;
@@ -46,7 +46,7 @@ namespace app
         std::string phoneNumber;
 
       public:
-        static const inline std::string descriptionStr = "EnterNumberSwitchData";
+        static constexpr auto descriptionStr = "EnterNumberSwitchData";
 
         EnterNumberData(const std::string &phoneNumber) : SwitchData(descriptionStr), phoneNumber(phoneNumber)
         {}
@@ -69,7 +69,6 @@ namespace app
       public:
         ExecuteCallData(const utils::PhoneNumber::View &phoneNumber)
             : CallSwitchData(phoneNumber, app::CallSwitchData::Type::EXECUTE_CALL){};
-
     };
 
     class CallAbortData : public gui::SwitchData

--- a/module-apps/application-call/widgets/Icons.hpp
+++ b/module-apps/application-call/widgets/Icons.hpp
@@ -16,9 +16,9 @@ namespace gui
     class AddContactIcon : public Icon<AddContactIconState>
     {
       protected:
-        static const inline std::string crossImg      = "cross";
-        static const inline std::string addContactStr = "app_call_contact";
-        static const inline Icon::IconMap iconMap     = {{AddContactIconState::ADD_CONTACT, {crossImg, addContactStr}}};
+        static constexpr auto crossImg            = "cross";
+        static constexpr auto addContactStr       = "app_call_contact";
+        static const inline Icon::IconMap iconMap = {{AddContactIconState::ADD_CONTACT, {crossImg, addContactStr}}};
 
       public:
         AddContactIcon() = delete;
@@ -35,9 +35,9 @@ namespace gui
     class SendSmsIcon : public Icon<SendSmsIconState>
     {
       protected:
-        static const inline std::string messageImg  = "mail";
-        static const inline std::string sendSmstStr = "app_call_message";
-        static const inline Icon::IconMap iconMap   = {{SendSmsIconState::SEND_SMS, {messageImg, sendSmstStr}}};
+        static constexpr auto messageImg          = "mail";
+        static constexpr auto sendSmstStr         = "app_call_message";
+        static const inline Icon::IconMap iconMap = {{SendSmsIconState::SEND_SMS, {messageImg, sendSmstStr}}};
 
       public:
         SendSmsIcon() = delete;
@@ -55,10 +55,10 @@ namespace gui
     class MicrophoneIcon : public Icon<MicrophoneIconState>
     {
       protected:
-        static const inline std::string muteImg   = "microphone_on";
-        static const inline std::string mutedImg  = "microphone_off";
-        static const inline std::string muteStr   = "app_call_mute";
-        static const inline std::string mutedStr  = "app_call_muted";
+        static constexpr auto muteImg             = "microphone_on";
+        static constexpr auto mutedImg            = "microphone_off";
+        static constexpr auto muteStr             = "app_call_mute";
+        static constexpr auto mutedStr            = "app_call_muted";
         static const inline Icon::IconMap iconMap = {{MicrophoneIconState::MUTE, {muteImg, muteStr}},
                                                      {MicrophoneIconState::MUTED, {mutedImg, mutedStr}}};
 
@@ -80,12 +80,12 @@ namespace gui
     class SpeakerIcon : public Icon<SpeakerIconState>
     {
       protected:
-        static const inline std::string speakerImg   = "speaker_off";
-        static const inline std::string speakerOnImg = "speaker_on";
-        // static const inline std::string bluetoothImg = "app_call_bluetooth";
-        static const inline std::string speakerStr   = "app_call_speaker";
-        static const inline std::string speakerOnStr = "app_call_speaker_on";
-        // static const inline std::string bluetoothStr = "app_call_bluetooth";
+        static constexpr auto speakerImg   = "speaker_off";
+        static constexpr auto speakerOnImg = "speaker_on";
+        // static constexpr auto bluetoothImg = "app_call_bluetooth";
+        static constexpr auto speakerStr   = "app_call_speaker";
+        static constexpr auto speakerOnStr = "app_call_speaker_on";
+        // static constexpr auto bluetoothStr = "app_call_bluetooth";
         static const inline Icon::IconMap iconMap = {
             {SpeakerIconState::SPEAKER, {speakerImg, speakerStr}},
             {SpeakerIconState::SPEAKERON, {speakerOnImg, speakerOnStr}},

--- a/module-apps/application-calllog/ApplicationCallLog.hpp
+++ b/module-apps/application-calllog/ApplicationCallLog.hpp
@@ -10,7 +10,7 @@
 namespace app
 {
 
-    const inline std::string CallLogAppStr = "ApplicationCallLog";
+    inline constexpr auto CallLogAppStr = "ApplicationCallLog";
 
     class ApplicationCallLog : public Application
     {

--- a/module-apps/application-calllog/data/CallLogInternals.hpp
+++ b/module-apps/application-calllog/data/CallLogInternals.hpp
@@ -34,9 +34,9 @@ namespace calllog
     namespace settings
     {
         // Windows
-        const inline std::string MainWindowStr       = gui::name::window::main_window;
-        const inline std::string DetailsWindowStr    = "DetailsWindow";
-        const inline std::string DialogYesNoStr      = "DialogYesNo";
+        inline constexpr auto MainWindowStr    = gui::name::window::main_window;
+        inline constexpr auto DetailsWindowStr = "DetailsWindow";
+        inline constexpr auto DialogYesNoStr   = "DialogYesNo";
 
     } // namespace settings
 } // namespace calllog

--- a/module-apps/application-calllog/data/CallLogSwitchData.hpp
+++ b/module-apps/application-calllog/data/CallLogSwitchData.hpp
@@ -9,7 +9,7 @@
 namespace calllog
 {
 
-    const inline std::string CALLLOG_SWITCH_DATA_STR = "CallLogSwitchData";
+    inline constexpr auto CALLLOG_SWITCH_DATA_STR = "CallLogSwitchData";
 
     class CallLogSwitchData : public gui::SwitchData
     {

--- a/module-apps/application-desktop/ApplicationDesktop.hpp
+++ b/module-apps/application-desktop/ApplicationDesktop.hpp
@@ -17,7 +17,7 @@
 
 namespace app
 {
-    inline const std::string name_desktop = "ApplicationDesktop";
+    inline constexpr auto name_desktop = "ApplicationDesktop";
 
     class ApplicationDesktop : public Application
     {

--- a/module-apps/application-desktop/windows/Names.hpp
+++ b/module-apps/application-desktop/windows/Names.hpp
@@ -3,15 +3,14 @@
 
 #pragma once
 #include "AppWindow.hpp"
-#include <string>
 
 namespace app::window::name
 {
-    inline const std::string desktop_main_window = gui::name::window::main_window;
-    inline const std::string desktop_menu        = "MenuWindow";
-    inline const std::string desktop_reboot      = "Reboot";
-    inline const std::string desktop_poweroff    = "PowerOffWindow";
-    inline const std::string desktop_pin_lock    = "PinLockWindow";
-    inline const std::string desktop_locked      = "LockedInfoWindow";
-    inline const std::string desktop_update      = "Update";
+    inline constexpr auto desktop_main_window = gui::name::window::main_window;
+    inline constexpr auto desktop_menu        = "MenuWindow";
+    inline constexpr auto desktop_reboot      = "Reboot";
+    inline constexpr auto desktop_poweroff    = "PowerOffWindow";
+    inline constexpr auto desktop_pin_lock    = "PinLockWindow";
+    inline constexpr auto desktop_locked      = "LockedInfoWindow";
+    inline constexpr auto desktop_update      = "Update";
 }; // namespace app::window::name

--- a/module-apps/application-meditation/ApplicationMeditation.hpp
+++ b/module-apps/application-meditation/ApplicationMeditation.hpp
@@ -10,7 +10,7 @@
 
 namespace app
 {
-    inline const std::string name_meditation = "ApplicationMeditation";
+    inline constexpr auto name_meditation = "ApplicationMeditation";
 
     class ApplicationMeditation : public Application
     {

--- a/module-apps/application-meditation/windows/Names.hpp
+++ b/module-apps/application-meditation/windows/Names.hpp
@@ -7,8 +7,8 @@
 
 namespace app::window::name
 {
-    inline const std::string meditation_main_window = gui::name::window::main_window;
-    inline const std::string meditation_options     = "Options";
-    inline const std::string meditation_preparation = "Preparation";
-    inline const std::string meditation_timer       = "Timer";
+    inline constexpr auto meditation_main_window = gui::name::window::main_window;
+    inline constexpr auto meditation_options     = "Options";
+    inline constexpr auto meditation_preparation = "Preparation";
+    inline constexpr auto meditation_timer       = "Timer";
 }; // namespace app::window::name

--- a/module-apps/application-messages/ApplicationMessages.hpp
+++ b/module-apps/application-messages/ApplicationMessages.hpp
@@ -18,13 +18,13 @@ namespace gui
     {
         namespace window
         {
-            inline const std::string dialog_yes_no     = "DialogYesNo";
-            inline const std::string dialog_confirm    = "DialogConfirm";
-            inline const std::string dialog            = "Dialog";
-            inline const std::string new_sms           = "NewSMS";
-            inline const std::string thread_sms_search = "SMSSearch";
-            inline const std::string sms_templates     = "SMSTemplates";
-            inline const std::string thread_view       = "ThreadViewWindow";
+            inline constexpr auto dialog_yes_no     = "DialogYesNo";
+            inline constexpr auto dialog_confirm    = "DialogConfirm";
+            inline constexpr auto dialog            = "Dialog";
+            inline constexpr auto new_sms           = "NewSMS";
+            inline constexpr auto thread_sms_search = "SMSSearch";
+            inline constexpr auto sms_templates     = "SMSTemplates";
+            inline constexpr auto thread_view       = "ThreadViewWindow";
 
         }; // namespace window
     };     // namespace name
@@ -33,7 +33,7 @@ namespace gui
 namespace app
 {
 
-    inline const std::string name_messages = "ApplicationMessages";
+    inline constexpr auto name_messages = "ApplicationMessages";
 
     class ApplicationMessages : public app::Application
     {

--- a/module-apps/application-messages/data/MessagesStyle.hpp
+++ b/module-apps/application-messages/data/MessagesStyle.hpp
@@ -9,102 +9,102 @@ namespace style
     {
         namespace threads
         {
-            constexpr uint32_t listPositionX = style::window::default_left_margin;
+            inline constexpr uint32_t listPositionX = style::window::default_left_margin;
             // Magic 1 -> discussed with Design for proper alignment.
-            constexpr uint32_t ListPositionY = style::header::height - 1;
+            inline constexpr uint32_t ListPositionY = style::header::height - 1;
             // Bottom margin need to be added to fit all elements.
-            constexpr uint32_t listHeight =
+            inline constexpr uint32_t listHeight =
                 style::window_height - ListPositionY - style::footer::height + style::margins::small;
-            constexpr uint32_t listWidth = style::listview::body_width_with_scroll;
+            inline constexpr uint32_t listWidth = style::listview::body_width_with_scroll;
         } // namespace threads
 
         namespace threadItem
         {
-            constexpr uint32_t sms_thread_item_h = 100;
+            inline constexpr uint32_t sms_thread_item_h = 100;
 
-            constexpr uint32_t topMargin    = 16;
-            constexpr uint32_t bottomMargin = 13;
+            inline constexpr uint32_t topMargin    = 16;
+            inline constexpr uint32_t bottomMargin = 13;
 
-            constexpr uint32_t leftMargin  = 10;
-            constexpr uint32_t rightMargin = 10;
+            inline constexpr uint32_t leftMargin  = 10;
+            inline constexpr uint32_t rightMargin = 10;
 
-            constexpr uint32_t timestampWidth             = 100;
-            constexpr uint32_t numberImportanceWidth      = 80;
-            constexpr uint32_t numberImportanceLeftMargin = 10;
-            constexpr uint32_t cotactWidthOffset          = timestampWidth + leftMargin + rightMargin;
-            constexpr uint32_t notSentIconWidth           = 20;
+            inline constexpr uint32_t timestampWidth             = 100;
+            inline constexpr uint32_t numberImportanceWidth      = 80;
+            inline constexpr uint32_t numberImportanceLeftMargin = 10;
+            inline constexpr uint32_t cotactWidthOffset          = timestampWidth + leftMargin + rightMargin;
+            inline constexpr uint32_t notSentIconWidth           = 20;
 
-            constexpr uint32_t previewWidthOffset = leftMargin + rightMargin + 10;
+            inline constexpr uint32_t previewWidthOffset = leftMargin + rightMargin + 10;
         } // namespace threadItem
 
         namespace newMessage
         {
             namespace recipientLabel
             {
-                constexpr uint32_t h = 42;
+                inline constexpr uint32_t h = 42;
             }
             namespace recipientImg
             {
-                constexpr uint32_t w = 32, h = 32;
+                inline constexpr uint32_t w = 32, h = 32;
             }
             namespace text
             {
-                constexpr uint32_t h = 43;
+                inline constexpr uint32_t h = 43;
             }
             namespace messageLabel
             {
-                constexpr uint32_t h = 44;
+                inline constexpr uint32_t h = 44;
             }
         } // namespace newMessage
 
         namespace smsInput
         {
-            constexpr gui::Length min_h                   = 40;
-            constexpr gui::Length default_input_w         = 395;
-            constexpr gui::Length default_input_h         = 30;
-            constexpr gui::Length bottom_padding          = 5;
-            constexpr gui::Length max_input_h             = default_input_h * 4 + bottom_padding;
-            constexpr gui::Length reply_bottom_margin     = 5;
-            constexpr gui::Length new_sms_vertical_spacer = 25;
+            inline constexpr gui::Length min_h                   = 40;
+            inline constexpr gui::Length default_input_w         = 395;
+            inline constexpr gui::Length default_input_h         = 30;
+            inline constexpr gui::Length bottom_padding          = 5;
+            inline constexpr gui::Length max_input_h             = default_input_h * 4 + bottom_padding;
+            inline constexpr gui::Length reply_bottom_margin     = 5;
+            inline constexpr gui::Length new_sms_vertical_spacer = 25;
         } // namespace smsInput
 
         namespace smsOutput
         {
-            constexpr gui::Length sms_radius                   = 8;
-            constexpr gui::Length default_h                    = 30;
-            constexpr gui::Length sms_max_width                = 320;
-            constexpr gui::Length sms_h_padding                = 15;
-            constexpr gui::Length sms_h_big_padding            = 25;
-            constexpr gui::Length sms_v_padding                = 10;
-            constexpr gui::Length sms_vertical_spacer          = 10;
-            constexpr gui::Length sms_error_icon_left_margin   = 5;
-            constexpr gui::Length sms_error_icon_right_margin  = 2;
-            const inline gui::Padding sms_left_bubble_padding  = gui::Padding(smsOutput::sms_h_big_padding,
-                                                                             smsOutput::sms_v_padding,
-                                                                             smsOutput::sms_h_padding,
-                                                                             smsOutput::sms_v_padding);
-            const inline gui::Padding sms_right_bubble_padding = gui::Padding(smsOutput::sms_h_padding,
-                                                                              smsOutput::sms_v_padding,
-                                                                              smsOutput::sms_h_big_padding,
-                                                                              smsOutput::sms_v_padding);
+            inline constexpr gui::Length sms_radius                  = 8;
+            inline constexpr gui::Length default_h                   = 30;
+            inline constexpr gui::Length sms_max_width               = 320;
+            inline constexpr gui::Length sms_h_padding               = 15;
+            inline constexpr gui::Length sms_h_big_padding           = 25;
+            inline constexpr gui::Length sms_v_padding               = 10;
+            inline constexpr gui::Length sms_vertical_spacer         = 10;
+            inline constexpr gui::Length sms_error_icon_left_margin  = 5;
+            inline constexpr gui::Length sms_error_icon_right_margin = 2;
+            inline constexpr gui::Padding sms_left_bubble_padding    = gui::Padding(smsOutput::sms_h_big_padding,
+                                                                                 smsOutput::sms_v_padding,
+                                                                                 smsOutput::sms_h_padding,
+                                                                                 smsOutput::sms_v_padding);
+            inline constexpr gui::Padding sms_right_bubble_padding   = gui::Padding(smsOutput::sms_h_padding,
+                                                                                  smsOutput::sms_v_padding,
+                                                                                  smsOutput::sms_h_big_padding,
+                                                                                  smsOutput::sms_v_padding);
         } // namespace smsOutput
 
         namespace smsList
         {
-            constexpr uint32_t x = style::window::default_left_margin;
-            constexpr uint32_t y = style::header::height;
-            constexpr uint32_t h = style::window::default_body_height;
-            constexpr uint32_t w = style::listview::body_width_with_scroll;
+            inline constexpr uint32_t x = style::window::default_left_margin;
+            inline constexpr uint32_t y = style::header::height;
+            inline constexpr uint32_t h = style::window::default_body_height;
+            inline constexpr uint32_t w = style::listview::body_width_with_scroll;
         } // namespace smsList
 
         namespace templates
         {
             namespace list
             {
-                constexpr uint32_t x = style::window::default_left_margin;
-                constexpr uint32_t y = style::header::height;
-                constexpr uint32_t h = style::window_height - y - style::footer::height;
-                constexpr uint32_t w = style::listview::body_width_with_scroll;
+                inline constexpr uint32_t x = style::window::default_left_margin;
+                inline constexpr uint32_t y = style::header::height;
+                inline constexpr uint32_t h = style::window_height - y - style::footer::height;
+                inline constexpr uint32_t w = style::listview::body_width_with_scroll;
 
             } // namespace list
         }     // namespace templates

--- a/module-apps/application-messages/widgets/ThreadItem.hpp
+++ b/module-apps/application-messages/widgets/ThreadItem.hpp
@@ -46,7 +46,7 @@ namespace gui
 
     class ThreadItemNotRead : public ThreadItemWithIndicator
     {
-        static const inline UTF8 indicatorName = "dot_12px_hard_alpha_W_M";
+        static constexpr auto indicatorName = "dot_12px_hard_alpha_W_M";
 
       public:
         ThreadItemNotRead();

--- a/module-apps/application-messages/windows/SearchResults.hpp
+++ b/module-apps/application-messages/windows/SearchResults.hpp
@@ -12,7 +12,7 @@ namespace gui
 {
     namespace name::window
     {
-        inline std::string search_results = "SearchResults";
+        inline constexpr auto search_results = "SearchResults";
     }
 
     class SearchResults : public AppWindow

--- a/module-apps/application-music-player/ApplicationMusicPlayer.hpp
+++ b/module-apps/application-music-player/ApplicationMusicPlayer.hpp
@@ -12,16 +12,16 @@ namespace gui
     {
         namespace window
         {
-            inline const std::string all_songs_window = "All Songs";
-            inline const std::string player_window    = "Player";
-            inline const std::string empty_window     = "Empty";
+            inline constexpr auto all_songs_window = "All Songs";
+            inline constexpr auto player_window    = "Player";
+            inline constexpr auto empty_window     = "Empty";
         }; // namespace window
     };     // namespace name
 };         // namespace gui
 
 namespace app
 {
-    const inline std::string name_music_player = "ApplicationMusicPlayer";
+    inline constexpr auto name_music_player = "ApplicationMusicPlayer";
 
     class ApplicationMusicPlayer : public Application
     {

--- a/module-apps/application-music-player/widgets/Action.hpp
+++ b/module-apps/application-music-player/widgets/Action.hpp
@@ -20,8 +20,8 @@ namespace gui
 
         using StateMap = std::map<const State, const std::string>;
 
-        static const inline std::string play  = "play";
-        static const inline std::string pause = "pause";
+        static constexpr auto play            = "play";
+        static constexpr auto pause           = "pause";
         static const inline StateMap stateMap = {{State::Play, play}, {State::Pause, pause}};
 
         void setState(State state);

--- a/module-apps/application-notes/ApplicationNotes.hpp
+++ b/module-apps/application-notes/ApplicationNotes.hpp
@@ -9,7 +9,7 @@
 
 namespace app
 {
-    inline const std::string name_notes = "ApplicationNotes";
+    inline constexpr auto name_notes = "ApplicationNotes";
 
     class ApplicationNotes : public Application
     {

--- a/module-apps/application-phonebook/ApplicationPhonebook.hpp
+++ b/module-apps/application-phonebook/ApplicationPhonebook.hpp
@@ -9,23 +9,23 @@
 
 namespace gui::window::name
 {
-    inline const std::string contact          = "Contact";
-    inline const std::string contact_options  = "Options";
-    inline const std::string namecard_options = "Namecard Options";
-    inline const std::string new_contact      = "New";
-    inline const std::string search           = "Search";
-    inline const std::string search_results   = "SearchResults";
-    inline const std::string dialog_yes_no    = "DialogYesNo";
-    inline const std::string dialog_confirm   = "DialogConfirm";
-    inline const std::string dialog           = "Dialog";
-    inline const std::string dialog_yes_no_icon_txt = "DialogYesNoIconTxt";
-    inline const std::string ice_contacts           = "IceContacts";
+    inline constexpr auto contact                = "Contact";
+    inline constexpr auto contact_options        = "Options";
+    inline constexpr auto namecard_options       = "Namecard Options";
+    inline constexpr auto new_contact            = "New";
+    inline constexpr auto search                 = "Search";
+    inline constexpr auto search_results         = "SearchResults";
+    inline constexpr auto dialog_yes_no          = "DialogYesNo";
+    inline constexpr auto dialog_confirm         = "DialogConfirm";
+    inline constexpr auto dialog                 = "Dialog";
+    inline constexpr auto dialog_yes_no_icon_txt = "DialogYesNoIconTxt";
+    inline constexpr auto ice_contacts           = "IceContacts";
 
 } // namespace gui::window::name
 
 namespace app
 {
-    const inline std::string name_phonebook      = "ApplicationPhonebook";
+    inline constexpr auto name_phonebook         = "ApplicationPhonebook";
     constexpr std::uint16_t phonebook_stack_size = 8192;
 
     class ApplicationPhonebook : public app::Application

--- a/module-apps/application-phonebook/data/PhonebookStyle.hpp
+++ b/module-apps/application-phonebook/data/PhonebookStyle.hpp
@@ -9,44 +9,44 @@ namespace phonebookStyle
 {
     namespace mainWindow
     {
-        constexpr uint32_t default_x = style::window::default_left_margin;
-        constexpr uint32_t default_w =
+        inline constexpr uint32_t default_x = style::window::default_left_margin;
+        inline constexpr uint32_t default_w =
             style::window_width - style::window::default_left_margin - style::window::default_right_margin;
         namespace leftArrowImage
         {
-            constexpr uint32_t x = default_x;
-            constexpr uint32_t y = 62;
-            constexpr uint32_t w = 11;
-            constexpr uint32_t h = 13;
+            inline constexpr uint32_t x = default_x;
+            inline constexpr uint32_t y = 62;
+            inline constexpr uint32_t w = 11;
+            inline constexpr uint32_t h = 13;
         } // namespace leftArrowImage
         namespace rightArrowImage
         {
-            constexpr uint32_t x = style::window_width - style::window::default_left_margin - 11;
-            constexpr uint32_t y = 62;
-            constexpr uint32_t w = 11;
-            constexpr uint32_t h = 13;
+            inline constexpr uint32_t x = style::window_width - style::window::default_left_margin - 11;
+            inline constexpr uint32_t y = 62;
+            inline constexpr uint32_t w = 11;
+            inline constexpr uint32_t h = 13;
         } // namespace rightArrowImage
         namespace newContactImage
         {
-            constexpr uint32_t x = style::window::default_left_margin + 20;
-            constexpr uint32_t y = 55;
-            constexpr uint32_t w = 24;
-            constexpr uint32_t h = 24;
+            inline constexpr uint32_t x = style::window::default_left_margin + 20;
+            inline constexpr uint32_t y = 55;
+            inline constexpr uint32_t w = 24;
+            inline constexpr uint32_t h = 24;
         } // namespace newContactImage
         namespace searchImage
         {
-            constexpr uint32_t x =
+            inline constexpr uint32_t x =
                 style::window_width - style::window::default_left_margin - rightArrowImage::w - 8 - 26;
-            constexpr uint32_t y = 55;
-            constexpr uint32_t w = 26;
-            constexpr uint32_t h = 26;
+            inline constexpr uint32_t y = 55;
+            inline constexpr uint32_t w = 26;
+            inline constexpr uint32_t h = 26;
         } // namespace searchImage
         namespace contactsList
         {
-            constexpr uint32_t x = style::window::default_left_margin;
-            constexpr uint32_t y = style::header::height;
-            constexpr uint32_t w = style::listview::body_width_with_scroll;
-            constexpr uint32_t h = style::window_height - y - style::footer::height;
+            inline constexpr uint32_t x = style::window::default_left_margin;
+            inline constexpr uint32_t y = style::header::height;
+            inline constexpr uint32_t w = style::listview::body_width_with_scroll;
+            inline constexpr uint32_t h = style::window_height - y - style::footer::height;
         } // namespace contactsList
     }     // namespace mainWindow
 
@@ -54,10 +54,10 @@ namespace phonebookStyle
     {
         namespace newContactsList
         {
-            constexpr uint32_t x = style::window::default_left_margin;
-            constexpr uint32_t y = style::header::height;
-            constexpr uint32_t w = style::listview::body_width_with_scroll;
-            constexpr uint32_t h = style::window_height - y - style::footer::height;
+            inline constexpr uint32_t x = style::window::default_left_margin;
+            inline constexpr uint32_t y = style::header::height;
+            inline constexpr uint32_t w = style::listview::body_width_with_scroll;
+            inline constexpr uint32_t h = style::window_height - y - style::footer::height;
         } // namespace newContactsList
     }     // namespace newContactWindow
 
@@ -65,17 +65,17 @@ namespace phonebookStyle
     {
         namespace contactDetailsList
         {
-            constexpr uint32_t x = style::window::default_left_margin;
-            constexpr uint32_t y = style::header::height + 74;
-            constexpr uint32_t w = style::listview::body_width_with_scroll;
-            constexpr uint32_t h = style::window_height - y - style::footer::height;
+            inline constexpr uint32_t x = style::window::default_left_margin;
+            inline constexpr uint32_t y = style::header::height + 74;
+            inline constexpr uint32_t w = style::listview::body_width_with_scroll;
+            inline constexpr uint32_t h = style::window_height - y - style::footer::height;
         } // namespace contactDetailsList
         namespace contactDetailsListNoFlags
         {
-            constexpr uint32_t x = style::window::default_left_margin;
-            constexpr uint32_t y = style::header::height;
-            constexpr uint32_t w = style::listview::body_width_with_scroll;
-            constexpr uint32_t h = style::window_height - y - style::footer::height;
+            inline constexpr uint32_t x = style::window::default_left_margin;
+            inline constexpr uint32_t y = style::header::height;
+            inline constexpr uint32_t w = style::listview::body_width_with_scroll;
+            inline constexpr uint32_t h = style::window_height - y - style::footer::height;
         } // namespace contactDetailsListNoFlags
 
     } // namespace contactDetailsWindow
@@ -84,10 +84,10 @@ namespace phonebookStyle
     {
         namespace searchResultList
         {
-            constexpr uint32_t x = style::window::default_left_margin;
-            constexpr uint32_t y = style::header::height;
-            constexpr uint32_t w = style::listview::body_width_with_scroll;
-            constexpr uint32_t h = style::window_height - y - style::footer::height;
+            inline constexpr uint32_t x = style::window::default_left_margin;
+            inline constexpr uint32_t y = style::header::height;
+            inline constexpr uint32_t w = style::listview::body_width_with_scroll;
+            inline constexpr uint32_t h = style::window_height - y - style::footer::height;
         } // namespace searchResultList
     }     // namespace searchResultsWindow
 
@@ -95,75 +95,75 @@ namespace phonebookStyle
     {
         namespace contactsListIce
         {
-            constexpr uint32_t x = style::window::default_left_margin;
-            constexpr uint32_t y = style::header::height;
-            constexpr uint32_t w = style::listview::body_width_with_scroll;
-            constexpr uint32_t h = style::window_height - y - style::footer::height;
+            inline constexpr uint32_t x = style::window::default_left_margin;
+            inline constexpr uint32_t y = style::header::height;
+            inline constexpr uint32_t w = style::listview::body_width_with_scroll;
+            inline constexpr uint32_t h = style::window_height - y - style::footer::height;
         } // namespace contactsListIce
     }     // namespace iceContactsWindow
 
     namespace contactItem
     {
-        constexpr uint32_t w                    = style::window::default_body_width;
-        constexpr uint32_t h                    = style::window::label::big_h;
-        constexpr uint32_t blocked_right_margin = 5;
-        const UTF8 favourites_string            = "Favourites";
+        inline constexpr uint32_t w                    = style::window::default_body_width;
+        inline constexpr uint32_t h                    = style::window::label::big_h;
+        inline constexpr uint32_t blocked_right_margin = 5;
+        inline constexpr auto favourites_string        = "Favourites";
     } // namespace contactItem
 
     namespace informationWidget
     {
-        constexpr uint32_t w             = style::window::default_body_width;
-        constexpr uint32_t title_label_h = 20;
-        constexpr uint32_t email_text_h  = 35;
+        inline constexpr uint32_t w             = style::window::default_body_width;
+        inline constexpr uint32_t title_label_h = 20;
+        inline constexpr uint32_t email_text_h  = 35;
     } // namespace informationWidget
 
     namespace inputBoxWithLabelAndIconIWidget
     {
-        constexpr uint32_t w = style::window::default_body_width;
-        constexpr uint32_t h = 50;
+        inline constexpr uint32_t w = style::window::default_body_width;
+        inline constexpr uint32_t h = 50;
 
-        constexpr uint32_t input_box_w           = 55;
-        constexpr uint32_t input_box_h           = h;
-        constexpr int32_t input_box_right_margin = 20;
+        inline constexpr uint32_t input_box_w           = 55;
+        inline constexpr uint32_t input_box_h           = h;
+        inline constexpr int32_t input_box_right_margin = 20;
 
-        constexpr uint32_t description_label_w           = 280;
-        constexpr uint32_t description_label_h           = 33;
-        constexpr int32_t description_label_right_margin = 40;
+        inline constexpr uint32_t description_label_w           = 280;
+        inline constexpr uint32_t description_label_h           = 33;
+        inline constexpr int32_t description_label_right_margin = 40;
 
-        constexpr int32_t tick_image_left_margin  = -64;
-        constexpr int32_t tick_image_right_margin = 32;
+        inline constexpr int32_t tick_image_left_margin  = -64;
+        inline constexpr int32_t tick_image_right_margin = 32;
 
     } // namespace inputBoxWithLabelAndIconIWidget
 
     namespace inputLinesWithLabelWidget
     {
-        constexpr uint32_t w                = style::window::default_body_width;
-        constexpr uint32_t h                = 63;
-        constexpr uint32_t title_label_h    = 20;
-        constexpr uint32_t input_text_h     = 37;
-        constexpr uint32_t span_size        = 6;
-        constexpr int32_t underline_padding = 4;
+        inline constexpr uint32_t w                = style::window::default_body_width;
+        inline constexpr uint32_t h                = 63;
+        inline constexpr uint32_t title_label_h    = 20;
+        inline constexpr uint32_t input_text_h     = 37;
+        inline constexpr uint32_t span_size        = 6;
+        inline constexpr int32_t underline_padding = 4;
     } // namespace inputLinesWithLabelWidget
 
     namespace outputLinesTextWithLabelWidget
     {
-        constexpr uint32_t w             = style::window::default_body_width;
-        constexpr uint32_t h             = 75;
-        constexpr uint32_t title_label_h = 20;
-        constexpr uint32_t input_text_h  = 33;
-        constexpr uint32_t span_size     = style::margins::huge;
+        inline constexpr uint32_t w             = style::window::default_body_width;
+        inline constexpr uint32_t h             = 75;
+        inline constexpr uint32_t title_label_h = 20;
+        inline constexpr uint32_t input_text_h  = 33;
+        inline constexpr uint32_t span_size     = style::margins::huge;
     } // namespace outputLinesTextWithLabelWidget
 
     namespace numbersWithIconsWidget
     {
-        constexpr uint32_t h                        = 55;
-        constexpr uint32_t sms_image_w              = 55;
-        constexpr uint32_t sms_image_h              = h;
-        constexpr uint32_t phone_image_w            = 55;
-        constexpr uint32_t phone_image_h            = h;
-        constexpr uint32_t phone_image_margin_left  = 30;
-        constexpr uint32_t phone_image_margin_right = 15;
-        constexpr uint32_t number_text_h            = h;
+        inline constexpr uint32_t h                        = 55;
+        inline constexpr uint32_t sms_image_w              = 55;
+        inline constexpr uint32_t sms_image_h              = h;
+        inline constexpr uint32_t phone_image_w            = 55;
+        inline constexpr uint32_t phone_image_h            = h;
+        inline constexpr uint32_t phone_image_margin_left  = 30;
+        inline constexpr uint32_t phone_image_margin_right = 15;
+        inline constexpr uint32_t number_text_h            = h;
     } // namespace numbersWithIconsWidget
 
 } // namespace phonebookStyle

--- a/module-apps/application-settings-new/ApplicationSettings.hpp
+++ b/module-apps/application-settings-new/ApplicationSettings.hpp
@@ -9,44 +9,43 @@
 
 namespace gui::window::name
 {
-    inline const std::string bluetooth   = "Bluetooth";
-    inline const std::string all_devices = "AllDevices";
-    inline const std::string phone_name  = "PhoneName";
-    inline const std::string add_device  = "AddDevice";
+    inline constexpr auto bluetooth   = "Bluetooth";
+    inline constexpr auto all_devices = "AllDevices";
+    inline constexpr auto phone_name  = "PhoneName";
+    inline constexpr auto add_device  = "AddDevice";
 
-    inline const std::string network        = "Network";
-    inline const std::string phone_modes    = "PhoneModes";
-    inline const std::string apps_and_tools = "AppsAndTools";
-    inline const std::string security       = "Security";
-    inline const std::string system         = "System";
+    inline constexpr auto network        = "Network";
+    inline constexpr auto phone_modes    = "PhoneModes";
+    inline constexpr auto apps_and_tools = "AppsAndTools";
+    inline constexpr auto security       = "Security";
+    inline constexpr auto system         = "System";
 
-    inline const std::string display_light  = "DisplayLight";
-    inline const std::string font_size      = "FontSize";
-    inline const std::string keypad_light   = "KeypadLight";
-    inline const std::string input_language = "InputLanguage";
-    inline const std::string locked_screen  = "LockedScreen";
+    inline constexpr auto display_light  = "DisplayLight";
+    inline constexpr auto font_size      = "FontSize";
+    inline constexpr auto keypad_light   = "KeypadLight";
+    inline constexpr auto input_language = "InputLanguage";
+    inline constexpr auto locked_screen  = "LockedScreen";
 
-    inline const std::string messages  = "Messages";
-    inline const std::string torch     = "Torch";
-    inline const std::string templates = "Templates";
+    inline constexpr auto messages  = "Messages";
+    inline constexpr auto torch     = "Torch";
+    inline constexpr auto templates = "Templates";
 
-    inline const std::string autolock  = "Autolock";
-    inline const std::string wallpaper = "Wallpaper";
-    inline const std::string quotes    = "Quotes";
-    inline const std::string new_quote = "NewQuote";
+    inline constexpr auto autolock  = "Autolock";
+    inline constexpr auto wallpaper = "Wallpaper";
+    inline constexpr auto quotes    = "Quotes";
+    inline constexpr auto new_quote = "NewQuote";
 
-    inline const std::string display_and_keypad = "DisplayAndKeypad";
-
-    inline const std::string change_settings = "ChangeSettings";
-    inline const std::string all_operators   = "AllOperators";
-    inline const std::string import_contacts = "ImportContacts";
-    inline const std::string dialog_settings = "DialogSettings";
+    inline constexpr auto display_and_keypad = "DisplayAndKeypad";
+    inline constexpr auto change_settings    = "ChangeSettings";
+    inline constexpr auto all_operators      = "AllOperators";
+    inline constexpr auto import_contacts    = "ImportContacts";
+    inline constexpr auto dialog_settings    = "DialogSettings";
 
 } // namespace gui::window::name
 
 namespace app
 {
-    inline const std::string name_settings_new = "ApplicationSettingsNew";
+    inline constexpr auto name_settings_new = "ApplicationSettingsNew";
 
     class ApplicationSettingsNew : public app::Application
     {

--- a/module-apps/application-settings-new/windows/NetworkWindow.hpp
+++ b/module-apps/application-settings-new/windows/NetworkWindow.hpp
@@ -11,7 +11,7 @@ namespace gui
 
     namespace window
     {
-        inline const std::string network_window = "Network";
+        inline constexpr auto network_window = "Network";
     };
 
     class NetworkWindow : public OptionWindow

--- a/module-apps/application-settings/ApplicationSettings.hpp
+++ b/module-apps/application-settings/ApplicationSettings.hpp
@@ -11,9 +11,9 @@
 namespace app
 {
 
-    inline const std::string name_settings  = "ApplicationSettings";
-    inline const std::string sim_select     = "SimSelect";
-    inline const std::string change_setting = "ChangeSetting";
+    inline constexpr auto name_settings  = "ApplicationSettings";
+    inline constexpr auto sim_select     = "SimSelect";
+    inline constexpr auto change_setting = "ChangeSetting";
 
     class ApplicationSettings : public app::Application
     {

--- a/module-apps/application-settings/windows/BtScanWindow.hpp
+++ b/module-apps/application-settings/windows/BtScanWindow.hpp
@@ -18,7 +18,7 @@ namespace gui
 {
     namespace name::window
     {
-        inline const std::string name_btscan = "BT_SCAN";
+        inline constexpr auto name_btscan = "BT_SCAN";
     }
 
     class BtScanWindow : public AppWindow

--- a/module-apps/application-settings/windows/CellularPassthroughWindow.hpp
+++ b/module-apps/application-settings/windows/CellularPassthroughWindow.hpp
@@ -15,18 +15,18 @@ namespace gui
     {
         namespace cellular_passthrough
         {
-            inline const std::string window_name = "CellularPassthroughWindow";
+            inline constexpr auto window_name = "CellularPassthroughWindow";
 
-            inline const UTF8 passNormalDescription = "Regular passthrough";
-            inline const UTF8 passNormalLabel       = "ON";
+            inline constexpr auto passNormalDescription = "Regular passthrough";
+            inline constexpr auto passNormalLabel       = "ON";
 
-            inline const UTF8 passDFUDescription = "Firmware Upgrade";
-            inline const UTF8 passDFULabel       = "ON (upgrade)";
-            inline const UTF8 passDFUNote        = "Reset modem with 2*PWR_KEY";
+            inline constexpr auto passDFUDescription = "Firmware Upgrade";
+            inline constexpr auto passDFULabel       = "ON (upgrade)";
+            inline constexpr auto passDFUNote        = "Reset modem with 2*PWR_KEY";
 
-            inline const UTF8 noPassDescription = "Disable passthrough";
-            inline const UTF8 noPassLabel       = "OFF";
-            inline const UTF8 noPassNote        = "Reset modem hard. (battery out)";
+            inline constexpr auto noPassDescription = "Disable passthrough";
+            inline constexpr auto noPassLabel       = "OFF";
+            inline constexpr auto noPassNote        = "Reset modem hard. (battery out)";
         } // namespace cellular_passthrough
     }     // namespace window
 

--- a/module-apps/application-settings/windows/EinkModeWindow.hpp
+++ b/module-apps/application-settings/windows/EinkModeWindow.hpp
@@ -2,7 +2,6 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 #pragma once
 
-#include <string>
 #include <functional>
 
 #include "AppWindow.hpp"
@@ -16,7 +15,7 @@ namespace gui
 {
     namespace window::name
     {
-        inline const std::string eink = "EinkModeWindow";
+        inline constexpr auto eink = "EinkModeWindow";
     } // namespace window::name
 
     class EinkModeWindow : public AppWindow

--- a/module-apps/application-settings/windows/FotaWindow.hpp
+++ b/module-apps/application-settings/windows/FotaWindow.hpp
@@ -22,7 +22,7 @@ namespace gui
     {
         namespace name
         {
-            inline const std::string fota_window = "fota_window";
+            inline constexpr auto fota_window = "fota_window";
         } // namespace name
     }     // namespace window
     /** @brief Window managing modem firmware update

--- a/module-apps/application-settings/windows/Info.hpp
+++ b/module-apps/application-settings/windows/Info.hpp
@@ -18,7 +18,7 @@ namespace gui
 
     namespace window
     {
-        inline const std::string hw_info = "hw_info";
+        inline constexpr auto hw_info = "hw_info";
     };
 
     class Info : public AppWindow

--- a/module-apps/application-settings/windows/USSDWindow.hpp
+++ b/module-apps/application-settings/windows/USSDWindow.hpp
@@ -19,7 +19,7 @@ namespace gui
     {
         namespace name
         {
-            inline const std::string ussd_window = "ussd_window";
+            inline constexpr auto ussd_window = "ussd_window";
         } // namespace name
     }     // namespace window
     class USSDWindow : public AppWindow

--- a/module-apps/application-special-input/ApplicationSpecialInput.hpp
+++ b/module-apps/application-special-input/ApplicationSpecialInput.hpp
@@ -10,8 +10,8 @@
 namespace app
 {
 
-    inline const std::string special_input = "ApplicationSpecialInput";
-    inline const std::string char_select   = gui::name::window::main_window;
+    inline constexpr auto special_input = "ApplicationSpecialInput";
+    inline constexpr auto char_select   = gui::name::window::main_window;
 
     // app just to provide input selection on UI
     class ApplicationSpecialInput : public app::Application

--- a/module-apps/windows/AppWindow.hpp
+++ b/module-apps/windows/AppWindow.hpp
@@ -21,8 +21,8 @@ namespace gui
     {
         namespace window
         {
-            const inline std::string main_window = "MainWindow";
-            const inline std::string no_window   = "";
+            inline constexpr auto main_window = "MainWindow";
+            inline constexpr auto no_window   = "";
         } // namespace window
     }     // namespace name
 

--- a/module-audio/Audio/AudioCommon.hpp
+++ b/module-audio/Audio/AudioCommon.hpp
@@ -15,20 +15,20 @@ namespace audio
 
 namespace audio
 {
-    constexpr Volume defaultVolumeStep = 1;
-    constexpr Gain defaultGainStep     = 10;
-    constexpr Volume defaultVolume     = 5;
-    constexpr Gain defaultGain         = 5;
+    inline constexpr Volume defaultVolumeStep = 1;
+    inline constexpr Gain defaultGainStep     = 10;
+    inline constexpr Volume defaultVolume     = 5;
+    inline constexpr Gain defaultGain         = 5;
 
-    constexpr Volume maxVolume = 10;
-    constexpr Volume minVolume = 0;
+    inline constexpr Volume maxVolume = 10;
+    inline constexpr Volume minVolume = 0;
 
-    constexpr Gain maxGain = 100;
-    constexpr Gain minGain = 0;
+    inline constexpr Gain maxGain = 100;
+    inline constexpr Gain minGain = 0;
 
-    constexpr uint32_t audioOperationTimeout = 1000;
+    inline constexpr auto audioOperationTimeout = 1000U;
 
-    static const std::string audioDbPrefix = "audio/";
+    inline constexpr auto audioDbPrefix = "audio/";
 
     enum class Setting
     {

--- a/module-gui/gui/core/FontManager.cpp
+++ b/module-gui/gui/core/FontManager.cpp
@@ -10,7 +10,7 @@
 
 namespace style::window::font
 {
-    const inline std::string default_fallback_font = "dejavu_sans_bold_27";
+    inline constexpr auto default_fallback_font = "dejavu_sans_bold_27";
 }
 
 namespace gui

--- a/module-gui/gui/widgets/Alignment.cpp
+++ b/module-gui/gui/widgets/Alignment.cpp
@@ -6,15 +6,6 @@
 namespace gui
 {
 
-    Alignment::Alignment(Alignment::Horizontal valH, Alignment::Vertical valV) : horizontal(valH), vertical(valV)
-    {}
-
-    Alignment::Alignment(Alignment::Horizontal valH) : horizontal(valH)
-    {}
-
-    Alignment::Alignment(Alignment::Vertical valV) : vertical(valV)
-    {}
-
     bool Alignment::operator==(const Alignment &alignment) const
     {
         return !(horizontal != alignment.horizontal || vertical != alignment.vertical);

--- a/module-gui/gui/widgets/Alignment.hpp
+++ b/module-gui/gui/widgets/Alignment.hpp
@@ -30,11 +30,16 @@ namespace gui
         Horizontal horizontal = Alignment::Horizontal::Left;
         Vertical vertical     = Alignment::Vertical::Top;
 
-        Alignment()                  = default;
-        Alignment(const Alignment &) = default;
-        Alignment(Horizontal valH, Vertical valV);
-        Alignment(Horizontal valH);
-        Alignment(Vertical valV);
+        constexpr Alignment() = default;
+
+        constexpr Alignment(Horizontal valH, Vertical valV) : horizontal(valH), vertical(valV)
+        {}
+
+        constexpr Alignment(Horizontal valH) : horizontal(valH)
+        {}
+
+        constexpr Alignment(Vertical valV) : vertical(valV)
+        {}
 
         [[nodiscard]] Position calculateHAlignment(Length parentSize, Length childSize) const;
         [[nodiscard]] Position calculateVAlignment(Length parentSize, Length childSize) const;

--- a/module-gui/gui/widgets/Margins.cpp
+++ b/module-gui/gui/widgets/Margins.cpp
@@ -14,16 +14,6 @@
 namespace gui
 {
 
-    Margins::Margins() : left{0}, top{0}, right{0}, bottom{0}
-    {}
-
-    Margins::Margins(const short left, const short top, const short right, const short bottom)
-        : left{left}, top{top}, right{right}, bottom{bottom}
-    {}
-
-    Margins::~Margins()
-    {}
-
     short Margins::getSumInAxis(gui::Axis axis) const
     {
         switch (axis) {

--- a/module-gui/gui/widgets/Margins.hpp
+++ b/module-gui/gui/widgets/Margins.hpp
@@ -18,9 +18,12 @@ namespace gui
       public:
         short left, top, right, bottom;
 
-        Margins();
-        Margins(const short left, const short top, const short right, const short bottom);
-        virtual ~Margins();
+        constexpr Margins() : left{0}, top{0}, right{0}, bottom{0}
+        {}
+
+        constexpr Margins(const short left, const short top, const short right, const short bottom)
+            : left{left}, top{top}, right{right}, bottom{bottom}
+        {}
 
         [[nodiscard]] short getSumInAxis(Axis axis) const;
         [[nodiscard]] short getMarginInAxis(Axis axis, MarginInAxis pos) const;
@@ -31,4 +34,3 @@ namespace gui
     using Padding = Margins;
 
 } /* namespace gui */
-

--- a/module-gui/gui/widgets/Style.hpp
+++ b/module-gui/gui/widgets/Style.hpp
@@ -3,12 +3,10 @@
 
 #pragma once
 
+#include <gui/core/Color.hpp>
+#include <gui/Common.hpp>
 #include <Alignment.hpp>
 #include <Margins.hpp>
-#include <gui/core/Color.hpp>
-#include <inttypes.h>
-#include <string>
-#include <gui/Common.hpp>
 
 namespace gui
 {
@@ -19,64 +17,64 @@ namespace gui
 /// one place to gather all common magical numbers from design
 namespace style
 {
-    const inline uint32_t window_height = 600;
-    const inline uint32_t window_width  = 480;
+    inline constexpr auto window_height = 600U;
+    inline constexpr auto window_width  = 480U;
     namespace header
     {
-        const inline uint32_t height = 105;
+        inline constexpr auto height = 105U;
         namespace font
         {
-            const inline std::string time  = "gt_pressura_regular_24";
-            const inline std::string modes = "gt_pressura_regular_20";
-            const inline std::string title = "gt_pressura_bold_32";
+            inline constexpr auto time  = "gt_pressura_regular_24";
+            inline constexpr auto modes = "gt_pressura_regular_20";
+            inline constexpr auto title = "gt_pressura_bold_32";
         }; // namespace font
     };     // namespace header
 
     namespace footer
     {
-        const inline uint32_t height = 54;
+        inline constexpr auto height = 54U;
         namespace font
         {
-            const inline std::string bold   = "gt_pressura_bold_24";
-            const inline std::string medium = "gt_pressura_regular_24";
+            inline constexpr auto bold   = "gt_pressura_bold_24";
+            inline constexpr auto medium = "gt_pressura_regular_24";
         }; // namespace font
     };     // namespace footer
 
     namespace window
     {
-        const inline uint32_t default_left_margin  = 20;
-        const inline uint32_t default_right_margin = 20;
-        const inline uint32_t default_body_width =
+        inline constexpr auto default_left_margin  = 20U;
+        inline constexpr auto default_right_margin = 20U;
+        inline constexpr auto default_body_width =
             style::window_width - style::window::default_right_margin - style::window::default_left_margin;
-        const inline uint32_t default_body_height =
+        inline constexpr auto default_body_height =
             style::window_height - style::header::height - style::footer::height;
-        const inline uint32_t default_border_focus_w       = 2;
-        const inline uint32_t default_border_rect_no_focus = 1;
-        const inline uint32_t default_border_no_focus_w    = 0;
-        const inline uint32_t default_rect_yaps            = 10;
+        inline constexpr auto default_border_focus_w       = 2U;
+        inline constexpr auto default_border_rect_no_focus = 1U;
+        inline constexpr auto default_border_no_focus_w    = 0U;
+        inline constexpr auto default_rect_yaps            = 10U;
         namespace font
         {
-            const inline std::string supersizemelight = "gt_pressura_light_90";
-            const inline std::string largelight       = "gt_pressura_light_46";
-            const inline std::string verybigbold      = "gt_pressura_bold_32";
-            const inline std::string bigbold          = "gt_pressura_bold_30";
-            const inline std::string big              = "gt_pressura_regular_30";
-            const inline std::string biglight         = "gt_pressura_light_30";
-            const inline std::string mediumbold       = "gt_pressura_bold_27";
-            const inline std::string medium           = "gt_pressura_regular_27";
-            const inline std::string mediumlight      = "gt_pressura_light_27";
-            const inline std::string smallbold        = "gt_pressura_bold_24";
-            const inline std::string small            = "gt_pressura_regular_24";
-            const inline std::string verysmallbold    = "gt_pressura_bold_20";
-            const inline std::string verysmall        = "gt_pressura_regular_20";
+            inline constexpr auto supersizemelight = "gt_pressura_light_90";
+            inline constexpr auto largelight       = "gt_pressura_light_46";
+            inline constexpr auto verybigbold      = "gt_pressura_bold_32";
+            inline constexpr auto bigbold          = "gt_pressura_bold_30";
+            inline constexpr auto big              = "gt_pressura_regular_30";
+            inline constexpr auto biglight         = "gt_pressura_light_30";
+            inline constexpr auto mediumbold       = "gt_pressura_bold_27";
+            inline constexpr auto medium           = "gt_pressura_regular_27";
+            inline constexpr auto mediumlight      = "gt_pressura_light_27";
+            inline constexpr auto smallbold        = "gt_pressura_bold_24";
+            inline constexpr auto small            = "gt_pressura_regular_24";
+            inline constexpr auto verysmallbold    = "gt_pressura_bold_20";
+            inline constexpr auto verysmall        = "gt_pressura_regular_20";
         }; // namespace font
 
-        const inline uint32_t list_offset_default = 12;
+        inline constexpr auto list_offset_default = 12U;
         namespace label
         {
-            const inline uint32_t small_h   = 33;
-            const inline uint32_t default_h = 50;
-            const inline uint32_t big_h     = 55;
+            inline constexpr auto small_h   = 33U;
+            inline constexpr auto default_h = 50U;
+            inline constexpr auto big_h     = 55U;
         }; // namespace label
 
         /// minimal label decoration - edges, focus & alignment
@@ -91,89 +89,89 @@ namespace style
     {
         namespace date
         {
-            const inline uint32_t date_time_item_height       = 107;
-            const inline uint32_t date_time_item_width        = 120;
-            const inline uint32_t date_time_item_title_height = 30;
-            const inline uint32_t date_time_spacer_width      = 20;
-            const inline uint32_t date_time_x_offset          = 30;
+            inline constexpr auto date_time_item_height       = 107U;
+            inline constexpr auto date_time_item_width        = 120U;
+            inline constexpr auto date_time_item_title_height = 30U;
+            inline constexpr auto date_time_spacer_width      = 20U;
+            inline constexpr auto date_time_x_offset          = 30U;
 
-            const inline uint32_t date_time_box_h = 107;
-            const inline uint32_t date_box_y_pos  = 123;
-            const inline uint32_t time_box_y_pos  = 285;
+            inline constexpr auto date_time_box_h = 107U;
+            inline constexpr auto date_box_y_pos  = 123U;
+            inline constexpr auto time_box_y_pos  = 285U;
 
         } // namespace date
         namespace ussd
         {
-            constexpr uint32_t commonXPos = 40;
-            constexpr uint32_t commonYPos = 110;
+            inline constexpr auto commonXPos = 40U;
+            inline constexpr auto commonYPos = 110U;
 
-            constexpr uint32_t commonW      = 420;
-            constexpr uint32_t commonLabelH = 33;
-            constexpr uint32_t commonTextH  = 99;
+            inline constexpr auto commonW      = 420U;
+            inline constexpr auto commonLabelH = 33U;
+            inline constexpr auto commonTextH  = 99U;
         } // namespace ussd
     }     // namespace settings
     namespace color
     {
-        const inline gui::Color lightgrey = gui::Color(3, 0);
+        inline constexpr auto lightgrey = gui::Color(3, 0);
     }; //  namespace color
     namespace text
     {
-        const inline gui::Alignment defaultTextAlignment =
+        inline constexpr auto defaultTextAlignment =
             gui::Alignment(gui::Alignment::Horizontal::Left, gui::Alignment::Vertical::Bottom);
-        const inline unsigned int maxTextLines = 10;
+        inline constexpr auto maxTextLines = 10;
     }; // namespace text
 
     namespace strings
     {
         namespace common
         {
-            const inline std::string add            = "common_add";
-            const inline std::string open           = "common_open";
-            const inline std::string call           = "common_call";
-            const inline std::string send           = "common_send";
-            const inline std::string save           = "common_save";
-            const inline std::string confirm        = "common_confirm";
-            const inline std::string select         = "common_select";
-            const inline std::string use            = "common_use";
-            const inline std::string ok             = "common_ok";
-            const inline std::string back           = "common_back";
-            const inline std::string set            = "common_set";
-            const inline std::string yes            = "common_yes";
-            const inline std::string no             = "common_no";
-            const inline std::string Switch         = "common_switch";
-            const inline std::string options        = "common_options";
-            const inline std::string information    = "common_information";
-            const inline std::string search         = "common_search";
-            const inline std::string search_results = "common_search_results";
-            const inline std::string emoji          = "common_emoji";
-            const inline std::string special_chars  = "common_special_characters";
-            const inline std::string start          = "common_start";
-            const inline std::string stop           = "common_stop";
-            const inline std::string resume         = "common_resume";
-            const inline std::string pause          = "common_pause";
+            inline constexpr auto add            = "common_add";
+            inline constexpr auto open           = "common_open";
+            inline constexpr auto call           = "common_call";
+            inline constexpr auto send           = "common_send";
+            inline constexpr auto save           = "common_save";
+            inline constexpr auto confirm        = "common_confirm";
+            inline constexpr auto select         = "common_select";
+            inline constexpr auto use            = "common_use";
+            inline constexpr auto ok             = "common_ok";
+            inline constexpr auto back           = "common_back";
+            inline constexpr auto set            = "common_set";
+            inline constexpr auto yes            = "common_yes";
+            inline constexpr auto no             = "common_no";
+            inline constexpr auto Switch         = "common_switch";
+            inline constexpr auto options        = "common_options";
+            inline constexpr auto information    = "common_information";
+            inline constexpr auto search         = "common_search";
+            inline constexpr auto search_results = "common_search_results";
+            inline constexpr auto emoji          = "common_emoji";
+            inline constexpr auto special_chars  = "common_special_characters";
+            inline constexpr auto start          = "common_start";
+            inline constexpr auto stop           = "common_stop";
+            inline constexpr auto resume         = "common_resume";
+            inline constexpr auto pause          = "common_pause";
             // days
-            const inline std::string Monday    = "common_monday";
-            const inline std::string Tuesday   = "common_tuesday";
-            const inline std::string Wednesday = "common_wednesday";
-            const inline std::string Thursday  = "common_thursday";
-            const inline std::string Friday    = "common_friday";
-            const inline std::string Saturday  = "common_saturday";
-            const inline std::string Sunday    = "common_sunday";
+            inline constexpr auto Monday    = "common_monday";
+            inline constexpr auto Tuesday   = "common_tuesday";
+            inline constexpr auto Wednesday = "common_wednesday";
+            inline constexpr auto Thursday  = "common_thursday";
+            inline constexpr auto Friday    = "common_friday";
+            inline constexpr auto Saturday  = "common_saturday";
+            inline constexpr auto Sunday    = "common_sunday";
             // months
-            const inline std::string January   = "common_january";
-            const inline std::string February  = "common_february";
-            const inline std::string March     = "common_march";
-            const inline std::string April     = "common_april";
-            const inline std::string May       = "common_may";
-            const inline std::string June      = "common_june";
-            const inline std::string July      = "common_july";
-            const inline std::string August    = "common_august";
-            const inline std::string September = "common_september";
-            const inline std::string October   = "common_october";
-            const inline std::string November  = "common_november";
-            const inline std::string December  = "common_december";
-            const inline std::string Yesterday = "common_yesterday";
-            const inline std::string Today     = "common_today";
+            inline constexpr auto January   = "common_january";
+            inline constexpr auto February  = "common_february";
+            inline constexpr auto March     = "common_march";
+            inline constexpr auto April     = "common_april";
+            inline constexpr auto May       = "common_may";
+            inline constexpr auto June      = "common_june";
+            inline constexpr auto July      = "common_july";
+            inline constexpr auto August    = "common_august";
+            inline constexpr auto September = "common_september";
+            inline constexpr auto October   = "common_october";
+            inline constexpr auto November  = "common_november";
+            inline constexpr auto December  = "common_december";
+            inline constexpr auto Yesterday = "common_yesterday";
+            inline constexpr auto Today     = "common_today";
         } // namespace common
     }     // namespace strings
 
@@ -212,41 +210,41 @@ namespace style
 
         namespace scroll
         {
-            const inline uint32_t x           = 0;
-            const inline uint32_t y           = 0;
-            const inline uint32_t w           = 5;
-            const inline uint32_t h           = 0;
-            const inline uint32_t radius      = 2;
-            const inline gui::Color color     = gui::Color{0, 0};
-            const inline uint32_t margin      = 5;
-            const inline uint32_t min_space   = 10;
-            const inline uint32_t item_margin = 10;
+            inline constexpr auto x           = 0U;
+            inline constexpr auto y           = 0U;
+            inline constexpr auto w           = 5U;
+            inline constexpr auto h           = 0U;
+            inline constexpr auto radius      = 2U;
+            inline constexpr auto color       = gui::Color{0, 0};
+            inline constexpr auto margin      = 5U;
+            inline constexpr auto min_space   = 10U;
+            inline constexpr auto item_margin = 10U;
         } // namespace scroll
 
-        const inline uint32_t item_width_with_scroll =
+        inline constexpr auto item_width_with_scroll =
             style::window::default_body_width - style::listview::scroll::item_margin;
-        const inline uint32_t body_width_with_scroll =
+        inline constexpr auto body_width_with_scroll =
             style::window::default_body_width + style::listview::scroll::margin;
-        const inline uint32_t right_margin        = 15;
-        const inline uint32_t top_margin_small    = 5;
-        const inline uint32_t top_margin_big      = 8;
-        const inline uint32_t top_margin_very_big = 12;
-        const inline uint32_t item_span_small     = 8;
-        const inline uint32_t item_span_big       = 12;
+        inline constexpr auto right_margin        = 15U;
+        inline constexpr auto top_margin_small    = 5U;
+        inline constexpr auto top_margin_big      = 8U;
+        inline constexpr auto top_margin_very_big = 12U;
+        inline constexpr auto item_span_small     = 8U;
+        inline constexpr auto item_span_big       = 12U;
 
     } // namespace listview
 
     namespace margins
     {
-        const inline uint32_t small    = 6;
-        const inline uint32_t big      = 8;
-        const inline uint32_t very_big = 12;
-        const inline uint32_t huge     = 24;
+        inline constexpr auto small    = 6U;
+        inline constexpr auto big      = 8U;
+        inline constexpr auto very_big = 12U;
+        inline constexpr auto huge     = 24U;
     } // namespace margins
 
     namespace padding
     {
-        const inline uint32_t default_left_text_padding = 10;
+        inline constexpr auto default_left_text_padding = 10U;
     } // namespace padding
 
 }; // namespace style

--- a/module-services/service-appmgr/service-appmgr/model/ApplicationManager.hpp
+++ b/module-services/service-appmgr/service-appmgr/model/ApplicationManager.hpp
@@ -86,7 +86,7 @@ namespace app::manager
     class ApplicationManager : public sys::Service, private ApplicationManagerBase
     {
       public:
-        static inline const std::string ServiceName = "ApplicationManager";
+        static constexpr auto ServiceName = "ApplicationManager";
 
         ApplicationManager(const ApplicationName &serviceName,
                            std::vector<std::unique_ptr<app::ApplicationLauncher>> &&launchers,

--- a/module-services/service-bluetooth/Constants.hpp
+++ b/module-services/service-bluetooth/Constants.hpp
@@ -3,9 +3,7 @@
 
 #pragma once
 
-#include <string>
-
 namespace service::name
 {
-    inline const std::string bluetooth = "ServiceBluetooth";
+    inline constexpr auto bluetooth = "ServiceBluetooth";
 }

--- a/module-services/service-desktop/Constants.hpp
+++ b/module-services/service-desktop/Constants.hpp
@@ -7,5 +7,5 @@
 
 namespace service::name
 {
-    inline const std::string service_desktop = "ServiceDesktop";
+    inline constexpr auto service_desktop = "ServiceDesktop";
 };

--- a/module-services/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/ServiceDesktop.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <memory> // for allocator, unique_ptr
-#include <string> // for string
 
 #include "WorkerDesktop.hpp"
 #include "module-services/service-desktop/endpoints/update/UpdateMuditaOS.hpp"
@@ -16,12 +15,11 @@
 class UpdateMuditaOS;
 class WorkerDesktop;
 
-
 namespace sdesktop
 {
-    const inline int service_stack         = 8192;
-    const inline int cdc_queue_len         = 10;
-    const inline int cdc_queue_object_size = 10;
+    inline constexpr auto service_stack         = 8192;
+    inline constexpr auto cdc_queue_len         = 10;
+    inline constexpr auto cdc_queue_object_size = 10;
 }; // namespace sdesktop
 
 class ServiceDesktop : public sys::Service

--- a/module-services/service-desktop/endpoints/Context.hpp
+++ b/module-services/service-desktop/endpoints/Context.hpp
@@ -10,11 +10,11 @@ namespace parserFSM
 
     namespace json
     {
-        const inline std::string method   = "method";
-        const inline std::string endpoint = "endpoint";
-        const inline std::string uuid     = "uuid";
-        const inline std::string status   = "status";
-        const inline std::string body     = "body";
+        inline constexpr auto method   = "method";
+        inline constexpr auto endpoint = "endpoint";
+        inline constexpr auto uuid     = "uuid";
+        inline constexpr auto status   = "status";
+        inline constexpr auto body     = "body";
     } // namespace json
 
     struct endpointResponseContext
@@ -73,7 +73,7 @@ namespace parserFSM
                     uuid = invalidUuid;
                 }
             }
-            method   = static_cast<http::Method>(js[json::method].int_value());
+            method = static_cast<http::Method>(js[json::method].int_value());
             validate();
         }
         Context()

--- a/module-services/service-desktop/endpoints/calllog/CalllogHelper.hpp
+++ b/module-services/service-desktop/endpoints/calllog/CalllogHelper.hpp
@@ -42,18 +42,18 @@ namespace parserFSM
 
     namespace json::calllog
     {
-        const inline std::string count        = "count";
-        const inline std::string limit        = "limit";
-        const inline std::string offset       = "offset";
-        const inline std::string presentation = "presentation";
-        const inline std::string date         = "date";
-        const inline std::string duration     = "duration";
-        const inline std::string id           = "id";
-        const inline std::string type         = "type";
-        const inline std::string name         = "name";
-        const inline std::string contactId    = "contactId";
-        const inline std::string phoneNumber  = "phoneNumber";
-        const inline std::string isRead       = "isRead";
+        inline constexpr auto count        = "count";
+        inline constexpr auto limit        = "limit";
+        inline constexpr auto offset       = "offset";
+        inline constexpr auto presentation = "presentation";
+        inline constexpr auto date         = "date";
+        inline constexpr auto duration     = "duration";
+        inline constexpr auto id           = "id";
+        inline constexpr auto type         = "type";
+        inline constexpr auto name         = "name";
+        inline constexpr auto contactId    = "contactId";
+        inline constexpr auto phoneNumber  = "phoneNumber";
+        inline constexpr auto isRead       = "isRead";
 
     } // namespace json::calllog
 } // namespace parserFSM

--- a/module-services/service-desktop/endpoints/contacts/ContactHelper.hpp
+++ b/module-services/service-desktop/endpoints/contacts/ContactHelper.hpp
@@ -42,14 +42,14 @@ namespace parserFSM
 
     namespace json::contacts
     {
-        const inline std::string count           = "count";
-        const inline std::string primaryName     = "priName";
-        const inline std::string alternativeName = "altName";
-        const inline std::string address         = "address";
-        const inline std::string id              = "id";
-        const inline std::string numbers         = "numbers";
-        const inline std::string isBlocked       = "blocked";
-        const inline std::string isFavourite     = "favourite";
+        inline constexpr auto count           = "count";
+        inline constexpr auto primaryName     = "priName";
+        inline constexpr auto alternativeName = "altName";
+        inline constexpr auto address         = "address";
+        inline constexpr auto id              = "id";
+        inline constexpr auto numbers         = "numbers";
+        inline constexpr auto isBlocked       = "blocked";
+        inline constexpr auto isFavourite     = "favourite";
 
     } // namespace json::contacts
 } // namespace parserFSM

--- a/module-services/service-desktop/endpoints/developerMode/DeveloperModeHelper.hpp
+++ b/module-services/service-desktop/endpoints/developerMode/DeveloperModeHelper.hpp
@@ -31,6 +31,6 @@ namespace parserFSM
 
     namespace json::developerMode
     {
-        const inline std::string keyPressed = "keyPressed";
+        inline constexpr auto keyPressed = "keyPressed";
     }
 } // namespace parserFSM

--- a/module-services/service-desktop/endpoints/messages/MessageHelper.hpp
+++ b/module-services/service-desktop/endpoints/messages/MessageHelper.hpp
@@ -59,23 +59,23 @@ namespace parserFSM
 
     namespace messages
     {
-        const inline std::string id           = "id";
-        const inline std::string count        = "count";
-        const inline std::string offset       = "offset";
-        const inline std::string phoneNumber  = "phoneNumber";
-        const inline std::string isUnread     = "unread";
-        const inline std::string contactID    = "contactID";
-        const inline std::string date         = "date";
-        const inline std::string dateSent     = "dateSent";
-        const inline std::string type         = "type";
-        const inline std::string threadID     = "threadID";
-        const inline std::string msgTemplate  = "template";
-        const inline std::string templateText = "text";
+        inline constexpr auto id           = "id";
+        inline constexpr auto count        = "count";
+        inline constexpr auto offset       = "offset";
+        inline constexpr auto phoneNumber  = "phoneNumber";
+        inline constexpr auto isUnread     = "unread";
+        inline constexpr auto contactID    = "contactID";
+        inline constexpr auto date         = "date";
+        inline constexpr auto dateSent     = "dateSent";
+        inline constexpr auto type         = "type";
+        inline constexpr auto threadID     = "threadID";
+        inline constexpr auto msgTemplate  = "template";
+        inline constexpr auto templateText = "text";
         namespace thread
         {
-            const inline std::string msgCount       = "msgCount";
-            const inline std::string snippet        = "snippet";
-            const inline std::string unreadMsgCount = "unreadMsgCount";
+            inline constexpr auto msgCount       = "msgCount";
+            inline constexpr auto snippet        = "snippet";
+            inline constexpr auto unreadMsgCount = "unreadMsgCount";
 
         } // namespace thread
 

--- a/module-services/service-desktop/endpoints/update/UpdateMuditaOS.cpp
+++ b/module-services/service-desktop/endpoints/update/UpdateMuditaOS.cpp
@@ -527,10 +527,10 @@ const json11::Json UpdateMuditaOS::getVersionInfoFromFile(const fs::path &update
         }
 
         std::unique_ptr<char[]> versionFilename(new char[purefs::buffer::crc_buf]);
-        sprintf(versionFilename.get(), "./%s", updateos::file::version.c_str());
+        sprintf(versionFilename.get(), "./%s", updateos::file::version);
         if (mtar_find(&tar, versionFilename.get(), &h) == MTAR_ENOTFOUND) {
             LOG_INFO("UpdateMuditaOS::getVersionInfoFromFile can't find %s in %s",
-                     updateos::file::version.c_str(),
+                     updateos::file::version,
                      updateFile.c_str());
 
             mtar_close(&tar);
@@ -541,7 +541,7 @@ const json11::Json UpdateMuditaOS::getVersionInfoFromFile(const fs::path &update
         std::unique_ptr<char[]> readBuf(new char[purefs::buffer::tar_buf]);
         if (mtar_read_data(&tar, readBuf.get(), h.size) != MTAR_ESUCCESS) {
             LOG_INFO("UpdateMuditaOS::getVersionInfoFromFile can't read %s in %s",
-                     updateos::file::version.c_str(),
+                     updateos::file::version,
                      updateFile.c_str());
 
             mtar_close(&tar);
@@ -555,7 +555,7 @@ const json11::Json UpdateMuditaOS::getVersionInfoFromFile(const fs::path &update
         json11::Json versionInfo = json11::Json::parse(dataPackage, parserError);
         if (parserError != "") {
             LOG_INFO("UpdateMuditaOS::getVersionInfoFromFile can't parse %s as JSON error: \"%s\"",
-                     updateos::file::version.c_str(),
+                     updateos::file::version,
                      parserError.c_str());
             return json11::Json();
         }

--- a/module-services/service-desktop/endpoints/update/UpdateMuditaOS.hpp
+++ b/module-services/service-desktop/endpoints/update/UpdateMuditaOS.hpp
@@ -19,15 +19,15 @@ namespace updateos
 {
     namespace file
     {
-        const inline std::string checksums = "checksums.txt";
-        const inline std::string sql_mig   = "sqlmig.json";
-        const inline std::string version   = "version.json";
+        inline constexpr auto checksums = "checksums.txt";
+        inline constexpr auto sql_mig   = "sqlmig.json";
+        inline constexpr auto version   = "version.json";
 
     } // namespace file
 
     namespace extension
     {
-        const inline std::string update = ".tar";
+        inline constexpr auto update = ".tar";
     }
 
     const inline int prefix_len = 8;

--- a/module-services/service-desktop/parser/ParserUtils.hpp
+++ b/module-services/service-desktop/parser/ParserUtils.hpp
@@ -27,15 +27,15 @@ namespace parserFSM
         developerMode,
     };
 
-    constexpr int lastEndpoint = static_cast<int>(EndpointType::developerMode);
+    inline constexpr auto lastEndpoint = static_cast<int>(EndpointType::developerMode);
     // Message defs and utils
     namespace message
     {
-        constexpr size_t size_length = 9;
-        constexpr size_t size_header = size_length + 1;
+        inline constexpr auto size_length = 9U;
+        inline constexpr auto size_header = size_length + 1;
 
-        constexpr char endpointChar = '#';
-        constexpr char rawDataChar  = '$';
+        inline constexpr auto endpointChar = '#';
+        inline constexpr auto rawDataChar  = '$';
 
         inline void removeHeader(std::string &msg)
         {
@@ -97,46 +97,46 @@ namespace parserFSM
 
     namespace json
     {
-        const inline std::string batteryLevel   = "batteryLevel";
-        const inline std::string batteryState   = "batteryState";
-        const inline std::string selectedSim    = "selectedSim";
-        const inline std::string trayState      = "trayState";
-        const inline std::string signalStrength = "signalStrength";
-        const inline std::string fsTotal        = "fsTotal";
-        const inline std::string fsFreePercent  = "fsFreePercent";
-        const inline std::string fsFree         = "fsFree";
-        const inline std::string gitRevision    = "gitRevision";
-        const inline std::string gitBranch      = "gitBranch";
-        const inline std::string gitTag         = "gitTag";
-        const inline std::string currentRTCTime = "currentRTCTime";
-        const inline std::string updateReady    = "updateReady";
-        const inline std::string updateFileList = "updateFileList";
-        const inline std::string backupRequest  = "backupRequest";
-        const inline std::string backupReady    = "backupReady";
-        const inline std::string backupUpload   = "backupUpload";
-        const inline std::string restoreRequest = "restoreRequest";
-        const inline std::string factoryRequest = "factoryRequest";
+        inline constexpr auto batteryLevel   = "batteryLevel";
+        inline constexpr auto batteryState   = "batteryState";
+        inline constexpr auto selectedSim    = "selectedSim";
+        inline constexpr auto trayState      = "trayState";
+        inline constexpr auto signalStrength = "signalStrength";
+        inline constexpr auto fsTotal        = "fsTotal";
+        inline constexpr auto fsFreePercent  = "fsFreePercent";
+        inline constexpr auto fsFree         = "fsFree";
+        inline constexpr auto gitRevision    = "gitRevision";
+        inline constexpr auto gitBranch      = "gitBranch";
+        inline constexpr auto gitTag         = "gitTag";
+        inline constexpr auto currentRTCTime = "currentRTCTime";
+        inline constexpr auto updateReady    = "updateReady";
+        inline constexpr auto updateFileList = "updateFileList";
+        inline constexpr auto backupRequest  = "backupRequest";
+        inline constexpr auto backupReady    = "backupReady";
+        inline constexpr auto backupUpload   = "backupUpload";
+        inline constexpr auto restoreRequest = "restoreRequest";
+        inline constexpr auto factoryRequest = "factoryRequest";
 
         namespace messages
         {
-            const inline std::string id           = "id";
-            const inline std::string count        = "count";
-            const inline std::string offset       = "offset";
-            const inline std::string phoneNumber  = "phoneNumber";
-            const inline std::string messageBody  = "messageBody";
-            const inline std::string isUnread     = "unread";
-            const inline std::string contactID    = "contactID";
-            const inline std::string date         = "date";
-            const inline std::string dateSent     = "dateSent";
-            const inline std::string type         = "type";
-            const inline std::string threadID     = "threadID";
-            const inline std::string msgTemplate  = "template";
-            const inline std::string templateText = "text";
+            inline constexpr auto id           = "id";
+            inline constexpr auto count        = "count";
+            inline constexpr auto offset       = "offset";
+            inline constexpr auto phoneNumber  = "phoneNumber";
+            inline constexpr auto messageBody  = "messageBody";
+            inline constexpr auto isUnread     = "unread";
+            inline constexpr auto contactID    = "contactID";
+            inline constexpr auto date         = "date";
+            inline constexpr auto dateSent     = "dateSent";
+            inline constexpr auto type         = "type";
+            inline constexpr auto threadID     = "threadID";
+            inline constexpr auto msgTemplate  = "template";
+            inline constexpr auto templateText = "text";
             namespace thread
             {
-                const inline std::string msgCount       = "msgCount";
-                const inline std::string snippet        = "snippet";
-                const inline std::string unreadMsgCount = "unreadMsgCount";
+                inline constexpr auto msgCount       = "msgCount";
+                inline constexpr auto snippet        = "snippet";
+                inline constexpr auto unreadMsgCount = "unreadMsgCount";
 
             } // namespace thread
 

--- a/module-services/service-evtmgr/Constants.hpp
+++ b/module-services/service-evtmgr/Constants.hpp
@@ -3,9 +3,7 @@
 
 #pragma once
 
-#include <string>
-
 namespace service::name
 {
-    inline const std::string evt_manager = "EventManager";
+    inline constexpr auto evt_manager = "EventManager";
 };

--- a/module-services/service-evtmgr/harness/Events.hpp
+++ b/module-services/service-evtmgr/harness/Events.hpp
@@ -9,8 +9,8 @@
 
 namespace harness
 {
-    inline const std::string Type = "t";
-    inline const std::string Data = "d";
+    inline constexpr auto Type = "t";
+    inline constexpr auto Data = "d";
     enum class Events;
 
     /// basic event structure:

--- a/module-services/service-evtmgr/harness/events/GPIO.hpp
+++ b/module-services/service-evtmgr/harness/events/GPIO.hpp
@@ -20,10 +20,10 @@ namespace harness::events
         auto decode(const json11::Json &js) -> bool final;
 
       private:
-        static inline const std::string num_s   = "num";
-        static inline const std::string state_s = "state";
-        static inline const std::string in_s    = "in";
-        std::map<std::string, int> data         = {{num_s, 0}, {state_s, 0}, {in_s, 0}};
+        static constexpr auto num_s     = "num";
+        static constexpr auto state_s   = "state";
+        static constexpr auto in_s      = "in";
+        std::map<std::string, int> data = {{num_s, 0}, {state_s, 0}, {in_s, 0}};
         void create_message();
     };
 } // namespace harness::events

--- a/module-services/service-time/ServiceTime.hpp
+++ b/module-services/service-time/ServiceTime.hpp
@@ -18,7 +18,7 @@
 
 namespace service::name
 {
-    const inline std::string service_time = "ServiceTime";
+    inline constexpr auto service_time = "ServiceTime";
 };
 
 namespace stm

--- a/module-sys/Service/Worker.hpp
+++ b/module-sys/Service/Worker.hpp
@@ -75,7 +75,7 @@ namespace sys
         static constexpr std::size_t controlMessagesCount = static_cast<std::size_t>(ControlMessage::MessageCount);
         static constexpr std::size_t defaultStackSize     = 2048;
         static constexpr TickType_t defaultJoinTimeout    = portMAX_DELAY;
-        static inline std::string controlQueueNamePrefix  = "wctrl";
+        static constexpr auto controlQueueNamePrefix      = "wctrl";
 
         xQueueHandle controlQueue      = nullptr;
         xSemaphoreHandle joinSemaphore = nullptr;

--- a/module-sys/SystemManager/Constants.hpp
+++ b/module-sys/SystemManager/Constants.hpp
@@ -7,5 +7,5 @@
 
 namespace service::name
 {
-    const inline std::string system_manager = "SysMgrService";
+    inline constexpr auto system_manager = "SysMgrService";
 };

--- a/module-sys/SystemManager/SystemManager.cpp
+++ b/module-sys/SystemManager/SystemManager.cpp
@@ -323,7 +323,7 @@ namespace sys
         for (bool retry{};; retry = false) {
             for (auto &service : servicesList) {
                 if (service->GetName() == service::name::evt_manager) {
-                    LOG_DEBUG("Delay closing %s", service::name::evt_manager.c_str());
+                    LOG_DEBUG("Delay closing %s", service::name::evt_manager);
                     continue;
                 }
                 if (service->parent == "") {

--- a/module-utils/Utils.hpp
+++ b/module-utils/Utils.hpp
@@ -14,7 +14,7 @@
 
 namespace utils
 {
-    static const std::string WHITESPACE = " \n\r\t\f\v";
+    inline constexpr auto WHITESPACE = " \n\r\t\f\v";
     constexpr unsigned int secondsInMinute =
         std::chrono::duration_cast<std::chrono::seconds>(std::chrono::minutes(1)).count();
 

--- a/module-utils/country.hpp
+++ b/module-utils/country.hpp
@@ -262,8 +262,8 @@ namespace utils::country
         UNKNOWN,
     };
 
-    constexpr std::size_t count = static_cast<std::size_t>(Id::UNKNOWN) + 1;
-    constexpr Id defaultCountry = Id::UNKNOWN;
+    inline constexpr auto count          = static_cast<std::size_t>(Id::UNKNOWN) + 1;
+    inline constexpr auto defaultCountry = Id::UNKNOWN;
 
     struct Data
     {
@@ -273,7 +273,7 @@ namespace utils::country
         unsigned int un_number;
     };
 
-    constexpr std::array<struct Data, count> map = {{
+    inline constexpr std::array<struct Data, count> map = {{
         {"Afghanistan", "AF", "AFG", 4},                       // AFGHANISTAN
         {"ALA Aland Islands", "AX", "ALA", 248},               // ALA_ALAND_ISLANDS
         {"Albania", "AL", "ALB", 8},                           // ALBANIA

--- a/module-utils/time/time_conversion.hpp
+++ b/module-utils/time/time_conversion.hpp
@@ -8,21 +8,23 @@
 
 #include "time/time_locale.hpp"
 #include <bsp/rtc/rtc.hpp>
+#include <log/log.hpp>
+
 #include <vector>
 #include <string>
-#include <log/log.hpp>
 
 namespace utils
 {
     namespace time
     {
-        constexpr auto secondsInMinute        = 60;
-        constexpr auto minutesInHour          = 60;
-        constexpr auto hoursInday             = 24;
-        constexpr auto minutesInQuarterOfHour = 15;
-        constexpr auto secondsInHour   = minutesInHour * secondsInMinute;
-        constexpr auto secondsInDay    = hoursInday * secondsInHour;
-        constexpr auto milisecondsInSecond = 1000;
+        inline constexpr auto secondsInMinute        = 60;
+        inline constexpr auto minutesInHour          = 60;
+        inline constexpr auto hoursInday             = 24;
+        inline constexpr auto minutesInQuarterOfHour = 15;
+        inline constexpr auto secondsInHour          = minutesInHour * secondsInMinute;
+        inline constexpr auto secondsInDay           = hoursInday * secondsInHour;
+        inline constexpr auto milisecondsInSecond    = 1000;
+
         enum class GetParameters
         {
             Hour,
@@ -35,7 +37,7 @@ namespace utils
         // helper class to not put everything in time
         struct Localer
         {
-            const inline static unsigned int abbrev_len = 3;
+            static constexpr auto abbrev_len = 3U;
             /// order matters, it's used in replace_locale with enum Replacements
             const inline static std::vector<std::string> specifiers_replacement = {"%a",  // day abbrew
                                                                                    "%A",  // day long
@@ -277,11 +279,11 @@ namespace utils
             }
 
           private:
-            static constexpr bool verboseConversion             = false; // debug switch
-            static const inline std::string durationFormatH0M0S = "duration_hour_0min_0sec";
-            static const inline std::string durationFormat0M0S  = "duration_0min_0sec";
-            static const inline std::string durationFormat0N0S  = "duration_0hmin_0sec";
-            static const inline std::string durationFormatM0S   = "duration_min_0sec";
+            static constexpr auto verboseConversion   = false; // debug switch
+            static constexpr auto durationFormatH0M0S = "duration_hour_0min_0sec";
+            static constexpr auto durationFormat0M0S  = "duration_0min_0sec";
+            static constexpr auto durationFormat0N0S  = "duration_0hmin_0sec";
+            static constexpr auto durationFormatM0S   = "duration_min_0sec";
 
             struct Format
             {

--- a/module-vfs/vfs.hpp
+++ b/module-vfs/vfs.hpp
@@ -55,36 +55,36 @@ namespace purefs
 
     namespace extension
     {
-        const inline std::string crc32 = ".crc32";
+        inline constexpr auto crc32 = ".crc32";
     }
 
     namespace buffer
     {
-        const inline int crc_buf       = 1024;
-        const inline int crc_char_size = 9;
-        const inline int crc_radix     = 16;
-        const inline int tar_buf       = 8192 * 4;
-        const inline int copy_buf      = 8192 * 4;
+        inline constexpr auto crc_buf       = 1024;
+        inline constexpr auto crc_char_size = 9;
+        inline constexpr auto crc_radix     = 16;
+        inline constexpr auto tar_buf       = 8192 * 4;
+        inline constexpr auto copy_buf      = 8192 * 4;
     } // namespace buffer
 
     namespace json
     {
-        const inline std::string main            = "main";
-        const inline std::string os_type         = "ostype";
-        const inline std::string os_image        = "imagename";
-        const inline std::string os_version      = "version";
-        const inline std::string version_major   = "major";
-        const inline std::string version_inor    = "minor";
-        const inline std::string version_patch   = "patch";
-        const inline std::string version_string  = "string";
-        const inline std::string timestamp       = "timestamp";
-        const inline std::string misc            = "misc";
-        const inline std::string builddate       = "builddate";
-        const inline std::string git_info        = "git";
-        const inline std::string os_git_tag      = "git_tag";
-        const inline std::string os_git_revision = "git_commit";
-        const inline std::string os_git_branch   = "git_branch";
-        const inline std::string bootloader      = "bootloader";
+        inline constexpr auto main            = "main";
+        inline constexpr auto os_type         = "ostype";
+        inline constexpr auto os_image        = "imagename";
+        inline constexpr auto os_version      = "version";
+        inline constexpr auto version_major   = "major";
+        inline constexpr auto version_inor    = "minor";
+        inline constexpr auto version_patch   = "patch";
+        inline constexpr auto version_string  = "string";
+        inline constexpr auto timestamp       = "timestamp";
+        inline constexpr auto misc            = "misc";
+        inline constexpr auto builddate       = "builddate";
+        inline constexpr auto git_info        = "git";
+        inline constexpr auto os_git_tag      = "git_tag";
+        inline constexpr auto os_git_revision = "git_commit";
+        inline constexpr auto os_git_branch   = "git_branch";
+        inline constexpr auto bootloader      = "bootloader";
     } // namespace json
 
     struct BootConfig

--- a/tools/find_global_data.sh
+++ b/tools/find_global_data.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -x
+
+# Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+# For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+# A script to find duplicated initialization code of global data
+
+rootdir="$(realpath $(dirname $(realpath $0))/..)"
+objfile="${1:-$(realpath ${rootdir}/build-rt1051-Debug/PurePhone.elf)}"
+
+if [ ! -f ${objfile} ]; then
+    echo "No such file: ${objfile}"
+    exit 1
+fi
+
+arm-none-eabi-nm --print-size ${objfile} | grep _Z41__static_initialization_and_destruction_0ii | awk '{print $1" "$2}' | tr 'a-f' 'A-F' | while read -r symbol_start symbol_size;
+do
+    symbol_end=$(echo "obase=16;ibase=16;$symbol_start+$symbol_size" | bc)
+    arm-none-eabi-objdump --start-address=0x$symbol_start --stop-address=0x$symbol_end -d -l $objfile
+done | grep ".hpp:" | awk '{print $1}' | xargs realpath | sed 's,^'${rootdir}/',,' | sort | uniq -c | sort -n


### PR DESCRIPTION
Reduce firmware size by refactoring global data defined in public
headers.

Each global variable which require runtime initialization adds
initialization code to every translation unit which includes the header
where the variable is defined and declared.
