### PR TITLE
[EGD-5061] Fix lack of audio during call

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 
 * Fix auto unlock screen on idle
 * Fix missing texts for ApplicationDesktop windows
+* Fix no audio during call
 
 ### Changed
 

--- a/module-audio/Audio/Operation/PlaybackOperation.cpp
+++ b/module-audio/Audio/Operation/PlaybackOperation.cpp
@@ -58,6 +58,7 @@ namespace audio
         operationToken = token;
 
         assert(dataStreamOut);
+
         dec->startDecodingWorker(*dataStreamOut, endOfFileCallback);
 
         if (!tags) {
@@ -196,6 +197,8 @@ namespace audio
     PlaybackOperation::~PlaybackOperation()
     {
         Stop();
+        dataStreamOut->reset();
+        dataStreamIn->reset();
     }
 
 } // namespace audio

--- a/module-audio/Audio/Operation/RouterOperation.cpp
+++ b/module-audio/Audio/Operation/RouterOperation.cpp
@@ -88,6 +88,8 @@ namespace audio
         state = State::Idle;
         audioDevice->Stop();
         audioDeviceCellular->Stop();
+        dataStreamOut->reset();
+        dataStreamIn->reset();
 
         return RetCode::Success;
     }

--- a/module-audio/Audio/Stream.cpp
+++ b/module-audio/Audio/Stream.cpp
@@ -245,6 +245,19 @@ bool Stream::blocksAvailable() const noexcept
     return !isEmpty();
 }
 
+void Stream::reset()
+{
+    _dataStart                = {_buffer.get(), _blockSize * _blockCount, _buffer.get(), _blockSize};
+    _dataEnd                  = _dataStart;
+    _peekPosition             = _dataStart;
+    _writeReservationPosition = _dataStart;
+    std::fill(_emptyBuffer.get(), _emptyBuffer.get() + _blockSize, 0);
+
+    _blocksUsed   = 0;
+    _peekCount    = 0;
+    _reserveCount = 0;
+}
+
 Stream::UniqueStreamBuffer StandardStreamAllocator::allocate(std::size_t size)
 {
     return std::make_unique<uint8_t[]>(size);

--- a/module-audio/Audio/Stream.hpp
+++ b/module-audio/Audio/Stream.hpp
@@ -101,6 +101,8 @@ namespace audio
         /// get empty data span
         Span getNullSpan() const noexcept;
 
+        void reset();
+
         [[nodiscard]] std::size_t getBlockSize() const noexcept;
         [[nodiscard]] std::size_t getBlockCount() const noexcept;
         [[nodiscard]] std::size_t getUsedBlockCount() const noexcept;

--- a/module-bsp/board/rt1051/bsp/audio/RT1051Audiocodec.cpp
+++ b/module-bsp/board/rt1051/bsp/audio/RT1051Audiocodec.cpp
@@ -297,6 +297,9 @@ namespace bsp
             SAI_TransferTerminateSendEDMA(BOARD_AUDIOCODEC_SAIx, &txHandle);
         }
         memset(&txHandle, 0, sizeof(txHandle));
+        if (sink.isConnected()) {
+            sink.getStream()->unpeek();
+        }
     }
 
     void RT1051Audiocodec::InStop()
@@ -306,6 +309,9 @@ namespace bsp
             SAI_TransferAbortReceiveEDMA(BOARD_AUDIOCODEC_SAIx, &rxHandle);
         }
         memset(&rxHandle, 0, sizeof(rxHandle));
+        if (source.isConnected()) {
+            source.getStream()->release();
+        }
     }
 
     void rxAudioCodecCallback(I2S_Type *base, sai_edma_handle_t *handle, status_t status, void *userData)

--- a/module-bsp/board/rt1051/bsp/audio/RT1051CellularAudio.cpp
+++ b/module-bsp/board/rt1051/bsp/audio/RT1051CellularAudio.cpp
@@ -259,6 +259,9 @@ namespace bsp
             SAI_TransferTerminateSendEDMA(BOARD_CELLULAR_AUDIO_SAIx, &txHandle);
         }
         memset(&txHandle, 0, sizeof(txHandle));
+        if (sink.isConnected()) {
+            sink.getStream()->unpeek();
+        }
     }
 
     void RT1051CellularAudio::InStop()
@@ -268,6 +271,9 @@ namespace bsp
             SAI_TransferAbortReceiveEDMA(BOARD_CELLULAR_AUDIO_SAIx, &rxHandle);
         }
         memset(&rxHandle, 0, sizeof(rxHandle));
+        if (source.isConnected()) {
+            source.getStream()->release();
+        }
     }
 
     void rxCellularCallback(I2S_Type *base, sai_edma_handle_t *handle, status_t status, void *userData)


### PR DESCRIPTION
Audio might have not work if audio streams
were reused. This was fixed by introducing proper
cleaning procedures.