### PR TITLE
[EGD-4801] Add application-wide top bar manager

### DIFF
--- a/module-apps/Application.cpp
+++ b/module-apps/Application.cpp
@@ -70,10 +70,12 @@ namespace app
                              uint32_t stackDepth,
                              sys::ServicePriority priority)
         : Service(std::move(name), std::move(parent), stackDepth, priority),
-          default_window(gui::name::window::main_window), windowsStack(this), startInBackground{startInBackground},
-          callbackStorage{std::make_unique<CallbackStorage>()}, settings(std::make_unique<settings::Settings>(this))
+          default_window(gui::name::window::main_window), windowsStack(this),
+          keyTranslator{std::make_unique<gui::KeyInputSimpleTranslation>()}, startInBackground{startInBackground},
+          callbackStorage{std::make_unique<CallbackStorage>()}, topBarManager{std::make_unique<TopBarManager>()},
+          settings(std::make_unique<settings::Settings>(this))
     {
-        keyTranslator = std::make_unique<gui::KeyInputSimpleTranslation>();
+        topBarManager->enableIndicators({gui::top_bar::Indicator::Time});
         busChannels.push_back(sys::BusChannels::ServiceCellularNotifications);
 
         longPressTimer = std::make_unique<sys::Timer>("LongPress", this, key_timer_ms);
@@ -691,6 +693,11 @@ namespace app
     {
         timer->sysapi.connect(item);
         item->attachTimer(std::move(timer));
+    }
+
+    const gui::top_bar::Configuration &Application::getTopBarConfiguration() const noexcept
+    {
+        return topBarManager->getConfiguration();
     }
 
     void Application::addActionReceiver(manager::actions::ActionId actionId, OnActionReceived &&callback)

--- a/module-apps/Application.hpp
+++ b/module-apps/Application.hpp
@@ -25,6 +25,7 @@
 #include <string>                                       // for string
 #include <utility>                                      // for move, pair
 #include <vector>                                       // for vector
+#include "TopBarManager.hpp"
 #include "WindowsFactory.hpp"
 #include "WindowsStack.hpp"
 
@@ -369,6 +370,8 @@ namespace app
 
         void addActionReceiver(manager::actions::ActionId actionId, OnActionReceived &&callback);
 
+        std::unique_ptr<TopBarManager> topBarManager;
+
         /// application's settings
         std::unique_ptr<settings::Settings> settings;
         virtual void timeFormatChanged(std::string value);
@@ -378,6 +381,7 @@ namespace app
         bool isTimeFormat12() const noexcept;
         void setLockScreenPasscodeOn(bool screenPasscodeOn) noexcept;
         bool isLockScreenPasscodeOn() const noexcept;
+        const gui::top_bar::Configuration &getTopBarConfiguration() const noexcept;
     };
 
     /// Parameter pack used by application launch action.

--- a/module-apps/CMakeLists.txt
+++ b/module-apps/CMakeLists.txt
@@ -15,6 +15,7 @@ set( SOURCES
     "Application.cpp"
     "GuiTimer.cpp"
     "WindowsFactory.cpp"
+    "TopBarManager.cpp"
     "AsyncTask.cpp"
     "CallbackStorage.cpp"
     "windows/AppWindow.cpp"

--- a/module-apps/TopBarManager.cpp
+++ b/module-apps/TopBarManager.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "TopBarManager.hpp"
+
+namespace app
+{
+    void TopBarManager::enableIndicators(const gui::top_bar::Indicators &indicators)
+    {
+        topBarConfiguration.enable(indicators);
+    }
+
+    auto TopBarManager::getConfiguration() const noexcept -> const gui::top_bar::Configuration &
+    {
+        return topBarConfiguration;
+    }
+} // namespace app

--- a/module-apps/TopBarManager.hpp
+++ b/module-apps/TopBarManager.hpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <TopBar.hpp>
+
+namespace app
+{
+    class TopBarManager
+    {
+      public:
+        void enableIndicators(const gui::top_bar::Indicators &indicators);
+        [[nodiscard]] auto getConfiguration() const noexcept -> const gui::top_bar::Configuration &;
+
+      private:
+        gui::top_bar::Configuration topBarConfiguration;
+    };
+} // namespace app

--- a/module-apps/application-alarm-clock/windows/AlarmClockMainWindow.cpp
+++ b/module-apps/application-alarm-clock/windows/AlarmClockMainWindow.cpp
@@ -32,7 +32,6 @@ namespace app::alarmClock
     {
         AppWindow::buildInterface();
 
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
         bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::Switch));

--- a/module-apps/application-alarm-clock/windows/CustomRepeatWindow.cpp
+++ b/module-apps/application-alarm-clock/windows/CustomRepeatWindow.cpp
@@ -18,9 +18,6 @@ namespace app::alarmClock
     {
         AppWindow::buildInterface();
 
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
-        topBar->setActive(gui::TopBar::Elements::SIM, false);
-        topBar->setActive(gui::TopBar::Elements::NETWORK_ACCESS_TECHNOLOGY, false);
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
         bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));

--- a/module-apps/application-alarm-clock/windows/NewEditAlarmWindow.cpp
+++ b/module-apps/application-alarm-clock/windows/NewEditAlarmWindow.cpp
@@ -21,7 +21,6 @@ namespace app::alarmClock
     {
         AppWindow::buildInterface();
 
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
         bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));

