### PR TITLE
 [EGD-4338] Fix menu notification dot

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 
 ### Fixed
 
+* Fix menu notification dot
 * Fix absent notifications
 * Fix newly added contact recognized as a duplicate of temporary contact.
 * Fix default borderCallback navigation in GridLayout.

--- a/module-apps/application-desktop/ApplicationDesktop.cpp
+++ b/module-apps/application-desktop/ApplicationDesktop.cpp
@@ -203,7 +203,11 @@ namespace app
              msg->interface == db::Interface::Name::SMS) &&
             msg->type != db::Query::Type::Read) {
             requestNotReadNotifications();
-            windowsFactory.build(this, app::window::name::desktop_menu);
+            if (auto menuWindow = dynamic_cast<gui::MenuWindow *>(getWindow(app::window::name::desktop_menu));
+                menuWindow != nullptr) {
+                menuWindow->refresh();
+                return true;
+            }
         }
 
         return false;
@@ -266,7 +270,6 @@ namespace app
     {
         notifications.notRead.Calls = DBServiceAPI::CalllogGetCount(this, EntryState::UNREAD);
         notifications.notRead.SMS   = DBServiceAPI::ThreadGetCount(this, EntryState::UNREAD);
-
         return true;
     }
 

--- a/module-apps/application-desktop/windows/MenuWindow.hpp
+++ b/module-apps/application-desktop/windows/MenuWindow.hpp
@@ -22,7 +22,13 @@ namespace gui
         Tile(UTF8 icon,
              std::string title,
              std::function<bool(Item &)> activatedCallback,
-             unsigned int notifications = 0);
+             std::function<bool()> hasNotificationsCallback = nullptr);
+
+        bool onNotificationsChange(gui::RefreshModes);
+
+      private:
+        std::function<bool(gui::RefreshModes)> onNotificationsChangeCallback = nullptr;
+        gui::Image *notificationThumbnail                                    = nullptr;
     };
 
     class MenuPage : public gui::GridLayout
@@ -36,6 +42,7 @@ namespace gui
         MenuPage(gui::Item *parent, UTF8 title, std::vector<Tile *> tiles);
         /// set child which should be selected on start of desktop
         void setFirstTimeSelection();
+        bool refresh(gui::RefreshModes mode);
     };
 
     class MenuWindow : public AppWindow
@@ -48,7 +55,6 @@ namespace gui
       public:
         MenuWindow(app::Application *app);
 
-        void onBeforeShow(ShowMode mode, SwitchData *data) override;
         bool onInput(const InputEvent &inputEvent) override;
 
         void rebuild() override;
@@ -56,6 +62,7 @@ namespace gui
         void destroyInterface() override;
 
         void switchMenu(MenuPage *page);
+        void refresh();
 
       private:
         void invalidate() noexcept;

--- a/module-gui/gui/widgets/Item.cpp
+++ b/module-gui/gui/widgets/Item.cpp
@@ -515,11 +515,6 @@ namespace gui
         return false;
     }
 
-    bool Item::onContent()
-    {
-        return false;
-    }
-
     auto Item::onTimer(Timer &timer) -> bool
     {
         if (timerCallback != nullptr) {

--- a/module-gui/gui/widgets/Item.hpp
+++ b/module-gui/gui/widgets/Item.hpp
@@ -139,9 +139,6 @@ namespace gui
         /// @param `this` item
         /// @param `InputEvent`
         std::function<bool(Item &, const InputEvent &inputEvent)> inputCallback;
-        /// callback when element insides are changed
-        /// @param `this` item
-        std::function<bool(Item &)> contentCallback;
         /// callback when timer is called on Item and onTimer is executed
         /// @param `this` item
         /// @param `timer` which triggered this callback
@@ -183,10 +180,6 @@ namespace gui
         /// calls: none, inconsistent api
         /// @note TODO should be fixed so that api would be consistent
         virtual bool onDimensionChanged(const BoundingBox &oldDim, const BoundingBox &newDim);
-        /// (should be) called each time content in item was changed, added for gui::Text widget
-        /// calls: none, inconsistent behaviour
-        /// @note TODO should be fixed so that api would be consistent
-        virtual bool onContent();
         /// called on Timer event in application, triggeres timerCallback
         /// @param timer timer element which triggered this action
         virtual bool onTimer(Timer &timer);

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -1044,6 +1044,9 @@ sys::MessagePointer ServiceCellular::DataReceivedHandler(sys::DataMessage *msgl,
             if (auto response = dynamic_cast<db::query::SMSSearchByTypeResult *>(result.get())) {
                 responseHandled = handle(response);
             }
+            else if (result->hasListener()) {
+                responseHandled = result->handle();
+            }
         }
         if (responseHandled) {
             return std::make_shared<sys::ResponseMessage>();


### PR DESCRIPTION
This PR fixes problem with not showing/disappearing notification dot in menu when not read / not seen 
count changed and no MenuWindow rebuild event occurred,
Now each tile in Menu that uses notification dot is refreshed. 

This PR also solves https://appnroll.atlassian.net/browse/EGD-4129
This PR also fixes missing `ServiceCellular`'s `QueryResult` handling