### PR TITLE
[EGD-5153] sectors count fix

### DIFF
--- a/module-vfs/include/user/purefs/blkdev/defs.hpp
+++ b/module-vfs/include/user/purefs/blkdev/defs.hpp
@@ -26,7 +26,7 @@ namespace purefs::blkdev
     // Information parameter
     enum class info_type
     {
-        sector_count, //! Number of sectors on disk
+        sector_count, //! Number of sectors on disk or part
         sector_size,  //! Single sector size
         erase_block   //! Number of sectors in erase block
     };

--- a/module-vfs/src/purefs/blkdev/disk_manager.cpp
+++ b/module-vfs/src/purefs/blkdev/disk_manager.cpp
@@ -272,7 +272,18 @@ namespace purefs::blkdev
             LOG_ERROR("Disk doesn't exists");
             return {};
         }
-        return disk->get_info(what);
+        //! When it is partition as for partition sectors count
+        if (what == info_type::sector_count && dfd->has_partition()) {
+            if (unsigned(dfd->partition()) >= disk->partitions().size()) {
+                LOG_ERROR("Partition number out of range");
+                return -ERANGE;
+            }
+            const auto part = disk->partitions()[dfd->partition()];
+            return part.num_sectors;
+        }
+        else {
+            return disk->get_info(what);
+        }
     }
     auto disk_manager::reread_partitions(disk_fd dfd) -> int
     {


### PR DESCRIPTION
Currently when partition handle is passed to the disk manager
it returns total disk sector count instead of partitions sector count