### PR TITLE
[EGD-4983] Create worker for log dumping

### DIFF
--- a/module-apps/tests/CMakeLists.txt
+++ b/module-apps/tests/CMakeLists.txt
@@ -6,4 +6,5 @@ add_catch2_executable(
         test-CallbackStorage.cpp
     LIBS
         ${PROJECT_NAME}
+        module-sys
 )

--- a/module-os/CMakeLists.txt
+++ b/module-os/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/memory/usermem.c
 
         ${CMAKE_CURRENT_SOURCE_DIR}/CriticalSectionGuard.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/LockGuard.cpp
         )
 
 #Substitute FreeRTOS SystemvView sources if enabled

--- a/module-os/LockGuard.cpp
+++ b/module-os/LockGuard.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "critical.hpp"
+#include "LockGuard.hpp"
+#include <macros.h>
+#include <stdexcept>
+
+LockGuard::LockGuard(cpp_freertos::MutexStandard& mutex) : mutex(mutex)
+{
+    if (isIRQ()) {
+        savedInterruptStatus = cpp_freertos::CriticalSection::EnterFromISR();
+    }
+    else if(!mutex.Lock()) {
+        throw std::runtime_error("LockGuard failed to lock mutex");
+    }
+}
+
+LockGuard::~LockGuard()
+{
+    if (isIRQ()) {
+        cpp_freertos::CriticalSection::ExitFromISR(savedInterruptStatus);
+    }
+    else {
+        mutex.Unlock();
+    }
+}

--- a/module-os/LockGuard.hpp
+++ b/module-os/LockGuard.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <mutex.hpp>
+
+class LockGuard
+{
+public:
+    explicit LockGuard(cpp_freertos::MutexStandard& mutex);
+    ~LockGuard();
+    LockGuard(const LockGuard &) = delete;
+    LockGuard(LockGuard &&)      = delete;
+
+    LockGuard &operator=(const LockGuard &) = delete;
+    LockGuard &operator=(LockGuard &&) = delete;
+
+private:
+    BaseType_t savedInterruptStatus;
+    cpp_freertos::MutexStandard &mutex;
+};

--- a/module-services/service-gui/tests/CMakeLists.txt
+++ b/module-services/service-gui/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_catch2_executable(
         MockedSynchronizationMechanism.hpp
     LIBS
         service-gui
+        module-sys
 )
 
 add_catch2_executable(
@@ -18,4 +19,5 @@ add_catch2_executable(
         MockedSynchronizationMechanism.hpp
     LIBS
         service-gui
+        module-sys
 )

--- a/module-utils/CMakeLists.txt
+++ b/module-utils/CMakeLists.txt
@@ -42,6 +42,7 @@ set (SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/log/LoggerBuffer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/circular_buffer/StringCircularBuffer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/generators/RandomStringGenerator.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/log/LoggerWorker.cpp
 )
 
 add_library(${PROJECT_NAME} STATIC ${SOURCES} ${BOARD_SOURCES})

--- a/module-utils/board/cross/log_rt1051.cpp
+++ b/module-utils/board/cross/log_rt1051.cpp
@@ -34,7 +34,7 @@ namespace Log
                                            loggerBufferSizeLeft(),
                                            "%s%-5s %s[%s] %s%s:%s:%d:%s ",
                                            logColors->levelColors[level].data(),
-                                           level_names[level],
+                                           levelNames[level],
                                            logColors->serviceNameColor.data(),
                                            getTaskDesc(),
                                            logColors->callerInfoColor.data(),
@@ -60,21 +60,24 @@ namespace Log
         loggerBufferCurrentPos += snprintf(&loggerBuffer[loggerBufferCurrentPos],
                                            loggerBufferSizeLeft(),
                                            "%-5s [%-10s] \x1b[31mASSERTION ",
-                                           level_names[LOGFATAL],
+                                           levelNames[LOGFATAL],
                                            getTaskDesc());
 
         loggerBufferCurrentPos += vsnprintf(&loggerBuffer[loggerBufferCurrentPos], loggerBufferSizeLeft(), fmt, args);
         logToDevice(Device::DEFAULT, loggerBuffer, loggerBufferCurrentPos);
     }
 
