### PR TITLE
[EGD-4150] Change filename i18 to i18n

### DIFF
--- a/module-apps/application-antenna/windows/AlgoParamsWindow.cpp
+++ b/module-apps/application-antenna/windows/AlgoParamsWindow.cpp
@@ -7,7 +7,7 @@
 #include "gui/widgets/Label.hpp"
 #include "gui/widgets/Window.hpp"
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include <Style.hpp>
 #include "gui/widgets/BoxLayout.hpp"
 #include "../AntennaAppStyle.hpp"

--- a/module-apps/application-antenna/windows/AntennaMainWindow.cpp
+++ b/module-apps/application-antenna/windows/AntennaMainWindow.cpp
@@ -13,7 +13,7 @@
 #include "gui/widgets/Label.hpp"
 #include "gui/widgets/Window.hpp"
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include <Style.hpp>
 
 #include "../AntennaAppStyle.hpp"

--- a/module-apps/application-antenna/windows/ScanModesWindow.cpp
+++ b/module-apps/application-antenna/windows/ScanModesWindow.cpp
@@ -7,7 +7,7 @@
 #include "gui/widgets/Label.hpp"
 #include "gui/widgets/Window.hpp"
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include <Style.hpp>
 
 #include "../AntennaAppStyle.hpp"

--- a/module-apps/application-calculator/ApplicationCalculator.cpp
+++ b/module-apps/application-calculator/ApplicationCalculator.cpp
@@ -3,7 +3,7 @@
 
 #include "ApplicationCalculator.hpp"
 #include "windows/CalculatorMainWindow.hpp"
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace app
 {

--- a/module-apps/application-calculator/data/CalculatorUtility.cpp
+++ b/module-apps/application-calculator/data/CalculatorUtility.cpp
@@ -4,7 +4,7 @@
 #include "CalculatorUtility.hpp"
 #include "application-calculator/widgets/CalculatorStyle.hpp"
 #include <module-utils/tinyexpr/tinyexpr.h>
-#include <module-utils/i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <Utils.hpp>
 #include <cmath>
 

--- a/module-apps/application-calculator/tests/CalculatorUtility_tests.cpp
+++ b/module-apps/application-calculator/tests/CalculatorUtility_tests.cpp
@@ -4,7 +4,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 #include "application-calculator/data/CalculatorUtility.hpp"
-#include <module-utils/i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <cstring>
 
 class vfs vfs;

--- a/module-apps/application-calculator/windows/CalculatorMainWindow.cpp
+++ b/module-apps/application-calculator/windows/CalculatorMainWindow.cpp
@@ -4,7 +4,7 @@
 #include "CalculatorMainWindow.hpp"
 #include "application-calculator/widgets/CalculatorStyle.hpp"
 #include "application-calculator/data/CalculatorUtility.hpp"
-#include <module-utils/i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-call/widgets/Icon.hpp
+++ b/module-apps/application-call/widgets/Icon.hpp
@@ -7,7 +7,7 @@
 #include "Label.hpp"
 #include <Style.hpp>
 #include <log/log.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -13,7 +13,7 @@
 #include "application-call/ApplicationCall.hpp"
 #include "application-call/data/CallSwitchData.hpp"
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 #include <service-audio/AudioServiceAPI.hpp>
 #include <service-cellular/CellularServiceAPI.hpp>

--- a/module-apps/application-call/windows/EmergencyCallWindow.cpp
+++ b/module-apps/application-call/windows/EmergencyCallWindow.cpp
@@ -5,7 +5,7 @@
 #include "../ApplicationCall.hpp"
 #include <service-appmgr/model/ApplicationManager.hpp>
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "EmergencyCallWindow.hpp"
 
 namespace gui

--- a/module-apps/application-call/windows/EnterNumberWindow.cpp
+++ b/module-apps/application-call/windows/EnterNumberWindow.cpp
@@ -9,7 +9,7 @@
 
 #include <ContactRecord.hpp>
 #include <country.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <InputMode.hpp>
 #include <service-appmgr/Controller.hpp>
 #include <service-cellular/CellularServiceAPI.hpp>

--- a/module-apps/application-calllog/ApplicationCallLog.cpp
+++ b/module-apps/application-calllog/ApplicationCallLog.cpp
@@ -13,7 +13,7 @@
 #include <service-db/DBMessage.hpp>
 #include <Dialog.hpp>
 #include <OptionWindow.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <log/log.hpp>
 #include <MessageType.hpp>
 #include <module-db/queries/calllog/QueryCalllogSetAllRead.hpp>

--- a/module-apps/application-calllog/windows/CallLogDetailsWindow.cpp
+++ b/module-apps/application-calllog/windows/CallLogDetailsWindow.cpp
@@ -14,7 +14,7 @@
 #include "../ApplicationCallLog.hpp"
 
 #include <service-db/DBMessage.hpp>
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 #include "../data/CallLogInternals.hpp" // TODO: alek: add easier paths
 #include "../data/CallLogSwitchData.hpp"

--- a/module-apps/application-calllog/windows/CallLogMainWindow.cpp
+++ b/module-apps/application-calllog/windows/CallLogMainWindow.cpp
@@ -9,7 +9,7 @@
 #include <application-call/ApplicationCall.hpp>
 #include <service-appmgr/model/ApplicationManager.hpp>
 #include <service-db/DBCalllogMessage.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <Label.hpp>
 #include <Margins.hpp>
 #include <Style.hpp>

--- a/module-apps/application-calllog/windows/CallLogOptionsWindow.cpp
+++ b/module-apps/application-calllog/windows/CallLogOptionsWindow.cpp
@@ -2,7 +2,7 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CallLogOptionsWindow.hpp"
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "log/log.hpp"
 #include <Options.hpp>
 #include <module-services/service-db/service-db/DBServiceAPI.hpp>

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -18,7 +18,7 @@
 #include <service-time/ServiceTime.hpp>
 #include <service-time/TimeMessage.hpp>
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "log/log.hpp"
 
 #include <application-settings-new/ApplicationSettings.hpp>

--- a/module-apps/application-desktop/windows/LockedInfoWindow.cpp
+++ b/module-apps/application-desktop/windows/LockedInfoWindow.cpp
@@ -13,7 +13,7 @@
 #include "Names.hpp"
 
 #include <application-phonebook/ApplicationPhonebook.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 using namespace gui;
 

--- a/module-apps/application-desktop/windows/MenuWindow.cpp
+++ b/module-apps/application-desktop/windows/MenuWindow.cpp
@@ -11,7 +11,7 @@
 #include <tools/Common.hpp>
 #include <Style.hpp>
 #include <cassert>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace style::design
 {

--- a/module-apps/application-desktop/windows/PinLockBaseWindow.cpp
+++ b/module-apps/application-desktop/windows/PinLockBaseWindow.cpp
@@ -4,7 +4,7 @@
 #include "PinLockBaseWindow.hpp"
 #include "application-desktop/data/AppDesktopStyle.hpp"
 #include "application-desktop/widgets/PinLock.hpp"
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace lock_style = style::window::pin_lock;
 namespace gui

--- a/module-apps/application-desktop/windows/PowerOffWindow.cpp
+++ b/module-apps/application-desktop/windows/PowerOffWindow.cpp
@@ -7,7 +7,7 @@
 #include "log/log.hpp"
 
 // module-utils
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 #include "PowerOffWindow.hpp"
 #include "../ApplicationDesktop.hpp"

--- a/module-apps/application-desktop/windows/PukLockBox.cpp
+++ b/module-apps/application-desktop/windows/PukLockBox.cpp
@@ -8,7 +8,7 @@
 #include "application-desktop/data/AppDesktopStyle.hpp"
 #include "gui/widgets/Label.hpp"
 #include "gui/widgets/Image.hpp"
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <Style.hpp>
 
 namespace lock_style = style::window::pin_lock;

--- a/module-apps/application-desktop/windows/Reboot.cpp
+++ b/module-apps/application-desktop/windows/Reboot.cpp
@@ -4,7 +4,7 @@
 #include "Reboot.hpp"
 #include "../ApplicationDesktop.hpp"
 #include <Style.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-desktop/windows/ScreenLockBox.cpp
+++ b/module-apps/application-desktop/windows/ScreenLockBox.cpp
@@ -8,7 +8,7 @@
 #include "application-desktop/data/AppDesktopStyle.hpp"
 #include "gui/widgets/Label.hpp"
 #include "gui/widgets/Image.hpp"
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace lock_style = style::window::pin_lock;
 

--- a/module-apps/application-desktop/windows/SimLockBox.cpp
+++ b/module-apps/application-desktop/windows/SimLockBox.cpp
@@ -10,7 +10,7 @@
 #include "RichTextParser.hpp"
 #include "FontManager.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <Style.hpp>
 
 namespace lock_style = style::window::pin_lock;

--- a/module-apps/application-desktop/windows/Update.cpp
+++ b/module-apps/application-desktop/windows/Update.cpp
@@ -8,7 +8,7 @@
 #include <source/version.hpp>
 
 // module-utils
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 #include "Update.hpp"
 #include "../ApplicationDesktop.hpp"

--- a/module-apps/application-meditation/widgets/IntervalBox.cpp
+++ b/module-apps/application-meditation/widgets/IntervalBox.cpp
@@ -6,7 +6,7 @@
 #include "application-meditation/data/Style.hpp"
 #include "InputEvent.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <cassert>
 
 using namespace gui;

--- a/module-apps/application-meditation/widgets/MeditationListItems.cpp
+++ b/module-apps/application-meditation/widgets/MeditationListItems.cpp
@@ -4,7 +4,7 @@
 #include "MeditationListItems.hpp"
 #include "application-meditation/data/Style.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 using namespace gui;
 namespace listStyle = style::meditation::itemList;

--- a/module-apps/application-meditation/windows/MeditationListViewWindows.cpp
+++ b/module-apps/application-meditation/windows/MeditationListViewWindows.cpp
@@ -9,7 +9,7 @@
 
 #include "ListView.hpp"
 #include "Label.hpp"
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 using namespace gui;
 namespace listViewWindow = style::meditation::listView::window;

--- a/module-apps/application-meditation/windows/MeditationTimerWindow.cpp
+++ b/module-apps/application-meditation/windows/MeditationTimerWindow.cpp
@@ -9,7 +9,7 @@
 #include "Names.hpp"
 
 #include <cassert>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 #include "RichTextParser.hpp"
 #include "FontManager.hpp"

--- a/module-apps/application-meditation/windows/MeditationWindow.cpp
+++ b/module-apps/application-meditation/windows/MeditationWindow.cpp
@@ -15,7 +15,7 @@
 
 #include <cassert>
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-messages/ApplicationMessages.cpp
+++ b/module-apps/application-messages/ApplicationMessages.cpp
@@ -17,7 +17,7 @@
 
 #include <MessageType.hpp>
 #include <Dialog.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <memory>
 #include <service-db/DBServiceAPI.hpp>
 #include <service-db/DBNotificationMessage.hpp>

--- a/module-apps/application-messages/widgets/SMSInputWidget.cpp
+++ b/module-apps/application-messages/widgets/SMSInputWidget.cpp
@@ -7,7 +7,7 @@
 #include <module-apps/application-messages/ApplicationMessages.hpp>
 
 #include <Style.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <Font.hpp>
 #include <utility>
 #include <algorithm>

--- a/module-apps/application-messages/windows/MessagesMainWindow.cpp
+++ b/module-apps/application-messages/windows/MessagesMainWindow.cpp
@@ -13,7 +13,7 @@
 #include <service-db/DBNotificationMessage.hpp>
 
 #include <service-appmgr/model/ApplicationManager.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <application-phonebook/data/PhonebookItemData.hpp>
 #include <Style.hpp>
 #include <log/log.hpp>

--- a/module-apps/application-messages/windows/NewMessage.cpp
+++ b/module-apps/application-messages/windows/NewMessage.cpp
@@ -11,7 +11,7 @@
 #include <application-phonebook/windows/PhonebookSearchResults.hpp>
 #include <service-appmgr/Controller.hpp>
 #include <service-db/DBServiceAPI.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <BoxLayout.hpp>
 #include <Text.hpp>
 

--- a/module-apps/application-messages/windows/OptionsMessages.cpp
+++ b/module-apps/application-messages/windows/OptionsMessages.cpp
@@ -8,7 +8,7 @@
 #include <common_data/Clipboard.hpp>
 #include <Options.hpp>
 #include <OptionWindow.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <log/log.hpp>
 
 #include <Text.hpp>

--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -9,7 +9,7 @@
 
 #include <service-appmgr/Controller.hpp>
 #include <service-db/DBSMSTemplateMessage.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <Style.hpp>
 #include <log/log.hpp>
 

--- a/module-apps/application-messages/windows/SearchResults.cpp
+++ b/module-apps/application-messages/windows/SearchResults.cpp
@@ -12,7 +12,7 @@
 #include <service-db/QueryMessage.hpp>
 #include <service-db/DBMessage.hpp>
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-messages/windows/SearchStart.cpp
+++ b/module-apps/application-messages/windows/SearchStart.cpp
@@ -3,7 +3,7 @@
 
 #include "SearchStart.hpp"
 #include "../ApplicationMessages.hpp"
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <widgets/InputBox.hpp>
 #include <cassert>
 

--- a/module-apps/application-messages/windows/ThreadWindowOptions.cpp
+++ b/module-apps/application-messages/windows/ThreadWindowOptions.cpp
@@ -2,7 +2,7 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ThreadWindowOptions.hpp"
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "log/log.hpp"
 #include <Options.hpp>
 #include <OptionWindow.hpp>

--- a/module-apps/application-music-player/ApplicationMusicPlayer.cpp
+++ b/module-apps/application-music-player/ApplicationMusicPlayer.cpp
@@ -6,7 +6,7 @@
 #include "windows/MusicPlayerEmptyWindow.hpp"
 
 #include <service-audio/AudioServiceAPI.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <log/log.hpp>
 #include <time/ScopedTime.hpp>
 

--- a/module-apps/application-music-player/windows/MusicPlayerAllSongsWindow.cpp
+++ b/module-apps/application-music-player/windows/MusicPlayerAllSongsWindow.cpp
@@ -6,7 +6,7 @@
 
 #include <Style.hpp>
 #include <cassert>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <log/log.hpp>
 #include <service-audio/AudioServiceAPI.hpp>
 

--- a/module-apps/application-music-player/windows/MusicPlayerEmptyWindow.cpp
+++ b/module-apps/application-music-player/windows/MusicPlayerEmptyWindow.cpp
@@ -6,7 +6,7 @@
 #include "application-music-player/data/MusicPlayerStyle.hpp"
 
 #include <Style.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <log/log.hpp>
 #include <service-audio/AudioServiceAPI.hpp>
 

--- a/module-apps/application-notes/windows/NotesEditWindow.cpp
+++ b/module-apps/application-notes/windows/NotesEditWindow.cpp
@@ -11,7 +11,7 @@
 #include "../ApplicationNotes.hpp"
 
 #include <service-db/DBMessage.hpp>
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 #include "Label.hpp"
 #include "Margins.hpp"

--- a/module-apps/application-notes/windows/NotesMainWindow.cpp
+++ b/module-apps/application-notes/windows/NotesMainWindow.cpp
@@ -10,7 +10,7 @@
 #include "../ApplicationNotes.hpp"
 
 #include <service-db/DBNotesMessage.hpp>
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 #include "Label.hpp"
 #include "Margins.hpp"

--- a/module-apps/application-phonebook/widgets/ContactFlagsWidget.cpp
+++ b/module-apps/application-phonebook/widgets/ContactFlagsWidget.cpp
@@ -8,7 +8,7 @@
 
 #include <Alignment.hpp>
 #include <BoxLayout.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <tools/Common.hpp>
 #include <Style.hpp>
 

--- a/module-apps/application-phonebook/widgets/InformationWidget.cpp
+++ b/module-apps/application-phonebook/widgets/InformationWidget.cpp
@@ -7,7 +7,7 @@
 #include "application-phonebook/data/PhonebookStyle.hpp"
 
 #include <ContactRecord.hpp>
-#include <module-utils/i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-phonebook/widgets/InputBoxWithLabelAndIconWidget.cpp
+++ b/module-apps/application-phonebook/widgets/InputBoxWithLabelAndIconWidget.cpp
@@ -6,7 +6,7 @@
 #include "application-phonebook/data/PhonebookStyle.hpp"
 
 #include <BottomBar.hpp>
-#include <module-utils/i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 #include <utility>
 

--- a/module-apps/application-phonebook/widgets/InputLinesWithLabelIWidget.cpp
+++ b/module-apps/application-phonebook/widgets/InputLinesWithLabelIWidget.cpp
@@ -7,7 +7,7 @@
 #include "application-phonebook/data/PhonebookStyle.hpp"
 
 #include <ContactRecord.hpp>
-#include <module-utils/i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <utility>
 
 namespace gui

--- a/module-apps/application-phonebook/widgets/OutputLinesTextWithLabelWidget.cpp
+++ b/module-apps/application-phonebook/widgets/OutputLinesTextWithLabelWidget.cpp
@@ -7,7 +7,7 @@
 #include "application-phonebook/data/PhonebookStyle.hpp"
 
 #include <ContactRecord.hpp>
-#include <module-utils/i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings-new/ApplicationSettings.cpp
+++ b/module-apps/application-settings-new/ApplicationSettings.cpp
@@ -27,7 +27,7 @@
 
 #include <service-evtmgr/EventManagerServiceAPI.hpp>
 #include <service-bluetooth/BluetoothMessage.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace app
 {

--- a/module-apps/application-settings-new/windows/AddDeviceWindow.cpp
+++ b/module-apps/application-settings-new/windows/AddDeviceWindow.cpp
@@ -6,7 +6,7 @@
 
 #include "OptionSetting.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <utility>
 
 namespace gui

--- a/module-apps/application-settings-new/windows/AllDevicesWindow.cpp
+++ b/module-apps/application-settings-new/windows/AllDevicesWindow.cpp
@@ -10,7 +10,7 @@
 #include "DialogMetadataMessage.hpp"
 
 #include <InputEvent.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <service-bluetooth/BluetoothMessage.hpp>
 
 namespace gui

--- a/module-apps/application-settings-new/windows/AppsAndToolsWindow.cpp
+++ b/module-apps/application-settings-new/windows/AppsAndToolsWindow.cpp
@@ -4,7 +4,7 @@
 #include "AppsAndToolsWindow.hpp"
 
 #include <application-settings-new/ApplicationSettings.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <OptionWindow.hpp>
 
 namespace gui

--- a/module-apps/application-settings-new/windows/AutolockWindow.cpp
+++ b/module-apps/application-settings-new/windows/AutolockWindow.cpp
@@ -5,7 +5,7 @@
 #include "application-settings-new/ApplicationSettings.hpp"
 #include "windows/OptionSetting.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings-new/windows/BaseSettingsWindow.cpp
+++ b/module-apps/application-settings-new/windows/BaseSettingsWindow.cpp
@@ -3,7 +3,7 @@
 
 #include "BaseSettingsWindow.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings-new/windows/BluetoothWindow.cpp
+++ b/module-apps/application-settings-new/windows/BluetoothWindow.cpp
@@ -6,7 +6,7 @@
 
 #include "OptionSetting.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <service-bluetooth/BluetoothMessage.hpp>
 
 namespace gui

--- a/module-apps/application-settings-new/windows/DisplayAndKeypadWindow.cpp
+++ b/module-apps/application-settings-new/windows/DisplayAndKeypadWindow.cpp
@@ -7,7 +7,7 @@
 #include "windows/OptionWindow.hpp"
 #include "windows/OptionSetting.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings-new/windows/DisplayLightWindow.cpp
+++ b/module-apps/application-settings-new/windows/DisplayLightWindow.cpp
@@ -6,7 +6,7 @@
 #include "application-settings-new/ApplicationSettings.hpp"
 #include "windows/OptionSetting.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings-new/windows/FontSizeWindow.cpp
+++ b/module-apps/application-settings-new/windows/FontSizeWindow.cpp
@@ -5,7 +5,7 @@
 
 #include "application-settings-new/ApplicationSettings.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings-new/windows/InputLanguageWindow.cpp
+++ b/module-apps/application-settings-new/windows/InputLanguageWindow.cpp
@@ -6,7 +6,7 @@
 #include "application-settings-new/ApplicationSettings.hpp"
 #include "windows/OptionSetting.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <module-services/service-appmgr/service-appmgr/Controller.hpp>
 
 namespace gui

--- a/module-apps/application-settings-new/windows/KeypadLightWindow.cpp
+++ b/module-apps/application-settings-new/windows/KeypadLightWindow.cpp
@@ -6,7 +6,7 @@
 #include "application-settings-new/ApplicationSettings.hpp"
 #include "windows/OptionSetting.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings-new/windows/LockedScreenWindow.cpp
+++ b/module-apps/application-settings-new/windows/LockedScreenWindow.cpp
@@ -5,7 +5,7 @@
 #include "application-settings-new/ApplicationSettings.hpp"
 #include "windows/OptionSetting.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings-new/windows/MessagesWindow.cpp
+++ b/module-apps/application-settings-new/windows/MessagesWindow.cpp
@@ -4,7 +4,7 @@
 #include "MessagesWindow.hpp"
 
 #include <application-settings-new/ApplicationSettings.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <OptionWindow.hpp>
 #include <OptionSetting.hpp>
 

--- a/module-apps/application-settings-new/windows/NetworkWindow.cpp
+++ b/module-apps/application-settings-new/windows/NetworkWindow.cpp
@@ -6,7 +6,7 @@
 
 #include "OptionSetting.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings-new/windows/QuotesAddWindow.cpp
+++ b/module-apps/application-settings-new/windows/QuotesAddWindow.cpp
@@ -5,7 +5,7 @@
 
 #include "application-settings-new/ApplicationSettings.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <widgets/Text.hpp>
 
 namespace gui

--- a/module-apps/application-settings-new/windows/QuotesMainWindow.cpp
+++ b/module-apps/application-settings-new/windows/QuotesMainWindow.cpp
@@ -8,7 +8,7 @@
 #include "windows/OptionSetting.hpp"
 
 #include <InputEvent.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <json/json11.hpp>
 #include <vfs.hpp>
 

--- a/module-apps/application-settings-new/windows/SettingsMainWindow.cpp
+++ b/module-apps/application-settings-new/windows/SettingsMainWindow.cpp
@@ -4,7 +4,7 @@
 #include "SettingsMainWindow.hpp"
 #include "application-settings-new/ApplicationSettings.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <log/log.hpp>
 #include <service-appmgr/Controller.hpp>
 

--- a/module-apps/application-settings-new/windows/TorchWindow.cpp
+++ b/module-apps/application-settings-new/windows/TorchWindow.cpp
@@ -7,7 +7,7 @@
 
 #include "OptionSetting.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings-new/windows/WallpaperWindow.cpp
+++ b/module-apps/application-settings-new/windows/WallpaperWindow.cpp
@@ -6,7 +6,7 @@
 #include "application-settings-new/ApplicationSettings.hpp"
 #include "windows/OptionSetting.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings/ApplicationSettings.cpp
+++ b/module-apps/application-settings/ApplicationSettings.cpp
@@ -26,7 +26,7 @@
 #include "windows/CellularPassthroughWindow.hpp"
 #include "windows/SettingsChange.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <service-evtmgr/EventManagerServiceAPI.hpp>
 #include <service-bluetooth/BluetoothMessage.hpp>
 #include <service-db/Settings.hpp>

--- a/module-apps/application-settings/windows/BtScanWindow.cpp
+++ b/module-apps/application-settings/windows/BtScanWindow.cpp
@@ -8,7 +8,7 @@
 
 #include "../ApplicationSettings.hpp"
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 #include "BtScanWindow.hpp"
 #include "Label.hpp"

--- a/module-apps/application-settings/windows/BtWindow.cpp
+++ b/module-apps/application-settings/windows/BtWindow.cpp
@@ -9,7 +9,7 @@
 #include "../ApplicationSettings.hpp"
 #include "../windows/BtScanWindow.hpp"
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 #include "BtWindow.hpp"
 #include "Label.hpp"

--- a/module-apps/application-settings/windows/CellularPassthroughWindow.cpp
+++ b/module-apps/application-settings/windows/CellularPassthroughWindow.cpp
@@ -2,7 +2,7 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CellularPassthroughWindow.hpp"
-#include <module-utils/i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <module-bsp/bsp/cellular/bsp_cellular.hpp>
 #include "Label.hpp"
 #include <cassert>

--- a/module-apps/application-settings/windows/DateTimeWindow.cpp
+++ b/module-apps/application-settings/windows/DateTimeWindow.cpp
@@ -16,7 +16,7 @@
 #include "../ApplicationSettings.hpp"
 #include "DateTimeWindow.hpp"
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "time/time_conversion.hpp"
 #include "time/time_date_validation.hpp"
 

--- a/module-apps/application-settings/windows/EinkModeWindow.cpp
+++ b/module-apps/application-settings/windows/EinkModeWindow.cpp
@@ -10,7 +10,7 @@
 #include "service-appmgr/Controller.hpp"
 #include "../ApplicationSettings.hpp"
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 #include "Label.hpp"
 #include "Margins.hpp"

--- a/module-apps/application-settings/windows/FotaWindow.cpp
+++ b/module-apps/application-settings/windows/FotaWindow.cpp
@@ -5,7 +5,7 @@
 
 #include "Fota.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings/windows/Info.cpp
+++ b/module-apps/application-settings/windows/Info.cpp
@@ -14,8 +14,7 @@
 #include <gui/widgets/Margins.hpp>
 #include <gui/widgets/Style.hpp>
 
-#include <i18/i18.hpp>
-
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/application-settings/windows/LanguageWindow.cpp
+++ b/module-apps/application-settings/windows/LanguageWindow.cpp
@@ -7,7 +7,7 @@
 
 #include "../ApplicationSettings.hpp"
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 #include "Label.hpp"
 #include "LanguageWindow.hpp"

--- a/module-apps/application-settings/windows/SettingsChange.cpp
+++ b/module-apps/application-settings/windows/SettingsChange.cpp
@@ -3,7 +3,7 @@
 
 #include "SettingsChange.hpp"
 #include "../ApplicationSettings.hpp"
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "tools/Common.hpp"
 #include <widgets/Text.hpp>
 #include <widgets/TextFixedSize.hpp>

--- a/module-apps/application-settings/windows/SettingsMainWindow.cpp
+++ b/module-apps/application-settings/windows/SettingsMainWindow.cpp
@@ -4,7 +4,7 @@
 #include "SettingsMainWindow.hpp"
 #include "../ApplicationSettings.hpp"
 #include "Info.hpp"
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "log/log.hpp"
 #include "CellularPassthroughWindow.hpp"
 #include "FotaWindow.hpp"

--- a/module-apps/application-settings/windows/SimSelectWindow.cpp
+++ b/module-apps/application-settings/windows/SimSelectWindow.cpp
@@ -4,7 +4,7 @@
 #include "SimSelectWindow.hpp"
 #include "Info.hpp"
 #include "SettingsMainWindow.hpp"
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "log/log.hpp"
 #include <bsp/cellular/bsp_cellular.hpp>
 #include <common_data/EventStore.hpp>

--- a/module-apps/application-settings/windows/TestMessageWindow.cpp
+++ b/module-apps/application-settings/windows/TestMessageWindow.cpp
@@ -15,7 +15,7 @@
 
 #include "../ApplicationSettings.hpp"
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 #include "Label.hpp"
 #include "Margins.hpp"

--- a/module-apps/application-settings/windows/UITestWindow.cpp
+++ b/module-apps/application-settings/windows/UITestWindow.cpp
@@ -5,7 +5,7 @@
 #include "../ApplicationSettings.hpp"
 #include "Label.hpp"
 #include "Margins.hpp"
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "log/log.hpp"
 #include "messages/AppMessage.hpp"
 #include <service-appmgr/model/ApplicationManager.hpp>

--- a/module-apps/application-settings/windows/USSDWindow.cpp
+++ b/module-apps/application-settings/windows/USSDWindow.cpp
@@ -5,7 +5,7 @@
 #include "../ApplicationSettings.hpp"
 #include "Label.hpp"
 #include "Margins.hpp"
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "messages/AppMessage.hpp"
 #include <service-appmgr/model/ApplicationManager.hpp>
 #include <GridLayout.hpp>

--- a/module-apps/application-special-input/windows/SpecialInputMainWindow.cpp
+++ b/module-apps/application-special-input/windows/SpecialInputMainWindow.cpp
@@ -5,7 +5,7 @@
 #include "../ApplicationSpecialInput.hpp"
 #include "Style.hpp"
 #include "messages/AppMessage.hpp"
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <cassert>
 
 using namespace gui;

--- a/module-apps/widgets/BrightnessBox.cpp
+++ b/module-apps/widgets/BrightnessBox.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include <module-utils/i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include "BightnessBox.hpp"
 
 namespace gui

--- a/module-apps/widgets/ButtonOnOff.cpp
+++ b/module-apps/widgets/ButtonOnOff.cpp
@@ -4,7 +4,7 @@
 #include "ButtonOnOff.hpp"
 
 #include <Style.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace gui
 {

--- a/module-apps/widgets/ModesBox.cpp
+++ b/module-apps/widgets/ModesBox.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include <module-utils/i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include "ModesBox.hpp"
 
 namespace gui

--- a/module-apps/windows/AppWindow.cpp
+++ b/module-apps/windows/AppWindow.cpp
@@ -6,7 +6,7 @@
 #include "InputEvent.hpp"
 #include <Style.hpp>
 #include <application-desktop/ApplicationDesktop.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <service-appmgr/Controller.hpp>
 #include <service-audio/AudioServiceAPI.hpp>
 

--- a/module-apps/windows/Dialog.cpp
+++ b/module-apps/windows/Dialog.cpp
@@ -4,7 +4,7 @@
 #include "Dialog.hpp"
 #include "DialogMetadataMessage.hpp"
 #include <service-appmgr/model/ApplicationManager.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 using namespace gui;
 

--- a/module-apps/windows/OptionWindow.cpp
+++ b/module-apps/windows/OptionWindow.cpp
@@ -4,7 +4,7 @@
 #include "OptionWindow.hpp"
 #include "Label.hpp"
 #include "Margins.hpp"
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "log/log.hpp"
 #include <service-appmgr/model/ApplicationManager.hpp>
 #include <Style.hpp>

--- a/module-apps/windows/Options.cpp
+++ b/module-apps/windows/Options.cpp
@@ -5,7 +5,7 @@
 #include "Text.hpp"
 #include "tools/Common.hpp"
 #include <cassert>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <utility>
 #include <FontManager.hpp>
 

--- a/module-apps/windows/VolumeWindow.cpp
+++ b/module-apps/windows/VolumeWindow.cpp
@@ -2,7 +2,7 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <module-gui/gui/input/InputEvent.hpp>
-#include <module-utils/i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include "VolumeWindow.hpp"
 
 namespace gui

--- a/module-db/Interface/ContactRecord.hpp
+++ b/module-db/Interface/ContactRecord.hpp
@@ -7,7 +7,7 @@
 #include <Common/Query.hpp>
 #include <Tables/ContactsGroups.hpp>
 
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "Record.hpp"
 #include "utf8/UTF8.hpp"
 

--- a/module-db/Interface/SettingsRecord.hpp
+++ b/module-db/Interface/SettingsRecord.hpp
@@ -7,7 +7,7 @@
 #include "utf8/UTF8.hpp"
 #include "../Common/Common.hpp"
 #include "../Databases/SettingsDB.hpp"
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 struct SettingsRecord
 {

--- a/module-db/Tables/SettingsTable.hpp
+++ b/module-db/Tables/SettingsTable.hpp
@@ -7,7 +7,7 @@
 #include "Database/Database.hpp"
 #include "utf8/UTF8.hpp"
 #include "Common/Common.hpp"
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 
 struct SettingsTableRow
 {

--- a/module-db/tests/ContactsRecord_tests.cpp
+++ b/module-db/tests/ContactsRecord_tests.cpp
@@ -4,7 +4,7 @@
 #include <catch2/catch.hpp>
 
 #include "Interface/ContactRecord.hpp"
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "vfs.hpp"
 
 TEST_CASE("Contact Record db tests")

--- a/module-gui/gui/widgets/Icon.cpp
+++ b/module-gui/gui/widgets/Icon.cpp
@@ -3,7 +3,7 @@
 
 #include "Icon.hpp"
 #include "TextParse.hpp"
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <Style.hpp>
 #include <Font.hpp>
 

--- a/module-gui/gui/widgets/InputMode.cpp
+++ b/module-gui/gui/widgets/InputMode.cpp
@@ -2,7 +2,7 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <InputMode.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <map>
 
 /// input mode strings - as these are stored in json (in files...)

--- a/module-gui/test/test-catch-text/main.cpp
+++ b/module-gui/test/test-catch-text/main.cpp
@@ -4,10 +4,10 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 #include <vfs.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
-class vfs vfs;       // needed for compilation, our vfs is global
-utils::i18 localize; // needed to load any keymap - these are stored in i18
+class vfs vfs;        // needed for compilation, our vfs is global
+utils::i18n localize; // needed to load any keymap - these are stored in i18
 
 struct vfs_initializer
 {

--- a/module-gui/test/test-catch-text/test-gui-Text.cpp
+++ b/module-gui/test/test-catch-text/test-gui-Text.cpp
@@ -6,7 +6,7 @@
 #include "Common.hpp"
 #include "InitializedFontManager.hpp"
 #include "TextParse.hpp"
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include "mock/InitializedFontManager.hpp"
 #include <catch2/catch.hpp>
 #include <limits>

--- a/module-services/service-appmgr/model/ApplicationManager.cpp
+++ b/module-services/service-appmgr/model/ApplicationManager.cpp
@@ -13,7 +13,7 @@
 #include <SystemManager/SystemManager.hpp>
 #include <application-call/ApplicationCall.hpp>
 #include <application-special-input/ApplicationSpecialInput.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <log/log.hpp>
 #include <service-appmgr/messages/Message.hpp>
 #include <service-db/DBServiceAPI.hpp>

--- a/module-services/service-appmgr/service-appmgr/Controller.hpp
+++ b/module-services/service-appmgr/service-appmgr/Controller.hpp
@@ -10,7 +10,7 @@
 #include <module-sys/Service/Service.hpp>
 #include <SwitchData.hpp>
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 #include <memory>
 #include <string>

--- a/module-services/service-appmgr/service-appmgr/messages/LanguageChangeRequest.hpp
+++ b/module-services/service-appmgr/service-appmgr/messages/LanguageChangeRequest.hpp
@@ -5,7 +5,7 @@
 
 #include "BaseMessage.hpp"
 
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 namespace app::manager
 {

--- a/module-utils/CMakeLists.txt
+++ b/module-utils/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 set (SOURCES
-        ${CMAKE_CURRENT_SOURCE_DIR}/i18/i18.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/i18n/i18n.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/json/json11.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/utf8/UTF8.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/time/time_conversion.cpp

--- a/module-utils/PhoneNumber.hpp
+++ b/module-utils/PhoneNumber.hpp
@@ -28,14 +28,14 @@ namespace utils
     class PhoneNumber
     {
       private:
-        using errCode    = i18n::phonenumbers::PhoneNumberUtil::ErrorType;
-        using formatType = i18n::phonenumbers::PhoneNumberUtil::PhoneNumberFormat;
+        using errCode    = ::i18n::phonenumbers::PhoneNumberUtil::ErrorType;
+        using formatType = ::i18n::phonenumbers::PhoneNumberUtil::PhoneNumberFormat;
 
       public:
         /**
          * @brief Number type enumeration, e.g. fixed line, mobile, etc.
          */
-        using numberType = i18n::phonenumbers::PhoneNumberUtil::PhoneNumberType;
+        using numberType = ::i18n::phonenumbers::PhoneNumberUtil::PhoneNumberType;
 
         /**
          * @brief Phone Number match type:
@@ -199,8 +199,8 @@ namespace utils
         };
 
       private:
-        using phn_util = i18n::phonenumbers::PhoneNumberUtil;
-        using gnumber  = i18n::phonenumbers::PhoneNumber;
+        using phn_util = ::i18n::phonenumbers::PhoneNumberUtil;
+        using gnumber  = ::i18n::phonenumbers::PhoneNumber;
 
       public:
         /**

--- a/module-utils/Utils.hpp
+++ b/module-utils/Utils.hpp
@@ -2,7 +2,7 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
-#include "i18/i18.hpp"
+#include "module-utils/i18n/i18n.hpp"
 #include <algorithm> // std::find_if_not
 #include <log/log.hpp>
 #include <sstream>

--- a/module-utils/i18n/i18n.cpp
+++ b/module-utils/i18n/i18n.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include "i18.hpp"
+#include "i18n.hpp"
 
 namespace utils
 {
@@ -16,7 +16,7 @@ namespace utils
         }
     } // namespace
 
-    i18 localize;
+    i18n localize;
     json11::Json LangLoader::createJson(const std::string &filename)
     {
         const fs::path path = LanguageDirPath / (filename + extension);
@@ -59,7 +59,7 @@ namespace utils
         return languageNames;
     }
 
-    void i18::setInputLanguage(const Language &lang)
+    void i18n::setInputLanguage(const Language &lang)
     {
         if (lang == currentInputLanguage) {
             return;
@@ -73,7 +73,7 @@ namespace utils
             inputLanguage     = pack;
         }
     }
-    const std::string &i18::getInputLanguage(const std::string &str)
+    const std::string &i18n::getInputLanguage(const std::string &str)
     {
         // if language pack returned nothing then try default language
         if (inputLanguage[str].string_value().empty()) {
@@ -82,7 +82,7 @@ namespace utils
         return returnNonEmptyString(inputLanguage[str].string_value(), str);
     }
 
-    const std::string &i18::get(const std::string &str)
+    const std::string &i18n::get(const std::string &str)
     {
         // if language pack returned nothing then try default language
         if (displayLanguage[str].string_value().empty()) {
@@ -91,7 +91,7 @@ namespace utils
         return returnNonEmptyString(displayLanguage[str].string_value(), str);
     }
 
-    void i18::setDisplayLanguage(const Language &lang)
+    void i18n::setDisplayLanguage(const Language &lang)
     {
         if (!backupLanguageInitializer) {
             fallbackLanguage          = loader.createJson(fallbackLanguageName);
@@ -114,7 +114,7 @@ namespace utils
         }
     }
 
-    void i18::setFallbackLanguage(const Language &lang)
+    void i18n::setFallbackLanguage(const Language &lang)
     {
         fallbackLanguageName = std::move(lang);
     }

--- a/module-utils/i18n/i18n.hpp
+++ b/module-utils/i18n/i18n.hpp
@@ -26,7 +26,7 @@ namespace utils
         json11::Json createJson(const std::string &filename);
     };
 
-    class i18
+    class i18n
     {
       private:
         json11::Json displayLanguage;
@@ -41,12 +41,12 @@ namespace utils
       public:
         static constexpr auto DefaultLanguage = "English";
         // Default constructor, left empty on purpose
-        i18()
+        i18n()
         {}
 
         // Explicit initialization point, default constructor is omitted. This is because LangLoader uses file system
         // which is not available at program's startup.
-        virtual ~i18()
+        virtual ~i18n()
         {}
         void setInputLanguage(const Language &lang);
         const std::string &getInputLanguage(const std::string &str);
@@ -56,7 +56,7 @@ namespace utils
     };
 
     // Global instance of i18 class
-    extern i18 localize;
+    extern i18n localize;
     inline auto translateI18(const std::string &text)
     {
         return utils::localize.get(text);

--- a/module-utils/test/unittest_duration.cpp
+++ b/module-utils/test/unittest_duration.cpp
@@ -13,7 +13,7 @@
 #include <catch2/catch.hpp>
 
 class vfs vfs;
-utils::i18 localize;
+utils::i18n localize;
 
 struct vfs_initializer
 {

--- a/module-utils/time/time_conversion.cpp
+++ b/module-utils/time/time_conversion.cpp
@@ -14,7 +14,7 @@
 #include <ctime>
 #include <iomanip>
 #include <locale>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 
 #include "time_locale.hpp"
 #include <Utils.hpp>

--- a/module-utils/time/time_locale.hpp
+++ b/module-utils/time/time_locale.hpp
@@ -5,7 +5,7 @@
 
 #include <array>
 #include <utf8/UTF8.hpp>
-#include <i18/i18.hpp>
+#include <module-utils/i18n/i18n.hpp>
 #include <log/log.hpp>
 
 namespace utils


### PR DESCRIPTION
Change filename of internationalization files from i18 to i18n.

I18n should stand for internationalization, not i18. That's why I changed in 'module-utils' name of the folder 'i18' and both .cpp and .hpp files to 'i18n'.