### PR TITLE
[EGD-5350] Add increase lfs cluster size

### DIFF
--- a/flash_emmc_experimental_littlefs.sh
+++ b/flash_emmc_experimental_littlefs.sh
@@ -104,6 +104,6 @@ mcopy -s -i "$PART1" data ::/current/sys
 mmd -i "$PART1" ::/updates
 
 #Littlefs generate image
-$GENLFS --image=$BLK_DEV --block_size=4096  --overwrite  --partition_num=3 -- user/*
+$GENLFS --image=$BLK_DEV --block_size=32768  --overwrite  --partition_num=3 -- user/*
 # back to previous dir
 cd -

--- a/generate_fatfs_image.sh
+++ b/generate_fatfs_image.sh
@@ -97,6 +97,6 @@ done
 mcopy -s -i "$PART1" sys/updates ::
 
 #Littlefs generate image
-$GENLFS --image=$IMAGE_NAME --block_size=4096  --overwrite  --partition_num=3 -- user/*
+$GENLFS --image=$IMAGE_NAME --block_size=32768  --overwrite  --partition_num=3 -- user/*
 # back to previous dir
 cd -

--- a/module-vfs/drivers/src/purefs/fs/filesystem_littlefs.cpp
+++ b/module-vfs/drivers/src/purefs/fs/filesystem_littlefs.cpp
@@ -23,7 +23,7 @@
 namespace
 {
     // NOTE: lfs block size is configured during format
-    static constexpr auto c_lfs_block_size = 4096;
+    static constexpr auto c_lfs_block_size = 32U * 1024U;
 
     template <typename T> auto lfs_to_errno(T error) -> T
     {
@@ -117,7 +117,7 @@ namespace
         cfg->block_cycles   = 512;
         cfg->block_size      = c_lfs_block_size;
         cfg->block_count    = 0; // Read later from super block
-        cfg->lookahead_size = 8192;
+        cfg->lookahead_size  = 131072;
         const auto total_siz = uint64_t(sector_size) * uint64_t(part_sectors_count);
         if (total_siz % cfg->block_size) {
             LOG_ERROR("Block size doesn't match partition size");

--- a/module-vfs/tests/genlfstestimg.sh
+++ b/module-vfs/tests/genlfstestimg.sh
@@ -39,5 +39,5 @@ unit: sectors
 
 /dev/sdz1 : start=$SECTOR_START, size=$SECTOR_END, type=9e
 ==sfdisk
-./genlittlefs --image $IMAGE_FILE --block_size=4096  --overwrite  --partition_num 1 -- assets/* .boot.json
+./genlittlefs --image $IMAGE_FILE --block_size=32768  --overwrite  --partition_num 1 -- assets/* .boot.json
 


### PR DESCRIPTION
Incrase LFS clustrer size and cache bitmap improve
the FS free blocks scan time, because LFS don't have
free block bitmap.