### PR TITLE
[EGD-4527] Add creating update package as CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include(ModuleConfig)
 include(module-lwip/lwip-includes.cmake)
 include(SerialPort)
 include(CopyGdbInit)
+include(Utils)
 
 message("PROJECT_TARGET: ${PROJECT_TARGET}")
 message("TARGET_SOURCES: ${TARGET_SOURCES}")
@@ -218,7 +219,14 @@ if (${PROJECT_TARGET} STREQUAL "TARGET_Linux")
 		DEPENDS ${FAT_IMAGE}
 	)
 	add_dependencies(check ${FAT_IMAGE}-target)
-    install(TARGETS ${CMAKE_PROJECT_NAME} DESTINATION "./")
+    multicomp_install(
+        TARGETS ${CMAKE_PROJECT_NAME}
+        DESTINATION "./"
+        COMPONENTS Standalone Update
+        )
+    set(CPACK_SYSTEM_NAME "Linux")
+    # only allow the standalone package in Linux config
+    set(CPACK_COMPONENTS_ALL Standalone)
 endif()
 
 
@@ -249,14 +257,39 @@ if (${PROJECT_TARGET} STREQUAL "TARGET_RT1051")
         ${HEX_FILE}-target ALL
         DEPENDS ${CMAKE_BINARY_DIR}/${HEX_FILE}
         )
-    install(FILES ${CMAKE_BINARY_DIR}/${BIN_FILE}
+
+    multicomp_install(FILES ${CMAKE_BINARY_DIR}/${BIN_FILE}
         DESTINATION "./"
         PERMISSIONS
             OWNER_READ OWNER_WRITE OWNER_EXECUTE
             GROUP_READ GROUP_EXECUTE
             WORLD_READ WORLD_EXECUTE
-            )
+        COMPONENTS Standalone Update
+        )
+
+    # download the bootloader
+    add_custom_target(ecoboot.bin
+        COMMAND ${CMAKE_SOURCE_DIR}/tools/download_asset.py
+        -w ${CMAKE_BINARY_DIR}/update ecoboot download
+        > ${CMAKE_BINARY_DIR}/update/download_info.txt
+        BYPRODUCTS update/ecoboot.bin
+        COMMENT "Downloading ecoboot.bin"
+        )
+    # generate version.json file (runs CMake script at build time)
+    add_custom_target(
+        version.json
+        COMMAND ${CMAKE_COMMAND}
+        -DSRC_DIR=${CMAKE_SOURCE_DIR}
+        -B ${CMAKE_BINARY_DIR}
+        -P ${CMAKE_SOURCE_DIR}/config/GenUpdateVersionJson.cmake
+        DEPENDS ecoboot.bin
+        )
+    install(FILES ${CMAKE_BINARY_DIR}/update/ecoboot.bin DESTINATION "./" COMPONENT Update)
+    install(FILES ${CMAKE_BINARY_DIR}/update/version.json DESTINATION "./" COMPONENT Update)
+
     set(CPACK_SYSTEM_NAME "RT1051")
+    # allow both standalone and update packages in RT1051 config
+    set(CPACK_COMPONENTS_ALL Standalone Update)
 endif()
 
 if (${CMAKE_BUILD_TYPE} STREQUAL "Release")
@@ -265,8 +298,10 @@ if (${CMAKE_BUILD_TYPE} STREQUAL "Release")
         )
 endif()
 
