### PR TITLE
[EGD-4973] Fix absent notifications on home screen

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,11 @@
 ### Changed
 
 * Input keyboard language files parser from KBD to JSON.
+
+### Fixed
+
+* Fix absent notifications
+
 ## [0.52.1 2020-12-23]
 
 ### Added

--- a/image/user/db/notifications_002.sql
+++ b/image/user/db/notifications_002.sql
@@ -1,0 +1,3 @@
+INSERT OR IGNORE INTO notifications (key, value) VALUES
+    ('1', '0'),
+    ('2', '0');

--- a/module-apps/application-desktop/data/Style.hpp
+++ b/module-apps/application-desktop/data/Style.hpp
@@ -9,7 +9,7 @@ namespace style::desktop
     namespace notifications
     {
         constexpr auto SpanSize     = 8;
-        constexpr auto DigitSize    = 14;
+        constexpr auto DigitSize    = 16;
         constexpr auto IconWidth    = 35;
         constexpr auto TextMaxWidth = 250;
 

--- a/module-apps/application-desktop/widgets/NotificationsBox.cpp
+++ b/module-apps/application-desktop/widgets/NotificationsBox.cpp
@@ -105,13 +105,12 @@ namespace
         auto number = new gui::Text();
         if (indicator.length() > 2) {
             number->setText(maxNotificationValue);
-            number->setMinimumWidth(strlen(maxNotificationValue) * notifications::DigitSize);
         }
         else {
             number->setText(indicator);
-            number->setMinimumWidth(indicator.length() * notifications::DigitSize);
         }
-        number->setMinimumWidth(indicator.length() * notifications::DigitSize);
+
+        number->setMinimumWidth(number->getText().length() * notifications::DigitSize);
         number->setFont(style::window::font::mediumbold);
         number->setPenWidth(style::window::default_border_no_focus_w);
         number->setMargins(gui::Margins(0, 0, style::window::default_right_margin, 0));


### PR DESCRIPTION
SMS and Calls notifications require default init of respective data base
Displaying notifications require wider space reservation for some digits (e.g. `8`)