### PR TITLE
[EGD-3596] Add python test environment in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ docker/Dockerfile
 docker/assets/actions*
 docker/assets/cmake*
 docker/assets/gcc-arm*
+docker/assets/requirements*
 
 # vim temporary files
 *.swp

--- a/config/bootstrap_config
+++ b/config/bootstrap_config
@@ -47,6 +47,7 @@ INSTALL_PACKAGES="
         tzdata \
         vim \
         wget \
-        python3-magic
+        python3-magic \
+        python3-pip
 "
 

--- a/config/download_assets
+++ b/config/download_assets
@@ -37,8 +37,14 @@ function get_gh_runner() {
     wget --no-verbose --show-progress -c -O ${GH_RUNNER_PKG} ${GH_RUNNER_LINK}
 }
 
+function getPythonReq() {
+    echo -e "\e[32m${FUNCNAME[0]}\e[0m"
+    cp ${SRC_ROOT}/test/requirements.txt $DEST_DIR
+}
+
 get_arm_toolchain
 get_cmake
 get_gh_runner
+getPythonReq
 
 

--- a/docker/Dockerfile.runner.in
+++ b/docker/Dockerfile.runner.in
@@ -17,6 +17,10 @@ RUN locale-gen pl_PL.UTF-8 \
     dpkg-reconfigure --frontend noninteractive tzdata
 RUN mkdir -p /home/runner/app/settings
 
+#add python packages
+ADD assets/requirements.txt /home/docker/requirements.txt
+RUN pip3 install -r /home/docker/requirements.txt
+
 # ARM compiler
 ADD assets/@ARM_GCC_PKG@ /usr/local/
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,23 @@
 version: '3'
 services:
-  gh-runner:
-    image: rwicik/pure_builder:1.0
-    env_file:
-      - runner_settings
-
+ gh-runner0:
+   image: wearemudita/mudita_os_builder:1.3
+   environment:
+     WORKER_NAME: PureBuilder0
+   env_file:
+     - runner_settings
+   entrypoint: /cmd.sh
+ gh-runner1:
+   image: wearemudita/mudita_os_builder:1.3
+   environment:
+     WORKER_NAME: PureBuilder1
+   env_file:
+     - runner_settings
+   entrypoint: /cmd.sh
+ gh-runner2:
+   image: wearemudita/mudita_os_builder:1.3
+   environment:
+     WORKER_NAME: PureBuilder2
+   env_file:
+     - runner_settings
+   entrypoint: /cmd.sh

--- a/in_docker.sh
+++ b/in_docker.sh
@@ -3,7 +3,7 @@
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 CONTAINER_NAME="wearemudita/mudita_os_builder"
-CONTAINER_TAG="1.2"
+CONTAINER_TAG="1.3"
 CONTAINER=${CONTAINER_NAME}:${CONTAINER_TAG}
 PURE_HOME=`pwd`
 STANDARD_OPTIONS="-v `pwd`:${PURE_HOME} --user \"$(id -u):$(id -g)\" --env HOME=${PURE_HOME} -t"


### PR DESCRIPTION
`[docker]` Add python requirements for test with simulator

Change is required to support running python test with simulator.