### PR TITLE
[EGD-4724] PowerManagement: Change hardware timers clock source

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 * `[desktop]` Windows refactor
 * `[notes]` A note characters limit set to 4'000.
 * `[PowerManagement]` Separation of CPU clock into separate clock domain
+* `[PowerManagement]` Change hardware timers clock source
 
 ### Fixed
 

--- a/module-bsp/board/rt1051/common/clock_config.cpp
+++ b/module-bsp/board/rt1051/common/clock_config.cpp
@@ -155,9 +155,9 @@ void BOARD_BootClockRUN(void)
 
     /* Set PERCLK_PODF. */
     /* IPG_CLK_ROOT/2 */
-    CLOCK_SetDiv(kCLOCK_PerclkDiv, 1); // CSCMR1
+    CLOCK_SetDiv(kCLOCK_PerclkDiv, 0); // CSCMR1
     /* Set per clock source. */
-    CLOCK_SetMux(kCLOCK_PerclkMux, 0); // CSCMR1  (6) 0 - ipg_clk_root, 1 - osc_clk - PIT, GPT
+    CLOCK_SetMux(kCLOCK_PerclkMux, 1); // CSCMR1  (6) 0 - ipg_clk_root, 1 - osc_clk - PIT, GPT
 
     /* Set USDHC1_PODF. */
     CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1); // CSCDR1
@@ -1453,9 +1453,9 @@ void LPM_EnterFullSpeed(void)
 
     /* Set PERCLK_PODF. */
     /* IPG_CLK_ROOT/2 */
-    CLOCK_SetDiv(kCLOCK_PerclkDiv, 1); // CSCMR1
+    CLOCK_SetDiv(kCLOCK_PerclkDiv, 0); // CSCMR1
     /* Set per clock source. */
-    CLOCK_SetMux(kCLOCK_PerclkMux, 0); // CSCMR1  (6) 0 - ipg_clk_root, 1 - osc_clk - PIT, GPT
+    CLOCK_SetMux(kCLOCK_PerclkMux, 1); // CSCMR1  (6) 0 - ipg_clk_root, 1 - osc_clk - PIT, GPT
 
     clkPLL2setup(CLK_ENABLE);
     CLOCK_SetMux(kCLOCK_SemcMux, 1);


### PR DESCRIPTION
Change clock source of GPT and PIT hardware clocks to an independent
source from an oscillator.