### PR TITLE
[EGD-5086] Change audio device switching logic

### DIFF
--- a/module-audio/Audio/Operation/RouterOperation.cpp
+++ b/module-audio/Audio/Operation/RouterOperation.cpp
@@ -25,17 +25,6 @@ namespace audio
         AddProfile(Profile::Type::RoutingHeadphones, PlaybackType::None, false);
         AddProfile(Profile::Type::RoutingEarspeaker, PlaybackType::None, true);
         AddProfile(Profile::Type::RoutingLoudspeaker, PlaybackType::None, true);
-
-        auto defaultProfile = GetProfile(Profile::Type::RoutingEarspeaker);
-        if (!defaultProfile) {
-            throw AudioInitException("Error during initializing profile", RetCode::ProfileNotSet);
-        }
-        currentProfile = defaultProfile;
-
-        auto retCode = SwitchToPriorityProfile();
-        if (retCode != RetCode::Success) {
-            throw AudioInitException("Failed to switch audio profile", retCode);
-        }
     }
 
     audio::RetCode RouterOperation::SetOutputVolume(float vol)
@@ -153,7 +142,11 @@ namespace audio
     audio::RetCode RouterOperation::SwitchProfile(const audio::Profile::Type type)
     {
         auto ret = GetProfile(type);
+
         if (ret) {
+            if (currentProfile && currentProfile->GetType() == ret->GetType()) {
+                return RetCode::Success;
+            }
             currentProfile = ret;
         }
         else {

--- a/module-audio/Audio/decoder/Decoder.cpp
+++ b/module-audio/Audio/decoder/Decoder.cpp
@@ -133,4 +133,12 @@ namespace audio
         }
     }
 
+    void Decoder::stopDecodingWorker()
+    {
+        if (audioWorker) {
+            audioWorker->close();
+        }
+        audioWorker = nullptr;
+    }
+
 } // namespace audio

--- a/module-audio/Audio/decoder/Decoder.hpp
+++ b/module-audio/Audio/decoder/Decoder.hpp
@@ -81,6 +81,7 @@ namespace audio
         virtual uint32_t decode(uint32_t samplesToRead, int16_t *pcmData) = 0;
 
         void startDecodingWorker(Stream &audioStream, DecoderWorker::EndOfFileCallback endOfFileCallback);
+        void stopDecodingWorker();
 
         std::unique_ptr<Tags> fetchTags();
 

--- a/module-bsp/board/rt1051/bsp/audio/RT1051Audiocodec.cpp
+++ b/module-bsp/board/rt1051/bsp/audio/RT1051Audiocodec.cpp
@@ -99,10 +99,10 @@ namespace bsp
             return AudioDevice::RetCode::Failure;
         }
 
-        codec.Stop();
-
         InStop();
         OutStop();
+
+        codec.Stop();
 
         state = State::Stopped;
         vTaskDelay(codecSettleTime);


### PR DESCRIPTION
Upon hardware change event, audio profile had been switched multiple
times forcing redundant initializations of all related objects. Logic
has been optimized and prepared for further refactor. Now upon hardware
event objects are initialized exactly once.