--- a/module-apps/application-antenna/windows/AlgoParamsWindow.cpp
+++ b/module-apps/application-antenna/windows/AlgoParamsWindow.cpp
@@ -39,10 +39,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::TIME, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
-
         setTitle(utils::localize.get("app_desktop_tools_antenna"));
 
         lowBandBox  = new gui::VBox(this,

--- a/module-apps/application-antenna/windows/AntennaMainWindow.cpp
+++ b/module-apps/application-antenna/windows/AntennaMainWindow.cpp
@@ -48,10 +48,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::TIME, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
-
         setTitle(utils::localize.get("app_desktop_tools_antenna"));
 
         for (auto title : titlesText) {

--- a/module-apps/application-antenna/windows/ScanModesWindow.cpp
+++ b/module-apps/application-antenna/windows/ScanModesWindow.cpp
@@ -37,10 +37,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::TIME, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
-
         setTitle(utils::localize.get("app_desktop_tools_antenna"));
 
         modeButtonParams.insert(std::pair<uint32_t, std::string>(scanModes::Auto, "AUTO"));

--- a/module-apps/application-calendar/windows/AllEventsWindow.cpp
+++ b/module-apps/application-calendar/windows/AllEventsWindow.cpp
@@ -34,7 +34,6 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
         bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));

--- a/module-apps/application-calendar/windows/CustomRepeatWindow.cpp
+++ b/module-apps/application-calendar/windows/CustomRepeatWindow.cpp
@@ -28,7 +28,6 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 

--- a/module-apps/application-calendar/windows/DayEventsWindow.cpp
+++ b/module-apps/application-calendar/windows/DayEventsWindow.cpp
@@ -64,7 +64,6 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
         bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));

--- a/module-apps/application-calendar/windows/EventDetailWindow.cpp
+++ b/module-apps/application-calendar/windows/EventDetailWindow.cpp
@@ -28,7 +28,6 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setActive(gui::BottomBar::Side::LEFT, true);
         bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));

--- a/module-apps/application-calendar/windows/EventReminderWindow.cpp
+++ b/module-apps/application-calendar/windows/EventReminderWindow.cpp
@@ -38,13 +38,20 @@ namespace gui
         buildInterface();
     }
 
+    top_bar::Configuration EventReminderWindow::configureTopBar(top_bar::Configuration appConfiguration)
+    {
+        using namespace top_bar;
+        appConfiguration.enable({Indicator::Signal,
+                                 Indicator::Time,
+                                 Indicator::Battery,
+                                 Indicator::SimCard,
+                                 Indicator::NetworkAccessTechnology});
+        return appConfiguration;
+    }
+
     void EventReminderWindow::buildInterface()
     {
         AppWindow::buildInterface();
-
-        topBar->setActive(TopBar::Elements::BATTERY, true);
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
 
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
         bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::ok));

--- a/module-apps/application-calendar/windows/EventReminderWindow.hpp
+++ b/module-apps/application-calendar/windows/EventReminderWindow.hpp
@@ -42,6 +42,7 @@ namespace gui
         void rebuild() override;
         void buildInterface() override;
         void destroyInterface() override;
+        top_bar::Configuration configureTopBar(top_bar::Configuration appConfiguration) override;
         auto handleSwitchData(SwitchData *data) -> bool override;
     };
 

--- a/module-apps/application-calendar/windows/NewEditEventWindow.cpp
+++ b/module-apps/application-calendar/windows/NewEditEventWindow.cpp
@@ -25,7 +25,6 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
         bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));

--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -33,6 +33,12 @@ namespace app
     ApplicationCall::ApplicationCall(std::string name, std::string parent, StartInBackground startInBackground)
         : Application(name, parent, startInBackground, app::call_stack_size)
     {
+        using namespace gui::top_bar;
+        topBarManager->enableIndicators({Indicator::Signal,
+                                         Indicator::Time,
+                                         Indicator::Battery,
+                                         Indicator::SimCard,
+                                         Indicator::NetworkAccessTechnology});
         addActionReceiver(manager::actions::Call, [this](auto &&data) {
             switchWindow(window::name_call, std::forward<decltype(data)>(data));
             return msgHandled();

--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -58,10 +58,6 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        topBar->setActive(gui::TopBar::Elements::BATTERY, true);
-        topBar->setActive(gui::TopBar::Elements::SIGNAL, true);
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
-
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
 

--- a/module-apps/application-call/windows/EnterNumberWindow.cpp
+++ b/module-apps/application-call/windows/EnterNumberWindow.cpp
@@ -58,10 +58,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("common_add"));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get("app_call_clear"));
 
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
-        topBar->setActive(TopBar::Elements::TIME, true);
-
         numberLabel = new gui::Label(this, numberLabel::x, numberLabel::y, numberLabel::w, numberLabel::h);
         numberLabel->setPenWidth(numberLabel::borderW);
         numberLabel->setFont(style::window::font::largelight);

--- a/module-apps/application-calllog/windows/CallLogDetailsWindow.cpp
+++ b/module-apps/application-calllog/windows/CallLogDetailsWindow.cpp
@@ -82,8 +82,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::call));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::TIME, true);
-
         // NOTE: height of all labels is set using decorators
 
         // Information

--- a/module-apps/application-calllog/windows/CallLogMainWindow.cpp
+++ b/module-apps/application-calllog/windows/CallLogMainWindow.cpp
@@ -47,8 +47,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::TIME, true);
-
         list = new gui::ListView(this, mainWindow::x, mainWindow::y, mainWindow::w, mainWindow::h, calllogModel);
 
         setFocusItem(list);

