### PR TITLE
[EGD-5415] Fix missing assets dep for lfstest.img

### DIFF
--- a/module-vfs/tests/CMakeLists.txt
+++ b/module-vfs/tests/CMakeLists.txt
@@ -30,12 +30,12 @@ set(LITTLEFS_IMAGE "lfstest.img")
 
 add_custom_command( 
     OUTPUT ${LITTLEFS_IMAGE}
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/genlfstestimg.sh 1G ${LITTLEFS_IMAGE}
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/genlfstestimg.sh 1G ${LITTLEFS_IMAGE} assets/* .boot.json
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     DEPENDS genlittlefs
 )
 
-add_custom_target( test_lfs_image DEPENDS ${LITTLEFS_IMAGE} )
+add_custom_target(test_lfs_image DEPENDS assets ${LITTLEFS_IMAGE})
 
 add_catch2_executable(
     NAME vfs-littlefs

--- a/module-vfs/tests/genlfstestimg.sh
+++ b/module-vfs/tests/genlfstestimg.sh
@@ -4,20 +4,22 @@
 
 usage() {
 cat << ==usage
-Usage: $(basename $0) [image_size] [image_file]
+Usage: $(basename $0) [image_size] [image_file] [files]...
 	image_size Target disk image size
 	image_file Target image name
+	files Files to include in the image
 ==usage
 }
 
 
-if [ $# -ne 2 ]; then
+if [ $# -lt 3 ]; then
 	echo "Error! Invalid argument count"
 	usage
 	exit -1
 fi
 IMAGE_SIZE="$1"
 IMAGE_FILE="$2"
+shift 2
 
 _REQ_CMDS="sfdisk truncate"
 for cmd in $_REQ_CMDS; do
@@ -39,5 +41,5 @@ unit: sectors
 
 /dev/sdz1 : start=$SECTOR_START, size=$SECTOR_END, type=9e
 ==sfdisk
-./genlittlefs --image $IMAGE_FILE --block_size=4096  --overwrite  --partition_num 1 -- assets/* .boot.json
+./genlittlefs --image $IMAGE_FILE --block_size=4096  --overwrite  --partition_num 1 -- "$@"
 


### PR DESCRIPTION
Addionally, the genlfstestimg.sh script now accepts files to include
in the image as arguments