### PR TITLE
[EGD-5034] Change gain values to reduce echo during call

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 * Input language files are now loaded based on files in "profiles" folder.
 * Minimum CPU frequency is now 132 MHz
 * Icon widget now accepts rich text.
+* Change default gain values for audio input.
 
 ### Fixed
 

--- a/module-services/service-audio/ServiceAudio.cpp
+++ b/module-services/service-audio/ServiceAudio.cpp
@@ -66,9 +66,9 @@ sys::ReturnCodes ServiceAudio::InitHandler()
 
         // ROUTING
         {dbPath(Setting::Gain, PlaybackType::None, Profile::Type::RoutingBluetoothHSP), "20"},
-        {dbPath(Setting::Gain, PlaybackType::None, Profile::Type::RoutingEarspeaker), "20"},
+        {dbPath(Setting::Gain, PlaybackType::None, Profile::Type::RoutingEarspeaker), "0"},
         {dbPath(Setting::Gain, PlaybackType::None, Profile::Type::RoutingLoudspeaker), "20"},
-        {dbPath(Setting::Gain, PlaybackType::None, Profile::Type::RoutingHeadphones), "50"},
+        {dbPath(Setting::Gain, PlaybackType::None, Profile::Type::RoutingHeadphones), "0"},
 
         {dbPath(Setting::Volume, PlaybackType::None, Profile::Type::RoutingBluetoothHSP), defaultVolumeHigh},
         {dbPath(Setting::Volume, PlaybackType::None, Profile::Type::RoutingEarspeaker), defaultVolumeHigh},


### PR DESCRIPTION
Default values of the gain for the build-in and headphones
microphone has been changed. Previously set excessive values
caused echo during call.

Signed-off-by: Lukasz Skrzypczak <lukasz.skrzypczak@mudita.com>