### PR TITLE
[EGD-5259] Fix littlefs format for block devices

### DIFF
--- a/host-tools/genlittlefs/lfs_ioaccess.c
+++ b/host-tools/genlittlefs/lfs_ioaccess.c
@@ -11,6 +11,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <linux/fs.h>
+#include <sys/ioctl.h>
 
 struct lfs_ioaccess_context
 {
@@ -179,6 +181,19 @@ struct lfs_ioaccess_context *lfs_ioaccess_open(struct lfs_config *cfg,
         free(ret);
         return NULL;
     }
+    if (S_ISBLK(statbuf.st_mode)) {
+        uint64_t blk_size;
+        err = ioctl(ret->file_des, BLKGETSIZE64, &blk_size);
+        if (err < 0) {
+            close(ret->file_des);
+            free(ret);
+            return NULL;
+        }
+        else {
+            statbuf.st_size = blk_size;
+        }
+    }
+
     off_t start_pos = 0;
     ret->last_offs  = statbuf.st_size;
     if (partition) {


### PR DESCRIPTION
Currently genlittlefs is unable to format block devices
currently it works only on the file images.
This patch resolves problem with bd format.