### PR TITLE
[EGD-3390] Add integration with clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,8 @@ endif()
 
 message_serial_status()
 
+include(tools/clang-tidy.cmake)
+
 option (BUILD_DOC_WITH_ALL "Build documentation" OFF)
 
 # check if Doxygen is installed

--- a/doc/development_workflow.md
+++ b/doc/development_workflow.md
@@ -53,6 +53,7 @@ Before submitting a Pull Request please go through some basic checks:
 
 - test your changes on both Linux and RT1051 platforms (please pay special attention to the things you might break unintentionally, e.g. when working on calling, check call log too,
 - run unit tests (`make check`),
+- [run static analysis](static_analysis.md)
 - check if your code formatting complies with [`.clang-format`](../clang-format),
 - whenever you add third-party software to MuditaOS source code, please make sure that the software component is added to a dedicated [section in `LICENSE.md` file on MuditaOS GitHub repository](../LICENSE.md) with a link to the text of the license where applicable.
 

--- a/doc/static_analysis.md
+++ b/doc/static_analysis.md
@@ -1,0 +1,31 @@
+# Static code analysis
+
+The Static code analysis is a method of debugging that is done by examining the source code without executing the program.
+
+Before submitting the Pull Request a developer should run static code analyzer tool and make sure that his code complies with the Coding Standards.
+
+## Clang-tidy
+
+The clang-tidy is a clang-based C++ “linter” tool. Its purpose is to provide an extensible framework for diagnosing and fixing typical programming errors, like style violations, interface misuse, or bugs that can be deduced via static analysis.
+
+### Install clang-tidy
+
+#### Linux Ubuntu
+
+The clang-tidy tool is available from the APT repository.
+
+`$ sudo apt install clang-tidy`
+
+### Run clang-tidy
+
+If `run-clang-tidy` program is installed, a CMake target called `clang-tidy` is available.
+
+In order to run `clang-tidy` analyzer on the MuditaOS repository, follow the steps:
+```
+$ cd <path/to/MuditaOS>
+$ ./configure.sh <platform> <build_type>
+$ cd <path/to/build/dir>
+$ make clang-tidy
+```
+
+The results of the analysis are available under `$(pwd)/StaticAnalysis` directory.

--- a/tools/clang-tidy.cmake
+++ b/tools/clang-tidy.cmake
@@ -1,0 +1,19 @@
+find_program(RUN_CLANG_TIDY_COMMAND NAMES run-clang-tidy)
+if (NOT RUN_CLANG_TIDY_COMMAND)
+	message(WARNING "run-clang-tidy can not be found.")
+	return()
+endif()
+
+if (NOT CMAKE_EXPORT_COMPILE_COMMANDS)
+	message(WARNING "Unable to run clang-tidy without the compile commands database.")
+	return()
+endif()
+
+set(STATIC_ANALYSIS_OUTPUT_DIR "StaticAnalysis")
+
+string(TIMESTAMP CURRENT_TIME)
+set(CLANG_TIDY_OUTPUL_FILE "clang-tidy_${CURRENT_TIME}")
+
+add_custom_target(clang-tidy
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${STATIC_ANALYSIS_OUTPUT_DIR}
+	COMMAND ${RUN_CLANG_TIDY_COMMAND} -header-filter='.*' -p ${CMAKE_BINARY_DIR} > "${STATIC_ANALYSIS_OUTPUT_DIR}/${CLANG_TIDY_OUTPUL_FILE}")


### PR DESCRIPTION
Clang-tidy is used to perform static code analysis.