### PR TITLE
[EGD-5392] Add switch vfat to RO mode

### DIFF
--- a/module-db/Database/Database.cpp
+++ b/module-db/Database/Database.cpp
@@ -64,12 +64,13 @@ extern "C"
     }
 }
 
-Database::Database(const char *name)
+Database::Database(const char *name, bool readOnly)
     : dbConnection(nullptr), dbName(name), queryStatementBuffer{nullptr}, isInitialized_(false),
       initializer(std::make_unique<DatabaseInitializer>(this))
 {
+    const int flags = (readOnly) ? (SQLITE_OPEN_READONLY) : (SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
     LOG_INFO("Creating database: %s", dbName.c_str());
-    if (const auto rc = sqlite3_open(name, &dbConnection); rc != SQLITE_OK) {
+    if (const auto rc = sqlite3_open_v2(name, &dbConnection, flags, nullptr); rc != SQLITE_OK) {
         LOG_ERROR("SQLITE INITIALIZATION ERROR! rc=%d dbName=%s", rc, name);
         throw DatabaseInitialisationError{"Failed to initialize the sqlite db"};
     }

--- a/module-db/Database/Database.hpp
+++ b/module-db/Database/Database.hpp
@@ -20,7 +20,7 @@ class DatabaseInitialisationError : public std::runtime_error
 class Database
 {
   public:
-    explicit Database(const char *name);
+    explicit Database(const char *name, bool readOnly = false);
     virtual ~Database();
 
     std::unique_ptr<QueryResult> query(const char *format, ...);

--- a/module-db/Databases/CountryCodesDB.cpp
+++ b/module-db/Databases/CountryCodesDB.cpp
@@ -3,7 +3,7 @@
 
 #include "CountryCodesDB.hpp"
 
-CountryCodesDB::CountryCodesDB(const char *name) : Database(name), countryCodes(this)
+CountryCodesDB::CountryCodesDB(const char *name) : Database(name, true), countryCodes(this)
 {
     if (countryCodes.create() == false)
         return;

--- a/module-vfs/src/purefs/vfs_subsystem.cpp
+++ b/module-vfs/src/purefs/vfs_subsystem.cpp
@@ -150,7 +150,9 @@ namespace purefs::subsystem
                 lfs_it = it;
             }
         }
+        bool vfat_ro = true;
         if (lfs_it == std::end(parts) && parts.size() == old_layout_part_count) {
+            vfat_ro = false;
             LOG_ERROR("!!!! Caution !!!! eMMC is formated with vFAT old layout scheme. Filesystem may be currupted on "
                       "power loss.");
             LOG_WARN("Please upgrade to new partition scheme based on the LittleFS filesystem.");
@@ -164,7 +166,8 @@ namespace purefs::subsystem
             LOG_FATAL("Unable to lock vfs core");
             return -EIO;
         }
-        auto err = vfs->mount(boot_it->name, purefs::dir::getRootDiskPath().string(), "vfat");
+        auto err = vfs->mount(
+            boot_it->name, purefs::dir::getRootDiskPath().string(), "vfat", vfat_ro ? fs::mount_flags::read_only : 0);
         if (err) {
             return err;
         }


### PR DESCRIPTION
VFAT partition should be mounted in RO mode by default
because writing to FAT filesystem is unsafe.
Writing is allowed only in the LFS filesystem.
If upgrade is needed FAT partition can be temporary
switched to RW mode using mount() syscall with REMOUNT flag
but it should be switched to RO mode again after upgrade.