### PR TITLE
Egd 4690 replace filelength

### DIFF
--- a/module-apps/application-settings-new/models/QuotesRepository.cpp
+++ b/module-apps/application-settings-new/models/QuotesRepository.cpp
@@ -86,7 +86,7 @@ namespace app
             return {};
         }
         auto _            = gsl::finally([file] { std::fclose(file); });
-        const auto length = utils::filesystem::filelength(file);
+        const auto length = std::filesystem::file_size(filename);
 
         if (length >= tar_buf) {
             LOG_ERROR("File %s length is too high!", filename.c_str());

--- a/module-gui/gui/core/FontManager.cpp
+++ b/module-gui/gui/core/FontManager.cpp
@@ -46,7 +46,7 @@ namespace gui
 
         auto file = std::fopen(filename.c_str(), "rb");
 
-        auto fileSize = utils::filesystem::filelength(file);
+        auto fileSize = std::filesystem::file_size(filename);
         std::rewind(file);
 
         char *fontData = new char[fileSize];
@@ -61,7 +61,7 @@ namespace gui
 
         // close file
         std::fclose(file);
-        if (static_cast<long>(bytesRead) != fileSize) {
+        if (static_cast<uintmax_t>(bytesRead) != fileSize) {
             LOG_ERROR("Failed to read all file");
             delete[] fontData;
             return nullptr;

--- a/module-gui/gui/core/ImageManager.cpp
+++ b/module-gui/gui/core/ImageManager.cpp
@@ -86,7 +86,7 @@ namespace gui
 
         auto file = std::fopen(filename.c_str(), "rb");
 
-        auto fileSize = utils::filesystem::filelength(file);
+        auto fileSize = std::filesystem::file_size(filename);
 
         char *data = new char[fileSize];
         if (data == nullptr) {
@@ -130,7 +130,7 @@ namespace gui
 
         auto file = std::fopen(filename.c_str(), "rb");
 
-        auto fileSize = utils::filesystem::filelength(file);
+        auto fileSize = std::filesystem::file_size(filename);
 
         char *data = new char[fileSize];
         if (data == nullptr) {

--- a/module-gui/gui/input/Profile.cpp
+++ b/module-gui/gui/input/Profile.cpp
@@ -35,7 +35,7 @@ namespace gui
             return json11::Json();
         }
 
-        uint32_t fsize = utils::filesystem::filelength(fd);
+        uint32_t fsize = std::filesystem::file_size(filepath);
 
         auto stream = std::make_unique<char[]>(fsize + 1);
 

--- a/module-services/service-desktop/endpoints/backup/BackupRestore.cpp
+++ b/module-services/service-desktop/endpoints/backup/BackupRestore.cpp
@@ -149,8 +149,9 @@ bool BackupRestore::PackUserFiles()
         if ((direntry.path().string().compare(".") != 0) && (direntry.path().string().compare("..") != 0) &&
             (direntry.path().string().compare("...") != 0)) {
 
-            LOG_INFO("PackUserFiles: archiving file %s...", (backupPathDB + direntry.path().string()).c_str());
-            auto *file = std::fopen((backupPathDB + direntry.path().string()).c_str(), "r");
+            auto path = backupPathDB + direntry.path().string().c_str();
+            LOG_INFO("PackUserFiles: archiving file %s...", path.c_str());
+            auto *file = std::fopen(path.c_str(), "r");
 
             if (file == nullptr) {
                 LOG_ERROR("PackUserFiles: archiving file %s failed, cannot open file, quitting...",
@@ -172,12 +173,13 @@ bool BackupRestore::PackUserFiles()
                 return false;
             }
 
-            uint32_t loopcount = (utils::filesystem::filelength(file) / tar_buf) + 1u;
+            uintmax_t filesize = std::filesystem::file_size(path);
+            uint32_t loopcount = (filesize / tar_buf) + 1u;
             uint32_t readsize  = 0u;
 
             for (uint32_t i = 0u; i < loopcount; i++) {
                 if (i + 1u == loopcount) {
-                    readsize = utils::filesystem::filelength(file) % tar_buf;
+                    readsize = filesize % tar_buf;
                 }
                 else {
                     readsize = tar_buf;

--- a/module-services/service-desktop/endpoints/factoryReset/FactoryReset.cpp
+++ b/module-services/service-desktop/endpoints/factoryReset/FactoryReset.cpp
@@ -30,18 +30,18 @@ namespace FactoryReset
 
     static bool CopyFile(std::string sourcefile, std::string targetfile);
 
-    static int recurseDepth             = 0;
-    static const int max_recurse_depth  = 120; /* 120 is just an arbitrary value of max number of recursive calls.
-                                                * If more then error is assumed, not the real depth of directories."
-                                                */
+    static int recurseDepth            = 0;
+    static const int max_recurse_depth = 120; /* 120 is just an arbitrary value of max number of recursive calls.
+                                               * If more then error is assumed, not the real depth of directories."
+                                               */
     static const int max_filepath_length = PATH_MAX;
 
     bool Run(sys::Service *ownerService)
     {
         LOG_INFO("FactoryReset: restoring factory state started...");
 
-        recurseDepth = 0;
-        const auto factoryOSPath                 = purefs::dir::getFactoryOSPath();
+        recurseDepth             = 0;
+        const auto factoryOSPath = purefs::dir::getFactoryOSPath();
 
         if (std::filesystem::is_directory(factoryOSPath.c_str()) && std::filesystem::is_empty(factoryOSPath.c_str())) {
             LOG_ERROR("FactoryReset: restoring factory state aborted");
@@ -114,7 +114,7 @@ namespace FactoryReset
             return false;
         }
 
-        const auto factoryOSPath                 = purefs::dir::getFactoryOSPath();
+        const auto factoryOSPath = purefs::dir::getFactoryOSPath();
 
         for (auto &direntry : std::filesystem::directory_iterator(sourcedir.c_str())) {
             if ((direntry.path().string().compare(".") == 0) || (direntry.path().string().compare("..") == 0) ||
@@ -182,12 +182,12 @@ namespace FactoryReset
             std::unique_ptr<unsigned char[]> buffer(new unsigned char[copy_buf]);
 
             if (buffer.get() != nullptr) {
-                uint32_t loopcount = (utils::filesystem::filelength(sf.get()) / copy_buf) + 1u;
+                uint32_t loopcount = (std::filesystem::file_size(sourcefile) / copy_buf) + 1u;
                 uint32_t readsize  = copy_buf;
 
                 for (uint32_t i = 0u; i < loopcount; i++) {
                     if (i + 1u == loopcount) {
-                        readsize = utils::filesystem::filelength(sf.get()) % copy_buf;
+                        readsize = std::filesystem::file_size(sourcefile) % copy_buf;
                     }
 
                     if (std::fread(buffer.get(), 1, readsize, sf.get()) != readsize) {

--- a/module-utils/Utils.cpp
+++ b/module-utils/Utils.cpp
@@ -12,19 +12,7 @@ namespace utils::filesystem
         inline constexpr auto crc_buf_len = 1024;
     } // namespace
 
-    long int filelength(std::FILE *file) noexcept
-    {
-        if (file == nullptr) {
-            return 0;
-        }
-        const auto startPosition = std::ftell(file);
-        std::fseek(file, 0, SEEK_END);
-        const auto endPosition = std::ftell(file);
-        std::fseek(file, startPosition, SEEK_SET);
-        return endPosition;
-    }
-
-    unsigned long computeFileCRC32(::FILE *file) noexcept
+    unsigned long computeFileCRC32(std::FILE *file) noexcept
     {
         auto buf = std::make_unique<unsigned char[]>(crc_buf_len);
 

--- a/module-utils/Utils.hpp
+++ b/module-utils/Utils.hpp
@@ -123,7 +123,7 @@ namespace utils
             }
         }
 
-        auto fractionalPart = static_cast<unsigned long int>(roundl(frac));
+        auto fractionalPart       = static_cast<unsigned long int>(roundl(frac));
         auto fractionalPartLength = std::to_string(fractionalPart).length();
         if (fractionalPartLength > precision) {
             base += 1;
@@ -252,7 +252,6 @@ namespace utils
 
     namespace filesystem
     {
-        [[nodiscard]] long int filelength(std::FILE *file) noexcept;
         [[nodiscard]] unsigned long computeFileCRC32(std::FILE *file) noexcept;
         [[nodiscard]] std::string generateRandomId(std::size_t length = 0) noexcept;
         [[nodiscard]] std::string getline(std::FILE *stream, uint32_t length = 1024) noexcept;

--- a/module-utils/i18n/i18n.cpp
+++ b/module-utils/i18n/i18n.cpp
@@ -27,7 +27,7 @@ namespace utils
             return json11::Json();
         }
 
-        uint32_t fsize = utils::filesystem::filelength(fd);
+        uint32_t fsize = std::filesystem::file_size(path);
 
         auto stream = std::make_unique<char[]>(fsize + 1); // +1 for NULL terminator
 

--- a/module-utils/test/unittest_utils.cpp
+++ b/module-utils/test/unittest_utils.cpp
@@ -13,7 +13,6 @@
 
 #include "Utils.hpp"
 
-
 TEST_CASE("Split tests")
 {
     std::string delimiter = "\r\n";
@@ -270,37 +269,4 @@ TEST_CASE("Fill leading digit in string")
     REQUIRE(utils::addLeadingZeros(test, 2) == "45");
     REQUIRE(utils::addLeadingZeros(test, 3) == "045");
     REQUIRE(utils::addLeadingZeros(test, 4) == "0045");
-}
-
-class ScopedDir
-{
-  public:
-    ScopedDir(const std::filesystem::path &dirPath) : dirPath{dirPath}
-    {
-        REQUIRE(std::filesystem::create_directory(dirPath));
-    }
-
-    ~ScopedDir()
-    {
-        REQUIRE(std::filesystem::remove(dirPath));
-    }
-
-    auto operator()(std::string file = "") -> std::filesystem::path
-    {
-        return dirPath.c_str() + file;
-    }
-
-  private:
-    std::filesystem::path dirPath;
-};
-
-TEST_CASE("Read file length")
-{
-    ScopedDir dir("mytest");
-    auto *file = std::fopen(dir("test.txt").c_str(), "w");
-    REQUIRE(file != nullptr);
-    std::array<int, 3> v = {42, -1, 7};
-    std::fwrite(v.data(), sizeof(v[0]), v.size(), file);
-    REQUIRE(utils::filesystem::filelength(file) == static_cast<long>(sizeof(v[0]) * v.size()));
-    REQUIRE(std::fclose(file) == 0);
 }


### PR DESCRIPTION
Replace utils::filesystem::filelength whereever possible with std::filesystem::file_size
In sqlite2vfs where file descriptor are used I just renamed filelength to file_size