### PR TITLE
[EGD-4727] Torch: Hardware control

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,9 @@
 
 * Fix missing texts for ApplicationDesktop windows
 
+### Changed
+
+* `[UserInterface]` Torch light control button press time recognition.
 ## [0.51.1 2020-12-18]
 
 ### Added

--- a/module-apps/Application.cpp
+++ b/module-apps/Application.cpp
@@ -540,7 +540,7 @@ namespace app
         return AudioServiceAPI::GetSetting(this, audio::Setting::Volume, volume);
     }
 
-    void Application::toggleTorchAndColourTemps()
+    void Application::toggleTorch(bsp::torch::ColourTemperature temperature)
     {
         using namespace bsp;
 
@@ -558,16 +558,10 @@ namespace app
             switch (msgGetState->state) {
             case torch::State::off:
                 msgSetState->state      = torch::State::on;
-                msgSetState->colourTemp = torch::warmest;
+                msgSetState->colourTemp = temperature;
                 break;
             case torch::State::on:
-                if (msgGetState->colourTemp == torch::warmest) { // toggle colour temp
-                    msgSetState->state      = torch::State::on;
-                    msgSetState->colourTemp = torch::coldest;
-                }
-                else {
-                    msgSetState->state = torch::State::off;
-                }
+                msgSetState->state = torch::State::off;
                 break;
             }
             sys::Bus::SendUnicast(msgSetState, service::name::evt_manager, this);

--- a/module-apps/Application.hpp
+++ b/module-apps/Application.hpp
@@ -280,7 +280,7 @@ namespace app
         }
         audio::RetCode getCurrentVolume(audio::Volume &volume);
 
-        void toggleTorchAndColourTemps();
+        void toggleTorch(bsp::torch::ColourTemperature temperature);
 
         /// @defgroup Application Application static functions
         /// All this functions are meant to be used in ApplicationManager only

--- a/module-apps/windows/AppWindow.cpp
+++ b/module-apps/windows/AppWindow.cpp
@@ -127,29 +127,35 @@ namespace gui
             LOG_INFO("exit to main menu");
             app::manager::Controller::sendAction(application, app::manager::actions::Home);
         }
-        // process only if key is released
-        if ((inputEvent.state != InputEvent::State::keyReleasedShort))
-            return false;
 
-        switch (inputEvent.keyCode) {
-        case KeyCode::KEY_VOLUP: {
-            application->increaseCurrentVolume();
-            return true;
+        if ((inputEvent.isShortPress())) {
+            switch (inputEvent.keyCode) {
+            case KeyCode::KEY_VOLUP: {
+                application->increaseCurrentVolume();
+                return true;
+            }
+            case KeyCode::KEY_VOLDN: {
+                application->decreaseCurrentVolume();
+                return true;
+            }
+            case KeyCode::KEY_RF: {
+                application->returnToPreviousWindow();
+                return true;
+            }
+            default:
+                break;
+            }
         }
-        case KeyCode::KEY_VOLDN: {
-            application->decreaseCurrentVolume();
-            return true;
-        }
-        case KeyCode::KEY_RF: {
-            application->returnToPreviousWindow();
-            return true;
-        }
-        case KeyCode::KEY_TORCH: {
-            application->toggleTorchAndColourTemps();
-            return true;
-        }
-        default:
-            break;
+
+        if (inputEvent.keyCode == KeyCode::KEY_TORCH) {
+            if (inputEvent.isLongPress()) {
+                application->toggleTorch(bsp::torch::ColourTemperature::warmest);
+                return true;
+            }
+            else if (inputEvent.isShortPress()) {
+                application->toggleTorch(bsp::torch::ColourTemperature::coldest);
+                return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
New way of torch light control as described in task. Used longPress detection (above 1s of button hold) to select warm light and short press to select cold light. Value of 1s of long press is suitable here and it is easy to get good feeling how to use it.