### PR TITLE
[EGD-5153] sectors count fix

### DIFF
--- a/generate_fatfs_image.sh
+++ b/generate_fatfs_image.sh
@@ -57,21 +57,29 @@ if [ -z ${GENLFS} ]; then
     exit -1
 fi
 
+# Partition sizes in sector 512 units
+PART1_START=2048
+PART1_SIZE=2097152
+PART2_START=$(($PART1_START + $PART1_SIZE))
+PART2_SIZE=$PART1_SIZE
+PART3_START=$(($PART2_START + $PART2_SIZE))
+PART3_SIZE=29358080
+
 truncate -s 16G $IMAGE_NAME
 sfdisk $IMAGE_NAME << ==sfdisk
 label: dos
 label-id: 0x09650eb4
 unit: sectors
 
-/dev/sdx1 : start=       2048,  size=    2097152, type=b, bootable
-/dev/sdx2 : start=    2099200,  size=    2097152, type=b
-/dev/sdx3 : start=    4196352,  size=   29358080, type=9e
+/dev/sdx1 : start=    $PART1_START,  size=    $PART1_SIZE, type=b, bootable
+/dev/sdx2 : start=    $PART2_START,  size=    $PART2_SIZE, type=b
+/dev/sdx3 : start=    $PART3_START,  size=    $PART3_SIZE, type=9e
 ==sfdisk
 
-PART1="$IMAGE_NAME@@1048576"
-PART2="$IMAGE_NAME@@14604566528"
-mformat -i "$PART1" -F -T 28522496 -v MUDITAOS
-mformat -i "$PART2" -F -T 2097152 -v RECOVER
+PART1="$IMAGE_NAME@@$(($PART1_START*512))"
+PART2="$IMAGE_NAME@@$(($PART2_START*512))"
+mformat -i "$PART1" -F -T $PART1_SIZE -M 512 -v MUDITAOS
+mformat -i "$PART2" -F -T $PART2_SIZE -M 512 -v RECOVER
 mmd -i "$PART1" ::/current
 cd "$SRC_DATA"
 for i in $ASSETS_DIR; do

--- a/module-vfs/board/linux/purefs/include/purefs/blkdev/disk_image.hpp
+++ b/module-vfs/board/linux/purefs/include/purefs/blkdev/disk_image.hpp
@@ -25,6 +25,7 @@ namespace purefs::blkdev
         auto status() const -> media_status override;
         auto get_info(info_type what) const -> scount_t override;
         auto erase(sector_t lba, std::size_t count) -> int override;
+        auto range_valid(sector_t lba, std::size_t count) const -> bool;
 
       private:
         int m_filedes{-1};


### PR DESCRIPTION
    Script for generate partitions for emulator by mistake
    overwrites the littlefs image and fatfs image due to the
    overlap fat parition and littlefs partition