--- a/module-apps/application-desktop/ApplicationDesktop.cpp
+++ b/module-apps/application-desktop/ApplicationDesktop.cpp
@@ -37,6 +37,12 @@ namespace app
     ApplicationDesktop::ApplicationDesktop(std::string name, std::string parent, StartInBackground startInBackground)
         : Application(name, parent, startInBackground), lockHandler(this)
     {
+        using namespace gui::top_bar;
+        topBarManager->enableIndicators({Indicator::Signal,
+                                         Indicator::Time,
+                                         Indicator::Battery,
+                                         Indicator::SimCard,
+                                         Indicator::NetworkAccessTechnology});
         busChannels.push_back(sys::BusChannels::ServiceDBNotifications);
 
         addActionReceiver(app::manager::actions::RequestPin, [this](auto &&data) {

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -35,8 +35,6 @@ namespace gui
         AppWindow::buildInterface();
 
         bottomBar->setActive(BottomBar::Side::CENTER, true);
-        topBar->setActive(
-            {{TopBar::Elements::SIGNAL, true}, {TopBar::Elements::LOCK, true}, {TopBar::Elements::BATTERY, true}});
 
         using namespace style::desktop;
 
@@ -75,6 +73,20 @@ namespace gui
         notifications = nullptr;
     }
 
+    top_bar::Configuration DesktopMainWindow::configureTopBar(top_bar::Configuration appConfiguration)
+    {
+        auto app            = getAppDesktop();
+        const auto isLocked = app->lockHandler.isScreenLocked();
+        updateTopBarConfiguration(isLocked, appConfiguration);
+        return appConfiguration;
+    }
+
+    void DesktopMainWindow::updateTopBarConfiguration(bool isScreenLocked, top_bar::Configuration &configuration)
+    {
+        configuration.set(top_bar::Indicator::Lock, isScreenLocked);
+        configuration.set(top_bar::Indicator::Time, !isScreenLocked);
+    }
+
     DesktopMainWindow::DesktopMainWindow(app::Application *app) : AppWindow(app, app::window::name::desktop_main_window)
     {
         buildInterface();
@@ -89,13 +101,18 @@ namespace gui
     void DesktopMainWindow::setVisibleState()
     {
         auto app = getAppDesktop();
+        applyToTopBar([isLocked = app->lockHandler.isScreenLocked()](top_bar::Configuration configuration) {
+            updateTopBarConfiguration(isLocked, configuration);
+            return configuration;
+        });
+
         if (app->lockHandler.isScreenLocked()) {
             bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("app_desktop_unlock"));
             bottomBar->setActive(BottomBar::Side::RIGHT, false);
             bottomBar->setText(BottomBar::Side::LEFT,
                                utils::localize.get("app_desktop_emergency"),
                                app->lockHandler.isScreenBlocked());
-            topBar->setActive(TopBar::Elements::LOCK, true);
+
             inputCallback = nullptr;
             setFocusItem(nullptr);
             buildNotifications(app);
@@ -104,8 +121,6 @@ namespace gui
                 std::make_shared<TimersProcessingStopMessage>(), service::name::service_time, application);
         }
         else {
-            topBar->setActive(TopBar::Elements::LOCK, false);
-
             if (!buildNotifications(app)) {
                 LOG_ERROR("Couldn't fit in all notifications");
             }
@@ -146,7 +161,6 @@ namespace gui
             if (inputEvent.is(KeyCode::KEY_PND)) {
                 app->lockHandler.lockScreen();
                 setVisibleState();
-                application->setSuspendFlag(true);
                 return true;
             }
             // long press of '0' key is translated to '+'

--- a/module-apps/application-desktop/windows/DesktopMainWindow.hpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.hpp
@@ -81,11 +81,14 @@ namespace gui
         void rebuild() override;
         void buildInterface() override;
         void destroyInterface() override;
+        top_bar::Configuration configureTopBar(top_bar::Configuration appConfiguration) override;
+
         bool updateTime(const UTF8 &timeStr) override;
         bool updateTime(const uint32_t &timestamp, bool mode24H) override;
 
       private:
         void invalidate() noexcept;
+        static void updateTopBarConfiguration(bool isScreenLocked, top_bar::Configuration &configuration);
 
         gui::KeyInputMappedTranslation translator;
     };

--- a/module-apps/application-desktop/windows/LockWindow.cpp
+++ b/module-apps/application-desktop/windows/LockWindow.cpp
@@ -14,7 +14,6 @@ namespace gui
     void LockWindow::build()
     {
         buildBottomBar();
-        buildTopBar();
         buildTitleBar();
         buildInfoTexts();
     }

--- a/module-apps/application-desktop/windows/LockWindow.hpp
+++ b/module-apps/application-desktop/windows/LockWindow.hpp
@@ -58,7 +58,6 @@ namespace gui
       protected:
         virtual void buildBottomBar();
         virtual void buildTitleBar() = 0;
-        virtual void buildTopBar()   = 0;
 
       private:
         [[nodiscard]] auto getText(TextType type) noexcept -> gui::Text *;

--- a/module-apps/application-desktop/windows/LockedInfoWindow.cpp
+++ b/module-apps/application-desktop/windows/LockedInfoWindow.cpp
@@ -34,10 +34,6 @@ void LockedInfoWindow::setVisibleState()
     bottomBar->setActive(BottomBar::Side::LEFT, true);
     bottomBar->setActive(BottomBar::Side::CENTER, false);
     bottomBar->setActive(BottomBar::Side::RIGHT, true);
-
-    topBar->setActive(TopBar::Elements::LOCK, true);
-    topBar->setActive(TopBar::Elements::BATTERY, true);
-    topBar->setActive(TopBar::Elements::SIGNAL, true);
 }
 
 bool LockedInfoWindow::onInput(const InputEvent &inputEvent)
@@ -59,6 +55,13 @@ void LockedInfoWindow::rebuild()
 {
     destroyInterface();
     buildInterface();
+}
+
+top_bar::Configuration LockedInfoWindow::configureTopBar(top_bar::Configuration appConfiguration)
+{
+    appConfiguration.enable(top_bar::Indicator::Lock);
+    appConfiguration.disable(top_bar::Indicator::Time);
+    return appConfiguration;
 }
 
 void LockedInfoWindow::buildInterface()

--- a/module-apps/application-desktop/windows/LockedInfoWindow.hpp
+++ b/module-apps/application-desktop/windows/LockedInfoWindow.hpp
@@ -25,5 +25,6 @@ namespace gui
         void rebuild() override;
         void buildInterface() override;
         void destroyInterface() override;
+        top_bar::Configuration configureTopBar(top_bar::Configuration appConfiguration) override;
     };
 } /* namespace gui */

