### PR TITLE
[EGD-5355] Fix emulator crash

### DIFF
--- a/module-bluetooth/Bluetooth/BtstackWorker.cpp
+++ b/module-bluetooth/Bluetooth/BtstackWorker.cpp
@@ -218,7 +218,9 @@ namespace Bt
     {
         BaseType_t taskerr = 0;
         LOG_INFO("Past last moment for Bt registration prior to RUN state");
-        hci_power_control(HCI_POWER_ON);
+        if (auto ret = hci_power_control(HCI_POWER_ON); ret != 0) {
+            return Error(Error::SystemError, ret);
+        }
         if ((taskerr = xTaskCreate(run_btstack, "BtStack", 1024, NULL, tskIDLE_PRIORITY, handle)) != pdPASS) {
             LOG_ERROR("BT Service failure! %lu", taskerr);
             return Error(Error::SystemError, taskerr);


### PR DESCRIPTION
lIndexOfLastAddedTask is shared between two separate functions
that should run consecutively but in some cases the thread
running can be yield in between which results in broken thread
stack.

This change reduces the risk but it does not entirely solve
the problem. It is still possible for the threads to return in
different order. Nevertheless the tests did not confirm that.