### PR TITLE
[EGD-5043] Add emergency call window

### DIFF
--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -158,6 +158,8 @@
   "app_notes_no_notes": "<text align='center' color='9'>No notes yet.<p>Press <b>left arrow</b> to add new.</p></text>",
   "app_notes_search_no_results": "No notes found.",
 
+  "app_call_emergency_text": "Emergency call",
+
   "app_calllog_title_main": "Calls",
   "app_calllog_new_note": "New Note",
   "app_calllog_save": "SAVE",

--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -47,6 +47,10 @@ namespace app
             switchWindow(window::name_enterNumber, std::forward<decltype(data)>(data));
             return msgHandled();
         });
+        addActionReceiver(manager::actions::EmergencyDial, [this](auto &&data) {
+            switchWindow(app::window::name_emergencyCall, std::forward<decltype(data)>(data));
+            return msgHandled();
+        });
     }
 
     //  number of seconds after end call to switch back to previous application

--- a/module-apps/application-call/ApplicationCall.hpp
+++ b/module-apps/application-call/ApplicationCall.hpp
@@ -24,6 +24,7 @@ namespace app
         inline constexpr auto name_emergencyCall     = "EmergencyCallWindow";
         inline constexpr auto name_duplicatedContact = "DuplicatedContactWindow";
         inline constexpr auto name_dialogConfirm     = "DialogConfirm";
+        inline constexpr auto name_number            = "NumberWindow";
     } // namespace window
 
     inline constexpr auto ringtone_path = "assets/audio/Ringtone-drum2.mp3"; // Should bo moved to database
@@ -100,7 +101,10 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch, manager::actions::Call, manager::actions::Dial}};
+            return {{manager::actions::Launch,
+                     manager::actions::Call,
+                     manager::actions::Dial,
+                     manager::actions::EmergencyDial}};
         }
     };
 } /* namespace app */

--- a/module-apps/application-call/CMakeLists.txt
+++ b/module-apps/application-call/CMakeLists.txt
@@ -22,13 +22,15 @@ target_sources( ${PROJECT_NAME}
 		"${CMAKE_CURRENT_LIST_DIR}/windows/EmergencyCallWindow.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/windows/CallWindow.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/widgets/StateIcons.cpp"
-	PUBLIC
+		"${CMAKE_CURRENT_LIST_DIR}/windows/NumberWindow.cpp"
+		PUBLIC
 		"${CMAKE_CURRENT_LIST_DIR}/ApplicationCall.hpp"
 		"${CMAKE_CURRENT_LIST_DIR}/windows/EnterNumberWindow.hpp"
 		"${CMAKE_CURRENT_LIST_DIR}/windows/EmergencyCallWindow.hpp"
 		"${CMAKE_CURRENT_LIST_DIR}/windows/CallWindow.hpp"
 		"${CMAKE_CURRENT_LIST_DIR}/data/CallSwitchData.hpp"
-)
+		"${CMAKE_CURRENT_LIST_DIR}/windows/NumberWindow.hpp"
+		)
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE

--- a/module-apps/application-call/data/CallAppStyle.hpp
+++ b/module-apps/application-call/data/CallAppStyle.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -35,6 +35,14 @@ namespace callAppStyle
         inline constexpr auto h       = 51U + 16U;
         inline constexpr auto borderW = 1U;
     } // namespace numberLabel
