### PR TITLE
[EGD-5387] volte settings made global; merge issue regarding screen lock

### DIFF
--- a/module-apps/Application.cpp
+++ b/module-apps/Application.cpp
@@ -727,7 +727,9 @@ namespace app
     void Application::setLockScreenPasscodeOn(bool screenPasscodeOn) noexcept
     {
         lockScreenPasscodeIsOn = screenPasscodeOn;
-        settings->setValue(settings::SystemProperties::lockScreenPasscodeIsOn, std::to_string(lockScreenPasscodeIsOn));
+        settings->setValue(settings::SystemProperties::lockScreenPasscodeIsOn,
+                           std::to_string(lockScreenPasscodeIsOn),
+                           settings::SettingsScope::Global);
     }
 
     bool Application::isLockScreenPasscodeOn() const noexcept

--- a/module-apps/application-settings-new/ApplicationSettings.cpp
+++ b/module-apps/application-settings-new/ApplicationSettings.cpp
@@ -179,8 +179,10 @@ namespace app
 
         settings->registerValueChange(settings::operators_on,
                                       [this](const std::string &value) { operatorOnChanged(value); });
-        settings->registerValueChange(::settings::Cellular::volte_on,
-                                      [this](const std::string &value) { volteChanged(value); });
+        settings->registerValueChange(
+            ::settings::Cellular::volte_on,
+            [this](const std::string &value) { volteChanged(value); },
+            ::settings::SettingsScope::Global);
         settings->registerValueChange(
             ::settings::SystemProperties::lockPassHash,
             [this](std::string value) { lockPassHash = utils::getNumericValue<unsigned int>(value); },

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -211,7 +211,7 @@ ServiceCellular::ServiceCellular() : sys::Service(serviceName, "", cellularStack
 ServiceCellular::~ServiceCellular()
 {
     LOG_INFO("[ServiceCellular] Cleaning resources");
-    settings->unregisterValueChange(settings::Cellular::volte_on);
+    settings->unregisterValueChange(settings::Cellular::volte_on, ::settings::SettingsScope::Global);
 }
 
 // this static function will be replaced by Settings API
@@ -233,8 +233,10 @@ sys::ReturnCodes ServiceCellular::InitHandler()
     board = EventManagerServiceAPI::GetBoard(this);
 
     state.set(this, State::ST::WaitForStartPermission);
-    settings->registerValueChange(settings::Cellular::volte_on,
-                                  [this](const std::string &value) { volteChanged(value); });
+    settings->registerValueChange(
+        settings::Cellular::volte_on,
+        [this](const std::string &value) { volteChanged(value); },
+        ::settings::SettingsScope::Global);
     return sys::ReturnCodes::Success;
 }
 
@@ -335,7 +337,7 @@ void ServiceCellular::registerMessageHandlers()
     connect(typeid(CellularChangeVoLTEDataMessage), [&](sys::Message *request) -> sys::MessagePointer {
         auto msg = static_cast<CellularChangeVoLTEDataMessage *>(request);
         volteOn  = msg->getVoLTEon();
-        settings->setValue(settings::Cellular::volte_on, std::to_string(volteOn));
+        settings->setValue(settings::Cellular::volte_on, std::to_string(volteOn), settings::SettingsScope::Global);
         return std::make_shared<CellularResponseMessage>(true);
     });
 


### PR DESCRIPTION
1. volte settings params are accessed from SettingsApp and ServiceCellular so it needs to be global
2. lockScreenPasscodeIsOn - EGD-4960 issue problem for Application - needs to be global