-install(FILES ${PROJECT_SOURCE_DIR}/changelog.md
+install(
+    FILES ${PROJECT_SOURCE_DIR}/changelog.md
     DESTINATION "./"
+    COMPONENT Standalone
     )
 
 if (${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
@@ -279,11 +314,6 @@ if (${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
                 $<TARGET_FILE:${CMAKE_PROJECT_NAME}>
         )
 endif()
-
-add_custom_target(ecoboot.bin 
-    COMMAND ${CMAKE_SOURCE_DIR}/tools/download_asset.py -w ${CMAKE_BINARY_DIR}/update ecoboot download
-    BYPRODUCTS update/ecoboot.bin
-    )
 
 message_serial_status()
 
@@ -321,39 +351,86 @@ else ()
 endif ()
 
 message("SRC DIR: ${CMAKE_SOURCE_DIR}")
+
 include(Version)
+configure_file(
+    ${SRC_DIR}/source/version.hpp.template
+    ${CMAKE_BINARY_DIR}/source/version.hpp
+    )
 add_custom_target(
     version ALL
-    COMMAND
-        ${CMAKE_COMMAND} -DSRC_DIR=${CMAKE_SOURCE_DIR} -B ${CMAKE_BINARY_DIR}  -P ${CMAKE_SOURCE_DIR}/config/Version.cmake
+    COMMAND ${CMAKE_COMMAND}
+    -DSRC_DIR=${CMAKE_SOURCE_DIR}
+    -B ${CMAKE_BINARY_DIR}
+    -P ${CMAKE_SOURCE_DIR}/config/GenVersionHpp.cmake
     COMMENT
-        "Generationg version info"
+        "Generating version info"
     )
-
 add_dependencies(${PROJECT_NAME} version)
 
 set(CPACK_PACKAGE_VENDOR "Mudita")
+set(CPACK_PACKAGE_NAME "PurePhone")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://mudita.com/products/pure/")
-if (${PROJECT_TARGET} STREQUAL "TARGET_RT1051")
-    set(CPACK_GENERATOR "ZIP")
-    set(PACKAGE_EXTENSION ".zip")
-    set(PACKAGE_MIME "application/zip")
-else()
-    set(CPACK_GENERATOR "TGZ")
-    set(PACKAGE_EXTENSION ".tar.gz")
-    set(PACKAGE_MIME "application/x-compressed-tar")
-endif()
+set(CPACK_TOPLEVEL_TAG ${CPACK_SYSTEM_NAME})
+# the CPACK_PACKAGE_FILE_NAME variable will be reset after include(CPack) hence a copy
+set(PACKAGE_COMMON_NAME ${CPACK_PACKAGE_NAME}-${CMAKE_PROJECT_VERSION}-${CPACK_TOPLEVEL_TAG})
+set(CPACK_PACKAGE_FILE_NAME ${PACKAGE_COMMON_NAME})
+# setting this will CPack prevent from additing the default 'package' target
+set(CPACK_OUTPUT_CONFIG_FILE ${CMAKE_BINARY_DIR}/PackageConfig.cmake)
+set(CPACK_GENERATOR "External")
+set(CPACK_COMPONENTS_GROUPING IGNORE)
+set(CPACK_EXTERNAL_ENABLE_STAGING TRUE)
+set(PACKAGE_STAGING_DIRECTORY ${CMAKE_BINARY_DIR}/_CPack_Packages/${CPACK_TOPLEVEL_TAG}/${CPACK_GENERATOR}/${CPACK_PACKAGE_FILE_NAME})
 
 include(CPack)
 
-if (NOT "$ENV{GITHUB_WORKSPACE}" STREQUAL "")
-    set(PACKAGE_FILE ${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_SYSTEM_NAME}${PACKAGE_EXTENSION})
+add_custom_target(package-standalone-staged
+    COMMAND ${CMAKE_CPACK_COMMAND}
+    -C $<CONFIGURATION>
+    --config ${CPACK_OUTPUT_CONFIG_FILE}
+    )
 
-    message("set-output name=package::${PACKAGE_FILE}")
-    message("::set-output name=package::${PACKAGE_FILE}")
-
-    message("set-output name=mime_type::${PACKAGE_MIME}")
-    message("::set-output name=mime_type::${PACKAGE_MIME}")
+if (${PROJECT_TARGET} STREQUAL "TARGET_RT1051")
+    set(PACKAGE_STANDALONE_FILE_NAME ${PACKAGE_COMMON_NAME}-Standalone.zip)
+    set(PACKAGE_STANDALONE_MIME "application/zip")
+    add_custom_target(package-update-staged
+        COMMAND ${CMAKE_CPACK_COMMAND}
+        -C $<CONFIGURATION>
+        --config ${CPACK_OUTPUT_CONFIG_FILE}
+        DEPENDS ecoboot.bin version.json
+    )
+    add_custom_target(package-standalone
+        COMMAND zip -rq ${CMAKE_BINARY_DIR}/${PACKAGE_STANDALONE_FILE_NAME} "."
+        WORKING_DIRECTORY ${PACKAGE_STAGING_DIRECTORY}/Standalone
+        DEPENDS package-standalone-staged
+        )
+    add_custom_target(package-update-checksums
+        COMMAND rhash
+        -u ${PACKAGE_STAGING_DIRECTORY}/Update/checksums.txt
+        -r ${PACKAGE_STAGING_DIRECTORY}/Update
+        DEPENDS package-update-staged
+        )
+    add_custom_target(package-update
+        COMMAND tar
+        -czf ${CMAKE_BINARY_DIR}/${PACKAGE_COMMON_NAME}-Update.tar.gz
+        -C ${PACKAGE_STAGING_DIRECTORY}/Update "."
+        DEPENDS package-update-staged package-update-checksums
+        )
+elseif (${PROJECT_TARGET} STREQUAL "TARGET_Linux")
+    set(PACKAGE_STANDALONE_FILE_NAME ${PACKAGE_COMMON_NAME}-Standalone.tar.gz)
+    set(PACKAGE_STANDALONE_MIME "application/x-compressed-tar")
+    add_custom_target(package-standalone
+        COMMAND tar
+        -czf ${CMAKE_BINARY_DIR}/${PACKAGE_STANDALONE_FILE_NAME}
+        -C ${PACKAGE_STAGING_DIRECTORY}/Standalone "."
+        DEPENDS package-standalone-staged
+        )
 endif()
 
-
+if (NOT "$ENV{GITHUB_WORKSPACE}" STREQUAL "")
+    message("set-output name=package::${PACKAGE_STANDALONE_FILE_NAME}")
+    message("::set-output name=package::${PACKAGE_STANDALONE_FILE_NAME}")
+    
+    message("set-output name=mime_type::${PACKAGE_STANDALONE_MIME}")
+    message("::set-output name=mime_type::${PACKAGE_STANDALONE_MIME}")
+endif()

--- a/config/GenUpdateVersionJson.cmake
+++ b/config/GenUpdateVersionJson.cmake
@@ -1,0 +1,21 @@
+# This script generates the version.json file which contains project
+# and bootloader version information for update packages . It is meant to be run
+# at build time by running CMake as a target.
+
+list(APPEND CMAKE_MODULE_PATH "${SRC_DIR}/config")
+include(Version)
+
+set(BOOTLOADER_INCLUDED "true")
+set(BOOTLOADER_FILENAME "ecoboot.bin")
+execute_process(
+    COMMAND grep "release:" "${CMAKE_BINARY_DIR}/update/download_info.txt"
+    COMMAND awk "{print $2}"
+    OUTPUT_VARIABLE BOOTLOADER_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+configure_file(
+    ${SRC_DIR}/config/version.json.cmake_template
+    ${CMAKE_BINARY_DIR}/update/version.json
+    @ONLY
+    )

--- a/config/GenVersionHpp.cmake
+++ b/config/GenVersionHpp.cmake
@@ -1,0 +1,14 @@
+# This script generates the source/version.hpp containing project version
+# information. It is meant to be run at build time by running CMake as a target.
+
+list(APPEND CMAKE_MODULE_PATH "${SRC_DIR}/config")
+include(Version)
+
+configure_file(
+    ${SRC_DIR}/source/version.hpp.template
+    ${CMAKE_BINARY_DIR}/source/version.hpp
+    )
+
+message("GIT_REV: ${GIT_REV}")
+message("GIT_TAG: ${GIT_TAG}")
+message("Version: ${CMAKE_PROJECT_VERSION}")

--- a/config/Utils.cmake
+++ b/config/Utils.cmake
@@ -1,0 +1,13 @@
+# An equivalent of install() which allows to declare multiple components using
+# a custom 'COMPONENTS' clause. This clause must be the last on the
+# argument list. The original 'COMPONENT' from install() clause must not appear
+# on the argument list.  
+function(multicomp_install)
+    list(FIND ARGN "COMPONENTS" CLAUSE_INDEX)
+    list(SUBLIST ARGN 0 ${CLAUSE_INDEX} INSTALL_ARGN)
+    math(EXPR COMPS_INDEX "${CLAUSE_INDEX}+1")
+    list(SUBLIST ARGN ${COMPS_INDEX} ${ARGC} COMPONENTS)
+    foreach(COMP IN LISTS COMPONENTS)
+        install(${INSTALL_ARGN} COMPONENT ${COMP})
+    endforeach()
+endfunction()

--- a/config/version.json.cmake_template
+++ b/config/version.json.cmake_template
@@ -1,0 +1,29 @@
+{
+	"git":
+	{
+		"git_branch": "@GIT_BRANCH@",
+		"git_commit": "@GIT_REV@",
+		"git_tag": "@GIT_TAG@"
+	},
+	"misc":
+	{
+		"codename": "@VERSION_CODENAME@",
+		"kernel": "@KERNEL_VERSION@",
+		"buildon": "@BUILD_HOST@",
+		"builddate": "@BUILD_DATE@",
+		"builduser": "@BUILD_USER@"
+	},
+	"version":
+	{
+		"major": "@CMAKE_PROJECT_VERSION_MAJOR@",
+		"minor": "@CMAKE_PROJECT_VERSION_MINOR@",
+		"patch": "@CMAKE_PROJECT_VERSION_PATCH@",
+		"string": "@CMAKE_PROJECT_VERSION@"
+	},
+	"bootloader":
+	{
+		"included": "@BOOTLOADER_INCLUDED@",
+		"version": "@BOOTLOADER_VERSION@",
+		"filename": "@BOOTLOADER_FILENAME@"
+	}
+}

--- a/image/CMakeLists.txt
+++ b/image/CMakeLists.txt
@@ -1,4 +1,6 @@
-﻿set(ASSETS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+﻿include(Utils)
+
+set(ASSETS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(ASSETS_DEST_DIR "${CMAKE_BINARY_DIR}")
 
 file (GLOB_RECURSE ASSETS_LIST
@@ -16,10 +18,17 @@ foreach(ASSET ${ASSETS_LIST})
 
     if(dir)
         set(destdir "${ASSETS_DEST_DIR}/${dir}")
-        install(FILES ${ASSET} DESTINATION ${dir})
+        multicomp_install(
+            FILES ${ASSET}
+            DESTINATION ${dir}
+            COMPONENTS Standalone Update
+            )
     else()
         set(destdir "${ASSETS_DEST_DIR}")
-        install(FILES ${ASSET} DESTINATION "./" )
+        multicomp_install(
+            FILES ${ASSET}
+            DESTINATION "./"
+            COMPONENTS Standalone Update)
     endif()
 
     set(outfile "${destdir}/${filename}")

--- a/module-services/service-eink/board/linux/renderer/CMakeLists.txt
+++ b/module-services/service-eink/board/linux/renderer/CMakeLists.txt
@@ -4,6 +4,8 @@ project( service_renderer VERSION 1.0
 	DESCRIPTION "GTK application for showing draw buffer."
 	LANGUAGES CXX )
 
+include(Utils)
+
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
 
@@ -14,7 +16,7 @@ add_executable( ${PROJECT_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/RArea.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/RWindow.hpp )
 
-install(TARGETS ${PROJECT_NAME} DESTINATION "./")
+install(TARGETS ${PROJECT_NAME} DESTINATION "./" COMPONENT Standalone)
 
 target_link_libraries( ${PROJECT_NAME}  ${GTKMM_LIBRARIES}  )
 target_include_directories(${PROJECT_NAME} PUBLIC ${GTKMM_LIBRARY_DIRS} )

--- a/tools/download_asset.py
+++ b/tools/download_asset.py
@@ -117,6 +117,7 @@ class Getter(object):
                     break
         if release is None:
             print("No release with tag:", args.tag)
+        print("release:", release['tag_name'])
         assets = release['assets']
         self.downloadAsset(assets[0])
 


### PR DESCRIPTION
Standalone and update packages can be generated by CMake targets. During
creation of update package, the bootloader will be downloaded
and included in the package along with version information.

Additionally, a small refactor was performed since the Version.cmake
script is now used for generating both the version.hpp and version.json
files. Observervable side effects from this script have been moved to
separate scripts which are invoked at build time.