--- a/module-apps/application-desktop/windows/MenuWindow.cpp
+++ b/module-apps/application-desktop/windows/MenuWindow.cpp
@@ -149,9 +149,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
-
         auto app = dynamic_cast<app::ApplicationDesktop *>(application);
         assert(app);
 

--- a/module-apps/application-desktop/windows/MmiPullWindow.cpp
+++ b/module-apps/application-desktop/windows/MmiPullWindow.cpp
@@ -37,8 +37,6 @@ MmiPullWindow::MmiPullWindow(app::Application *app, const std::string &name) : g
 {
     AppWindow::buildInterface();
 
-    topBar->setActive(TopBar::Elements::TIME, true);
-    topBar->setActive(TopBar::Elements::SIM, false);
     bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("app_desktop_replay"));
     bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
     text = new Text(

--- a/module-apps/application-desktop/windows/MmiPushWindow.cpp
+++ b/module-apps/application-desktop/windows/MmiPushWindow.cpp
@@ -30,8 +30,6 @@ namespace style::desktop
 MmiPushWindow::MmiPushWindow(app::Application *app, const std::string &name) : gui::AppWindow(app, name)
 {
     AppWindow::buildInterface();
-    topBar->setActive(TopBar::Elements::TIME, true);
-    topBar->setActive(TopBar::Elements::SIM, false);
     bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::ok));
     icon = new Image(this, style::desktop::image::x, style::desktop::image::y, "");
     icon->set("info_big_circle_W_G");

--- a/module-apps/application-desktop/windows/PinLockBaseWindow.cpp
+++ b/module-apps/application-desktop/windows/PinLockBaseWindow.cpp
@@ -32,7 +32,12 @@ namespace gui
         }
         return std::string{};
     }
-
+    top_bar::Configuration PinLockBaseWindow::configureTopBar(top_bar::Configuration appConfiguration)
+    {
+        appConfiguration.enable(top_bar::Indicator::Lock);
+        appConfiguration.disable(top_bar::Indicator::Time);
+        return appConfiguration;
+    }
     void PinLockBaseWindow::restore() noexcept
     {
         LockWindow::restore();
@@ -91,10 +96,4 @@ namespace gui
         title->setPenWidth(2);
     }
 
-    void PinLockBaseWindow::buildTopBar()
-    {
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
-        topBar->setActive(TopBar::Elements::LOCK, true);
-    }
 } // namespace gui

--- a/module-apps/application-desktop/windows/PinLockBaseWindow.hpp
+++ b/module-apps/application-desktop/windows/PinLockBaseWindow.hpp
@@ -12,6 +12,9 @@ namespace gui
       public:
         PinLockBaseWindow(app::Application *app, std::string name) : LockWindow(app, name)
         {}
+
+        top_bar::Configuration configureTopBar(top_bar::Configuration appConfiguration) override;
+
         void buildImages(const std::string &lockImg, const std::string &infoImg);
         [[nodiscard]] auto getToken(Token token) const -> std::string;
         void restore() noexcept override;
@@ -25,6 +28,5 @@ namespace gui
       private:
         void buildBottomBar() override;
         void buildTitleBar() override;
-        void buildTopBar() override;
     };
 } // namespace gui

--- a/module-apps/application-meditation/windows/MeditationListViewWindows.cpp
+++ b/module-apps/application-meditation/windows/MeditationListViewWindows.cpp
@@ -64,7 +64,6 @@ void MeditationOptionsWindow::buildInterface()
     MeditationListViewWindow::buildInterface();
     setTitle(utils::localize.get("common_options"));
     bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::Switch));
-    topBar->setActive(TopBar::Elements::TIME, true);
 }
 
 PreparationTimeWindow::PreparationTimeWindow(app::Application *app)
@@ -79,5 +78,4 @@ void PreparationTimeWindow::buildInterface()
     MeditationListViewWindow::buildInterface();
     setTitle(utils::localize.get("app_meditation_preparation_time"));
     bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-    topBar->setActive(TopBar::Elements::TIME, true);
 }

--- a/module-apps/application-meditation/windows/MeditationTimerWindow.cpp
+++ b/module-apps/application-meditation/windows/MeditationTimerWindow.cpp
@@ -112,7 +112,11 @@ auto MeditationTimerWindow::onInput(const InputEvent &inputEvent) -> bool
 
 void MeditationTimerWindow::setWidgetVisible(bool tBar, bool bBar, bool counter)
 {
-    topBar->setActive(TopBar::Elements::TIME, tBar);
+    applyToTopBar([tBar](top_bar::Configuration configuration) {
+        configuration.set(top_bar::Indicator::Time, tBar);
+        return configuration;
+    });
+
     title->setVisible(tBar);
     bottomBar->setActive(BottomBar::Side::CENTER, bBar);
     bottomBar->setActive(BottomBar::Side::LEFT, bBar);

--- a/module-apps/application-messages/windows/MessagesMainWindow.cpp
+++ b/module-apps/application-messages/windows/MessagesMainWindow.cpp
@@ -64,8 +64,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::TIME, true);
-
         setTitle(utils::localize.get("app_messages_title_main"));
 
         leftArrowImage  = new gui::Image(this, 30, 62, 0, 0, "arrow_left");

