### PR TITLE
[EGD-5007] Add bluetooth message (bonded devices) to application settings

### DIFF
--- a/module-apps/application-settings-new/ApplicationSettings.cpp
+++ b/module-apps/application-settings-new/ApplicationSettings.cpp
@@ -29,8 +29,9 @@
 #include <service-evtmgr/EventManagerServiceAPI.hpp>
 #include <service-bluetooth/BluetoothMessage.hpp>
 #include <module-utils/i18n/i18n.hpp>
-#include <service-bluetooth/messages/Status.hpp>
+#include <service-bluetooth/messages/BondedDevices.hpp>
 #include <service-bluetooth/messages/DeviceName.hpp>
+#include <service-bluetooth/messages/Status.hpp>
 #include <service-cellular/CellularServiceAPI.hpp>
 #include <service-db/Settings.hpp>
 
@@ -102,8 +103,16 @@ namespace app
         else if (auto responseDeviceNameMsg = dynamic_cast<message::bluetooth::ResponseDeviceName *>(msgl);
                  nullptr != responseDeviceNameMsg) {
             if (gui::window::name::phone_name == getCurrentWindow()->getName()) {
-                auto btPhoneNameData = std::make_unique<gui::PhoneNameData>(responseDeviceNameMsg->getName());
-                switchWindow(gui::window::name::phone_name, std::move(btPhoneNameData));
+                auto phoneNameData = std::make_unique<gui::PhoneNameData>(responseDeviceNameMsg->getName());
+                switchWindow(gui::window::name::phone_name, std::move(phoneNameData));
+            }
+        }
+        else if (auto responseBondedDevicesMsg = dynamic_cast<message::bluetooth::ResponseBondedDevices *>(msgl);
+                 nullptr != responseBondedDevicesMsg) {
+            if (gui::window::name::all_devices == getCurrentWindow()->getName()) {
+                auto bondedDevicesData =
+                    std::make_unique<gui::BondedDevicesData>(responseBondedDevicesMsg->getDevices());
+                switchWindow(gui::window::name::all_devices, std::move(bondedDevicesData));
             }
         }
 

--- a/module-apps/application-settings-new/windows/AllDevicesWindow.hpp
+++ b/module-apps/application-settings-new/windows/AllDevicesWindow.hpp
@@ -5,17 +5,35 @@
 
 #include "OptionWindow.hpp"
 
+#include <Device.hpp>
+
 namespace gui
 {
     class AllDevicesWindow : public OptionWindow
     {
       public:
-        AllDevicesWindow(app::Application *app);
-        auto onInput(const InputEvent &inputEvent) -> bool override;
+        explicit AllDevicesWindow(app::Application *app);
 
       private:
+        auto allDevicesOptionsList(const std::vector<Devicei> &vector) -> std::list<Option>;
+        void onBeforeShow(ShowMode mode, SwitchData *data) override;
+        auto onInput(const InputEvent &inputEvent) -> bool override;
+
         Image *leftArrowImage = nullptr;
         Image *crossImage     = nullptr;
-        auto allDevicesOptionsList() -> std::list<Option>;
     };
-}; // namespace gui
+
+    class BondedDevicesData : public SwitchData
+    {
+      public:
+        explicit BondedDevicesData(std::vector<Devicei> devices) : SwitchData(), devices(std::move(devices))
+        {}
+        [[nodiscard]] auto getDevices() const -> const std::vector<Devicei> &
+        {
+            return devices;
+        }
+
+      private:
+        const std::vector<Devicei> devices;
+    };
+} // namespace gui

--- a/module-apps/application-settings-new/windows/BluetoothWindow.hpp
+++ b/module-apps/application-settings-new/windows/BluetoothWindow.hpp
@@ -14,8 +14,8 @@ namespace gui
         explicit BluetoothWindow(app::Application *app);
 
       private:
-        void onBeforeShow(ShowMode mode, SwitchData *data) override;
         auto bluetoothOptionsList() -> std::list<gui::Option>;
+        void onBeforeShow(ShowMode mode, SwitchData *data) override;
         void rebuildOptionList();
         void switchHandler(bool &switchState);
 

--- a/module-apps/application-settings-new/windows/PhoneNameWindow.hpp
+++ b/module-apps/application-settings-new/windows/PhoneNameWindow.hpp
@@ -33,6 +33,6 @@ namespace gui
         }
 
       private:
-        std::string name;
+        const std::string name;
     };
 } /* namespace gui */

--- a/module-services/service-bluetooth/ServiceBluetooth.cpp
+++ b/module-services/service-bluetooth/ServiceBluetooth.cpp
@@ -4,6 +4,7 @@
 #include "Constants.hpp"
 #include "service-bluetooth/ServiceBluetooth.hpp"
 #include "service-bluetooth/BluetoothMessage.hpp"
+#include <service-bluetooth/messages/BondedDevices.hpp>
 #include <service-bluetooth/messages/DeviceName.hpp>
 #include <service-bluetooth/messages/SetDeviceName.hpp>
 #include "service-bluetooth/messages/Status.hpp"
@@ -85,6 +86,12 @@ sys::MessagePointer ServiceBluetooth::DataReceivedHandler(sys::DataMessage *msg,
     if (auto setDeviceNameMsg = dynamic_cast<message::bluetooth::SetDeviceName *>(msg); nullptr != setDeviceNameMsg) {
         phoneName = setDeviceNameMsg->getName();
         sys::Bus::SendBroadcast(std::make_shared<message::bluetooth::ResponseDeviceName>(phoneName), this);
+    }
+
+    // mock response on message::bluetooth::RequestBondedDevices
+    if (auto requestBondedDevicesMsg = dynamic_cast<message::bluetooth::RequestBondedDevices *>(msg);
+        nullptr != requestBondedDevicesMsg) {
+        sys::Bus::SendUnicast(std::make_shared<message::bluetooth::ResponseBondedDevices>(devices), msg->sender, this);
     }
 
     try {

--- a/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
@@ -35,6 +35,11 @@ class ServiceBluetooth : public sys::Service
 
     // will be replaced with settings storage introduced in [EGD-4579]
     BluetoothStatus btStatus;
+    std::vector<Devicei> devices{Devicei("Paired_device1"),
+                                 Devicei("Paired_device2"),
+                                 Devicei("Paired_device3"),
+                                 Devicei("Paired_device4"),
+                                 Devicei("Paired_device5")};
     std::string phoneName = "PurePhone";
 
     void stateSettingChanged(std::string value);


### PR DESCRIPTION
Utilize Bluetooth message BondedDevices to proper display related data in
All Devices window. Responses to Bluetooth messages are mocked
because settings storage and message handlers in Service Bluetooth
are not ready yet.