### PR TITLE
[EGD-5287] Add Languages window

### DIFF
--- a/module-apps/application-settings-new/ApplicationSettings.cpp
+++ b/module-apps/application-settings-new/ApplicationSettings.cpp
@@ -30,6 +30,7 @@
 #include "windows/ChangePasscodeWindow.hpp"
 #include "windows/SystemMainWindow.hpp"
 #include "windows/NewApnWindow.hpp"
+#include "windows/LanguagesWindow.hpp"
 
 #include "Dialog.hpp"
 
@@ -42,6 +43,7 @@
 #include <service-db/agents/settings/SystemSettings.hpp>
 #include <application-settings-new/data/ApnListData.hpp>
 #include <application-settings-new/data/BondedDevicesData.hpp>
+#include <application-settings-new/data/LanguagesData.hpp>
 #include <application-settings-new/data/PhoneNameData.hpp>
 #include <module-services/service-db/agents/settings/SystemSettings.hpp>
 #include <service-db/Settings.hpp>
@@ -49,6 +51,8 @@
 #include <i18n/i18n.hpp>
 #include <module-services/service-evtmgr/service-evtmgr/ScreenLightControlMessage.hpp>
 #include <module-services/service-evtmgr/service-evtmgr/Constants.hpp>
+#include <module-services/service-appmgr/service-appmgr/messages/Message.hpp>
+#include <module-services/service-appmgr/service-appmgr/model/ApplicationManager.hpp>
 
 namespace app
 {
@@ -158,6 +162,17 @@ namespace app
             return sys::MessageNone{};
         });
 
+        connect(typeid(manager::GetCurrentDisplayLanguageResponse), [&](sys::Message *msg) {
+            if (gui::window::name::languages == getCurrentWindow()->getName()) {
+                auto response = dynamic_cast<manager::GetCurrentDisplayLanguageResponse *>(msg);
+                if (response != nullptr) {
+                    auto languagesData = std::make_unique<LanguagesData>(response->getLanguage());
+                    switchWindow(gui::window::name::languages, std::move(languagesData));
+                }
+            }
+            return sys::MessageNone{};
+        });
+
         createUserInterface();
 
         setActiveWindow(gui::name::window::main_window);
@@ -258,6 +273,9 @@ namespace app
         });
         windowsFactory.attach(gui::window::name::new_apn, [](Application *app, const std::string &name) {
             return std::make_unique<gui::NewApnWindow>(app);
+        });
+        windowsFactory.attach(gui::window::name::languages, [](Application *app, const std::string &name) {
+            return std::make_unique<gui::LanguagesWindow>(app);
         });
     }
 

--- a/module-apps/application-settings-new/ApplicationSettings.hpp
+++ b/module-apps/application-settings-new/ApplicationSettings.hpp
@@ -50,7 +50,7 @@ namespace gui::window::name
     inline constexpr auto dialog_settings    = "DialogSettings";
     inline constexpr auto change_passcode    = "ChangePasscode";
 
-    inline constexpr auto language        = "Language";
+    inline constexpr auto languages       = "Languages";
     inline constexpr auto date_and_time   = "DateAndTime";
     inline constexpr auto factory_reset   = "FactoryReset";
     inline constexpr auto about_your_pure = "AboutYourPure";

