### PR TITLE
[EGD-4420] Test harness startup check

### DIFF
--- a/module-bsp/board/linux/usb_cdc/usb_cdc.cpp
+++ b/module-bsp/board/linux/usb_cdc/usb_cdc.cpp
@@ -4,6 +4,7 @@
 #include "bsp/usb/usb.hpp"
 #include <termios.h>
 #include <fcntl.h>
+#include <fstream>
 
 namespace bsp
 {
@@ -56,6 +57,14 @@ namespace bsp
         }
     }
 
+    void writePtsToFile(const char *pts_name)
+    {
+        constexpr auto fileName = "/tmp/purephone_pts_name";
+        std::ofstream ptsNameFile;
+        ptsNameFile.open(fileName, std::ios::out | std::ios::trunc);
+        ptsNameFile << pts_name;
+    }
+
     int usbInit(xQueueHandle receiveQueue, USBDeviceListener *)
     {
 
@@ -74,6 +83,8 @@ namespace bsp
             LOG_ERROR("bsp::usbInit ptsname returned NULL, no pseudo terminal allocated");
             return -1;
         }
+
+        writePtsToFile(pts_name);
         LOG_INFO("bsp::usbInit linux ptsname: %s", pts_name);
         struct termios newtio;
         memset(&newtio, 0, sizeof(newtio));

--- a/test/harness/__init__.py
+++ b/test/harness/__init__.py
@@ -3,6 +3,6 @@
 
 import logging
 import harness.interface
-# logging.basicConfig(format='%(asctime)s %(message)s', level=logging.DEBUG)
+logging.basicConfig(format='%(asctime)s %(message)s', level=logging.DEBUG)
 log = logging.getLogger(__name__)
 

--- a/test/harness/harness.py
+++ b/test/harness/harness.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 import time
+from enum import Enum
 
-from harness import utils
+from harness import utils, log
 from harness.interface import CDCSerial as serial
 from harness.interface.defs import key_codes, endpoint, method
 from harness.utils import send_keystoke, application_keypath, send_char
@@ -27,9 +28,9 @@ class Harness:
             self.connection.send_key(3)
             self.connection.send_key(3)
             self.connection.send_key(3)
-            print("Phone unlocked")
+            log.info("Phone unlocked")
         else:
-            print("Phone already unlocked")
+            log.info("Phone already unlocked")
 
     def with_phone_unlocked(self, func):
         if not self.is_phone_unlocked:

--- a/test/harness/interface/error.py
+++ b/test/harness/interface/error.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+# For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+from enum import IntEnum
+
+
+class Error(IntEnum):
+    PORT_NOT_FOUND = 1,
+    PORT_FILE_NOT_FOUND = 2,
+    TEST_FAILED = 3,
+    OTHER_ERROR = 4
+
+
+class TestError(Exception):
+
+    def __init__(self, error_code: Error):
+        self.error_code = error_code
+        self.message = f"Test failed with error code: {error_code.name}"
+        super().__init__(self.message)
+
+    def __str__(self):
+        return self.message
+
+    def get_error_code(self):
+        return int(self.error_code)
+

--- a/test/harness/utils.py
+++ b/test/harness/utils.py
@@ -2,9 +2,11 @@
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 import time
+from enum import Enum
 
 from harness.interface.CDCSerial import Keytype
 from harness.interface.defs import key_codes
+
 
 # assuming that the harness is actually in the menu
 application_keypath = {

--- a/test/send_message.py
+++ b/test/send_message.py
@@ -5,8 +5,10 @@
 import sys
 import time
 
+from harness import log
 from harness.harness import Harness
 from harness.interface.defs import key_codes, endpoint, method
+from harness.interface.error import TestError, Error
 
 
 def send_message(harness, phone_number: str, message: str):
@@ -39,11 +41,24 @@ def get_message_by_text(harness, message: str):
 
 
 def main():
-    if len(sys.argv) == 1 or sys.argv[1] is None:
-        print(f'Please pass port name as the parameter: python {sys.argv[0]} /dev/ttyACM0 number text ')
-        exit(1)
+    if len(sys.argv) == 1 or "/dev" not in sys.argv[1]:
+        log.warning("Port name not passed, trying port name filename from simulator...")
+        try:
+            file = open("/tmp/purephone_pts_name", "r")
+        except FileNotFoundError as err:
+            raise TestError(Error.PORT_FILE_NOT_FOUND)
 
-    harness = Harness(sys.argv[1])
+
+        port_name = file.readline()
+        if port_name.isascii():
+            log.debug("found {} entry!".format(port_name))
+        else:
+            print(f'Please pass port name as the parameter: python {sys.argv[0]} /dev/ttyACM0 number text ')
+            raise TestError(Error.PORT_NOT_FOUND)
+    else:
+        port_name = sys.argv[1]
+
+    harness = Harness(port_name)
     message = str(sys.argv[3])
     messages = get_message_by_text(harness, message.upper())
 
@@ -53,11 +68,16 @@ def main():
 
     diff = [i for i in messages + new_messages if i not in messages or i not in new_messages]
     if len(diff) != 1 or diff[0]["type"] != 0x08:  # 0x08 - SMSType::OUTBOX
-        print("sending error!")
-        exit(1)
+        log.error("sending error!")
+        raise TestError(Error.TEST_FAILED)
     else:
-        print("sending success!")
+        log.info("sending success!")
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except TestError as err:
+        log.error(err)
+        exit(err.get_error_code())
+


### PR DESCRIPTION
- added timeout to port opening in case the test harness would be launched before the simulator/ target.
- added possibility to auto-detect the pts name in simulator via temp file - in this case, pass `sim` as a port name in the test case