--- a/module-apps/application-messages/windows/NewMessage.cpp
+++ b/module-apps/application-messages/windows/NewMessage.cpp
@@ -188,9 +188,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        topBar->setActive(TopBar::Elements::BATTERY, false);
-        topBar->setActive(TopBar::Elements::SIM, false);
-        topBar->setActive(TopBar::Elements::SIGNAL, false);
 
         setTitle(utils::localize.get("sms_title_message"));
 

--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -44,8 +44,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::use));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::TIME, true);
-
         namespace style = style::messages::templates::list;
 
         list = new gui::ListView(this, style::x, style::y, style::w, style::h, smsTemplateModel);

--- a/module-apps/application-messages/windows/SMSThreadViewWindow.cpp
+++ b/module-apps/application-messages/windows/SMSThreadViewWindow.cpp
@@ -29,7 +29,6 @@ namespace gui
     {
         AppWindow::buildInterface();
         setTitle(utils::localize.get("app_messages_title_main"));
-        topBar->setActive(TopBar::Elements::TIME, true);
         bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 

--- a/module-apps/application-music-player/windows/MusicPlayerAllSongsWindow.cpp
+++ b/module-apps/application-music-player/windows/MusicPlayerAllSongsWindow.cpp
@@ -54,8 +54,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("app_music_player_play"));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::TIME, true);
-
         songsList = new gui::ListView(this,
                                       musicPlayerStyle::allSongsWindow::x,
                                       musicPlayerStyle::allSongsWindow::y,

--- a/module-apps/application-music-player/windows/MusicPlayerEmptyWindow.cpp
+++ b/module-apps/application-music-player/windows/MusicPlayerEmptyWindow.cpp
@@ -33,8 +33,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get("app_music_player_music_library"));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get("app_music_player_quit"));
 
-        topBar->setActive(TopBar::Elements::TIME, true);
-
         img = new gui::Image(this, noteImg::x, noteImg::y, "note");
 
         text = new Text(this, infoText::x, infoText::y, infoText::w, infoText::h);

--- a/module-apps/application-notes/windows/NoteEditWindow.cpp
+++ b/module-apps/application-notes/windows/NoteEditWindow.cpp
@@ -85,8 +85,6 @@ namespace app::notes
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(::style::strings::common::back));
 
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
-
         setFocusItem(edit);
     }
 

--- a/module-apps/application-notes/windows/NoteMainWindow.cpp
+++ b/module-apps/application-notes/windows/NoteMainWindow.cpp
@@ -54,7 +54,6 @@ namespace app::notes
         bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(::style::strings::common::open));
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(::style::strings::common::back));
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
 
         namespace windowStyle = app::notes::style::main_window;
         leftArrowImage        = new gui::Image(this,

--- a/module-apps/application-notes/windows/NotePreviewWindow.cpp
+++ b/module-apps/application-notes/windows/NotePreviewWindow.cpp
@@ -79,8 +79,6 @@ namespace app::notes
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(::style::strings::common::back));
 
-        topBar->setActive(gui::TopBar::Elements::TIME, true);
-
         setFocusItem(note);
     }
 

--- a/module-apps/application-phonebook/windows/PhonebookContactDetails.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookContactDetails.cpp
@@ -25,7 +25,6 @@ namespace gui
     void PhonebookContactDetails::buildInterface()
     {
         AppWindow::buildInterface();
-        topBar->setActive(TopBar::Elements::TIME, true);
 
         bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));

--- a/module-apps/application-phonebook/windows/PhonebookIceContacts.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookIceContacts.cpp
@@ -25,7 +25,6 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        topBar->setActive(TopBar::Elements::TIME, true);
         setTitle(utils::localize.get("app_phonebook_ice_contacts_title"));
 
         contactsListIce = new gui::ListView(this,

--- a/module-apps/application-phonebook/windows/PhonebookMainWindow.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookMainWindow.cpp
@@ -30,7 +30,6 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        topBar->setActive(TopBar::Elements::TIME, true);
         setTitle(utils::localize.get("app_phonebook_title_main"));
         leftArrowImage  = new gui::Image(this,
                                         phonebookStyle::mainWindow::leftArrowImage::x,

--- a/module-apps/application-phonebook/windows/PhonebookSearch.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookSearch.cpp
@@ -16,7 +16,6 @@ namespace gui
     void PhonebookSearch::buildInterface()
     {
         AppWindow::buildInterface();
-        topBar->setActive(TopBar::Elements::TIME, true);
 
         setTitle(utils::localize.get("app_phonebook_title_main"));
 

--- a/module-apps/application-phonebook/windows/PhonebookSearchResults.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookSearchResults.cpp
@@ -40,8 +40,6 @@ namespace gui
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::TIME, true);
-
         setTitle(utils::localize.get("common_results_prefix"));
     }
 

--- a/module-apps/application-settings-new/windows/AllDevicesWindow.cpp
+++ b/module-apps/application-settings-new/windows/AllDevicesWindow.cpp
@@ -71,10 +71,6 @@ namespace gui
                 gui::option::SettingRightItem::Bt));
         }
 