+
+    namespace numberDescriptionLabel
+    {
+        inline constexpr auto x = 60U;
+        inline constexpr auto y = 254U;
+        inline constexpr auto w = style::window_width - 2 * x;
+        inline constexpr auto h = 20U;
+    } // namespace numberDescriptionLabel
 
     namespace icon
     {

--- a/module-apps/application-call/windows/EmergencyCallWindow.cpp
+++ b/module-apps/application-call/windows/EmergencyCallWindow.cpp
@@ -1,52 +1,40 @@
 ﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include "../data/CallSwitchData.hpp"
-#include "../ApplicationCall.hpp"
-#include <service-appmgr/model/ApplicationManager.hpp>
-
-#include <i18n/i18n.hpp>
 #include "EmergencyCallWindow.hpp"
 
-#include <cassert>
+#include "application-call/data/CallAppStyle.hpp"
+
+#include <service-appmgr/Controller.hpp>
 
 namespace gui
 {
 
     EmergencyCallWindow::EmergencyCallWindow(app::Application *app, app::EnterNumberWindowInterface *interface)
-        : EnterNumberWindow(app, interface, app::window::name_emergencyCall)
+        : NumberWindow(app, interface, app::window::name_emergencyCall)
     {
-        assert(app != nullptr);
-        assert(interface != nullptr);
-        numberLabel->setText(utils::localize.get("app_call_emergency"));
+        buildInterface();
     }
 
-    void EmergencyCallWindow::rebuild()
-    {}
     void EmergencyCallWindow::buildInterface()
     {
-        AppWindow::buildInterface();
-    }
-    void EmergencyCallWindow::destroyInterface()
-    {
-        AppWindow::destroyInterface();
+        using namespace callAppStyle;
+        NumberWindow::buildInterface();
+
+        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("app_phonebook_ice_contacts_title"));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+
+        numberDescriptionLabel->setText(utils::localize.get("app_call_emergency_text"));
     }
 
     bool EmergencyCallWindow::onInput(const InputEvent &inputEvent)
     {
-        bool ret = EnterNumberWindow::onInput(inputEvent);
+        if (inputEvent.is(gui::KeyCode::KEY_ENTER)) {
+            app::manager::Controller::sendAction(application, app::manager::actions::ShowEmergencyContacts);
+            return true;
+        }
 
-        //	if( number.empty() ) {
-        //		numberLabel->setText( utils::localize.get("app_call_emergency") );
-        //	}
-
-        return ret;
-    }
-    bool EmergencyCallWindow::handleSwitchData(SwitchData *data)
-    {
-        bool ret = EnterNumberWindow::handleSwitchData(data);
-
-        return ret;
+        return NumberWindow::onInput(inputEvent);
     }
 
 } /* namespace gui */

--- a/module-apps/application-call/windows/EmergencyCallWindow.hpp
+++ b/module-apps/application-call/windows/EmergencyCallWindow.hpp
@@ -3,22 +3,20 @@
 
 #pragma once
 
-#include "EnterNumberWindow.hpp"
+#include "NumberWindow.hpp"
 
 namespace gui
 {
 
-    class EmergencyCallWindow : public EnterNumberWindow
+    class EmergencyCallWindow : public NumberWindow
     {
       public:
         EmergencyCallWindow(app::Application *app, app::EnterNumberWindowInterface *interface);
+        ~EmergencyCallWindow() override = default;
 
         bool onInput(const InputEvent &inputEvent) override;
-        bool handleSwitchData(SwitchData *data) override;
 
-        void rebuild() override;
         void buildInterface() override;
-        void destroyInterface() override;
     };
 
 } /* namespace gui */

--- a/module-apps/application-call/windows/EnterNumberWindow.cpp
+++ b/module-apps/application-call/windows/EnterNumberWindow.cpp
@@ -3,9 +3,8 @@
 
 #include "EnterNumberWindow.hpp"
 
-#include "../ApplicationCall.hpp"
-#include "../data/CallAppStyle.hpp"
-#include "../data/CallSwitchData.hpp"
+#include "application-call/data/CallAppStyle.hpp"
+#include "application-call/data/CallSwitchData.hpp"
 
 #include <ContactRecord.hpp>
 #include <country.hpp>
@@ -19,51 +18,24 @@
 
 #include <cassert>
 
-using namespace utils;
-
 namespace gui
 {
-    using namespace callAppStyle;
-    using namespace callAppStyle::enterNumberWindow;
-
     EnterNumberWindow::EnterNumberWindow(app::Application *app,
                                          app::EnterNumberWindowInterface *interface,
                                          std::string windowName)
-        : AppWindow(app, windowName), interface(interface), currentCountry(defaultCountry),
-          numberUtil(*PhoneNumberUtil::GetInstance())
+        : NumberWindow(app, interface, std::move(windowName))
     {
-        assert(interface != nullptr);
-        assert(app != nullptr);
-        switchFormatter(country::getAlpha2Code(currentCountry));
         buildInterface();
-    }
-
-    void EnterNumberWindow::setNumberLabel(const std::string num)
-    {
-        numberLabel->setText(num);
-
-        if (numberLabel->getText().length() == 0) {
-            bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-            return;
-        }
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get("app_call_clear"));
     }
 
     void EnterNumberWindow::buildInterface()
     {
+        using namespace callAppStyle;
+        using namespace callAppStyle::enterNumberWindow;
+        NumberWindow::buildInterface();
 
-        AppWindow::buildInterface();
-
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get("app_call_call"));
         bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("common_add"));
         bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get("app_call_clear"));
