### PR TITLE
[EGD-5383] Fixed Sim indicator displaying on top bar

### DIFF
--- a/module-gui/gui/widgets/TopBar.cpp
+++ b/module-gui/gui/widgets/TopBar.cpp
@@ -184,7 +184,7 @@ namespace gui::top_bar
             showBattery(enabled);
             break;
         case Indicator::SimCard:
-            simSet();
+            showSim(enabled);
             break;
         case Indicator::NetworkAccessTechnology:
             updateNetworkAccessTechnology();
@@ -249,6 +249,15 @@ namespace gui::top_bar
                 break;
             }
         }
+    }
+
+    void TopBar::showSim(bool enabled)
+    {
+        if (!enabled) {
+            sim->setVisible(false);
+            return;
+        }
+        sim->show(Store::GSM::get()->sim);
     }
 
     bool TopBar::updateSignalStrength()
@@ -326,10 +335,7 @@ namespace gui::top_bar
         if (sim == nullptr) {
             return;
         }
-        if (configuration.isEnabled(Indicator::SimCard)) {
-            return sim->show(Store::GSM::get()->sim);
-        }
-        sim->visible = false;
+        showSim(configuration.isEnabled(Indicator::SimCard));
     }
 
     void TopBar::accept(GuiVisitor &visitor)

--- a/module-gui/gui/widgets/TopBar.hpp
+++ b/module-gui/gui/widgets/TopBar.hpp
@@ -89,6 +89,8 @@ namespace gui::top_bar
 
         /// show bars in number - 0 bars, 1 bar, 2 bars...
         void batteryShowBars(uint32_t val);
+        void showBattery(bool shown);
+        void showSim(bool enabled);
 
         static uint32_t calculateBatteryBars(uint32_t percentage);
 
@@ -115,7 +117,6 @@ namespace gui::top_bar
          */
         bool updateBattery(uint32_t percent);
         bool updateBattery(bool plugged);
-        void showBattery(bool shown);
 
         /**
          * @brief updates signal strength. This will cause appropriate image to be displayed.


### PR DESCRIPTION
Sim indicator should be displayed on desktop main window's top bar.