-        topBar->setActive(TopBar::Elements::SIGNAL, false);
-        topBar->setActive(TopBar::Elements::BATTERY, false);
-        topBar->setActive(TopBar::Elements::SIM, false);
-
         leftArrowImage = new gui::Image(this,
                                         style::settings::window::leftArrowImage::x,
                                         style::settings::window::leftArrowImage::y,

--- a/module-apps/application-settings-new/windows/ApnSettingsWindow.cpp
+++ b/module-apps/application-settings-new/windows/ApnSettingsWindow.cpp
@@ -34,10 +34,6 @@ namespace gui
     {
         setTitle(utils::localize.get("app_settings_network_apn_settings"));
 
-        topBar->setActive(TopBar::Elements::SIGNAL, false);
-        topBar->setActive(TopBar::Elements::BATTERY, false);
-        topBar->setActive(TopBar::Elements::SIM, false);
-
         leftArrowImage = new gui::Image(this,
                                         style::settings::window::leftArrowImage::x,
                                         style::settings::window::leftArrowImage::y,

--- a/module-apps/application-settings-new/windows/AppsAndToolsWindow.cpp
+++ b/module-apps/application-settings-new/windows/AppsAndToolsWindow.cpp
@@ -33,10 +33,6 @@ namespace gui
                                                 gui::option::Arrow::Enabled});
         };
 
-        topBar->setActive(TopBar::Elements::SIGNAL, false);
-        topBar->setActive(TopBar::Elements::BATTERY, false);
-        topBar->setActive(TopBar::Elements::SIM, false);
-
         addMenu(i18("app_settings_apps_messages"), gui::window::name::messages);
         addMenu(i18("app_settings_apps_torch"), gui::window::name::torch);
 

--- a/module-apps/application-settings-new/windows/BaseSettingsWindow.cpp
+++ b/module-apps/application-settings-new/windows/BaseSettingsWindow.cpp
@@ -16,9 +16,6 @@ namespace gui
 
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        topBar->setActive(TopBar::Elements::BATTERY, false);
-        topBar->setActive(TopBar::Elements::SIM, false);
-        topBar->setActive(TopBar::Elements::TIME, true);
     }
 
     void BaseSettingsWindow::destroyInterface()

--- a/module-apps/application-settings-new/windows/BluetoothWindow.cpp
+++ b/module-apps/application-settings-new/windows/BluetoothWindow.cpp
@@ -15,8 +15,6 @@ namespace gui
 
     BluetoothWindow::BluetoothWindow(app::Application *app) : OptionWindow(app, gui::window::name::bluetooth)
     {
-        topBar->setActive(TopBar::Elements::BATTERY, false);
-        topBar->setActive(TopBar::Elements::SIM, false);
         sys::Bus::SendUnicast(
             std::make_shared<::message::bluetooth::RequestStatus>(), service::name::bluetooth, application);
     }

--- a/module-apps/application-settings-new/windows/ChangePasscodeWindow.cpp
+++ b/module-apps/application-settings-new/windows/ChangePasscodeWindow.cpp
@@ -76,14 +76,6 @@ namespace gui
         setTitle(utils::localize.get("app_settings_security_change_passcode"));
     }
 
-    void ChangePasscodeWindow::buildTopBar()
-    {
-        topBar->setActive(TopBar::Elements::SIM, false);
-        topBar->setActive(TopBar::Elements::LOCK, false);
-        topBar->setActive(TopBar::Elements::BATTERY, false);
-        topBar->setActive(TopBar::Elements::TIME, true);
-    }
-
     void ChangePasscodeWindow::destroyInterface()
     {
         erase();

--- a/module-apps/application-settings-new/windows/ChangePasscodeWindow.hpp
+++ b/module-apps/application-settings-new/windows/ChangePasscodeWindow.hpp
@@ -21,7 +21,6 @@ namespace gui
         void buildBottomBar() override;
         void buildInterface() override;
         void buildTitleBar() override;
-        void buildTopBar() override;
         void destroyInterface() override;
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
         void processPasscode();

--- a/module-apps/application-settings-new/windows/MessagesWindow.cpp
+++ b/module-apps/application-settings-new/windows/MessagesWindow.cpp
@@ -64,9 +64,6 @@ namespace gui
         };
 
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-        topBar->setActive(TopBar::Elements::SIGNAL, false);
-        topBar->setActive(TopBar::Elements::BATTERY, false);
-        topBar->setActive(TopBar::Elements::SIM, false);
 
         addMenuSwitch(utils::translateI18("app_settings_show_unread_first"), "");
         addMenu(utils::translateI18("app_settings_Templates"), gui::window::name::templates);

--- a/module-apps/application-settings-new/windows/NetworkWindow.cpp
+++ b/module-apps/application-settings-new/windows/NetworkWindow.cpp
@@ -122,9 +122,6 @@ namespace gui
 
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
 
-        topBar->setActive(TopBar::Elements::SIGNAL, false);
-        topBar->setActive(TopBar::Elements::BATTERY, false);
-        topBar->setActive(TopBar::Elements::SIM, false);
         return optList;
     }
     void NetworkWindow::rebuild()

