### PR TITLE
[EGD-4832] Fix "Device freeze when adding new contact from Home Screen" bug

### DIFF
--- a/module-apps/application-phonebook/models/PhonebookModel.cpp
+++ b/module-apps/application-phonebook/models/PhonebookModel.cpp
@@ -60,8 +60,8 @@ void PhonebookModel::requestRecords(const uint32_t offset, const uint32_t limit)
 {
     auto query =
         std::make_unique<db::query::ContactGet>(offset, limit, queryFilter, queryGroupFilter, queryDisplayMode);
-    query->setQueryListener(
-        db::QueryCallback::fromFunction([this](auto response) { return handleQueryResponse(response); }));
+    query->setQueryListener(db::QueryCallback::fromFunction(
+        [_this = shared_from_this()](auto response) { return _this->handleQueryResponse(response); }));
     DBServiceAPI::GetQuery(application, db::Interface::Name::Contact, std::move(query));
 }
 
@@ -104,7 +104,9 @@ auto PhonebookModel::updateRecords(std::vector<ContactRecord> records) -> bool
 #endif
 
     DatabaseModel::updateRecords(std::move(records));
-    list->onProviderDataUpdate();
+    if (list != nullptr) {
+        list->onProviderDataUpdate();
+    }
 
     return true;
 }

--- a/module-apps/application-phonebook/models/PhonebookModel.hpp
+++ b/module-apps/application-phonebook/models/PhonebookModel.hpp
@@ -17,7 +17,9 @@
 
 #include <string>
 
-class PhonebookModel : public app::DatabaseModel<ContactRecord>, public gui::ListItemProvider
+class PhonebookModel : public app::DatabaseModel<ContactRecord>,
+                       public gui::ListItemProvider,
+                       public std::enable_shared_from_this<PhonebookModel>
 {
   private:
     std::string queryFilter;

--- a/module-apps/application-phonebook/windows/PhonebookMainWindow.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookMainWindow.cpp
@@ -86,6 +86,7 @@ namespace gui
 
     void PhonebookMainWindow::destroyInterface()
     {
+        phonebookModel->list = nullptr;
         erase();
     }
 


### PR DESCRIPTION
PhonebookModel passed self to QueryCallback in requestRecords method.

There are two problems with above action:
1.
Problem:
After adding new contact from Home Screen
PhonebookMainWindow is destroyed, destroying also PhonebookModel.

Solution:
Pass shared_from_this to QueryCallback
2.
Problem:
list member from ListItemProvider is also destroyed.

Solution:
Assign list member to nullptr when destroying PhonebookMainWindow.
Check list for nullptr in QueryCallback.