### PR TITLE
[EGD-5009] Change messy callback logic in audio module

### DIFF
--- a/module-audio/Audio/Audio.cpp
+++ b/module-audio/Audio/Audio.cpp
@@ -10,11 +10,10 @@
 namespace audio
 {
 
-    Audio::Audio(AsyncCallback asyncCallback, DbCallback dbCallback)
-        : currentOperation(), asyncCallback(asyncCallback), dbCallback(dbCallback)
+    Audio::Audio(AudioServiceMessage::Callback callback) : currentOperation(), serviceCallback(callback)
     {
 
-        auto ret = Operation::Create(Operation::Type::Idle, "", audio::PlaybackType::None, dbCallback);
+        auto ret = Operation::Create(Operation::Type::Idle, "", audio::PlaybackType::None, callback);
         if (ret) {
             currentOperation = std::move(ret);
         }
@@ -76,7 +75,7 @@ namespace audio
     {
 
         try {
-            auto ret = Operation::Create(op, fileName, playbackType, dbCallback);
+            auto ret = Operation::Create(op, fileName, playbackType, serviceCallback);
             switch (op) {
             case Operation::Type::Playback:
                 currentState = State::Playback;
@@ -108,7 +107,7 @@ namespace audio
             return audioException.getErrorCode();
         }
 
-        return currentOperation->Start(asyncCallback, token);
+        return currentOperation->Start(token);
     }
 
     audio::RetCode Audio::Start()

--- a/module-audio/Audio/Audio.hpp
+++ b/module-audio/Audio/Audio.hpp
@@ -29,7 +29,7 @@ namespace audio
             Routing,
         };
 
-        Audio(AsyncCallback asyncCallback, DbCallback dbCallback);
+        Audio(AudioServiceMessage::Callback callback);
 
         virtual ~Audio() = default;
 
@@ -116,8 +116,7 @@ namespace audio
         State currentState = State::Idle;
         std::unique_ptr<Operation> currentOperation;
 
-        AsyncCallback asyncCallback;
-        DbCallback dbCallback;
+        AudioServiceMessage::Callback serviceCallback;
 
         // for efficiency multiple of 24 and 32 (max audio samples size)
         static constexpr auto defaultAudioStreamBlockSize = 2048;

--- a/module-audio/Audio/AudioCommon.cpp
+++ b/module-audio/Audio/AudioCommon.cpp
@@ -54,7 +54,7 @@ namespace audio
         return path;
     }
 
-    auto GetVolumeText(const audio::Volume &volume) -> const std::string
+    auto GetVolumeText(const audio::Volume &volume) -> std::string
     {
         return (static_cast<std::ostringstream &&>(std::ostringstream() << "Vol: " << std::to_string(volume))).str();
     }

--- a/module-audio/Audio/AudioMux.cpp
+++ b/module-audio/Audio/AudioMux.cpp
@@ -18,14 +18,13 @@ namespace audio
         };
     } // namespace
 
-    AudioMux::AudioMux(audio::AsyncCallback asyncClbk, audio::DbCallback dbClbk, size_t audioInputsCount)
+    AudioMux::AudioMux(AudioServiceMessage::Callback callback, size_t audioInputsCount)
         : audioInputs(audioInputsInternal)
     {
         audioInputsCount = audioInputsCount > 0 ? audioInputsCount : 1;
         audioInputsInternal.reserve(audioInputsCount);
         for (size_t i = 0; i < audioInputsCount; i++) {
-            audioInputsInternal.emplace_back(
-                Input(std::make_unique<Audio>(asyncClbk, dbClbk), refToken.IncrementToken()));
+            audioInputsInternal.emplace_back(Input(std::make_unique<Audio>(callback), refToken.IncrementToken()));
         }
     }
 

--- a/module-audio/Audio/AudioMux.hpp
+++ b/module-audio/Audio/AudioMux.hpp
@@ -44,11 +44,10 @@ namespace audio
         };
         /**
          * Constructs class with fixed number of managed inputs
-         * @param asyncClbk Callback for async control events from of managed audio::Audio() instances
-         * @param dbClbk Callback for async DB change events from of managed audio::Audio() instances
+         * @param callback Callback for async requests to audio service from audio module
          * @param audioInputsCount Number of inputs managed and internal audio::Audio() classes created
          */
