### PR TITLE
[EGD-5165] Fix emulator crash on lfs and fat

### DIFF
--- a/board/linux/libiosyscalls/include/iosyscalls.hpp
+++ b/board/linux/libiosyscalls/include/iosyscalls.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/board/linux/libiosyscalls/src/iosyscalls.cpp
+++ b/board/linux/libiosyscalls/src/iosyscalls.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <iosyscalls.hpp>

--- a/module-utils/bootconfig/include/boot/bootconstants.hpp
+++ b/module-utils/bootconfig/include/boot/bootconstants.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/module-vfs/board/linux/purefs/include/purefs/blkdev/disk_image.hpp
+++ b/module-vfs/board/linux/purefs/include/purefs/blkdev/disk_image.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <purefs/blkdev/disk.hpp>
+#include <mutex>
 
 namespace purefs::blkdev
 {
@@ -31,5 +32,6 @@ namespace purefs::blkdev
         int m_filedes{-1};
         unsigned long m_sectors{0};
         std::string m_image_name;
+        mutable std::recursive_mutex m_mtx;
     };
 } // namespace purefs::blkdev

--- a/module-vfs/board/rt1051/purefs/src/vfs_subsystem_internal.cpp
+++ b/module-vfs/board/rt1051/purefs/src/vfs_subsystem_internal.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <purefs/vfs_subsystem_internal.hpp>


### PR DESCRIPTION
Disk access was not protected by the mutex and race contition
occurs when multiple access was made for lfs and fat