### PR TITLE
[EGD-5022] Fix invalid open flags in vfscore

### DIFF
--- a/module-vfs/drivers/src/purefs/fs/filesystem_vfat.cpp
+++ b/module-vfs/drivers/src/purefs/fs/filesystem_vfat.cpp
@@ -76,7 +76,7 @@ namespace purefs::fs::drivers
             if (flags & O_APPEND)
                 fat_mode |= FA_OPEN_APPEND;
             if (flags & O_CREAT)
-                fat_mode |= FA_CREATE_NEW;
+                fat_mode |= FA_OPEN_ALWAYS;
             if (flags & O_TRUNC)
                 fat_mode |= FA_CREATE_ALWAYS;
             return fat_mode;


### PR DESCRIPTION
Opening file with O_CREAT mode on the mounted fat filesystem
should create file if doesn't exist. Currently it returns ENOENT
This path fix this issue. ff_fat create flags are fixed.