-        AudioMux(audio::AsyncCallback asyncClbk, audio::DbCallback dbClbk, size_t audioInputsCount = 1);
+        AudioMux(AudioServiceMessage::Callback callback, size_t audioInputsCount = 1);
         /**
          * Constructs mux managing externally allocated instances of Input
          * @param extAudioInputs Instances of Input to be managed

--- a/module-audio/Audio/Operation/IdleOperation.cpp
+++ b/module-audio/Audio/Operation/IdleOperation.cpp
@@ -8,7 +8,7 @@
 namespace audio
 {
 
-    IdleOperation::IdleOperation([[maybe_unused]] const char *file)
+    IdleOperation::IdleOperation([[maybe_unused]] const char *file) : Operation(nullptr)
     {
         supportedProfiles.emplace_back(Profile::Create(Profile::Type::Idle, nullptr), true);
         currentProfile = supportedProfiles[0].profile;

--- a/module-audio/Audio/Operation/IdleOperation.hpp
+++ b/module-audio/Audio/Operation/IdleOperation.hpp
@@ -15,11 +15,11 @@ namespace audio
     class IdleOperation : public Operation
     {
       public:
-        IdleOperation(const char *file);
+        explicit IdleOperation([[maybe_unused]] const char *file);
 
         ~IdleOperation() = default;
 
-        audio::RetCode Start([[maybe_unused]] audio::AsyncCallback callback, audio::Token token) final
+        audio::RetCode Start(audio::Token token) final
         {
             return audio::RetCode::Success;
         }

--- a/module-audio/Audio/Operation/PlaybackOperation.hpp
+++ b/module-audio/Audio/Operation/PlaybackOperation.hpp
@@ -23,14 +23,13 @@ namespace audio
     class PlaybackOperation : public Operation
     {
       public:
-        PlaybackOperation(
-            const char *file,
-            const audio::PlaybackType &playbackType,
-            std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback = nullptr);
+        PlaybackOperation(const char *file,
+                          const audio::PlaybackType &playbackType,
+                          AudioServiceMessage::Callback callback = nullptr);
 
         virtual ~PlaybackOperation();
 
-        audio::RetCode Start(audio::AsyncCallback callback, audio::Token token) final;
+        audio::RetCode Start(audio::Token token) final;
         audio::RetCode Stop() final;
         audio::RetCode Pause() final;
         audio::RetCode Resume() final;

--- a/module-audio/Audio/Operation/RecorderOperation.hpp
+++ b/module-audio/Audio/Operation/RecorderOperation.hpp
@@ -13,10 +13,9 @@ namespace audio
     class RecorderOperation : public Operation
     {
       public:
-        RecorderOperation(const char *file,
-                          std::function<uint32_t(const std::string &path, const uint32_t &defaultValue)> dbCallback);
+        RecorderOperation(const char *file, AudioServiceMessage::Callback callback);
 
-        audio::RetCode Start(audio::AsyncCallback callback, audio::Token token) final;
+        audio::RetCode Start(audio::Token token) final;
         audio::RetCode Stop() final;
         audio::RetCode Pause() final;
         audio::RetCode Resume() final;

--- a/module-audio/Audio/Operation/RouterOperation.hpp
+++ b/module-audio/Audio/Operation/RouterOperation.hpp
@@ -27,12 +27,10 @@ namespace audio
         static const std::size_t INPUT_BUFFER_START_SIZE = 1024;
 
       public:
-        RouterOperation(
-            const char *file,
-            std::function<std::uint32_t(const std::string &path, const std::uint32_t &defaultValue)> dbCallback);
+        RouterOperation(const char *file, AudioServiceMessage::Callback callback);
         ~RouterOperation() = default;
 
-        audio::RetCode Start([[maybe_unused]] audio::AsyncCallback callback, audio::Token token) final;
+        audio::RetCode Start(audio::Token token) final;
         audio::RetCode Stop() final;
         audio::RetCode Pause() final;
         audio::RetCode Resume() final;

--- a/module-audio/Audio/Profiles/Profile.cpp
+++ b/module-audio/Audio/Profiles/Profile.cpp
@@ -24,40 +24,53 @@
 namespace audio
 {
 
-    std::unique_ptr<Profile> Profile::Create(const Type t, std::function<int32_t()> callback, Volume vol, Gain gain)
+    std::unique_ptr<Profile> Profile::Create(const Type t,
+                                             std::function<int32_t()> callback,
+                                             std::optional<Volume> vol,
+                                             std::optional<Gain> gain)
     {
         std::unique_ptr<Profile> inst;
 
         switch (t) {
         case Type::PlaybackHeadphones:
-            inst = std::make_unique<ProfilePlaybackHeadphones>(callback, vol);
+            assert(vol);
+            inst = std::make_unique<ProfilePlaybackHeadphones>(callback, vol.value());
             break;
         case Type::PlaybackLoudspeaker:
-            inst = std::make_unique<ProfilePlaybackLoudspeaker>(callback, vol);
+            assert(vol);
+            inst = std::make_unique<ProfilePlaybackLoudspeaker>(callback, vol.value());
             break;
         case Type::PlaybackBluetoothA2DP:
-            inst = std::make_unique<ProfilePlaybackBluetoothA2DP>(callback, vol);
+            assert(vol);
+            inst = std::make_unique<ProfilePlaybackBluetoothA2DP>(callback, vol.value());
             break;
         case Type::RecordingBuiltInMic:
-            inst = std::make_unique<ProfileRecordingOnBoardMic>(callback, gain);
+            assert(gain);
+            inst = std::make_unique<ProfileRecordingOnBoardMic>(callback, gain.value());
             break;
         case Type::RecordingHeadphones:
-            inst = std::make_unique<ProfileRecordingHeadphones>(callback, gain);
+            assert(gain);
+            inst = std::make_unique<ProfileRecordingHeadphones>(callback, gain.value());
             break;
         case Type::RecordingBluetoothHSP:
-            inst = std::make_unique<ProfileRecordingBluetoothHSP>(callback, gain);
+            assert(gain);
+            inst = std::make_unique<ProfileRecordingBluetoothHSP>(callback, gain.value());
             break;
         case Type::RoutingHeadphones:
-            inst = std::make_unique<ProfileRoutingHeadphones>(callback, vol, gain);
+            assert(gain && vol);
+            inst = std::make_unique<ProfileRoutingHeadphones>(callback, vol.value(), gain.value());
             break;
         case Type::RoutingLoudspeaker:
-            inst = std::make_unique<ProfileRoutingLoudspeaker>(callback, vol, gain);
+            assert(gain && vol);
+            inst = std::make_unique<ProfileRoutingLoudspeaker>(callback, vol.value(), gain.value());
             break;
         case Type::RoutingEarspeaker:
-            inst = std::make_unique<ProfileRoutingEarspeaker>(callback, vol, gain);
+            assert(gain && vol);
+            inst = std::make_unique<ProfileRoutingEarspeaker>(callback, vol.value(), gain.value());
             break;
         case Type::RoutingBluetoothHSP:
-            inst = std::make_unique<ProfileRoutingBluetoothHSP>(callback, vol, gain);
+            assert(gain && vol);
+            inst = std::make_unique<ProfileRoutingBluetoothHSP>(callback, vol.value(), gain.value());
             break;
         case Type::Idle:
             inst = std::make_unique<ProfileIdle>();

--- a/module-audio/Audio/Profiles/Profile.hpp
+++ b/module-audio/Audio/Profiles/Profile.hpp
@@ -44,8 +44,8 @@ namespace audio
 
         static std::unique_ptr<Profile> Create(const Type t,
                                                std::function<int32_t()> callback = nullptr,
-                                               Volume vol                        = 0,
-                                               Gain gain                         = 0);
+                                               std::optional<Volume> vol         = 0,
+                                               std::optional<Gain> gain          = 0);
 
         void SetOutputVolume(Volume vol);
 

--- a/module-audio/Audio/test/unittest_audio.cpp
+++ b/module-audio/Audio/test/unittest_audio.cpp
@@ -74,8 +74,7 @@ class MockAudio : public audio::Audio
 
   public:
     MockAudio(audio::Audio::State state, audio::PlaybackType plbckType, audio::Operation::State opState)
-        : audio::Audio([](audio::PlaybackEvent e) { return 0; },
-                       [](const std::string &path, const uint32_t &defaultValue) { return 0; }),
+        : audio::Audio([](const AudioServiceMessage::Message *e) { return std::optional<std::string>(); }),
           state(state), plbckType(plbckType), opState(opState)
     {}
 

--- a/module-services/service-audio/service-audio/AudioMessage.hpp
+++ b/module-services/service-audio/service-audio/AudioMessage.hpp
@@ -52,7 +52,7 @@ class AudioNotificationMessage : public AudioMessage
         ServiceSleep,
     };
 
-    explicit AudioNotificationMessage(Type type, audio::Token token = audio::Token()) : type(type), token(token)
+    explicit AudioNotificationMessage(Type type, const audio::Token token = audio::Token()) : type(type), token(token)
     {}
 
     const Type type;

--- a/module-services/service-audio/service-audio/ServiceAudio.hpp
+++ b/module-services/service-audio/service-audio/ServiceAudio.hpp
@@ -56,8 +56,7 @@ class ServiceAudio : public sys::Service
         return vibrationMotorStatus == audio::AudioMux::VibrationStatus::On;
     }
 
-    auto AsyncCallback(audio::PlaybackEvent e) -> int32_t;
-    auto DbCallback(const std::string &path, const uint32_t &defaultValue) -> uint32_t;
+    auto AudioServicesCallback(const AudioServiceMessage::Message *msg) -> std::optional<std::string>;
 
     auto HandleStart(const audio::Operation::Type opType,
                      const std::string                       = "",


### PR DESCRIPTION
* Refactor audio module to use only one callback for communication
  with audio service. This also simplifies the logic and removes
  necessity to define defaults for audio values in multiple places.
* Remove not used interfaces and classes