-
-        numberLabel = new gui::Label(this, numberLabel::x, numberLabel::y, numberLabel::w, numberLabel::h);
-        numberLabel->setPenWidth(numberLabel::borderW);
-        numberLabel->setFont(style::window::font::largelight);
-        numberLabel->setEdges(RectangleEdge::Bottom);
-        numberLabel->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
-        numberLabel->setEllipsis(Ellipsis::Left);
 
         newContactIcon                    = new gui::AddContactIcon(this, newContactIcon::x, newContactIcon::y);
         newContactIcon->activatedCallback = [=](gui::Item &item) { return addNewContact(); };
@@ -74,69 +46,6 @@ namespace gui
     {
         interface->handleAddContactEvent(enteredNumber);
         return true;
-    }
-
-    void EnterNumberWindow::destroyInterface()
-    {
-        erase();
-    }
-
-    bool EnterNumberWindow::onInput(const InputEvent &inputEvent)
-    {
-        auto code = translator.handle(inputEvent.key, InputMode({InputMode::phone}).get());
-        if (inputEvent.state == InputEvent::State::keyReleasedShort) {
-            // Call function
-            if (inputEvent.keyCode == KeyCode::KEY_LF) {
-                interface->handleCallEvent(enteredNumber);
-                return true;
-            }
-            // Clear/back function
-            else if (inputEvent.keyCode == KeyCode::KEY_RF) {
-                // if there isn't any char in phone number field return to previous application
-                if (enteredNumber.empty()) {
-                    formatter->Clear();
-                    app::manager::Controller::switchBack(application);
-                }
-                // if there is the last char just clear input
-                else if (enteredNumber.size() == 1) {
-                    clearInput();
-                }
-                else {
-                    // remove last digit and reformat entered number otherwise
-                    enteredNumber = enteredNumber.substr(0, enteredNumber.size() - 1);
-                    initFormatterInput(enteredNumber);
-                    setNumberLabel(formattedNumber);
-
-                    application->refreshWindow(RefreshModes::GUI_REFRESH_FAST);
-                }
-                return true;
-            }
-            else if (code != 0) {
-                addDigit(code);
-                return true;
-            }
-        }
-        else if (inputEvent.state == InputEvent::State::keyReleasedLong) {
-            // erase all characters from phone number
-            if (inputEvent.keyCode == KeyCode::KEY_RF) {
-                // if there isn't any char in phone number field return to previous application
-                if (enteredNumber.empty()) {
-                    app::manager::Controller::switchBack(application);
-                    return true;
-                }
-                clearInput();
-
-                return true;
-            }
-            // long press of '0' key is translated to '+'
-            else if (inputEvent.keyCode == KeyCode::KEY_0) {
-                addDigit('+');
-                return true;
-            }
-        }
-
-        // check if any of the lower inheritance onInput methods catch the event
-        return AppWindow::onInput(inputEvent);
     }
 
     bool EnterNumberWindow::handleSwitchData(SwitchData *data)
@@ -174,43 +83,5 @@ namespace gui
         }
 
         return true;
-    }
-
-    void EnterNumberWindow::switchFormatter(const std::string &regionCode)
-    {
-        auto newFormatter = std::unique_ptr<Formatter>(numberUtil.GetAsYouTypeFormatter(regionCode));
-        formatter.swap(newFormatter);
-        LOG_INFO("Switched formatter to region: %s", regionCode.c_str());
-    }
-
-    void EnterNumberWindow::initFormatterInput(const std::string &number)
-    {
-        enteredNumber = number;
-        formatter->Clear();
-        for (auto c : number) {
-            formatter->InputDigit(c, &formattedNumber);
-        }
-    }
-
-    void EnterNumberWindow::addDigit(const std::string::value_type &digit)
-    {
-        enteredNumber += digit;
-        formatter->InputDigit(digit, &formattedNumber);
-        setNumberLabel(formattedNumber);
-        application->refreshWindow(RefreshModes::GUI_REFRESH_FAST);
-    }
-
-    const std::string &EnterNumberWindow::getEnteredNumber() const noexcept
-    {
-        return enteredNumber;
-    }
-
-    void EnterNumberWindow::clearInput()
-    {
-        enteredNumber.clear();
-        formattedNumber.clear();
-        formatter->Clear();
-        setNumberLabel("");
-        application->refreshWindow(RefreshModes::GUI_REFRESH_FAST);
     }
 } /* namespace gui */

