### PR TITLE
[EGD-4950] Fix of statics between USB CDC and ServiceDesktop

### DIFF
--- a/module-bsp/board/linux/usb_cdc/usb_cdc.cpp
+++ b/module-bsp/board/linux/usb_cdc/usb_cdc.cpp
@@ -32,7 +32,6 @@ namespace bsp
     {
         LOG_INFO("[ServiceDesktop:BSP_Driver] Start reading on fd:%d", fd);
         char inputData[SERIAL_BUFFER_LEN];
-        static std::string receiveMsg;
 
         while (1) {
             if (uxQueueSpacesAvailable(USBReceiveQueue) != 0) {
@@ -61,7 +60,7 @@ namespace bsp
                         continue;
                     }
 #endif
-                    receiveMsg = std::string(inputData, inputData + length);
+                    std::string *receiveMsg = new std::string(inputData, inputData + length);
                     xQueueSend(USBReceiveQueue, &receiveMsg, portMAX_DELAY);
                 }
                 else {

--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -42,7 +42,7 @@ sys::ReturnCodes ServiceDesktop::InitHandler()
 {
     desktopWorker = std::make_unique<WorkerDesktop>(this);
     const bool ret = desktopWorker->init(
-        {{sdesktop::RECEIVE_QUEUE_BUFFER_NAME, sizeof(std::string), sdesktop::cdc_queue_len},
+        {{sdesktop::RECEIVE_QUEUE_BUFFER_NAME, sizeof(std::string *), sdesktop::cdc_queue_len},
          {sdesktop::SEND_QUEUE_BUFFER_NAME, sizeof(std::string *), sdesktop::cdc_queue_object_size}});
 
     if (ret == false) {

--- a/module-services/service-desktop/parser/MessageHandler.cpp
+++ b/module-services/service-desktop/parser/MessageHandler.cpp
@@ -23,7 +23,7 @@ using namespace parserFSM;
 
 xQueueHandle MessageHandler::sendQueue;
 
-MessageHandler::MessageHandler(std::string &message, sys::Service *OwnerService) : OwnerServicePtr(OwnerService)
+MessageHandler::MessageHandler(const std::string &message, sys::Service *OwnerService) : OwnerServicePtr(OwnerService)
 {
     try {
         messageJson = json11::Json::parse(message, JsonErrorMsg);
@@ -53,10 +53,10 @@ void MessageHandler::processMessage()
     }
 }
 
-void MessageHandler::putToSendQueue(const std::string msg)
+void MessageHandler::putToSendQueue(const std::string &msg)
 {
     if (uxQueueSpacesAvailable(sendQueue) != 0) {
-        auto *responseString = new std::string(msg);
+        auto responseString = new std::string(msg);
         xQueueSend(sendQueue, &responseString, portMAX_DELAY);
     }
 }

--- a/module-services/service-desktop/parser/MessageHandler.hpp
+++ b/module-services/service-desktop/parser/MessageHandler.hpp
@@ -24,29 +24,32 @@ namespace parserFSM
 {
     class MessageHandler
     {
-
-      public:
-        MessageHandler(std::string &message, sys::Service *OwnerService);
         static xQueueHandle sendQueue;
 
-        bool isJSONNull()
+        json11::Json messageJson;
+        std::string JsonErrorMsg;
+        sys::Service *OwnerServicePtr = nullptr;
+
+      public:
+        MessageHandler(const std::string &message, sys::Service *OwnerService);
+
+        [[nodiscard]] auto isJSONNull() const -> bool
         {
             return messageJson.is_null();
         };
-        bool isValid()
+        [[nodiscard]] auto isValid() const noexcept -> bool
         {
             return JsonErrorMsg.empty();
         }
-        std::string &getErrorString()
+        [[nodiscard]] auto getErrorString() const -> const std::string &
         {
             return JsonErrorMsg;
         };
         void processMessage();
-        static void putToSendQueue(const std::string msg);
-
-      private:
-        json11::Json messageJson;
-        std::string JsonErrorMsg;
-        sys::Service *OwnerServicePtr = nullptr;
+        static void putToSendQueue(const std::string &msg);
+        static void setSendQueueHandle(xQueueHandle handle)
+        {
+            sendQueue = handle;
+        }
     };
 } // namespace parserFSM

--- a/module-services/service-desktop/parser/ParserFSM.hpp
+++ b/module-services/service-desktop/parser/ParserFSM.hpp
@@ -23,21 +23,21 @@ namespace parserFSM
     class StateMachine
     {
       public:
-        StateMachine(sys::Service *OwnerService);
-        void processMessage(std::string &msg);
-        State getCurrentState()
+        explicit StateMachine(sys::Service *OwnerService);
+        void processMessage(std::string &&msg);
+        [[nodiscard]] auto getCurrentState() const noexcept -> State
         {
             return state;
         };
 
-        void setState(const parserFSM::State newState)
+        void setState(const parserFSM::State newState) noexcept
         {
             state = newState;
         }
 
       private:
-        std::string *receivedMsgPtr = nullptr;
-        parserFSM::State state      = State::NoMsg;
+        std::string receivedMsg;
+        parserFSM::State state = State::NoMsg;
         std::string payload;
         std::string header;
         unsigned long payloadLength   = 0;

--- a/module-services/service-desktop/tests/unittest.cpp
+++ b/module-services/service-desktop/tests/unittest.cpp
@@ -68,76 +68,80 @@ using namespace parserFSM;
 TEST_CASE("Parser Test")
 {
     StateMachine parser(nullptr);
-    std::string testMessage("#00000");
 
     SECTION("Parse message with divided header and payload")
     {
-        parser.processMessage(testMessage);
+        std::string testMessage("#00000");
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::ReceivedPartialHeader);
 
         testMessage = R"(0050{"endpo)";
-        parser.processMessage(testMessage);
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::ReceivedPartialPayload);
 
         testMessage = R"(int":1, "method":1, "body":{"test":"test"}})";
-        parser.processMessage(testMessage);
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::ReceivedPayload);
     }
 
     SECTION("Parse whole message")
     {
-        testMessage = R"(#000000050{"endpoint":1, "method":1, "body":{"test":"test"}})";
-        parser.processMessage(testMessage);
+        std::string testMessage = R"(#000000050{"endpoint":1, "method":1, "body":{"test":"test"}})";
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::ReceivedPayload);
     }
 
     SECTION("Parse message with start char detached from mesage")
     {
-        testMessage = R"(#)";
-        parser.processMessage(testMessage);
+        std::string testMessage = R"(#)";
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::ReceivedPartialHeader);
 
         testMessage = R"(000000050{"en)";
