### PR TITLE
[EGD-4889] Fix add/edit contact from dial window

### DIFF
--- a/module-services/service-db/DBServiceAPI.cpp
+++ b/module-services/service-db/DBServiceAPI.cpp
@@ -137,9 +137,9 @@ auto DBServiceAPI::MatchContactByPhoneNumber(sys::Service *serv, const utils::Ph
 {
     auto msg = std::make_shared<DBContactNumberMessage>(numberView);
 
-    auto ret             = sys::Bus::SendUnicast(msg, service::name::db, serv, DefaultTimeoutInMs);
+    auto ret             = sys::Bus::SendUnicast(std::move(msg), service::name::db, serv, DefaultTimeoutInMs);
     auto contactResponse = dynamic_cast<DBContactNumberResponseMessage *>(ret.second.get());
-    if (contactResponse == nullptr) {
+    if (contactResponse == nullptr || contactResponse->retCode != sys::ReturnCodes::Success) {
         LOG_ERROR("DB response error, return code: %s", c_str(ret.first));
         return nullptr;
     }
@@ -241,7 +241,7 @@ auto DBServiceAPI::ContactSearch(sys::Service *serv, UTF8 primaryName, UTF8 alte
                                                  (alternativeName.length() > 0) ? alternativeName.c_str() : "",
                                                  (number.length() > 0) ? number.c_str() : "");
 
-    auto ret             = sys::Bus::SendUnicast(msg, service::name::db, serv, DefaultTimeoutInMs);
+    auto ret             = sys::Bus::SendUnicast(std::move(msg), service::name::db, serv, DefaultTimeoutInMs);
     auto contactResponse = dynamic_cast<DBContactResponseMessage *>(ret.second.get());
     if (contactResponse == nullptr) {
         LOG_ERROR("DB response error, return code: %s", c_str(ret.first));

--- a/module-services/service-db/ServiceDB.cpp
+++ b/module-services/service-db/ServiceDB.cpp
@@ -334,7 +334,7 @@ sys::MessagePointer ServiceDB::DataReceivedHandler(sys::DataMessage *msgl, sys::
 
         if (ret.has_value()) {
             responseMsg = std::make_shared<DBContactNumberResponseMessage>(
-                sys::ReturnCodes::Success, std::make_unique<ContactRecord>(ret->contact));
+                sys::ReturnCodes::Success, std::make_unique<ContactRecord>(std::move(ret->contact)));
         }
         else {
             responseMsg = std::make_shared<DBContactNumberResponseMessage>(sys::ReturnCodes::Failure,


### PR DESCRIPTION
Original behaviour (from dial window) was that user-provided number
was send to db with partial match query. This could cause more than
one result, with no further selection rule. Solution to this
particular behavior was to switch to full number match query.

Additionally problem with unrecognizable prefixes in user-provided
numbers was solved.