--- a/module-apps/application-call/windows/EnterNumberWindow.hpp
+++ b/module-apps/application-call/windows/EnterNumberWindow.hpp
@@ -3,43 +3,14 @@
 
 #pragma once
 
-#include "application-call/ApplicationCall.hpp"
-#include "application-call/widgets/StateIcons.hpp"
-
-#include <Application.hpp>
-#include <AppWindow.hpp>
-#include <ContactRecord.hpp>
-#include <country.hpp>
-#include <gui/input/Translator.hpp>
-#include <gui/widgets/BottomBar.hpp>
-#include <gui/widgets/Image.hpp>
-#include <gui/widgets/Label.hpp>
-#include <gui/widgets/TopBar.hpp>
-#include <gui/widgets/Window.hpp>
-
-#include <phonenumbers/phonenumberutil.h>
-#include <phonenumbers/asyoutypeformatter.h>
-
-#include <memory>
-#include <string>
+#include "NumberWindow.hpp"
 
 namespace gui
 {
-    class EnterNumberWindow : public AppWindow
+    class EnterNumberWindow : public NumberWindow
     {
-      public:
-        using CountryCode = utils::country::Id;
-
       private:
-        using PhoneNumberUtil = i18n::phonenumbers::PhoneNumberUtil;
-        using Formatter       = i18n::phonenumbers::AsYouTypeFormatter;
-
-      protected:
-        app::EnterNumberWindowInterface *interface = nullptr;
-        gui::Label *numberLabel                    = nullptr;
-        gui::AddContactIcon *newContactIcon        = nullptr;
-
-        void setNumberLabel(const std::string num);
+        gui::AddContactIcon *newContactIcon = nullptr;
 
       public:
         EnterNumberWindow(app::Application *app,
@@ -47,27 +18,11 @@ namespace gui
                           std::string windowName = app::window::name_enterNumber);
         ~EnterNumberWindow() override = default;
 
-        auto onInput(const InputEvent &inputEvent) -> bool override;
         auto handleSwitchData(SwitchData *data) -> bool override;
-        [[nodiscard]] auto getEnteredNumber() const noexcept -> const std::string &;
 
         void buildInterface() override;
-        void destroyInterface() override;
-
-      private:
-        CountryCode defaultCountry = utils::country::defaultCountry;
-        CountryCode currentCountry;
-        gui::KeyInputMappedTranslation translator;
-        PhoneNumberUtil &numberUtil;
-        std::unique_ptr<Formatter> formatter;
-        std::string formattedNumber;
-        std::string enteredNumber;
 
         auto addNewContact() -> bool;
-        void switchFormatter(const std::string &countryCode);
-        void initFormatterInput(const std::string &number);
-        void addDigit(const std::string::value_type &digit);
-        void clearInput();
     };
 
 } /* namespace gui */