--- a/module-apps/application-settings-new/windows/NightshiftWindow.cpp
+++ b/module-apps/application-settings-new/windows/NightshiftWindow.cpp
@@ -16,9 +16,6 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        topBar->setActive(TopBar::Elements::SIM, false);
-        topBar->setActive(TopBar::Elements::TIME, true);
-
         setTitle(utils::localize.get("app_settings_title_nightshift"));
 
         body = new gui::VBox(this,

--- a/module-apps/application-settings-new/windows/PhoneNameWindow.cpp
+++ b/module-apps/application-settings-new/windows/PhoneNameWindow.cpp
@@ -22,8 +22,6 @@ namespace gui
     void PhoneNameWindow::buildInterface()
     {
         AppWindow::buildInterface();
-        topBar->setActive(TopBar::Elements::SIM, false);
-        topBar->setActive(TopBar::Elements::TIME, true);
 
         setTitle(utils::localize.get("app_settings_bluetooth_phone_name"));
 

--- a/module-apps/application-settings/windows/BtScanWindow.cpp
+++ b/module-apps/application-settings/windows/BtScanWindow.cpp
@@ -57,8 +57,6 @@ namespace gui
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
 
         setTitle(utils::localize.get("BT_scan_results"));
 

--- a/module-apps/application-settings/windows/BtWindow.cpp
+++ b/module-apps/application-settings/windows/BtWindow.cpp
@@ -59,8 +59,6 @@ namespace gui
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
 
         setTitle(utils::localize.get("app_settings_bt"));
 

--- a/module-apps/application-settings/windows/CellularPassthroughWindow.cpp
+++ b/module-apps/application-settings/windows/CellularPassthroughWindow.cpp
@@ -31,8 +31,6 @@ namespace gui
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
 
         setTitle(utils::localize.get("app_settings_cellular_passthrough"));
 

--- a/module-apps/application-settings/windows/DateTimeWindow.cpp
+++ b/module-apps/application-settings/windows/DateTimeWindow.cpp
@@ -52,9 +52,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
-
         setTitle(utils::localize.get("app_settings_date_and_time"));
 
         // create date widgets

--- a/module-apps/application-settings/windows/EinkModeWindow.cpp
+++ b/module-apps/application-settings/windows/EinkModeWindow.cpp
@@ -27,8 +27,6 @@ namespace gui
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
 
         setTitle("Change eink mode");
         auto label               = new Label(this, 100, 200, 300, 50, "Change mode on click");

--- a/module-apps/application-settings/windows/FotaWindow.cpp
+++ b/module-apps/application-settings/windows/FotaWindow.cpp
@@ -37,9 +37,6 @@ namespace gui
         AppWindow::buildInterface();
         setTitle("Modem Firmware update (FOTA)");
 
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
-
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("Go"));

--- a/module-apps/application-settings/windows/Info.cpp
+++ b/module-apps/application-settings/windows/Info.cpp
@@ -36,8 +36,6 @@ namespace gui
         AppWindow::buildInterface();
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
 
         setTitle("Info");
 

--- a/module-apps/application-settings/windows/LanguageWindow.cpp
+++ b/module-apps/application-settings/windows/LanguageWindow.cpp
@@ -49,9 +49,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
-
         setTitle(utils::localize.get("app_settings_title_languages"));
         const auto &langList = loader.getAvailableDisplayLanguages();
         for (const auto &lang : langList) {

--- a/module-apps/application-settings/windows/TestMessageWindow.cpp
+++ b/module-apps/application-settings/windows/TestMessageWindow.cpp
@@ -61,9 +61,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
-
         receivedLabel = new gui::Label(this, 10, 50, 480 - 20, 50, "Received SMS");
         receivedLabel->setAlignment(
             gui::Alignment(gui::Alignment::Vertical::Center, gui::Alignment::Horizontal::Center));

--- a/module-apps/application-special-input/windows/SpecialInputMainWindow.cpp
+++ b/module-apps/application-special-input/windows/SpecialInputMainWindow.cpp
@@ -36,8 +36,6 @@ void SpecialInputMainWindow::buildInterface()
     bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
     bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::emoji));
 
-    topBar->setActive(TopBar::Elements::TIME, true);
-
     charList = new gui::ListView(this,
                                  specialInputStyle::specialInputListView::x,
                                  specialInputStyle::specialInputListView::y,

--- a/module-apps/windows/AppWindow.cpp
+++ b/module-apps/windows/AppWindow.cpp
@@ -49,10 +49,22 @@ namespace gui
         title->setEllipsis(Ellipsis::Right);
         title->visible = false;
 
-        topBar = new gui::TopBar(this, 0, 0, 480, 50);
-        topBar->setActive(TopBar::Elements::LOCK, false);
-        topBar->setActive(TopBar::Elements::BATTERY, false);
-        topBar->setActive(TopBar::Elements::SIGNAL, false);
+        auto config = configureTopBar(application->getTopBarConfiguration());
+        topBar      = new gui::top_bar::TopBar(this, 0, 0, 480, 50);
+        topBar->configure(std::move(config));
+    }
+
+    top_bar::Configuration AppWindow::configureTopBar(top_bar::Configuration appConfiguration)
+    {
+        return appConfiguration;
+    }
+
+    void AppWindow::applyToTopBar(TopBarConfigurationChangeFunction configChange)
+    {
+        if (configChange) {
+            auto newConfiguration = configChange(topBar->getConfiguration());
+            topBar->configure(std::move(newConfiguration));
+        }
     }
 
     bool AppWindow::setSIM()

--- a/module-apps/windows/AppWindow.hpp
+++ b/module-apps/windows/AppWindow.hpp
@@ -40,11 +40,16 @@ namespace gui
         /**
          * Information bar for signal, battery and lock icon on the top of the screen.
          */
-        gui::TopBar *topBar = nullptr;
+        gui::top_bar::TopBar *topBar = nullptr;
         /**
          * Pointer to the application object that owns the window.
          */
         app::Application *application = nullptr;
+
+        /**
+         * A function that applies configuration changes to the current top bar configuration.
+         */
+        using TopBarConfigurationChangeFunction = std::function<top_bar::Configuration(top_bar::Configuration)>;
 
       public:
         AppWindow() = delete;
@@ -54,10 +59,7 @@ namespace gui
         {
             return application;
         };
-        void setApplication(app::Application *app)
-        {
-            application = app;
-        };
+
         virtual bool onDatabaseMessage(sys::Message *msg);
 
         bool updateBatteryCharger(bool charging);
