### PR TITLE
[EGD-4416] Fix setting time functionality and initial time value

### DIFF
--- a/module-bsp/board/linux/rtc/rtc.cpp
+++ b/module-bsp/board/linux/rtc/rtc.cpp
@@ -20,7 +20,7 @@ extern "C"
 
 static time_t timestampOffset;
 static time_t timestampAlarm;
-time_t localOffset;
+// time_t localOffset; // never used
 static xQueueHandle qHandleRtcIrq   = NULL;
 static TaskHandle_t rtcWorkerHandle = NULL;
 
@@ -45,7 +45,7 @@ namespace bsp
         time_t current   = time(NULL);
         struct tm *local = localtime(&current);
 
-        localOffset = local->tm_gmtoff;
+        //        localOffset = local->tm_gmtoff; // never used (only set)
 
         timestampOffset = timestamp - current;
         return RtcBspOK;
@@ -156,8 +156,8 @@ namespace bsp
     {
         uint32_t secondsToMinute = 60 - (timestamp % 60);
 
-        struct tm date;
-        rtc_GetCurrentDateTime(&date);
+        //        struct tm date; /// never used
+        //        rtc_GetCurrentDateTime(&date);
 
         return rtc_SetAlarmInSecondsFromNow(secondsToMinute);
     }

--- a/module-bsp/bsp/rtc/rtc.hpp
+++ b/module-bsp/bsp/rtc/rtc.hpp
@@ -49,6 +49,7 @@ namespace bsp {
 
 	RtcBspError_e rtc_SetDateTime(struct tm* time);
 
+    // never used, rem?
 	RtcBspError_e rtc_GetCurrentDateTime(struct tm* datetime);
 
 	RtcBspError_e rtc_GetCurrentTimestamp(time_t* timestamp);

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -55,15 +55,15 @@ EventManager::~EventManager()
 }
 
 // those static functions and variables will be replaced by Settings API
-static std::string tzSet;
-static void setSettingsTimeZone(const std::string &timeZone)
-{
-    tzSet = timeZone;
-}
-std::string getSettingsTimeZone()
-{
-    return tzSet;
-}
+// static std::string tzSet; /// never used (only set)
+// static void setSettingsTimeZone(const std::string &timeZone)
+//{
+//    tzSet = timeZone;
+//}
+// std::string getSettingsTimeZone()
+//{
+//    return tzSet;
+//}
 
 // Invoked upon receiving data message
 sys::MessagePointer EventManager::DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp)
@@ -206,7 +206,8 @@ sys::MessagePointer EventManager::DataReceivedHandler(sys::DataMessage *msgl, sy
                 bsp::rtc_SetDateTime(&time.value());
             }
             if (auto timeZoneOffset = msg->getTimeZoneOffset(); timeZoneOffset) {
-                setSettingsTimeZone(msg->getTimeZoneString().value());
+                //                setSettingsTimeZone(msg->getTimeZoneString().value()); // tzSet is never used (only
+                //                set)
                 utils::time::Time::setTimeZoneOffset(msg->getTimeZoneOffset().value());
             }
             auto notification = std::make_shared<sys::DataMessage>(MessageType::EVMTimeUpdated);

--- a/module-services/service-evtmgr/WorkerEvent.cpp
+++ b/module-services/service-evtmgr/WorkerEvent.cpp
@@ -127,9 +127,10 @@ bool WorkerEvent::handleMessage(uint32_t queueID)
         bsp::rtc_GetCurrentTimestamp(&timestamp);
         bsp::rtc_SetMinuteAlarm(timestamp);
 
-        struct tm time;
-
-        bsp::rtc_GetCurrentDateTime(&time);
+        // never used
+        //        struct tm time;
+        //
+        //        bsp::rtc_GetCurrentDateTime(&time);
 
         auto message       = std::make_shared<sevm::RtcMinuteAlarmMessage>(MessageType::EVMMinuteUpdated);
         message->timestamp = timestamp;

--- a/module-utils/time/time_conversion.cpp
+++ b/module-utils/time/time_conversion.cpp
@@ -53,7 +53,9 @@ namespace utils::time
     } // namespace
 
     Locale tlocale;
-    static int msTimeGmtOff = 4 * utils::time::minutesInQuarterOfHour * utils::time::secondsInMinute;
+    // why 3600 up from the start?
+    //    static int msTimeGmtOff = 4 * utils::time::minutesInQuarterOfHour * utils::time::secondsInMinute;
+    static int msTimeGmtOff = 0;
 
     UTF8 Localer::get_replacement(Replacements val, const struct tm &timeinfo)
     {
@@ -112,16 +114,15 @@ namespace utils::time
     constexpr uint32_t datasize = 128;
     UTF8 Timestamp::str(std::string fmt)
     {
-        if (fmt.compare("") != 0) {
-            this->format = fmt;
+        if (!fmt.empty()) {
+            format = fmt;
         }
-        UTF8 datetimestr = "";
         auto replaceFunc = [&](int idx) { return get_replacement(Replacements(idx), timeinfo); };
-        utils::findAndReplaceAll(this->format, specifiers_replacement, replaceFunc);
+        utils::findAndReplaceAll(format, specifiers_replacement, std::move(replaceFunc));
         auto data = std::unique_ptr<char[]>(new char[datasize]);
-        std::strftime(data.get(), datasize, this->format.c_str(), &timeinfo);
-        datetimestr = UTF8(data.get());
-        return datetimestr;
+        std::strftime(data.get(), datasize, format.c_str(), &timeinfo);
+        ;
+        return UTF8(data.get());
     }
 
     UTF8 Timestamp::day(bool abbrev)


### PR DESCRIPTION
The problem: Time set by settings was always one hour ahead of user input. 
Solution: When user sets user-defined time, offset for time zone should be set to 0;

Secondary problem (emulator). Initial time value was again ahead of system time by one hour.
Solution: offset to time zone was initialized with 3600, changed it to 0;

PR also covers (at this point) commented-out variables or setters/getter to these variables 
that are never used or don't provide any logical value (e.g. setting local value that is never used)  
 