--- a/module-apps/application-settings-new/CMakeLists.txt
+++ b/module-apps/application-settings-new/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources( ${PROJECT_NAME}
     PRIVATE
         ApplicationSettings.cpp
         models/ApnSettingsModel.cpp
+        models/LanguagesModel.cpp
         models/NewApnModel.cpp
         widgets/timeWidget.cpp
         widgets/ChangePasscodeLockHandler.cpp
@@ -50,6 +51,7 @@ target_sources( ${PROJECT_NAME}
         widgets/SpinBox.cpp
         widgets/SpinBoxOptionSetting.cpp
         windows/SystemMainWindow.cpp
+        windows/LanguagesWindow.cpp
 
     PUBLIC
         ApplicationSettings.hpp
@@ -71,6 +73,7 @@ target_sources( ${PROJECT_NAME}
         windows/WallpaperWindow.hpp
         windows/ChangePasscodeWindow.hpp
         windows/SystemMainWindow.hpp
+        windows/LanguagesWindow.hpp
 )
 
 add_dependencies(${PROJECT_NAME} version)

--- a/module-apps/application-settings-new/data/LanguagesData.hpp
+++ b/module-apps/application-settings-new/data/LanguagesData.hpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <SwitchData.hpp>
+
+class LanguagesData : public gui::SwitchData
+{
+  public:
+    explicit LanguagesData(Language currentDisplayLanguage) : currentDisplayLanguage(std::move(currentDisplayLanguage))
+    {}
+    [[nodiscard]] auto getCurrentDisplayLanguage() const noexcept -> Language
+    {
+        return currentDisplayLanguage;
+    }
+
+  private:
+    Language currentDisplayLanguage;
+};

--- a/module-apps/application-settings-new/models/LanguagesModel.cpp
+++ b/module-apps/application-settings-new/models/LanguagesModel.cpp
@@ -1,0 +1,13 @@
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <service-appmgr/service-appmgr/messages/GetCurrentDisplayLanguageRequest.hpp>
+#include <service-appmgr/service-appmgr/model/ApplicationManager.hpp>
+#include "LanguagesModel.hpp"
+
+void LanguagesModel::requestCurrentDisplayLanguage()
+{
+    sys::Bus::SendUnicast(std::make_shared<app::manager::GetCurrentDisplayLanguageRequest>(),
+                          app::manager::ApplicationManager::ServiceName,
+                          application);
+}

--- a/module-apps/application-settings-new/models/LanguagesModel.hpp
+++ b/module-apps/application-settings-new/models/LanguagesModel.hpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <Application.hpp>
+
+class LanguagesModel
+{
+  public:
+    explicit LanguagesModel(app::Application *application) : application(application)
+    {}
+
+    void requestCurrentDisplayLanguage();
+
+  private:
+    app::Application *application = nullptr;
+};

--- a/module-apps/application-settings-new/windows/LanguagesWindow.cpp
+++ b/module-apps/application-settings-new/windows/LanguagesWindow.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "application-settings-new/ApplicationSettings.hpp"
+#include "application-settings-new/data/LanguagesData.hpp"
+#include "LanguagesWindow.hpp"
+#include "OptionSetting.hpp"
+#include "service-appmgr/Controller.hpp"
+
+namespace gui
+{
+    LanguagesWindow::LanguagesWindow(app::Application *app)
+        : BaseSettingsWindow(app, window::name::languages), langList(loader.getAvailableDisplayLanguages()),
+          languagesModel(app)
+    {
+        setTitle(utils::localize.get("app_settings_title_languages"));
+        languagesModel.requestCurrentDisplayLanguage();
+    }
+
+    void LanguagesWindow::addOptions(std::list<Option> &optionList)
+    {
+        OptionWindow::addOptions(optionList);
+        optionsList->setFocusOnElement(selectedLanguageIndex);
+    }
+
+    auto LanguagesWindow::buildOptionsList() -> std::list<gui::Option>
+    {
+        std::list<gui::Option> options;
+
+        for (const auto &lang : langList) {
+            options.emplace_back(std::make_unique<gui::option::OptionSettings>(
+                lang,
+                [=](const gui::Item &item) {
+                    app::manager::Controller::changeDisplayLanguage(application, lang);
+                    return true;
+                },
+                nullptr,
+                this,
+                selectedLanguage == lang ? gui::option::SettingRightItem::Checked
+                                         : gui::option::SettingRightItem::Disabled));
+        }
+
+        return options;
+    }
+
+    auto LanguagesWindow::handleSwitchData(SwitchData *data) -> bool
+    {
+        auto *languagesData = dynamic_cast<LanguagesData *>(data);
+        if (languagesData == nullptr) {
+            return false;
+        }
+        selectedLanguage = languagesData->getCurrentDisplayLanguage();
+        setLanguageIndex();
+
+        return true;
+    }
+
+    void LanguagesWindow::setLanguageIndex()
+    {
+        for (unsigned int langIndex = 0; langIndex < langList.size(); ++langIndex) {
+            if (selectedLanguage == langList[langIndex]) {
+                selectedLanguageIndex = langIndex;
+                break;
+            }
+        }
+    }
+} /* namespace gui */

--- a/module-apps/application-settings-new/windows/LanguagesWindow.hpp
+++ b/module-apps/application-settings-new/windows/LanguagesWindow.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "application-settings-new/models/LanguagesModel.hpp"
+#include "BaseSettingsWindow.hpp"
+#include <i18n/i18n.hpp>
+
+namespace gui
+{
+    class LanguagesWindow : public BaseSettingsWindow
+    {
+      public:
+        explicit LanguagesWindow(app::Application *app);
+
+      private:
+        void addOptions(std::list<Option> &optionList) override;
+        auto buildOptionsList() -> std::list<Option> override;
+        auto handleSwitchData(SwitchData *data) -> bool override;
+        void setLanguageIndex();
+
+        utils::LangLoader loader;
+        const std::vector<Language> langList;
+        LanguagesModel languagesModel;
+        Language selectedLanguage;
+        unsigned int selectedLanguageIndex{0};
+    };
+} /* namespace gui */

--- a/module-apps/application-settings-new/windows/SystemMainWindow.cpp
+++ b/module-apps/application-settings-new/windows/SystemMainWindow.cpp
@@ -26,7 +26,7 @@ namespace gui
                 option::SettingRightItem::ArrowWhite));
         };
 
