### PR TITLE
[EGD-3247] Remove reminders of unused ping-pong feature

### DIFF
--- a/module-services/service-db/test/test-service-db-settings-api.cpp
+++ b/module-services/service-db/test/test-service-db-settings-api.cpp
@@ -14,7 +14,6 @@
 #include <service-evtmgr/EventManager.hpp>
 #include <service-evtmgr/Constants.hpp>
 
-
 #include "test-service-db-settings-testmsgs.hpp"
 #include "test-service-db-settings-testservices.hpp"
 #include "test-service-db-settings-testapps.hpp"
@@ -32,7 +31,7 @@ TEST_CASE("SettingsApi")
 {
     SECTION("variable/profile/mode register/set/get/unregister")
     {
-        std::shared_ptr<sys::SystemManager> manager = std::make_shared<sys::SystemManager>(5000);
+        auto manager = std::make_shared<sys::SystemManager>();
         std::shared_ptr<settings::MyService> varWritter;
         std::shared_ptr<settings::MyService> varReader;
         std::shared_ptr<settings::AppTest> testVar;
@@ -111,24 +110,27 @@ TEST_CASE("SettingsApi")
 
         // check the results
         std::cout << "testVar values:" << std::endl << std::flush;
-        for (auto s : testVar->v)
+        for (auto s : testVar->v) {
             std::cout << s << std::endl << std::flush;
+        }
         REQUIRE(testVar->v.size() == 3);
         REQUIRE(testVar->v[1] == testVar->v[0] + "1");
         REQUIRE(testVar->v[2] == testVar->v[1] + "2");
 
         // check the result
         std::cout << "testProf values:" << std::endl << std::flush;
-        for (auto s : testProf->v)
+        for (auto s : testProf->v) {
             std::cout << s << std::endl << std::flush;
+        }
         REQUIRE(testProf->v[1] == testProf->v[0] + "1");
         REQUIRE(testProf->v[2] == testProf->v[0] + "12");
         REQUIRE(testProf->v[3] == "other");
         REQUIRE(testProf->v[4] == "other");
 
         std::cout << "testMode values:" << std::endl << std::flush;
-        for (auto s : testMode->v)
+        for (auto s : testMode->v) {
             std::cout << s << std::endl << std::flush;
+        }
         REQUIRE(testMode->v[1] == testMode->v[0] + "1");
         REQUIRE(testMode->v[2] == testMode->v[0] + "12");
         REQUIRE(testMode->v[3] == "other");

--- a/module-sys/SystemManager/SystemManager.cpp
+++ b/module-sys/SystemManager/SystemManager.cpp
@@ -33,8 +33,7 @@ namespace sys
         this->state = state;
     }
 
-    SystemManager::SystemManager(TickType_t pingInterval)
-        : Service(service::name::system_manager, "", systemManagerStack), pingInterval(pingInterval)
+    SystemManager::SystemManager() : Service(service::name::system_manager, "", systemManagerStack)
     {
         // Specify list of channels which System Manager is registered to
         busChannels = {BusChannels::SystemManagerRequests};
@@ -104,17 +103,13 @@ namespace sys
 
     void SystemManager::StartSystem(InitFunction init)
     {
-        powerManager = std::make_unique<PowerManager>();
+        powerManager  = std::make_unique<PowerManager>();
         cpuStatistics = std::make_unique<CpuStatistics>();
 
         userInit = init;
 
         // Start System manager
         StartService();
-
-        // M.P: Ping/pong mechanism is turned off. It doesn't bring any value to the system.
-        // pingPongTimerID = CreateTimer(Ticks::MsToTicks(pingInterval), true);
-        // ReloadTimer(pingPongTimerID);
 
         cpuStatisticsTimer = std::make_unique<sys::Timer>("cpuStatistics", this, constants::timerInitInterval.count());
         cpuStatisticsTimer->connect([&](sys::Timer &) { CpuStatisticsTimerHandler(); });
@@ -342,8 +337,9 @@ namespace sys
                     break;
                 }
             }
-            if (!retry)
+            if (!retry) {
                 break;
+            }
         }
         set(State::Shutdown);
     }

--- a/module-sys/SystemManager/SystemManager.hpp
+++ b/module-sys/SystemManager/SystemManager.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 /*
@@ -62,10 +62,11 @@ namespace sys
             ShutdownReady,
             Reboot,
         } state = State::Running;
-        void set(enum State state);
-        SystemManager(TickType_t pingInterval);
 
-        ~SystemManager();
+        SystemManager();
+        ~SystemManager() override;
+
+        void set(enum State state);
 
         void StartSystem(InitFunction init);
 
@@ -105,7 +106,7 @@ namespace sys
             return ReturnCodes::Success;
         }
 
-        ReturnCodes SwitchPowerModeHandler(const ServicePowerMode mode) override final
+        ReturnCodes SwitchPowerModeHandler(const ServicePowerMode mode) final
         {
             return ReturnCodes::Success;
         }
@@ -132,8 +133,6 @@ namespace sys
         /// periodic update of cpu statistics
         void CpuStatisticsTimerHandler();
 
-        TickType_t pingInterval;
-        uint32_t pingPongTimerID;
         bool cpuStatisticsTimerInit{false};
 
         InitFunction userInit;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "config.h"
@@ -67,7 +67,7 @@ int main()
 
     bsp::BoardInit();
 
-    auto sysmgr = std::make_shared<sys::SystemManager>(5000);
+    auto sysmgr = std::make_shared<sys::SystemManager>();
 
     sysmgr->StartSystem([sysmgr]() {
         /// force initialization of PhonenumberUtil because of its stack usage


### PR DESCRIPTION
Feature was already removed some time ago but still some reminders
persist. This commit only removed mentioned reminders.
Some minor style fixes suggested by clang tidy were also applied.