### PR TITLE
[EGD-5378] Add informative message before aborting iosyscalls

### DIFF
--- a/board/linux/libiosyscalls/src/syscalls_real.hpp
+++ b/board/linux/libiosyscalls/src/syscalls_real.hpp
@@ -4,7 +4,11 @@
 #pragma once
 
 /* Helpers for intercepting library calls */
-#define __REAL_DECL(fun)  decltype(::fun) *fun
-#define __REAL_DLSYM(fun) real::fun = reinterpret_cast<decltype(real::fun)>(dlsym(RTLD_NEXT, #fun))
+#define __REAL_DECL(fun) decltype(::fun) *fun
+#define __REAL_DLSYM(fun)                                                                                              \
+    do {                                                                                                               \
+        real::fun = reinterpret_cast<decltype(real::fun)>(dlsym(RTLD_NEXT, #fun));                                     \
+        fprintf(stderr, "Missing libc syscall: %s()\n", #fun);                                                         \
+    } while (0);
 
 #include <dlfcn.h> // for dlsym()


### PR DESCRIPTION
This fix gives basic information about missing syscalls
before aborting from libiosyscalls preload.