### PR TITLE
[EGD-5343] Add allow access /tmp dir when redir.

### DIFF
--- a/board/linux/libiosyscalls/src/iosyscalls.cpp
+++ b/board/linux/libiosyscalls/src/iosyscalls.cpp
@@ -25,6 +25,7 @@ namespace {
         "/run/user",
         "/home",
         "/proc",
+        "/tmp",
         "/dev/shm",
         "PurePhone.img",
         "MuditaOS.log",


### PR DESCRIPTION
Allow access Linux /tmp directory on emulator when redirect
to image is enabled.