### PR TITLE
[EGD-5313] Mention license version

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,6 +3,8 @@
 MuditaOS – https://github.com/mudita/MuditaOS
 Copyright (c) 2017-2021, Mudita Sp. z o.o. All rights reserved.
 
+MuditaOS is licensed under GNU GPLv3.
+
 ## Sources of Intellectual Property Included in MuditaOS
 
 Where not otherwise indicated, all MuditaOS content is authored by Mudita engineers and consists of Mudita-owned intellectual property. In some specific instances, MuditaOS will incorporate work done by developers outside of Mudita with their expressed permission.


### PR DESCRIPTION
Spotted by one community member - we need to mention
clearly the license version in `LICENSE.md`.

Fixes #1340 