--- a/module-apps/application-call/windows/NumberWindow.cpp
+++ b/module-apps/application-call/windows/NumberWindow.cpp
@@ -1,0 +1,177 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "NumberWindow.hpp"
+
+#include "application-call/ApplicationCall.hpp"
+#include "application-call/data/CallAppStyle.hpp"
+#include "application-call/data/CallSwitchData.hpp"
+
+#include <ContactRecord.hpp>
+#include <gui/widgets/BottomBar.hpp>
+#include <gui/widgets/Image.hpp>
+#include <gui/widgets/Label.hpp>
+#include <gui/widgets/TopBar.hpp>
+#include <gui/widgets/Window.hpp>
+#include <i18n/i18n.hpp>
+#include <InputMode.hpp>
+#include <service-appmgr/Controller.hpp>
+#include <service-cellular/CellularServiceAPI.hpp>
+
+#include <cassert>
+
+namespace gui
+{
+    NumberWindow::NumberWindow(app::Application *app,
+                               app::EnterNumberWindowInterface *interface,
+                               std::string windowName)
+        : AppWindow(app, std::move(windowName)), interface(interface), currentCountry(defaultCountry),
+          numberUtil(*PhoneNumberUtil::GetInstance())
+    {
+        assert(interface != nullptr);
+        assert(app != nullptr);
+        switchFormatter(utils::country::getAlpha2Code(currentCountry));
+    }
+
+    void NumberWindow::setNumberLabel(const std::string &num)
+    {
+        numberLabel->setText(num);
+
+        if (num.empty()) {
+            bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+            return;
+        }
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get("app_call_clear"));
+    }
+
+    void NumberWindow::buildInterface()
+    {
+        using namespace callAppStyle;
+        using namespace callAppStyle::enterNumberWindow;
+        AppWindow::buildInterface();
+
+        bottomBar->setActive(BottomBar::Side::LEFT, true);
+        bottomBar->setActive(BottomBar::Side::CENTER, true);
+        bottomBar->setActive(BottomBar::Side::RIGHT, true);
+
+        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(callAppStyle::strings::call));
+
+        numberLabel = new gui::Label(this, numberLabel::x, numberLabel::y, numberLabel::w, numberLabel::h);
+        numberLabel->setPenWidth(numberLabel::borderW);
+        numberLabel->setFont(style::window::font::largelight);
+        numberLabel->setEdges(RectangleEdge::Bottom);
+        numberLabel->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
+        numberLabel->setEllipsis(Ellipsis::Left);
+
+        numberDescriptionLabel = new gui::Label(this,
+                                                numberDescriptionLabel::x,
+                                                numberDescriptionLabel::y,
+                                                numberDescriptionLabel::w,
+                                                numberDescriptionLabel::h);
+        numberDescriptionLabel->setFont(style::window::font::mediumlight);
+        numberDescriptionLabel->setAlignment(
+            gui::Alignment{gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center});
+        numberDescriptionLabel->setEdges(RectangleEdge::None);
+    }
+
+    void NumberWindow::destroyInterface()
+    {
+        erase();
+    }
+
+    bool NumberWindow::onInput(const InputEvent &inputEvent)
+    {
+        auto code = translator.handle(inputEvent.key, InputMode({InputMode::phone}).get());
+        if (inputEvent.isShortPress()) {
+            // Call function
+            if (inputEvent.is(KeyCode::KEY_LF)) {
+                interface->handleCallEvent(enteredNumber);
+                return true;
+            }
+            // Clear/back function
+            else if (inputEvent.is(KeyCode::KEY_RF)) {
+                // if there isn't any char in phone number field return to previous application
+                if (enteredNumber.empty()) {
+                    formatter->Clear();
+                    app::manager::Controller::switchBack(application);
+                }
+                // if there is the last char just clear input
+                else if (enteredNumber.size() == 1) {
+                    clearInput();
+                }
+                else {
+                    // remove last digit and reformat entered number otherwise
+                    enteredNumber = enteredNumber.substr(0, enteredNumber.size() - 1);
+                    initFormatterInput(enteredNumber);
+                    setNumberLabel(formattedNumber);
+
+                    application->refreshWindow(RefreshModes::GUI_REFRESH_FAST);
+                }
+                return true;
+            }
+            else if (code != 0) {
+                addDigit(code);
+                return true;
+            }
+        }
+        else if (inputEvent.isLongPress()) {
+            // erase all characters from phone number
+            if (inputEvent.is(KeyCode::KEY_RF)) {
+                // if there isn't any char in phone number field return to previous application
+                if (enteredNumber.empty()) {
+                    app::manager::Controller::switchBack(application);
+                    return true;
+                }
+                clearInput();
+
+                return true;
+            }
+            // long press of '0' key is translated to '+'
+            else if (inputEvent.is(KeyCode::KEY_0)) {
+                addDigit('+');
+                return true;
+            }
+        }
+
+        // check if any of the lower inheritance onInput methods catch the event
+        return AppWindow::onInput(inputEvent);
+    }
+
+    void NumberWindow::switchFormatter(const std::string &regionCode)
+    {
+        auto newFormatter = std::unique_ptr<Formatter>(numberUtil.GetAsYouTypeFormatter(regionCode));
+        formatter.swap(newFormatter);
+        LOG_INFO("Switched formatter to region: %s", regionCode.c_str());
+    }
+
+    void NumberWindow::initFormatterInput(const std::string &number)
+    {
+        enteredNumber = number;
+        formatter->Clear();
+        for (auto c : number) {
+            formatter->InputDigit(c, &formattedNumber);
+        }
+    }
+
+    void NumberWindow::addDigit(const std::string::value_type &digit)
+    {
+        enteredNumber += digit;
+        formatter->InputDigit(digit, &formattedNumber);
+        setNumberLabel(formattedNumber);
+        application->refreshWindow(RefreshModes::GUI_REFRESH_FAST);
+    }
+
+    const std::string &NumberWindow::getEnteredNumber() const noexcept
+    {
+        return enteredNumber;
+    }
+
+    void NumberWindow::clearInput()
+    {
+        enteredNumber.clear();
+        formattedNumber.clear();
+        formatter->Clear();
+        setNumberLabel("");
+        application->refreshWindow(RefreshModes::GUI_REFRESH_FAST);
+    }
+} /* namespace gui */

