### PR TITLE
[EGD-5193] Eink - power off

### DIFF
--- a/module-services/service-eink/EinkDisplay.hpp
+++ b/module-services/service-eink/EinkDisplay.hpp
@@ -33,7 +33,7 @@ namespace service::eink
         void powerOff();
         void shutdown();
 
-        bool setWaveform(EinkWaveforms_e mode, std::int32_t temperature);
+        EinkStatus_e setWaveform(EinkWaveforms_e mode, std::int32_t temperature);
         void setMode(EinkDisplayColorMode_e mode) noexcept;
 
         std::int32_t getLastTemperature() const noexcept;

--- a/module-services/service-eink/ServiceEink.hpp
+++ b/module-services/service-eink/ServiceEink.hpp
@@ -6,6 +6,7 @@
 #include <Service/Common.hpp>
 #include <Service/Message.hpp>
 #include <Service/Service.hpp>
+#include <Service/Timer.hpp>
 
 #include "EinkDisplay.hpp"
 
@@ -47,8 +48,11 @@ namespace service::eink
 
         void enterActiveMode();
         void suspend();
-        void updateDisplay(std::uint8_t *frameBuffer, ::gui::RefreshModes refreshMode);
-        void prepareDisplay(::gui::RefreshModes refreshMode, WaveformTemperature behaviour);
+
+        void showImage(std::uint8_t *frameBuffer, ::gui::RefreshModes refreshMode);
+        EinkStatus_e prepareDisplay(::gui::RefreshModes refreshMode, WaveformTemperature behaviour);
+        EinkStatus_e refreshDisplay(::gui::RefreshModes refreshMode);
+        EinkStatus_e updateDisplay(uint8_t *frameBuffer, ::gui::RefreshModes refreshMode);
 
         sys::MessagePointer handleEinkModeChangedMessage(sys::Message *message);
         sys::MessagePointer handleImageMessage(sys::Message *message);
@@ -56,11 +60,7 @@ namespace service::eink
 
         EinkDisplay display;
         State currentState;
-
-        /*
-         * PowerOffTimer to be implemented when needed.
-         * It should power off the display when not used for 3000ms.
-         */
+        std::unique_ptr<sys::Timer> displayPowerOffTimer;
     };
 } // namespace service::eink
 

--- a/module-services/service-gui/ServiceGUI.hpp
+++ b/module-services/service-gui/ServiceGUI.hpp
@@ -71,6 +71,7 @@ namespace service::gui
         void sendOnDisplay(::gui::Context *context, int contextId, ::gui::RefreshModes refreshMode);
         void scheduleContextRelease(int contextId);
         bool isNextFrameReady() const noexcept;
+        bool isAnyFrameBeingRenderedOrDisplayed() const noexcept;
         void trySendNextFrame();
 
         void setState(State state) noexcept;


### PR DESCRIPTION
Powering the eink display is mandatory.
This implementation does this turning the display off 3.8 seconds after last operation (e.g. new image frame).
If messages were delivered in a deterministic way, the display could be powered off immediately after every operation.