### PR TITLE
[EGD-5139] Add some missing POSIX calls

### DIFF
--- a/board/linux/libiosyscalls/version.txt
+++ b/board/linux/libiosyscalls/version.txt
@@ -32,7 +32,7 @@ GLIBC_2.2.5 {
                 fscanf;
                 vfscanf;
 #                ungetc;
-# stdio - disabled
+# stdio - buffering disabled
                 setbuf;
                 setvbuf;
                 setbuffer;
@@ -63,6 +63,11 @@ GLIBC_2.2.5 {
                 __lxstat64;
                 __fxstat64;
                 read;
+                write;
+                lseek;
+                lseek64;
+                ioctl;
+                poll;
                 mount;
                 umount;
 # posix - dirent
@@ -73,13 +78,6 @@ GLIBC_2.2.5 {
                 rewinddir;
                 seekdir;
                 telldir;
-# posix - not implemented
-#                write;
-#                lseek;
-#                lseek64;
-#                ioctl;
-#                poll;
-
         local:
                 *;
 };


### PR DESCRIPTION
This commit adds interceptions for common POSIX calls.
Issue [EGD-4551] has shown that some call can be made from
stdlibc++ that we didn't trace or intercept so far. Our goal
here is to improve our POSIX coverage.

[EGD-4551]: https://appnroll.atlassian.net/browse/EGD-4551