### PR TITLE
[EGD-4551] Add missing read() interception

### DIFF
--- a/board/linux/libiosyscalls/CMakeLists.txt
+++ b/board/linux/libiosyscalls/CMakeLists.txt
@@ -43,3 +43,7 @@ target_link_options(${PROJECT_NAME} PRIVATE
 target_include_directories(${PROJECT_NAME} PUBLIC ${INCLUDES} )
 target_link_libraries( ${PROJECT_NAME} dl )
 target_compile_definitions( ${PROJECT_NAME} PUBLIC TARGET_Linux )
+
+if (${ENABLE_TESTS})
+    add_subdirectory(test)
+endif ()

--- a/board/linux/libiosyscalls/include/iosyscalls.hpp
+++ b/board/linux/libiosyscalls/include/iosyscalls.hpp
@@ -22,7 +22,8 @@ namespace vfsn::linux::internal
         int ungetchar {-1};
     };
 
-    int get_native_fd(FILEX*);
+    int to_native_fd(int fd);
+    int to_image_fd(int fd);
 
     FILEX* allocate_filex(int fd);
     bool is_filex(const void* fd);

--- a/board/linux/libiosyscalls/src/iosyscalls.cpp
+++ b/board/linux/libiosyscalls/src/iosyscalls.cpp
@@ -27,6 +27,7 @@ namespace {
         "/proc",
         "/dev/shm",
         "PurePhone.img",
+        "MuditaOS.log",
         nullptr,
     };
     constexpr const char * EXCLUDED_PATHS[] = {
@@ -104,9 +105,14 @@ namespace vfsn::linux::internal
         return false;
     }
 
-    int get_native_fd(FILEX* file)
+    int to_native_fd(int fd)
     {
-        return file ? (FIRST_FILEDESC + file->fd) : -1;
+        return FIRST_FILEDESC + fd;
+    }
+
+    int to_image_fd(int fd)
+    {
+        return fd - FIRST_FILEDESC;
     }
 
     bool is_image_fd(int fd)

--- a/board/linux/libiosyscalls/src/syscalls_stdio.cpp
+++ b/board/linux/libiosyscalls/src/syscalls_stdio.cpp
@@ -378,7 +378,7 @@ extern "C"
         if(vfs::is_filex(__stream))
         {
             TRACE_SYSCALLN("(%p) -> VFS", __stream);
-            ret =  vfs::get_native_fd(reinterpret_cast<FILEX*>(__stream));
+            ret = vfs::to_native_fd(reinterpret_cast<FILEX*>(__stream)->fd);
         }
         else
         {

--- a/board/linux/libiosyscalls/test/CMakeLists.txt
+++ b/board/linux/libiosyscalls/test/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.12)
+
+# iosyscalls tests
+add_catch2_executable(
+    NAME
+        iosyscalls
+    SRCS
+        ${CMAKE_CURRENT_LIST_DIR}/unittest_iosys.cpp
+    LIBS
+        module-vfs iosyscalls
+    DEPS
+        PurePhone.img-target
+)

--- a/board/linux/libiosyscalls/test/unittest_iosys.cpp
+++ b/board/linux/libiosyscalls/test/unittest_iosys.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch.hpp>
+#include <purefs/vfs_subsystem.hpp>
+
+#include <filesystem>
+
+TEST_CASE("VFS linux support")
+{
+    auto vfs = purefs::subsystem::initialize();
+    auto err = purefs::subsystem::mount_defaults();
+    REQUIRE(err == 0);
+
+    static constexpr auto filenm = "assets/lang/English.json";
+
+    SECTION("std::filesystem") {
+        REQUIRE(std::filesystem::file_size(filenm) > 0);
+    }
+
+    SECTION("iterators") {
+        std::ifstream myfile(filenm);
+        REQUIRE (myfile.is_open());
+
+        auto __first = std::istreambuf_iterator<char>(myfile);
+        auto __last = std::istreambuf_iterator<char>();
+        std::vector<char> testvec(__first, __last);
+
+        testvec.push_back('\0');
+        REQUIRE(std::string(testvec.data()).length() > 0);
+    }
+
+    REQUIRE(purefs::subsystem::unmount_all() == 0);
+}

--- a/board/linux/libiosyscalls/version.txt
+++ b/board/linux/libiosyscalls/version.txt
@@ -62,6 +62,7 @@ GLIBC_2.2.5 {
                 __xstat64;
                 __lxstat64;
                 __fxstat64;
+                read;
                 mount;
                 umount;
 # posix - dirent
@@ -73,7 +74,6 @@ GLIBC_2.2.5 {
                 seekdir;
                 telldir;
 # posix - not implemented
-#                read;
 #                write;
 #                lseek;
 #                lseek64;


### PR DESCRIPTION
Fix error caused by libstdc++ passing our fd to native read()