-        parser.processMessage(testMessage);
+        testMessage = R"(000000050{"en)";
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::ReceivedPartialPayload);
 
         testMessage = R"(dpoint":1, "method":1, "body":{"test":"test"}})";
-        parser.processMessage(testMessage);
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::ReceivedPayload);
     }
 
     SECTION("Parse message with beginning of another one")
     {
-        testMessage = R"(#000000050{"endpoint":1, "method":1, "body":{"test":"test"}}#000000050{"end)";
-        parser.processMessage(testMessage);
+        std::string testMessage = R"(#000000050{"endpoint":1, "method":1, "body":{"test":"test"}}#000000050{"end)";
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::ReceivedPartialPayload);
 
         testMessage = R"(point":1, "method":1, "body":{"test":"test"}})";
-        parser.processMessage(testMessage);
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::ReceivedPayload);
     }
     SECTION("Parse junk message")
     {
-        testMessage = R"({"address": "6 Czeczota St.\n02600 Warsaw"})";
-        parser.processMessage(testMessage);
+        std::string testMessage = R"({"address": "6 Czeczota St.\n02600 Warsaw"})";
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::NoMsg);
     }
     SECTION("Parse message with incorrect header length")
     {
-        testMessage = R"(#000000072{"endpoint":7, "method":2, "uuid":3, "body":{"threadID":1,"unread":false}})";
-        parser.processMessage(testMessage);
+        std::string testMessage =
+            R"(#000000072{"endpoint":7, "method":2, "uuid":3, "body":{"threadID":1,"unread":false}})";
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::NoMsg);
     }
     SECTION("Parse message with damaged json ")
     {
-        testMessage = R"(#000000074{"endpoint":7, "method":2, "uuid":3, "bo}}dy":{"threadID":1,"unread":false)";
-        parser.processMessage(testMessage);
+        std::string testMessage =
+            R"(#000000074{"endpoint":7, "method":2, "uuid":3, "bo}}dy":{"threadID":1,"unread":false)";
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::NoMsg);
     }
     SECTION("Parse message with damaged json and incorrect header length")
     {
-        testMessage = R"(#000000072{"endpoint":7, "method":2, "uuid":3, "bo}}dy":{"threadID":1,"unread":false)";
-        parser.processMessage(testMessage);
+        std::string testMessage =
+            R"(#000000072{"endpoint":7, "method":2, "uuid":3, "bo}}dy":{"threadID":1,"unread":false)";
+        parser.processMessage(std::move(testMessage));
         REQUIRE(parser.getCurrentState() == State::NoMsg);
     }
 }


### PR DESCRIPTION
Handling queues with `static std::string` implementation caused 
problem of double-free memory on turning off simulator. Applied 
solution to the problem is to pass ownership of queued string to 
a receiver side. 