### PR TITLE
[EGD-5348] test harness - Be more verbose on an error

### DIFF
--- a/test/harness/harness.py
+++ b/test/harness/harness.py
@@ -72,7 +72,11 @@ class Harness:
 
     def send_text(self, text: str):
         for letter in text:
-            send_char(letter, self.connection)
+            try:
+                send_char(letter, self.connection)
+            except KeyError as e:
+                available = ' '.join((f"'{_}'" for _ in utils.keymap.keys()))
+                raise LookupError(f"Character {e} not present in the keymap\nAvailable characters: {available}")
 
     def send_number(self, number: str):
         utils.send_number(number, self.connection)

--- a/test/harness/utils.py
+++ b/test/harness/utils.py
@@ -156,7 +156,8 @@ class Timeout(Exception):
 
     @classmethod
     @contextmanager
-    def limit(cls, seconds):
+    def limit(cls, seconds: int):
+        assert seconds >= 1, "Timeout must be at least 1 second !"
         def signal_handler(signum, frame):
             raise Timeout("Timed out!")
 

--- a/test/pytest/conftest.py
+++ b/test/pytest/conftest.py
@@ -54,7 +54,7 @@ def harness(request):
     Try to init one Pure phone with serial port path or automatically
     '''
     port_name = request.config.option.port
-    TIMEOUT = int(request.config.option.timeout)
+    TIMEOUT = min(1, request.config.option.timeout)
     timeout_started = time.time()
 
     RETRY_EVERY_SECONDS = 1.0


### PR DESCRIPTION
Be more verbose on KeyError.
Relates to `--sms_text` argument

Currently we only support upper case characters in a direct way.