@@ -76,6 +78,20 @@ namespace gui
         void destroyInterface() override;
         bool onInput(const InputEvent &inputEvent) override;
         void accept(GuiVisitor &visitor) override;
+
+        /**
+         * Configure the top bar using window-specific configuration.
+         * @param appConfiguration      Application-wide top bar configuration that it to be modified.
+         * @return window-specific configuration of the top bar.
+         */
+        virtual top_bar::Configuration configureTopBar(top_bar::Configuration appConfiguration);
+
+        /**
+         * Applies configuration change on the current top bar configuration.
+         * @param configChange  The function that contains the top bar configuration changes.
+         */
+        void applyToTopBar(TopBarConfigurationChangeFunction configChange);
+
         /// Setting bottom bar temporary text
         /// @param text - bottomBar text
         /// @param overwriteOthers - set or not other bottomBar texts to "" (default true)

--- a/module-apps/windows/Dialog.cpp
+++ b/module-apps/windows/Dialog.cpp
@@ -50,7 +50,6 @@ Dialog::Dialog(app::Application *app, const std::string &name) : gui::AppWindow(
 {
     AppWindow::buildInterface();
 
-    topBar->setActive(TopBar::Elements::TIME, true);
     bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
     setTitle("");
@@ -77,9 +76,6 @@ void Dialog::onBeforeShow(ShowMode mode, SwitchData *data)
 
 DialogConfirm::DialogConfirm(app::Application *app, const std::string &name) : Dialog(app, name)
 {
-    topBar->setActive(TopBar::Elements::BATTERY, true);
-    topBar->setActive(TopBar::Elements::SIGNAL, true);
-
     bottomBar->setActive(BottomBar::Side::RIGHT, false);
     bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::ok));
     setFocusItem(icon);
@@ -169,8 +165,6 @@ void DialogYesNoIconTxt::onBeforeShow(ShowMode mode, SwitchData *data)
     if (auto metadata = dynamic_cast<DialogMetadataMessage *>(data); metadata != nullptr) {
         DialogYesNo::onBeforeShow(mode, metadata);
         iconText->setText(metadata->get().iconText);
-        topBar->setActive(TopBar::Elements::BATTERY, false);
-        topBar->setActive(TopBar::Elements::SIM, false);
         setFocusItem(no);
     }
 }

--- a/module-apps/windows/OptionWindow.cpp
+++ b/module-apps/windows/OptionWindow.cpp
@@ -63,8 +63,6 @@ namespace gui
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
 
-        topBar->setActive(TopBar::Elements::SIGNAL, true);
-        topBar->setActive(TopBar::Elements::BATTERY, true);
         setTitle(name);
 
         optionsList = new gui::ListView(this,

--- a/module-gui/gui/dom/Item2JsonSerializingVisitor.cpp
+++ b/module-gui/gui/dom/Item2JsonSerializingVisitor.cpp
@@ -85,7 +85,7 @@ void Item2JsonSerializingVisitor::visit(gui::BottomBar &item)
     visit(static_cast<gui::Item &>(item));
 }
 
-void Item2JsonSerializingVisitor::visit(gui::TopBar &item)
+void Item2JsonSerializingVisitor::visit(gui::top_bar::TopBar &item)
 {
     if (itemName.empty()) {
         itemName = magic_enum::enum_name(visitor::Names::TopBar);

--- a/module-gui/gui/dom/Item2JsonSerializingVisitor.hpp
+++ b/module-gui/gui/dom/Item2JsonSerializingVisitor.hpp
@@ -29,7 +29,7 @@ namespace gui
         void visit(gui::Window &item) override;
         void visit(gui::Label &item) override;
         void visit(gui::BottomBar &item) override;
-        void visit(gui::TopBar &item) override;
+        void visit(gui::top_bar::TopBar &item) override;
 
       public:
         /// retrieves current state of the `sink`. The state of the `sink` after call is default-initialized

--- a/module-gui/gui/widgets/visitor/GuiVisitor.hpp
+++ b/module-gui/gui/widgets/visitor/GuiVisitor.hpp
@@ -11,7 +11,10 @@ namespace gui
     class Window;
     class Label;
     class BottomBar;
-    class TopBar;
+    namespace top_bar
+    {
+        class TopBar;
+    }
 
     /// The general purpose abstract interface for enabling Double-Dispatch behavior throughout `gui::Item`'s
     /// inheritance hierarchy.
@@ -24,7 +27,7 @@ namespace gui
         virtual void visit(gui::Window &item)    = 0;
         virtual void visit(gui::Label &item)     = 0;
         virtual void visit(gui::BottomBar &item) = 0;
-        virtual void visit(gui::TopBar &item)    = 0;
+        virtual void visit(gui::top_bar::TopBar &item) = 0;
         virtual ~GuiVisitor()                    = default;
     };
 } // namespace gui

--- a/module-gui/test/test-google/test-gui-visitor-call.cpp
+++ b/module-gui/test/test-google/test-gui-visitor-call.cpp
@@ -25,7 +25,7 @@ class VisitorMock : public gui::GuiVisitor
     MOCK_METHOD1(visit, void(gui::Window &item));
     MOCK_METHOD1(visit, void(gui::Label &item));
     MOCK_METHOD1(visit, void(gui::BottomBar &item));
-    MOCK_METHOD1(visit, void(gui::TopBar &item));
+    MOCK_METHOD1(visit, void(gui::top_bar::TopBar &item));
 };
 
 class CustomRect : public gui::Rect


### PR DESCRIPTION
In most cases, applications configure the top bar once for all their windows. In a few cases however, windows need to configure the top bar with window-specific configuration.