### PR TITLE
[EGD-5309] Add a new message Abort in Update endpoint API

### DIFF
--- a/module-services/service-desktop/endpoints/update/UpdateEndpoint.cpp
+++ b/module-services/service-desktop/endpoints/update/UpdateEndpoint.cpp
@@ -35,6 +35,25 @@ auto UpdateEndpoint::handle(Context &context) -> void
 
 auto UpdateEndpoint::run(Context &context) -> sys::ReturnCodes
 {
+    std::string cmd = context.getBody()[parserFSM::json::updateprocess::command].string_value();
+    if (cmd == parserFSM::json::updateprocess::commands::abort) {
+        auto owner        = static_cast<ServiceDesktop *>(ownerServicePtr);
+        auto currentState = owner->updateOS->status;
+        if (currentState <= updateos::UpdateState::ExtractingFiles) {
+            owner->updateOS->setUpdateAbortFlag(true);
+            context.setResponseBody(json11::Json::object({{parserFSM::json::updateprocess::updateAborted, true}}));
+            context.setResponseStatus(http::Code::OK);
+            MessageHandler::putToSendQueue(context.createSimpleResponse());
+            return sys::ReturnCodes::Success;
+        }
+        else {
+            context.setResponseBody(json11::Json::object({{parserFSM::json::updateprocess::updateAborted, false}}));
+            context.setResponseStatus(http::Code::NotAcceptable);
+            MessageHandler::putToSendQueue(context.createSimpleResponse());
+            return sys::ReturnCodes::Failure;
+        }
+    }
+
     std::string fileName = context.getBody()["fileName"].string_value();
     auto path            = purefs::dir::getUpdatesOSPath() / fileName;
     auto fileExists      = std::filesystem::exists(path.c_str());

--- a/module-services/service-desktop/endpoints/update/UpdateMuditaOS.hpp
+++ b/module-services/service-desktop/endpoints/update/UpdateMuditaOS.hpp
@@ -66,7 +66,8 @@ namespace updateos
         NoBootloaderFile,
         CantOpenBootloaderFile,
         CantAllocateBuffer,
-        CantLoadBootloaderFile
+        CantLoadBootloaderFile,
+        UpdateAborted
     };
 
     enum class UpdateState
@@ -171,10 +172,19 @@ class UpdateMuditaOS : public updateos::UpdateStats
     {
         return updateHistory;
     }
+    void setUpdateAbortFlag(bool flag)
+    {
+        updateAbort = flag;
+    }
+    bool isUpdateToBeAborted() const noexcept
+    {
+        return updateAbort;
+    }
 
   private:
     std::vector<FileInfo> filesInUpdatePackage;
     mtar_t updateTar      = {};
+    std::atomic_bool updateAbort = false;
     ServiceDesktop *owner = nullptr;
 
     void storeRunStatusInDB();

--- a/module-services/service-desktop/parser/ParserUtils.hpp
+++ b/module-services/service-desktop/parser/ParserUtils.hpp
@@ -130,6 +130,7 @@ namespace parserFSM
         inline constexpr auto errorCode        = "errorCode";
         inline constexpr auto statusCode       = "statusCode";
         inline constexpr auto updateHistory    = "updateHistory";
+
         namespace filesystem
         {
             inline constexpr auto command = "command";
@@ -140,6 +141,16 @@ namespace parserFSM
                 inline constexpr auto download = "download";
             } // namespace commands
         }     // namespace filesystem
+
+        namespace updateprocess
+        {
+            inline constexpr auto command       = "command";
+            inline constexpr auto updateAborted = "updateAborted";
+            namespace commands
+            {
+                inline constexpr auto abort = "abort";
+            } // namespace commands
+        }     // namespace updateprocess
 
         namespace messages
         {


### PR DESCRIPTION
In order to be able to interrupt the OS update after its launch in
the phone, it was necessary to implement the new "Abort" message
for the Update Endpoint API.