-    void Logger::logToDevice(Device device, std::string_view log, size_t length)
+    void Logger::logToDevice(Device device, std::string_view logMsg, size_t length)
     {
         switch (device) {
         case Device::DEFAULT:
-            log_WriteToDevice(reinterpret_cast<const uint8_t *>(log.data()), length);
+            log_WriteToDevice(reinterpret_cast<const uint8_t *>(logMsg.data()), length);
             break;
         case Device::SEGGER_RTT:
-            SEGGER_RTT_Write(0, reinterpret_cast<const void *>(log.data()), length);
+            SEGGER_RTT_Write(0, reinterpret_cast<const void *>(logMsg.data()), length);
+            break;
+        case Device::FILE:
+            sendLogMsgToWorker(logMsg, length);
             break;
         default:
             break;

--- a/module-utils/board/linux/log_linux.cpp
+++ b/module-utils/board/linux/log_linux.cpp
@@ -20,7 +20,7 @@ namespace Log
                                            LOGGER_BUFFER_SIZE - loggerBufferCurrentPos,
                                            "%s%-5s %s%s:%s:%d:%s ",
                                            logColors->levelColors[level].data(),
-                                           level_names[level],
+                                           levelNames[level],
                                            logColors->callerInfoColor.data(),
                                            file,
                                            function,
@@ -38,8 +38,13 @@ namespace Log
         assert(false && "Not implemented");
     }
 
-    void Logger::logToDevice(Device, std::string_view log, size_t)
+    void Logger::logToDevice(Device device, std::string_view logMsg, size_t length)
     {
-        std::cout << log;
+        if (device == Device::FILE) {
+            sendLogMsgToWorker(logMsg, length);
+        }
+        else {
+            std::cout << logMsg;
+        }
     }
 } // namespace Log

--- a/module-utils/log/LoggerBuffer.hpp
+++ b/module-utils/log/LoggerBuffer.hpp
@@ -5,19 +5,27 @@
 
 #include "circular_buffer/StringCircularBuffer.hpp"
 
-class LoggerBuffer : public StringCircularBuffer
+namespace Log
 {
-  public:
-    using StringCircularBuffer::StringCircularBuffer;
+    class LoggerBuffer : public StringCircularBuffer
+    {
+      public:
+        using StringCircularBuffer::StringCircularBuffer;
 
-    [[nodiscard]] std::pair<bool, std::string> get() override;
-    void put(const std::string &logMsg) override;
-    void put(std::string &&logMsg) override;
+        [[nodiscard]] std::pair<bool, std::string> get() override;
+        void put(const std::string &logMsg) override;
+        void put(std::string &&logMsg) override;
+        [[nodiscard]] size_t getNumOfBytes() const noexcept
+        {
+            return numOfBytesInBuffer;
+        }
 
-    static constexpr auto lostBytesMessage = "bytes was lost.";
+        static constexpr auto lostBytesMessage = "bytes was lost.";
 
-  private:
-    void updateNumOfLostBytes();
+      private:
+        void updateNumOfLostBytes();
 
-    size_t numOfLostBytes{0};
-};
+        size_t numOfLostBytes{0};
+        size_t numOfBytesInBuffer{0};
+    };
+} // namespace Log

