### PR TITLE
[EGD-5014] Change MMC erase logic

### DIFF
--- a/module-vfs/board/rt1051/purefs/src/blkdev/disk_emmc.cpp
+++ b/module-vfs/board/rt1051/purefs/src/blkdev/disk_emmc.cpp
@@ -25,11 +25,6 @@ namespace purefs::blkdev
             initStatus = err;
             return initStatus;
         }
-        err = MMC_SetMaxEraseUnitSize(&mmcCard);
-        if (err != kStatus_Success) {
-            initStatus = err;
-            return initStatus;
-        }
         return statusBlkDevSuccess;
     }
 
@@ -58,16 +53,8 @@ namespace purefs::blkdev
 
     auto disk_emmc::erase(sector_t lba, std::size_t count) -> int
     {
-        // temporarily commented out until erase is tested
-        /* cpp_freertos::LockGuard lock(mutex);
-        if (!mmcCard.isHostReady) {
-            return statusBlkDevFail;
-        }
-
-        auto err = MMC_EraseGroups(&mmcCard, lba, lba + count);
-        if (err != kStatus_Success) {
-            return err;
-        } */
+        // erase group size is 512kB so it has been deliberately disallowed
+        // group of this size would make the solution inefficient in this case
         return statusBlkDevSuccess;
     }
     auto disk_emmc::read(void *buf, sector_t lba, std::size_t count) -> int
@@ -123,7 +110,8 @@ namespace purefs::blkdev
         case info_type::sector_count:
             return mmcCard.userPartitionBlocks;
         case info_type::erase_block:
-            return mmcCard.eraseGroupBlocks;
+            // not supported
+            return 0;
         }
         return -1;
     }

--- a/module-vfs/drivers/src/thirdparty/fatfs/ff_glue.cpp
+++ b/module-vfs/drivers/src/thirdparty/fatfs/ff_glue.cpp
@@ -174,7 +174,7 @@ namespace purefs::fs::drivers::ffat::internal
                 }
                 break;
             case GET_SECTOR_SIZE:
-                ret = diskmm->get_info(diskh, blkdev::info_type::sector_count);
+                ret = diskmm->get_info(diskh, blkdev::info_type::sector_size);
                 if (ret >= 0) {
                     if (!buff) {
                         ret = -EINVAL;


### PR DESCRIPTION
MMC erase group size is 512 kB which would enforce
512 kB blocks on file system. Since for our purposes this
would be inefficient erase command has been disallowed.