### PR TITLE
[EGD-5186] Change minimum CPU frequency to 132 MHz

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 
 * Input keyboard language files parser from KBD to JSON.
 * Input language files are now loaded based on files in "profiles" folder.
+* Minimum CPU frequency is now 132 MHz
 
 ### Fixed
 

--- a/module-sys/SystemManager/PowerManager.cpp
+++ b/module-sys/SystemManager/PowerManager.cpp
@@ -79,23 +79,14 @@ namespace sys
         const auto freq = lowPowerControl->GetCurrentFrequency();
         auto level      = bsp::LowPowerMode::CpuFrequency::Level_1;
 
+        // We temporarily limit the minimum CPU frequency
+        // due to problems with the UART of the GSM modem
         switch (freq) {
         case bsp::LowPowerMode::CpuFrequency::Level_6:
             level = bsp::LowPowerMode::CpuFrequency::Level_5;
             break;
-        case bsp::LowPowerMode::CpuFrequency::Level_5:
+        default:
             level = bsp::LowPowerMode::CpuFrequency::Level_4;
-            break;
-        case bsp::LowPowerMode::CpuFrequency::Level_4:
-            level = bsp::LowPowerMode::CpuFrequency::Level_3;
-            break;
-        case bsp::LowPowerMode::CpuFrequency::Level_3:
-            level = bsp::LowPowerMode::CpuFrequency::Level_2;
-            break;
-        case bsp::LowPowerMode::CpuFrequency::Level_2:
-            level = bsp::LowPowerMode::CpuFrequency::Level_1;
-            break;
-        case bsp::LowPowerMode::CpuFrequency::Level_1:
             break;
         }
 


### PR DESCRIPTION
Temporary minimum CPU frequency limitation