### PR TITLE
[EGD-5344] Fix commit subject check

### DIFF
--- a/tools/check_commit_messages.py
+++ b/tools/check_commit_messages.py
@@ -33,7 +33,7 @@ def validate_commit(commit):
   empty_line = lines[1]
   body = ''.join(lines[2:]).strip()
 
-  subject_format = r'^\[\w+-\d+\] .+[^.]$'
+  subject_format = r'^\[EGD-\d+\] [A-Z].+[^.]$'
   if not re.match(subject_format, subject):
     errors.append(f'[{commit.hexsha}] invalid subject "{subject}", should match format "{subject_format}"')
 


### PR DESCRIPTION
Commit subject check run with CI was lacking check for:
 - EGD identifier (any word was allowed),
 - capital letter start.