--- a/module-utils/log/LoggerWorker.cpp
+++ b/module-utils/log/LoggerWorker.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <gsl/gsl_util>
+#include "LockGuard.hpp"
+#include "LoggerWorker.hpp"
+#include <module-vfs/include/user/purefs/filesystem_paths.hpp>
+
+namespace Log
+{
+    LoggerWorker::LoggerWorker() : sys::Worker(workerName, workerPriority), loggerBuffer(loggerBufferSize)
+    {}
+
+    void LoggerWorker::handleLogMessage(std::string *logMsg)
+    {
+        LockGuard lock(mutex);
+
+        loggerBuffer.put(std::move(*logMsg));
+        if (loggerBuffer.getNumOfBytes() > logFileSize) {
+            dumpToFile();
+        }
+    }
+
+    bool LoggerWorker::handleMessage(uint32_t queueID)
+    {
+        auto queue          = queues[queueID]->GetQueueHandle();
+        std::string *logMsg = nullptr;
+        if (xQueueReceive(queue, &logMsg, 0) != pdTRUE) {
+            return false;
+        }
+        handleLogMessage(logMsg);
+        delete logMsg;
+        return true;
+    }
+
+    void LoggerWorker::dumpToFile()
+    {
+        std::fstream logFile(purefs::dir::getUserDiskPath() / logFileName, std::fstream::out | std::fstream::app);
+        while (!loggerBuffer.isEmpty()) {
+            const auto &[_, logMsg] = loggerBuffer.get();
+            logFile.write(logMsg.data(), logMsg.size());
+        }
+    }
+} // namespace Log

--- a/module-utils/log/LoggerWorker.hpp
+++ b/module-utils/log/LoggerWorker.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <fstream>
+#include "LoggerBuffer.hpp"
+#include <mutex.hpp>
+#include "Service/Message.hpp"
+#include "Service/Service.hpp"
+#include "Service/Worker.hpp"
+#include <string_view>
+
+namespace Log
+{
+    class LoggerWorker : public sys::Worker
+    {
+      public:
+        LoggerWorker();
+
+        [[nodiscard]] auto getQueue() const noexcept -> xQueueHandle
+        {
+            return Worker::getQueueHandleByName(loggerQueueName);
+        }
+        void handleLogMessage(std::string *logData);
+        bool handleMessage(uint32_t queueID) override;
+
+        static constexpr auto loggerQueueName = "loggerQueueBuffer";
+
+      private:
+        void dumpToFile();
+
+        LoggerBuffer loggerBuffer;
+        cpp_freertos::MutexStandard mutex;
+
+        static constexpr auto logFileName        = "MuditaOS.log";
+        static constexpr size_t loggerBufferSize = 100;
+        static constexpr auto logFileSize        = 1000;
+        static constexpr auto workerName         = "LoggerWorker";
+        static constexpr auto workerPriority     = static_cast<UBaseType_t>(sys::ServicePriority::Idle);
+    };
+} // namespace Log

--- a/module-utils/log/log.cpp
+++ b/module-utils/log/log.cpp
@@ -11,7 +11,7 @@ void log_Printf(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    Logger::get().log(Log::Device::DEFAULT, fmt, args);
+    Logger::get().log(fmt, args);
     va_end(args);
 }
 

--- a/module-utils/log/log.hpp
+++ b/module-utils/log/log.hpp
@@ -84,7 +84,6 @@ extern "C"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 static const size_t LOGGER_BUFFER_SIZE  = 8192;
-static const double MAX_BUFFER_UTIL_MEM = 0.8 * LOGGER_BUFFER_SIZE;
 #pragma GCC diagnostic pop
 
 #endif /* LOG_LOG_H_ */

--- a/module-utils/test/CMakeLists.txt
+++ b/module-utils/test/CMakeLists.txt
@@ -28,6 +28,7 @@ add_catch2_executable(
         unittest_clipboard.cpp
     LIBS
         module-utils
+        module-sys
 )
 
 # UCS2 tests

--- a/module-utils/test/test_LoggerBuffer.cpp
+++ b/module-utils/test/test_LoggerBuffer.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 using namespace std;
+using namespace Log;
 
 void TestBuffer(const LoggerBuffer &buffer, size_t capacity, size_t numOfMsgs)
 {


### PR DESCRIPTION
Initialize and run LoggerWorker on system start.
Increase linux heap size because adding LoggerWorker
cause out of memory issues.
    
How it works:
1. Logger sends logMsg to LoggerWorker
2. LoggerWorker receives logMsg and puts it into LoggerBuffer
3. If LoggerBuffer size is greater than max buffer util mem,
    then it dumps all log msgs to a file