### PR TITLE
[EGD-5014] Remove global FS locks

### DIFF
--- a/module-vfs/src/purefs/fs/filesystem_syscalls.cpp
+++ b/module-vfs/src/purefs/fs/filesystem_syscalls.cpp
@@ -9,127 +9,105 @@
 #include <purefs/fs/thread_local_cwd.hpp>
 #include <fcntl.h>
 
-#include <mutex.hpp>
-
 namespace purefs::fs
 {
     auto filesystem::stat_vfs(std::string_view path, struct ::statvfs &stat) const noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(iaccess::ro, &filesystem_operations::stat_vfs, path, stat);
     }
 
     auto filesystem::stat(std::string_view file, struct stat &st) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(iaccess::ro, &filesystem_operations::stat, file, st);
     }
 
     auto filesystem::unlink(std::string_view name) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(iaccess::rw, &filesystem_operations::unlink, name);
     }
 
     auto filesystem::mkdir(std::string_view path, int mode) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(iaccess::rw, &filesystem_operations::mkdir, path, mode);
     }
 
     auto filesystem::ioctl(std::string_view path, int cmd, void *arg) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(iaccess::ro, &filesystem_operations::ioctl, path, cmd, arg);
     }
 
     auto filesystem::utimens(std::string_view path, std::array<timespec, 2> &tv) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(iaccess::ro, &filesystem_operations::utimens, path, tv);
     }
 
     auto filesystem::flock(int fd, int cmd) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(&filesystem_operations::flock, fd, cmd);
     }
 
     auto filesystem::isatty(int fd) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(&filesystem_operations::isatty, fd);
     }
 
     auto filesystem::chmod(std::string_view path, mode_t mode) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(iaccess::rw, &filesystem_operations::chmod, path, mode);
     }
 
     auto filesystem::write(int fd, const char *ptr, size_t len) noexcept -> ssize_t
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(&filesystem_operations::write, fd, ptr, len);
     }
 
     auto filesystem::read(int fd, char *ptr, size_t len) noexcept -> ssize_t
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(&filesystem_operations::read, fd, ptr, len);
     }
 
     auto filesystem::seek(int fd, off_t pos, int dir) noexcept -> off_t
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(&filesystem_operations::seek, fd, pos, dir);
     }
 
     auto filesystem::fstat(int fd, struct stat &st) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(&filesystem_operations::fstat, fd, st);
     }
 
     auto filesystem::ftruncate(int fd, off_t len) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(&filesystem_operations::ftruncate, fd, len);
     }
 
     auto filesystem::fsync(int fd) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(&filesystem_operations::fsync, fd);
     }
 
     auto filesystem::fchmod(int fd, mode_t mode) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(&filesystem_operations::fchmod, fd, mode);
     }
 
     auto filesystem::symlink(std::string_view existing, std::string_view newlink) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops_same_mp(&filesystem_operations::symlink, existing, newlink);
     }
 
     auto filesystem::link(std::string_view existing, std::string_view newlink) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops_same_mp(&filesystem_operations::link, existing, newlink);
     }
 
     auto filesystem::rename(std::string_view oldname, std::string_view newname) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops_same_mp(&filesystem_operations::rename, oldname, newname);
     }
 
     auto filesystem::open(std::string_view path, int flags, int mode) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         const auto abspath     = absolute_path(path);
         auto [mountp, pathpos] = find_mount_point(abspath);
         if (!mountp) {
@@ -161,7 +139,6 @@ namespace purefs::fs
 
     auto filesystem::close(int fd) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         auto ret = invoke_fops(&filesystem_operations::close, fd);
         if (!ret) {
             ret = (remove_filehandle(fd)) ? (0) : (-EBADF);
@@ -171,7 +148,6 @@ namespace purefs::fs
 
     auto filesystem::diropen(std::string_view path) noexcept -> fsdir
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         const auto abspath     = absolute_path(path);
         auto [mountp, pathpos] = find_mount_point(abspath);
         if (!mountp) {
@@ -195,13 +171,11 @@ namespace purefs::fs
 
     auto filesystem::dirreset(fsdir dirstate) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         return invoke_fops(&filesystem_operations::dirreset, dirstate);
     }
 
     auto filesystem::dirnext(fsdir dirstate, std::string &filename, struct stat &filestat) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         if (!dirstate) {
             LOG_ERROR("No directory handle");
             return -ENXIO;
@@ -211,7 +185,6 @@ namespace purefs::fs
 
     auto filesystem::dirclose(fsdir dirstate) noexcept -> int
     {
-        cpp_freertos::LockGuard lock(*m_lock);
         if (!dirstate) {
             LOG_ERROR("No directory handle");
             return -ENXIO;


### PR DESCRIPTION
Global locks are redundant and lower the performance.