### PR TITLE
[EGD-5199] Add support for mount umount

### DIFF
--- a/board/linux/libiosyscalls/version.txt
+++ b/board/linux/libiosyscalls/version.txt
@@ -68,6 +68,9 @@ GLIBC_2.2.5 {
                 __xstat64;
                 __lxstat64;
                 __fxstat64;
+                mount;
+                umount;
+
         local:
                 *;
 };


### PR DESCRIPTION
Add support for mount umount in the libiosyscall library
due to planning to use ro fatfs and remount to rw only
for update purposes.