-        addOption("app_settings_language", gui::window::name::language);
+        addOption("app_settings_language", gui::window::name::languages);
         addOption("app_settings_date_and_time", gui::window::name::date_and_time);
         addOption("app_settings_factory_reset", gui::window::name::factory_reset);
         addOption("app_settings_about_your_pure", gui::window::name::about_your_pure);

--- a/module-apps/windows/OptionWindow.hpp
+++ b/module-apps/windows/OptionWindow.hpp
@@ -23,7 +23,7 @@ namespace gui
         std::shared_ptr<OptionsModel> optionsModel = nullptr;
         ListView *optionsList                      = nullptr;
         std::list<Option> options;
-        void addOptions(std::list<Option> &optionList);
+        virtual void addOptions(std::list<Option> &optionList);
         void addOptions(std::list<Option> &&optionList);
         void resetOptions(std::list<Option> &&optionList);
 

--- a/module-gui/gui/widgets/ListView.cpp
+++ b/module-gui/gui/widgets/ListView.cpp
@@ -141,6 +141,11 @@ namespace gui
         }
     }
 
+    void ListView::setFocusOnElement(unsigned int elementNumber)
+    {
+        body->setFocusOnElement(elementNumber);
+    }
+
     void ListView::setProvider(std::shared_ptr<ListItemProvider> prov)
     {
         if (prov != nullptr) {

--- a/module-gui/gui/widgets/ListView.hpp
+++ b/module-gui/gui/widgets/ListView.hpp
@@ -87,6 +87,7 @@ namespace gui
         std::shared_ptr<ListItemProvider> getProvider();
         void setOrientation(style::listview::Orientation value);
         void setBoundaries(style::listview::Boundaries value);
+        void setFocusOnElement(unsigned int elementNumber);
         void setScrollTopMargin(int value);
         void setAlignment(const Alignment &value) override;
         void onProviderDataUpdate();

--- a/module-services/service-appmgr/model/ApplicationManager.cpp
+++ b/module-services/service-appmgr/model/ApplicationManager.cpp
@@ -246,6 +246,9 @@ namespace app::manager
             handleAction(actionMsg);
             return std::make_shared<sys::ResponseMessage>();
         });
+        connect(typeid(GetCurrentDisplayLanguageRequest), [&](sys::Message *request) {
+            return std::make_shared<GetCurrentDisplayLanguageResponse>(displayLanguage);
+        });
 
         auto convertibleToActionHandler = [this](sys::Message *request) { return handleMessageAsAction(request); };
         connect(typeid(CellularSimRequestPinMessage), convertibleToActionHandler);

--- a/module-services/service-appmgr/service-appmgr/messages/GetCurrentDisplayLanguageRequest.hpp
+++ b/module-services/service-appmgr/service-appmgr/messages/GetCurrentDisplayLanguageRequest.hpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "Message.hpp"
+
+namespace app::manager
+{
+    class GetCurrentDisplayLanguageRequest : public sys::Message
+    {};
+} // namespace app::manager

--- a/module-services/service-appmgr/service-appmgr/messages/GetCurrentDisplayLanguageResponse.hpp
+++ b/module-services/service-appmgr/service-appmgr/messages/GetCurrentDisplayLanguageResponse.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <Service/Message.hpp>
+#include <i18n/i18n.hpp>
+
+namespace app::manager
+{
+    class GetCurrentDisplayLanguageResponse : public sys::ResponseMessage
+    {
+      public:
+        explicit GetCurrentDisplayLanguageResponse(Language language) : language(std::move(language))
+        {}
+        [[nodiscard]] auto getLanguage() const -> Language
+        {
+            return language;
+        }
+
+      private:
+        Language language;
+    };
+} // namespace app::manager

--- a/module-services/service-appmgr/service-appmgr/messages/Message.hpp
+++ b/module-services/service-appmgr/service-appmgr/messages/Message.hpp
@@ -16,3 +16,5 @@
 #include "PowerSaveModeInitRequest.hpp"
 #include "PreventBlockingRequest.hpp"
 #include "ShutdownRequest.hpp"
+#include "GetCurrentDisplayLanguageRequest.hpp"
+#include "GetCurrentDisplayLanguageResponse.hpp"


### PR DESCRIPTION
[EGD-5287] Add Languages window

- add LanguagesWindow,
- add GetCurrentDisplayLanguageRequest message used for
  sending request from LanguagesModel,
- add GetCurrentDisplayLanguageResponse message sent by
  ApplicationManager and handled by ApplicationSettingsNew,
- add setFocusOnElement method in ListView so current
  display language can be focused on when entering
  LanguagesWindow

[EGD-5287]: https://appnroll.atlassian.net/browse/EGD-5287