### PR TITLE
[EGD-5115] Fix dangling ptrs in module-db tests

### DIFF
--- a/module-db/tests/AlarmsRecord_tests.cpp
+++ b/module-db/tests/AlarmsRecord_tests.cpp
@@ -26,10 +26,10 @@ TEST_CASE("Alarms Record tests")
 {
     Database::initialize();
 
-    const auto alarmsPath = (purefs::dir::getUserDiskPath() / "alarms.db").c_str();
+    const auto alarmsPath = purefs::dir::getUserDiskPath() / "alarms.db";
     std::filesystem::remove(alarmsPath);
 
-    auto alarmsDB = AlarmsDB(alarmsPath);
+    AlarmsDB alarmsDB(alarmsPath.c_str());
     REQUIRE(alarmsDB.isInitialized());
 
     SECTION("Default Constructor")

--- a/module-db/tests/AlarmsTable_tests.cpp
+++ b/module-db/tests/AlarmsTable_tests.cpp
@@ -21,10 +21,10 @@ TEST_CASE("Alarms Table tests")
 {
     Database::initialize();
 
-    const auto alarmsPath = (purefs::dir::getUserDiskPath() / "alarms.db").c_str();
+    const auto alarmsPath = purefs::dir::getUserDiskPath() / "alarms.db";
     std::filesystem::remove(alarmsPath);
 
-    AlarmsDB alarmsDb(alarmsPath);
+    AlarmsDB alarmsDb(alarmsPath.c_str());
     REQUIRE(alarmsDb.isInitialized());
 
     auto &alarmsTbl = alarmsDb.alarms;

--- a/module-db/tests/CalllogRecord_tests.cpp
+++ b/module-db/tests/CalllogRecord_tests.cpp
@@ -20,13 +20,13 @@ TEST_CASE("Calllog Record tests")
 {
     Database::initialize();
 
-    const auto callogPath   = (purefs::dir::getUserDiskPath() / "callog.db").c_str();
-    const auto contactsPath = (purefs::dir::getUserDiskPath() / "contacts.db").c_str();
+    const auto callogPath   = purefs::dir::getUserDiskPath() / "callog.db";
+    const auto contactsPath = purefs::dir::getUserDiskPath() / "contacts.db";
     std::filesystem::remove(callogPath);
     std::filesystem::remove(contactsPath);
 
-    CalllogDB calllogDb(callogPath);
-    ContactsDB contactsDb(contactsPath);
+    CalllogDB calllogDb(callogPath.c_str());
+    ContactsDB contactsDb(contactsPath.c_str());
 
     REQUIRE(calllogDb.isInitialized());
     REQUIRE(contactsDb.isInitialized());

--- a/module-db/tests/CalllogTable_tests.cpp
+++ b/module-db/tests/CalllogTable_tests.cpp
@@ -20,10 +20,10 @@ TEST_CASE("Calllog Table tests")
 {
     Database::initialize();
 
-    const auto callogPath = (purefs::dir::getUserDiskPath() / "callog.db").c_str();
+    const auto callogPath = purefs::dir::getUserDiskPath() / "callog.db";
     std::filesystem::remove(callogPath);
 
-    CalllogDB calllogDb{callogPath};
+    CalllogDB calllogDb{callogPath.c_str()};
     REQUIRE(calllogDb.isInitialized());
 
     auto &callsTbl = calllogDb.calls;

--- a/module-db/tests/ContactGroups_tests.cpp
+++ b/module-db/tests/ContactGroups_tests.cpp
@@ -28,9 +28,9 @@ TEST_CASE("Contact Groups tests", "[Groups]")
 {
     INFO("sqlite Init");
     Database::initialize();
-    const auto callogPath = (purefs::dir::getUserDiskPath() / "contacts.db").c_str();
+    const auto callogPath = purefs::dir::getUserDiskPath() / "contacts.db";
     std::filesystem::remove(callogPath);
-    ContactsDB contactDb{callogPath};
+    ContactsDB contactDb{callogPath.c_str()};
     INFO("contactDB init");
     REQUIRE(contactDb.isInitialized());
     ContactsGroupsTable contactGroupsTable = ContactsGroupsTable(&contactDb);

--- a/module-db/tests/ContactsAddressTable_tests.cpp
+++ b/module-db/tests/ContactsAddressTable_tests.cpp
@@ -12,10 +12,10 @@ TEST_CASE("Contacts address Table tests")
 {
     Database::initialize();
 
-    const auto callogPath = (purefs::dir::getUserDiskPath() / "contacts.db").c_str();
+    const auto callogPath = purefs::dir::getUserDiskPath() / "contacts.db";
     std::filesystem::remove(callogPath);
 
-    ContactsDB contactsdb{callogPath};
+    ContactsDB contactsdb{callogPath.c_str()};
     REQUIRE(contactsdb.isInitialized());
 
     ContactsAddressTableRow testRow1 = {{.ID = DB_ID_NONE},

--- a/module-db/tests/ContactsNameTable_tests.cpp
+++ b/module-db/tests/ContactsNameTable_tests.cpp
@@ -18,10 +18,10 @@ TEST_CASE("Contacts Name Table tests")
 {
     Database::initialize();
 
-    const auto contactsPath = (purefs::dir::getUserDiskPath() / "contacts.db").c_str();
-    std::remove(contactsPath);
+    const auto contactsPath = purefs::dir::getUserDiskPath() / "contacts.db";
+    std::filesystem::remove(contactsPath);
 
-    ContactsDB contactsdb(contactsPath);
+    ContactsDB contactsdb(contactsPath.c_str());
     REQUIRE(contactsdb.isInitialized());
 
     ContactsNameTableRow testRow1 = {

--- a/module-db/tests/ContactsNumberTable_tests.cpp
+++ b/module-db/tests/ContactsNumberTable_tests.cpp
@@ -20,10 +20,10 @@ TEST_CASE("Contacts Number Table tests")
 {
     Database::initialize();
 
-    const auto contactsPath = (purefs::dir::getUserDiskPath() / "contacts.db").c_str();
+    const auto contactsPath = purefs::dir::getUserDiskPath() / "contacts.db";
     std::filesystem::remove(contactsPath);
 
-    ContactsDB contactsdb{contactsPath};
+    ContactsDB contactsdb{contactsPath.c_str()};
     REQUIRE(contactsdb.isInitialized());
 
     ContactsNumberTableRow testRow1 = {

--- a/module-db/tests/ContactsRecord_tests.cpp
+++ b/module-db/tests/ContactsRecord_tests.cpp
@@ -12,11 +12,11 @@ TEST_CASE("Contact Record db tests")
 {
     Database::initialize();
 
-    const auto contactsPath = (purefs::dir::getUserDiskPath() / "contacts.db").c_str();
+    const auto contactsPath = purefs::dir::getUserDiskPath() / "contacts.db";
     std::filesystem::remove(contactsPath);
 
-    auto contactDB = std::make_unique<ContactsDB>(contactsPath);
-    REQUIRE(contactDB->isInitialized());
+    ContactsDB contactDB(contactsPath.c_str());
+    REQUIRE(contactDB.isInitialized());
 
     const char *primaryNameTest                   = "PrimaryNameTest";
     const char *alternativeNameTest               = "AlternativeNameTest";
@@ -29,7 +29,7 @@ TEST_CASE("Contact Record db tests")
     const char *speeddialTest                     = "100";
     const ContactNumberType contactNumberTypeTest = ContactNumberType ::PAGER;
 
-    ContactRecordInterface contRecInterface(contactDB.get());
+    ContactRecordInterface contRecInterface(&contactDB);
 
     ContactRecord recordIN;
 
@@ -261,13 +261,13 @@ TEST_CASE("Test converting contact data to string")
 TEST_CASE("Contact record numbers update")
 {
     Database::initialize();
-    const auto contactsPath = (purefs::dir::getUserDiskPath() / "contacts.db").c_str();
+    const auto contactsPath = purefs::dir::getUserDiskPath() / "contacts.db";
     std::filesystem::remove(contactsPath);
 
-    auto contactDB = std::make_unique<ContactsDB>(contactsPath);
-    REQUIRE(contactDB->isInitialized());
+    ContactsDB contactDB(contactsPath.c_str());
+    REQUIRE(contactDB.isInitialized());
 
-    auto records = ContactRecordInterface(contactDB.get());
+    auto records = ContactRecordInterface(&contactDB);
 
     ContactRecord testRecord, otherRecord;
     std::array<std::string, 4> numbers = {{{"600100100"}, {"600100200"}, {"600100300"}, {"600100400"}}};
@@ -289,7 +289,7 @@ TEST_CASE("Contact record numbers update")
         auto newRecord = records.GetByID(1);
         REQUIRE(newRecord.numbers.size() == 2);
         REQUIRE(records.Update(newRecord));
-        REQUIRE(contactDB->number.count() == 4);
+        REQUIRE(contactDB.number.count() == 4);
 
         auto validatationRecord = records.GetByID(1);
         REQUIRE(validatationRecord.numbers.size() == 2);
@@ -310,7 +310,7 @@ TEST_CASE("Contact record numbers update")
         newRecord.numbers = std::vector<ContactRecord::Number>({ContactRecord::Number(numbers[1], std::string(""))});
         REQUIRE(records.Update(newRecord));
 
-        REQUIRE(contactDB->number.count() == 3);
+        REQUIRE(contactDB.number.count() == 3);
 
         auto validatationRecord = records.GetByID(1);
         REQUIRE(validatationRecord.numbers.size() == 1);
@@ -324,7 +324,7 @@ TEST_CASE("Contact record numbers update")
         newRecord.numbers = std::vector<ContactRecord::Number>(
             {ContactRecord::Number(numbers[0], std::string("")), ContactRecord::Number(numbers[1], std::string(""))});
         REQUIRE(records.Update(newRecord));
-        REQUIRE(contactDB->number.count() == 4);
+        REQUIRE(contactDB.number.count() == 4);
 
         validatationRecord = records.GetByID(1);
         REQUIRE(validatationRecord.numbers.size() == 2);
@@ -349,7 +349,7 @@ TEST_CASE("Contact record numbers update")
         REQUIRE(records.Update(newRecord));
 
         auto validatationRecord = records.GetByID(1);
-        REQUIRE(contactDB->number.count() == 4);
+        REQUIRE(contactDB.number.count() == 4);
         REQUIRE(validatationRecord.numbers.size() == 2);
         REQUIRE(validatationRecord.numbers[0].number.getEntered() == numbers[1]);
         REQUIRE(validatationRecord.numbers[1].number.getEntered() == numbers[0]);
@@ -363,7 +363,7 @@ TEST_CASE("Contact record numbers update")
         newRecord.numbers = std::vector<ContactRecord::Number>(
             {ContactRecord::Number(numbers[2], std::string("")), ContactRecord::Number(numbers[1], std::string(""))});
         REQUIRE(records.Update(newRecord));
-        REQUIRE(contactDB->number.count() == 3);
+        REQUIRE(contactDB.number.count() == 3);
 
         auto validatationRecord = records.GetByID(1);
         REQUIRE(validatationRecord.numbers.size() == 2);
@@ -383,7 +383,7 @@ TEST_CASE("Contact record numbers update")
         newRecord.numbers = std::vector<ContactRecord::Number>(
             {ContactRecord::Number(numbers[2], std::string("")), ContactRecord::Number(numbers[3], std::string(""))});
         REQUIRE(records.Update(newRecord));
-        REQUIRE(contactDB->number.count() == 2);
+        REQUIRE(contactDB.number.count() == 2);
 
         auto validatationRecord = records.GetByID(1);
         REQUIRE(validatationRecord.numbers.size() == 2);

--- a/module-db/tests/ContactsRingtonesTable_tests.cpp
+++ b/module-db/tests/ContactsRingtonesTable_tests.cpp
@@ -20,10 +20,10 @@ TEST_CASE("Contacts Ringtones Table tests")
 {
     Database::initialize();
 
-    const auto contactsPath = (purefs::dir::getUserDiskPath() / "contacts.db").c_str();
+    const auto contactsPath = purefs::dir::getUserDiskPath() / "contacts.db";
     std::filesystem::remove(contactsPath);
 
-    ContactsDB contactsdb{contactsPath};
+    ContactsDB contactsdb{contactsPath.c_str()};
     REQUIRE(contactsdb.isInitialized());
 
     ContactsRingtonesTableRow testRow1(DB_ID_NONE, DB_ID_NONE, "/test/assets/path/ringtone.wr");

--- a/module-db/tests/ContactsTable_tests.cpp
+++ b/module-db/tests/ContactsTable_tests.cpp
@@ -14,10 +14,10 @@ TEST_CASE("Contacts Table tests")
 {
     Database::initialize();
 
-    const auto contactsPath = (purefs::dir::getUserDiskPath() / "contacts.db").c_str();
+    const auto contactsPath = purefs::dir::getUserDiskPath() / "contacts.db";
     std::filesystem::remove(contactsPath);
 
-    ContactsDB contactsdb{contactsPath};
+    ContactsDB contactsdb{contactsPath.c_str()};
     REQUIRE(contactsdb.isInitialized());
 
     ContactsTableRow testRow1 = {{.ID = DB_ID_NONE},

--- a/module-db/tests/EventsRecord_tests.cpp
+++ b/module-db/tests/EventsRecord_tests.cpp
@@ -39,10 +39,10 @@ TEST_CASE("Events Record tests")
 {
     Database::initialize();
 
-    const auto eventsPath = (purefs::dir::getUserDiskPath() / "events.db").c_str();
+    const auto eventsPath = purefs::dir::getUserDiskPath() / "events.db";
     std::filesystem::remove(eventsPath);
 
-    EventsDB eventsDb{eventsPath};
+    EventsDB eventsDb{eventsPath.c_str()};
 
     REQUIRE(eventsDb.isInitialized());
 

--- a/module-db/tests/EventsTable_tests.cpp
+++ b/module-db/tests/EventsTable_tests.cpp
@@ -31,10 +31,10 @@ TEST_CASE("Events Table tests")
 
     Database::initialize();
 
-    const auto eventsPath = (purefs::dir::getUserDiskPath() / "events.db").c_str();
+    const auto eventsPath = purefs::dir::getUserDiskPath() / "events.db";
     std::filesystem::remove(eventsPath);
 
-    EventsDB eventsDb{eventsPath};
+    EventsDB eventsDb{eventsPath.c_str()};
     REQUIRE(eventsDb.isInitialized());
 
     auto &eventsTbl = eventsDb.events;

--- a/module-db/tests/NotesRecord_tests.cpp
+++ b/module-db/tests/NotesRecord_tests.cpp
@@ -17,10 +17,11 @@ TEST_CASE("Notes Record tests")
 {
     Database::initialize();
 
-    auto notesDb = std::make_unique<NotesDB>((purefs::dir::getUserDiskPath() / "notes.db").c_str());
-    REQUIRE(notesDb->isInitialized());
+    const auto notesDbPath = purefs::dir::getUserDiskPath() / "notes.db";
+    NotesDB notesDb{notesDbPath.c_str()};
+    REQUIRE(notesDb.isInitialized());
 
-    NotesRecordInterface notesRecordInterface{notesDb.get()};
+    NotesRecordInterface notesRecordInterface{&notesDb};
     notesRecordInterface.RemoveAll(); // Empty the notes database.
 
     constexpr auto testSnippet = "TEST SNIPPET";

--- a/module-db/tests/NotesTable_tests.cpp
+++ b/module-db/tests/NotesTable_tests.cpp
@@ -12,10 +12,11 @@ TEST_CASE("Notes Table tests")
 {
     Database::initialize();
 
-    auto notesDb = std::make_unique<NotesDB>((purefs::dir::getUserDiskPath() / "notes.db").c_str());
-    REQUIRE(notesDb->isInitialized());
+    const auto notesDbPath = purefs::dir::getUserDiskPath() / "notes.db";
+    NotesDB notesDb{notesDbPath.c_str()};
+    REQUIRE(notesDb.isInitialized());
 
-    NotesTable table{notesDb.get()};
+    NotesTable table{&notesDb};
     table.removeAll();
     REQUIRE(table.count() == 0);
 

--- a/module-db/tests/NotificationsRecord_tests.cpp
+++ b/module-db/tests/NotificationsRecord_tests.cpp
@@ -25,10 +25,10 @@ TEST_CASE("Notifications Record tests")
 {
     Database::initialize();
 
-    const auto notificationsPath = (purefs::dir::getUserDiskPath() / "notifications.db").c_str();
+    const auto notificationsPath = purefs::dir::getUserDiskPath() / "notifications.db";
     std::filesystem::remove(notificationsPath);
 
-    NotificationsDB notificationsDb{notificationsPath};
+    NotificationsDB notificationsDb{notificationsPath.c_str()};
 
     REQUIRE(notificationsDb.isInitialized());
 

--- a/module-db/tests/NotificationsTable_tests.cpp
+++ b/module-db/tests/NotificationsTable_tests.cpp
@@ -20,10 +20,10 @@ TEST_CASE("Notifications Table tests")
 {
     Database::initialize();
 
-    const auto notificationsPath = (purefs::dir::getUserDiskPath() / "notifications.db").c_str();
+    const auto notificationsPath = purefs::dir::getUserDiskPath() / "notifications.db";
     std::filesystem::remove(notificationsPath);
 
-    NotificationsDB notificationsDb{notificationsPath};
+    NotificationsDB notificationsDb{notificationsPath.c_str()};
     REQUIRE(notificationsDb.isInitialized());
 
     auto &notificationsTbl = notificationsDb.notifications;

--- a/module-db/tests/SMSTable_tests.cpp
+++ b/module-db/tests/SMSTable_tests.cpp
@@ -17,10 +17,10 @@ TEST_CASE("SMS Table tests")
 {
     Database::initialize();
 
-    const auto smsPath = (purefs::dir::getUserDiskPath() / "sms.db").c_str();
+    const auto smsPath = purefs::dir::getUserDiskPath() / "sms.db";
     std::filesystem::remove(smsPath);
 
-    SmsDB smsdb(smsPath);
+    SmsDB smsdb(smsPath.c_str());
     REQUIRE(smsdb.isInitialized());
 
     SMSTableRow testRow1 = {{.ID = 0},

--- a/module-db/tests/SMSTemplateRecord_tests.cpp
+++ b/module-db/tests/SMSTemplateRecord_tests.cpp
@@ -21,13 +21,13 @@ TEST_CASE("SMS templates Record tests")
 {
     Database::initialize();
 
-    const auto smsPath = (purefs::dir::getUserDiskPath() / "sms.db").c_str();
+    const auto smsPath = purefs::dir::getUserDiskPath() / "sms.db";
     std::filesystem::remove(smsPath);
 
-    auto smsDB = std::make_unique<SmsDB>(smsPath);
-    REQUIRE(smsDB->isInitialized());
+    SmsDB smsDB(smsPath.c_str());
+    REQUIRE(smsDB.isInitialized());
 
-    SMSTemplateRecordInterface SMSTemplateRecordInterface(smsDB.get());
+    SMSTemplateRecordInterface SMSTemplateRecordInterface(&smsDB);
     SMSTemplateRecord testRec;
     testRec.text               = "Test text";
     testRec.lastUsageTimestamp = 100;

--- a/module-db/tests/SMSTemplateTable_tests.cpp
+++ b/module-db/tests/SMSTemplateTable_tests.cpp
@@ -21,10 +21,10 @@ TEST_CASE("SMS Templates Table tests")
 {
     Database::initialize();
 
-    const auto smsPath = (purefs::dir::getUserDiskPath() / "sms.db").c_str();
+    const auto smsPath = purefs::dir::getUserDiskPath() / "sms.db";
     std::filesystem::remove(smsPath);
 
-    SmsDB smsDb{smsPath};
+    SmsDB smsDb{smsPath.c_str()};
     REQUIRE(smsDb.isInitialized());
 
     auto &templatesTbl = smsDb.templates;

--- a/module-db/tests/ThreadRecord_tests.cpp
+++ b/module-db/tests/ThreadRecord_tests.cpp
@@ -30,15 +30,15 @@ TEST_CASE("Thread Record tests")
 {
     Database::initialize();
 
-    const auto contactsPath = (purefs::dir::getUserDiskPath() / "contacts.db").c_str();
-    const auto smsPath      = (purefs::dir::getUserDiskPath() / "sms.db").c_str();
+    const auto contactsPath = purefs::dir::getUserDiskPath() / "contacts.db";
+    const auto smsPath      = purefs::dir::getUserDiskPath() / "sms.db";
     std::filesystem::remove(contactsPath);
     std::filesystem::remove(smsPath);
 
-    auto smsDB = std::make_unique<SmsDB>(smsPath);
-    REQUIRE(smsDB->isInitialized());
-    auto contactsDB = std::make_unique<ContactsDB>(contactsPath);
-    REQUIRE(contactsDB->isInitialized());
+    SmsDB smsDB(smsPath.c_str());
+    REQUIRE(smsDB.isInitialized());
+    ContactsDB contactsDB(contactsPath.c_str());
+    REQUIRE(contactsDB.isInitialized());
 
     const uint32_t dateTest      = 123456789;
     const char *snippetTest      = "Test snippet";
@@ -46,7 +46,7 @@ TEST_CASE("Thread Record tests")
     const SMSType typeTest       = SMSType ::UNKNOWN;
     const uint32_t contactIDTest = 100;
 
-    ThreadRecordInterface threadRecordInterface1(smsDB.get(), contactsDB.get());
+    ThreadRecordInterface threadRecordInterface1(&smsDB, &contactsDB);
 
     ThreadRecord recordIN;
     recordIN.date      = dateTest;
@@ -208,7 +208,7 @@ TEST_CASE("Thread Record tests")
         const utils::PhoneNumber phoneNumber("+48600123456", utils::country::Id::UNKNOWN);
         const std::string lastSmsBody = "Ola";
 
-        SMSRecordInterface smsRecInterface(smsDB.get(), contactsDB.get());
+        SMSRecordInterface smsRecInterface(&smsDB, &contactsDB);
         SMSRecord recordIN;
         recordIN.date      = 123456789;
         recordIN.dateSent  = 987654321;

--- a/module-db/tests/ThreadsTable_tests.cpp
+++ b/module-db/tests/ThreadsTable_tests.cpp
@@ -21,10 +21,10 @@ TEST_CASE("Threads Table tests")
 {
     Database::initialize();
 
-    const auto smsPath = (purefs::dir::getUserDiskPath() / "sms.db").c_str();
+    const auto smsPath = purefs::dir::getUserDiskPath() / "sms.db";
     std::filesystem::remove(smsPath);
 
-    SmsDB smsdb{smsPath};
+    SmsDB smsdb{smsPath.c_str()};
     REQUIRE(smsdb.isInitialized());
 
     ThreadsTableRow testRow1 = {{.ID = 0},


### PR DESCRIPTION
The dangling ptrs derefencing freed memory has been fixed.
They caused the tests to trigger the ASan. Additionally, in some tests
where DB objects were allocated dynamically, they are now allocated
automatically on the stack to simplify the code.