### PR TITLE
[EGD-5248] Add statvfs to the libiosyscall library

### DIFF
--- a/board/linux/libiosyscalls/version.txt
+++ b/board/linux/libiosyscalls/version.txt
@@ -70,6 +70,7 @@ GLIBC_2.2.5 {
                 __fxstat64;
                 mount;
                 umount;
+                statvfs;
 
         local:
                 *;


### PR DESCRIPTION
Added support for statvfs in the libiosyscall library.
It is needed in service desktop implementation.