### PR TITLE
[EGD-2519] Fix keyboard mode in the search windows

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,14 +7,14 @@
 * VoLTE ON/OFF switch in Settings Network window
 * Add PLL2 clock switching
 * Support for asynchronous callbacks on application side.
-* APN settings window - empty
+* APN settings window - empty.
 
 ### Changed
 
 * Input keyboard language files parser from KBD to JSON.
 * Input language files are now loaded based on files in "profiles" folder.
 * Minimum CPU frequency is now 132 MHz
-* Icon widget now accepts rich text
+* Icon widget now accepts rich text.
 
 ### Fixed
 
@@ -22,6 +22,7 @@
 * Fix newly added contact recognized as a duplicate of temporary contact.
 * Fix default borderCallback navigation in GridLayout.
 * Fix crash on enter Settings -> Information.
+* Fix keyboard mode in the search windows.
 
 ## [0.52.1 2020-12-23]
 

--- a/module-apps/application-messages/windows/SearchStart.cpp
+++ b/module-apps/application-messages/windows/SearchStart.cpp
@@ -22,6 +22,11 @@ namespace gui
         body->setBoundingBox(bodySize());
         addWidget(body);
         auto text = inputBox(this, utils::localize.get("common_search_uc"), "search");
+        text->setInputMode(new InputMode(
+            {InputMode::ABC, InputMode::abc, InputMode::digit},
+            [=](const UTF8 &Text) { application->getCurrentWindow()->bottomBarTemporaryMode(Text); },
+            [=]() { application->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); },
+            [=]() { application->getCurrentWindow()->selectSpecialCharacter(); }));
 
         inputCallback = [=](Item &, const InputEvent &inputEvent) -> bool {
             auto app = dynamic_cast<app::ApplicationMessages *>(application);

--- a/module-apps/application-phonebook/windows/PhonebookSearch.hpp
+++ b/module-apps/application-phonebook/windows/PhonebookSearch.hpp
@@ -3,11 +3,8 @@
 
 #pragma once
 
-#include "application-phonebook/data/PhonebookItemData.hpp"
-#include "application-phonebook/models/PhonebookModel.hpp"
-#include "application-phonebook/widgets/PhonebookListView.hpp"
-
 #include <AppWindow.hpp>
+#include <ContactRecord.hpp>
 #include <Text.hpp>
 
 namespace gui
@@ -15,19 +12,16 @@ namespace gui
     class PhonebookSearch : public AppWindow
     {
       public:
-        PhonebookSearch(app::Application *app);
-        ~PhonebookSearch() override = default;
-
-        bool onInput(const InputEvent &inputEvent) override;
-        void onBeforeShow(ShowMode mode, SwitchData *data) override;
-        bool handleSwitchData(SwitchData *data) override;
-        void rebuild() override;
-        void buildInterface() override;
-        void destroyInterface() override;
+        explicit PhonebookSearch(app::Application *app);
 
       private:
-        Text *inputField                       = nullptr;
+        void buildInterface() override;
+        auto handleSwitchData(SwitchData *data) -> bool override;
+        void onBeforeShow(ShowMode mode, SwitchData *data) override;
+        auto onInput(const InputEvent &inputEvent) -> bool override;
+
         std::shared_ptr<ContactRecord> contact = nullptr;
+        Text *inputField                       = nullptr;
     };
 
 } /* namespace gui */


### PR DESCRIPTION
Keyboard mode was not displayed in the search windows.
Now its fixed, both in Phonebook and Messages search.
Additionaly code of the Phonebook Search window is cleaned up.