### PR TITLE
[EGD-5103] Fix year in license header check

### DIFF
--- a/config/license_header_check.sh
+++ b/config/license_header_check.sh
@@ -17,7 +17,7 @@ REPO_ROOT="${SCRIPT_DIR%/*}"
 
 pushd ${REPO_ROOT} >> /dev/null
 
-LICENSE1="Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved."
+LICENSE1="Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved."
 LICENSE2="For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md"
 
 CHECK_ONLY="false"


### PR DESCRIPTION
Bumped year to 2021 in automated license header checker.