### PR TITLE
[EGD-4778] Add Bluetooth settings to db & add examples how to read them

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * `[PowerManagement]` PowerManagement: Enable FreeRTOS Run Time Statistics
 * `[cellular]` USSD session handling.
 * `[settings]` Nightshift window - GUI.
+* `[bluetooth][settings]` Add Bluetooth settings to database.
 
 ### Changed
 

--- a/image/user/db/settings_v2_002.sql
+++ b/image/user/db/settings_v2_002.sql
@@ -13,4 +13,8 @@ INSERT OR REPLACE INTO settings_tab (path, value) VALUES
     ('gs_lock_pass_hash', '3333'),
     ('gs_lock_time', '30000'),
     ('gs_display_language', 'En'),
-    ('gs_input_language', 'En');
+    ('gs_input_language', 'En'),
+    ('bt_state', '0'),
+    ('bt_device_visibility', '0'),
+    ('bt_device_name', 'PurePhone'),
+    ('bt_bonded_devices', '');

--- a/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
@@ -11,6 +11,10 @@
 #include <memory> // for unique_ptr
 
 class BluetoothWorker;
+namespace settings
+{
+    class Settings;
+}
 
 class ServiceBluetooth : public sys::Service
 {
@@ -26,4 +30,10 @@ class ServiceBluetooth : public sys::Service
 
   private:
     std::unique_ptr<BluetoothWorker> worker;
+    std::unique_ptr<settings::Settings> settingsProvider;
+
+    void stateSettingChanged(std::string value);
+    void deviceVisibilitySettingChanged(std::string value);
+    void deviceNameSettingChanged(std::string value);
+    void bondedDevicesSettingChanged(std::string value);
 };

--- a/module-services/service-db/agents/settings/SystemSettings.hpp
+++ b/module-services/service-db/agents/settings/SystemSettings.hpp
@@ -3,13 +3,24 @@
 
 #pragma once
 
-namespace settings::SystemProperties
+namespace settings
 {
-    constexpr inline auto timeFormat12    = "gs_time_format_12";
-    constexpr inline auto timeDateFormat  = "gs_time_date_format";
-    constexpr inline auto activeSim       = "gs_active_sim";
-    constexpr inline auto lockPassHash    = "gs_lock_pass_hash";
-    constexpr inline auto lockTime        = "gs_lock_time";
-    constexpr inline auto displayLanguage = "gs_display_language";
-    constexpr inline auto inputLanguage   = "gs_input_language";
-}; // namespace settings::SystemProperties
+    namespace SystemProperties
+    {
+        constexpr inline auto timeFormat12    = "gs_time_format_12";
+        constexpr inline auto timeDateFormat  = "gs_time_date_format";
+        constexpr inline auto activeSim       = "gs_active_sim";
+        constexpr inline auto lockPassHash    = "gs_lock_pass_hash";
+        constexpr inline auto lockTime        = "gs_lock_time";
+        constexpr inline auto displayLanguage = "gs_display_language";
+        constexpr inline auto inputLanguage   = "gs_input_language";
+    } // namespace SystemProperties
+    namespace Bluetooth
+    {
+        constexpr inline auto state            = "bt_state";
+        constexpr inline auto deviceVisibility = "bt_device_visibility";
+        constexpr inline auto deviceName       = "bt_device_name";
+        constexpr inline auto bondedDevices    = "bt_bonded_devices";
+    } // namespace Bluetooth
+
+}; // namespace settings


### PR DESCRIPTION
The purpose of callbacks added in Service Bluetooth is to demonstrate how to read Bluetooth settings from db.
They will be changed in the future.