### PR TITLE
[EGD-5050] Brownout detection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # MuditaOS changelog
 
+## Latest Changes
+### Added
+
+* Battery Brownout detection
 ## [0.52.1 2020-12-23]
 
 ### Added

--- a/module-bsp/board/linux/battery-charger/battery_charger.cpp
+++ b/module-bsp/board/linux/battery-charger/battery_charger.cpp
@@ -127,4 +127,10 @@ namespace bsp
             vTaskDelay(50);
         }
     }
+
+    std::uint16_t battery_getStatusRegister()
+    {
+        return static_cast<std::uint16_t>(batteryINTBSource::SOCOnePercentChange);
+    }
+
 } // namespace bsp

--- a/module-bsp/board/rt1051/bsp/battery-charger/battery_charger.cpp
+++ b/module-bsp/board/rt1051/bsp/battery-charger/battery_charger.cpp
@@ -55,8 +55,8 @@ static const uint8_t battery_DischargedPercent   = 15;
 static const uint8_t battery_maxTemperatureDegrees = 50;
 static const uint8_t battery_minTemperatureDegrees = 5;
 
-static const uint16_t battery_maxVoltagemV = 4200;
-static const uint16_t battery_minVoltagemV = 3700;
+static constexpr inline uint16_t battery_maxVoltagemV = 4200;
+static constexpr inline uint16_t battery_minVoltagemV = 3600;
 
 using namespace drivers;
 
@@ -97,7 +97,7 @@ static bsp::batteryRetval battery_enableFuelGuageIRQs(void);
 
 static bsp::batteryRetval battery_enableTopIRQs(void);
 
-static bsp::batteryRetval battery_disableAlerts(void);
+static bsp::batteryRetval battery_configureAlerts();
 
 static void s_BSP_BatteryChargerIrqPinsInit();
 
@@ -140,7 +140,27 @@ namespace bsp
         AICL_I  = (1 << 7),
     };
 
-    uint16_t battery_get_STATUS();
+    // CONFIG register bits
+    enum class B_CONFIG
+    {
+        Ber    = 1 << 0,
+        Bei    = 1 << 1,
+        Aen    = 1 << 2,
+        FTHRM  = 1 << 3,
+        ETHRM  = 1 << 4,
+        SPR_5  = 1 << 5,
+        I2CSH  = 1 << 6,
+        SHDN   = 1 << 7,
+        Tex    = 1 << 8,
+        Ten    = 1 << 9,
+        AINSH  = 1 << 10,
+        SPR_11 = 1 << 11,
+        Vs     = 1 << 12,
+        Ts     = 1 << 13,
+        Ss     = 1 << 14,
+        SPR_15 = 1 << 15
+    };
+
     uint16_t battery_get_CHG_INT_OK();
 
     int battery_Init(xQueueHandle qHandle)
@@ -166,7 +186,7 @@ namespace bsp
             battery_setServiceVoltageThresholds(battery_maxVoltagemV, battery_minVoltagemV);
         }
 
-        battery_disableAlerts();
+        battery_configureAlerts();
         battery_enableFuelGuageIRQs();
 
         uint8_t level = 0;
@@ -223,7 +243,7 @@ namespace bsp
         }
     }
 
-    uint16_t battery_get_STATUS()
+    std::uint16_t battery_getStatusRegister()
     {
         uint16_t status = 0;
         battery_fuelGaugeRead(bsp::batteryChargerRegisters::STATUS_REG, &status);
@@ -239,7 +259,7 @@ namespace bsp
             battery_chargerWrite(bsp::batteryChargerRegisters::CHG_INT_REG, 0);
         }
 
-        uint16_t status = battery_get_STATUS();
+        uint16_t status = battery_getStatusRegister();
         if (status != 0) {
             // write zero to clear irq source
             battery_fuelGaugeWrite(bsp::batteryChargerRegisters::STATUS_REG, 0);
@@ -251,6 +271,7 @@ namespace bsp
         // write zero to clear interrupt source
         battery_fuelGaugeWrite(bsp::batteryChargerRegisters::STATUS_REG, 0x0000);
     }
+
 } // namespace bsp
 
 static int battery_fuelGaugeWrite(bsp::batteryChargerRegisters registerAddress, uint16_t value)
@@ -493,12 +514,12 @@ static bsp::batteryRetval battery_enableFuelGuageIRQs(void)
     return bsp::batteryRetval::battery_OK;
 }
 
