### PR TITLE
[EGD-5250] AM/PM mark next to actual hour should not be vissible on Home Screen and Status Bar

### DIFF
--- a/image/assets/lang/Deutsch.json
+++ b/image/assets/lang/Deutsch.json
@@ -38,6 +38,7 @@
   "common_yesterday": "Yesterday",
   "common_today": "Today",
   "locale_12hour_min": "%I:%M %p",
+  "locale_12hour_min_short": "%I:%M",
   "locale_24hour_min": "%H:%M",
   "locale_date_full": "%m/%d/%y",
   "locale_date_short": "%d/%m",

--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -62,6 +62,7 @@
   "common_search": "SEARCH",
   "common_empty_list": "Default Info: No elements on list.",
   "locale_12hour_min": "%I:%M %p",
+  "locale_12hour_min_short": "%I:%M",
   "locale_24hour_min": "%H:%M",
   "locale_date_full": "%m/%d/%y",
   "locale_date_short": "%d/%m",

--- a/image/assets/lang/Espanol.json
+++ b/image/assets/lang/Espanol.json
@@ -38,6 +38,7 @@
   "common_yesterday": "Yesterday",
   "common_today": "Today",
   "locale_12hour_min": "%I:%M %p",
+  "locale_12hour_min_short": "%I:%M",
   "locale_24hour_min": "%H:%M",
   "locale_date_full": "%m/%d/%y",
   "locale_date_short": "%d/%m",

--- a/image/assets/lang/Francais.json
+++ b/image/assets/lang/Francais.json
@@ -38,6 +38,7 @@
   "common_yesterday": "Yesterday",
   "common_today": "Today",
   "locale_12hour_min": "%I:%M %p",
+  "locale_12hour_min_short": "%I:%M",
   "locale_24hour_min": "%H:%M",
   "locale_date_full": "%m/%d/%y",
   "locale_date_short": "%d/%m",

--- a/image/assets/lang/Polski.json
+++ b/image/assets/lang/Polski.json
@@ -38,6 +38,7 @@
   "common_yesterday": "wczoraj",
   "common_today": "dzisiaj",
   "locale_12hour_min": "%I:%M",
+  "locale_12hour_min_short": "%I:%M",
   "locale_24hour_min": "%H:%M",
   "locale_date_full": "%d.%m.%y",
   "locale_date_short": "%d.%m",

--- a/module-apps/application-desktop/data/Style.hpp
+++ b/module-apps/application-desktop/data/Style.hpp
@@ -24,7 +24,7 @@ namespace style::desktop
         constexpr auto X     = 0;
         constexpr auto Y     = 106;
         constexpr auto Width = style::window_width;
-        constexpr auto Hight = 96;
+        constexpr auto Height = 96;
 
     } // namespace timeLabel
 
@@ -33,7 +33,7 @@ namespace style::desktop
         constexpr auto X     = 0;
         constexpr auto Y     = 204;
         constexpr auto Width = style::window_width;
-        constexpr auto Hight = 51;
+        constexpr auto Height = 51;
 
     } // namespace dayLabel
 

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -40,14 +40,14 @@ namespace gui
 
         using namespace style::desktop;
 
-        time = new gui::Label(this, timeLabel::X, timeLabel::Y, timeLabel::Width, timeLabel::Hight);
+        time = new gui::Label(this, timeLabel::X, timeLabel::Y, timeLabel::Width, timeLabel::Height);
         time->setFilled(false);
         time->setBorderColor(gui::ColorNoColor);
         time->setFont(style::window::font::supersizemelight);
         time->setText(ttime);
         time->setAlignment(Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
 
-        dayText = new gui::Label(this, dayLabel::X, dayLabel::Y, dayLabel::Width, dayLabel::Hight);
+        dayText = new gui::Label(this, dayLabel::X, dayLabel::Y, dayLabel::Width, dayLabel::Height);
         dayText->setFilled(false);
         dayText->setBorderColor(gui::ColorNoColor);
         dayText->setFont(style::window::font::biglight);

--- a/module-utils/time/time_conversion.cpp
+++ b/module-utils/time/time_conversion.cpp
@@ -277,7 +277,7 @@ namespace utils::time
         }
         else {
             return Timestamp::str(
-                Locale::format(Locale::FormatTime12H)); // @TODO: M.G. FormatLocaleTime which actually works
+                Locale::format(Locale::FormatTime12HShort)); // @TODO: M.G. FormatLocaleTime which actually works
         }
     }
 

--- a/module-utils/time/time_locale.hpp
+++ b/module-utils/time/time_locale.hpp
@@ -21,7 +21,7 @@ namespace utils
         {
             static const int num_days       = 7;
             static const int num_monts      = 12;
-            static const int num_formatters = 4;
+            static const int num_formatters = 5;
             // imo it would be nicer to have datetime locales in different json with thiny bit nicer and more effective
             // getters
             const std::array<std::string, num_days> daysShort = {
@@ -50,6 +50,7 @@ namespace utils
 
             const std::array<std::string, num_formatters> time_formats{
                 "locale_12hour_min",
+                "locale_12hour_min_short",
                 "locale_24hour_min",
                 "locale_date_full",
                 "locale_date_short",
@@ -90,6 +91,7 @@ namespace utils
             enum TimeFormat
             {
                 FormatTime12H = 0,     // H:M in 12h format
+                FormatTime12HShort,    // H:M in 12h format, am/pm excluded
                 FormatTime24H,         // H:M in 24h format
                 FormatLocaleDateFull,  // format locale specified format
                 FormatLocaleDateShort, // format locale specified format


### PR DESCRIPTION
This PR changes time format displayed on home screen and on status bar
by adding new locale for 12H format, which excludes am/pm suffix.
The new locale is set as new default format for time string.

Minor: Grammar typo fixed.