### PR TITLE
[EGD-4648] Fix auto screen change

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+* Fix auto unlock screen on idle
 * Fix missing texts for ApplicationDesktop windows
 
 ### Changed

--- a/module-apps/application-desktop/widgets/PinLockHandler.cpp
+++ b/module-apps/application-desktop/widgets/PinLockHandler.cpp
@@ -106,9 +106,11 @@ namespace gui
     void PinLockHandler::handleUnlockSim(app::manager::actions::ActionParamsPtr &&data)
     {
         LOG_DEBUG("Handling UnlockSim action");
-        simLock.lockState   = PinLock::LockState::Unlocked;
         promptSimLockWindow = false;
-        unlock();
+        if (!simLock.isState(PinLock::LockState::Unlocked)) {
+            simLock.lockState = PinLock::LockState::Unlocked;
+            unlock();
+        }
     }
 
     void PinLockHandler::handleCMEError(app::manager::actions::ActionParamsPtr &&data) const


### PR DESCRIPTION
`UnlockSim` action should be handled only if there is ongoing SIM flow processing