--- a/module-apps/application-call/windows/NumberWindow.hpp
+++ b/module-apps/application-call/windows/NumberWindow.hpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "application-call/ApplicationCall.hpp"
+#include "application-call/widgets/StateIcons.hpp"
+
+#include <AppWindow.hpp>
+#include <ContactRecord.hpp>
+#include <country.hpp>
+#include <gui/input/Translator.hpp>
+
+#include <phonenumbers/phonenumberutil.h>
+#include <phonenumbers/asyoutypeformatter.h>
+
+#include <memory>
+#include <string>
+
+namespace gui
+{
+    class Label;
+    class NumberWindow : public AppWindow
+    {
+      public:
+        using CountryCode = utils::country::Id;
+
+        NumberWindow(app::Application *app,
+                     app::EnterNumberWindowInterface *interface,
+                     std::string windowName = app::window::name_number);
+
+        auto onInput(const InputEvent &inputEvent) -> bool override;
+        [[nodiscard]] auto getEnteredNumber() const noexcept -> const std::string &;
+
+        void buildInterface() override;
+        void destroyInterface() override;
+        void initFormatterInput(const std::string &number);
+
+      protected:
+        app::EnterNumberWindowInterface *interface = nullptr;
+        gui::Label *numberLabel                    = nullptr;
+        gui::Label *numberDescriptionLabel         = nullptr;
+        std::string formattedNumber;
+        std::string enteredNumber;
+
+        void setNumberLabel(const std::string &num);
+
+        void switchFormatter(const std::string &countryCode);
+        void addDigit(const std::string::value_type &digit);
+        void clearInput();
+
+      private:
+        using PhoneNumberUtil = i18n::phonenumbers::PhoneNumberUtil;
+        using Formatter       = i18n::phonenumbers::AsYouTypeFormatter;
+
+        CountryCode defaultCountry = utils::country::defaultCountry;
+        CountryCode currentCountry;
+        gui::KeyInputMappedTranslation translator;
+        PhoneNumberUtil &numberUtil;
+        std::unique_ptr<Formatter> formatter;
+    };
+} /* namespace gui */

--- a/module-apps/application-desktop/windows/PinLockWindow.cpp
+++ b/module-apps/application-desktop/windows/PinLockWindow.cpp
@@ -112,11 +112,11 @@ namespace gui
         }
         // accept only LF, enter, RF, #, and numeric values;
         if (inputEvent.is(KeyCode::KEY_LEFT) && iceBox->visible) {
-            app::manager::Controller::sendAction(application, app::manager::actions::ShowEmergencyContacts);
+            app::manager::Controller::sendAction(application, app::manager::actions::EmergencyDial);
             return true;
         }
         else if (inputEvent.is(KeyCode::KEY_LF) && bottomBar->isActive(BottomBar::Side::LEFT)) {
-            app::manager::Controller::sendAction(application, app::manager::actions::ShowEmergencyContacts);
+            app::manager::Controller::sendAction(application, app::manager::actions::EmergencyDial);
             return true;
         }
         else if (inputEvent.is(KeyCode::KEY_RF) && bottomBar->isActive(BottomBar::Side::RIGHT)) {

--- a/module-services/service-appmgr/service-appmgr/Actions.hpp
+++ b/module-services/service-appmgr/service-appmgr/Actions.hpp
@@ -27,6 +27,7 @@ namespace app::manager
             CloseSystem,
             Call,
             Dial,
+            EmergencyDial,
             ShowCallLog,
             CreateSms,
             ShowSmsTemplates,


### PR DESCRIPTION
According to PurePhone design emergency call
window is needed after "SOS" callback at the screen lock.
This PR introduce implementation of emergency call window
and also refactor in the enter number window. Both windows
derives from new number window.