-static bsp::batteryRetval battery_disableAlerts(void)
+static bsp::batteryRetval battery_configureAlerts()
 {
-    uint16_t regVal = 0;
+    auto regVal = static_cast<std::uint16_t>(bsp::B_CONFIG::Aen); // Enable alerts
 
     if (battery_fuelGaugeWrite(bsp::batteryChargerRegisters::CONFIG_REG, regVal) != kStatus_Success) {
-        LOG_ERROR("battery_disableAlerts failed.");
+        LOG_ERROR("battery_configureAlerts failed.");
         return bsp::batteryRetval::battery_ChargerError;
     }
 

--- a/module-bsp/bsp/battery-charger/battery_charger.hpp
+++ b/module-bsp/bsp/battery-charger/battery_charger.hpp
@@ -8,6 +8,7 @@
 #ifndef MODULE_BSP_BSP_BATTERY_CHARGER_BATTERY_CHARGER_HPP_
 #define MODULE_BSP_BSP_BATTERY_CHARGER_BATTERY_CHARGER_HPP_
 
+#include <cstdint>
 namespace bsp{
 
 	enum class batteryChargerRegisters{
@@ -100,6 +101,12 @@ namespace bsp{
 		INOKB = 0x02
 	};
 
+	enum class batteryINTBSource{
+		minSOCAlert = 1 << 10,
+		minVAlert = 1 << 8,
+		SOCOnePercentChange = 1 << 7
+	};
+
 	int battery_Init(xQueueHandle qHandle);
 
 	void battery_Deinit(void);
@@ -111,6 +118,8 @@ namespace bsp{
 	void battery_ClearAllIRQs(void);
 
 	void battery_clearFuelGuageIRQ(void);
+
+	std::uint16_t battery_getStatusRegister();
 }
 
 BaseType_t BSP_BatteryChargerINOKB_IRQHandler();

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -123,9 +123,7 @@ sys::MessagePointer EventManager::DataReceivedHandler(sys::DataMessage *msgl, sy
     else if (msgl->messageType == MessageType::EVMBatteryLevel && msgl->sender == this->GetName()) {
         auto *msg = static_cast<sevm::BatteryLevelMessage *>(msgl);
 
-        auto message           = std::make_shared<sevm::BatteryLevelMessage>();
-        message->levelPercents = msg->levelPercents;
-        message->fullyCharged  = msg->fullyCharged;
+        auto message = std::make_shared<sevm::BatteryLevelMessage>(msg->levelPercents, msg->fullyCharged);
 
         if (!targetApplication.empty()) {
             sys::Bus::SendUnicast(message, targetApplication, this);

--- a/module-services/service-evtmgr/service-evtmgr/BatteryMessages.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/BatteryMessages.hpp
@@ -12,7 +12,8 @@ namespace sevm
     class BatteryLevelMessage : public Message
     {
       public:
-        BatteryLevelMessage() : Message(MessageType::EVMBatteryLevel)
+        BatteryLevelMessage(uint8_t levelPercents, bool fullyCharged)
+            : Message(MessageType::EVMBatteryLevel), levelPercents(levelPercents), fullyCharged(fullyCharged)
         {
             type = Type::Data;
         }
@@ -44,4 +45,12 @@ namespace sevm
         BatteryLevelCriticalMessage() : Message(MessageType::EVMBatteryLevelCritical)
         {}
     };
+
+    class BatteryBrownoutMessage : public Message
+    {
+      public:
+        BatteryBrownoutMessage() : Message(MessageType::EVMBatteryBrownout)
+        {}
+    };
+
 } // namespace sevm

--- a/module-sys/SystemManager/SystemManager.cpp
+++ b/module-sys/SystemManager/SystemManager.cpp
@@ -256,7 +256,12 @@ namespace sys
         });
 
         connect(sevm::BatteryLevelCriticalMessage(), [&](Message *) {
-            LOG_INFO("Battery Critical Level reached!");
+            LOG_INFO("Battery Critical SOC Level reached!");
+            return MessageNone{};
+        });
+
+        connect(sevm::BatteryBrownoutMessage(), [&](Message *) {
+            LOG_INFO("Battery Brownout voltage level reached!");
             return MessageNone{};
         });
 

--- a/source/MessageType.hpp
+++ b/source/MessageType.hpp
@@ -168,6 +168,7 @@ enum class MessageType
     EVMChargerPlugged,
     EVMBatterySetCriticalLevel,
     EVMBatteryLevelCritical,
+    EVMBatteryBrownout,
     // rtc messages
     EVMMinuteUpdated, ///< This message is send to current focused application on every minute time change.
     EVMTimeUpdated,   ///< This message is send on every time update.


### PR DESCRIPTION
Simple brownout detection done by charger chip. Configuration of charger + message to communicate system manager about the event. Action in application to be done in follow-up. Brownout (battery level < 3.6V) -> detection by charger -> interrupt -> message to sys manager.