### PR TITLE
[EGD-5045] Change call flow handling for lock screen

### DIFF
--- a/module-apps/application-call/ApplicationCall.hpp
+++ b/module-apps/application-call/ApplicationCall.hpp
@@ -59,6 +59,7 @@ namespace app
         void CallActiveHandler();
         void IncomingCallHandler(const CellularCallMessage *const msg);
         void RingingHandler(const CellularCallMessage *const msg);
+        auto HandleMessageAsAction(sys::Message *request) -> std::shared_ptr<sys::ResponseMessage>;
 
       protected:
         call::State state = call::State::IDLE;

--- a/module-cellular/CMakeLists.txt
+++ b/module-cellular/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/at/src/Cmd.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/at/response.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/at/cmd/src/CSCA.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/at/cmd/src/QECCNUM.cpp
         )
 
 if(NOT ${PROJECT_TARGET} STREQUAL "TARGET_Linux")

--- a/module-cellular/at/Result.hpp
+++ b/module-cellular/at/Result.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -24,6 +24,11 @@ namespace at
             UNDEFINED,     /// undefined result - usage of Undefined result, define and pin result to use it
             PARSING_ERROR, /// parser error
         } code = Code::UNDEFINED;
+
+        Result() = default;
+
+        Result(Code code, std::vector<std::string> response) : code(code), response(std::move(response))
+        {}
 
         //! Information about Equipment or Network error as variant type
         /*!

--- a/module-cellular/at/cmd/QECCNUM.hpp
+++ b/module-cellular/at/cmd/QECCNUM.hpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "Result.hpp"
+#include <at/Cmd.hpp>
+#include <functional>
+#include <PhoneNumber.hpp>
+
+namespace at
+{
+    namespace result
+    {
+        /// more details: EC25&EC21_AT_Commands_Manual_V1.3
+        class QECCNUM : public Result
+        {
+          public:
+            explicit QECCNUM(const Result &);
+
+            std::vector<std::string> eccNumbersNoSim;
+            std::vector<std::string> eccNumbersSim;
+        };
+    } // namespace result
+
+    namespace cmd
+    {
+        class QECCNUM : public Cmd
+        {
+          public:
+            enum class Mode
+            {
+                Query,
+                Add,
+                Delete
+            };
+
+            enum class NumberType
+            {
+                WithSim,
+                WithoutSim,
+            };
+
+            QECCNUM() noexcept;
+            explicit QECCNUM(Mode mode, NumberType numberType, const std::vector<std::string> &number) noexcept;
+
+            [[nodiscard]] auto parse(Result &base_result) -> result::QECCNUM & final;
+
+          private:
+            void setRequestParameters(Mode mode, NumberType numberType, const std::vector<std::string> &numbers);
+
+            static constexpr auto qeccnumCmd      = "+QECCNUM";
+            static constexpr auto commandPostfix  = ":";
+            static constexpr auto dataSeparator   = ',';
+            static constexpr auto stringDelimiter = '\"';
+        };
+    } // namespace cmd
+
+} // namespace at

--- a/module-cellular/at/cmd/src/QECCNUM.cpp
+++ b/module-cellular/at/cmd/src/QECCNUM.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <log/log.hpp>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <at/cmd/QECCNUM.hpp>
+
+namespace at
+{
+    namespace result
+    {
+        QECCNUM::QECCNUM(const Result &that) : Result(that)
+        {}
+    } // namespace result
+
+    namespace cmd
+    {
+
+        QECCNUM::QECCNUM(Mode mode, NumberType numberType, const std::vector<std::string> &number) noexcept
+            : Cmd(std::string("AT") + std::string(qeccnumCmd), at::cmd::Modifier::Set)
+        {
+            setRequestParameters(mode, numberType, number);
+        }
+
+        QECCNUM::QECCNUM() noexcept : Cmd(std::string("AT") + std::string(qeccnumCmd), at::cmd::Modifier::Get)
+        {}
+
+        result::QECCNUM &QECCNUM::parse(Result &base_result)
+        {
+            auto *p = new result::QECCNUM(base_result);
+            result  = std::unique_ptr<result::QECCNUM>(p);
+
+            if (p->response.empty()) {
+                p->code = result::QECCNUM::Code::PARSING_ERROR;
+                return *p;
+            }
+
+            bool hasData = false;
+            for (auto &responseLine : p->response) {
+                responseLine.erase(std::remove(responseLine.begin(), responseLine.end(), stringDelimiter),
+                                   responseLine.end());
+                auto commandHeader = std::string(qeccnumCmd).append(commandPostfix);
+
+                if (responseLine.find(commandHeader) == 0) {
+                    hasData     = true;
+                    auto parsed = utils::split(std::string(responseLine, commandHeader.size()), dataSeparator);
+                    if (parsed.size() <= 1) {
+                        continue;
+                    }
+
+                    if (int category = 0; utils::toNumeric(parsed.front(), category)) {
+                        const auto firstNumberPosition = 1;
+                        if (category == 0) {
+                            p->eccNumbersNoSim =
+                                std::vector<std::string>(parsed.begin() + firstNumberPosition, parsed.end());
+                        }
+                        else if (category == 1) {
+                            p->eccNumbersSim =
+                                std::vector<std::string>(parsed.begin() + firstNumberPosition, parsed.end());
+                        }
+                    }
+                }
+            }
+
+            if (hasData && p->eccNumbersSim.empty() && p->eccNumbersNoSim.empty()) {
+                p->code = result::QECCNUM::Code::PARSING_ERROR;
+            }
+
+            return *p;
+        }
+
+        void QECCNUM::setRequestParameters(Mode mode, NumberType numberType, const std::vector<std::string> &numbers)
+        {
+            body += utils::to_string(magic_enum::enum_integer(mode)) + "," +
+                    utils::to_string(magic_enum::enum_integer(numberType));
+            for (auto &number : numbers) {
+                if (!number.empty()) {
+                    const std::string delim = std::string(1, stringDelimiter);
+                    body.append("," + delim + number + delim);
+                }
+            }
+        }
+    } // namespace cmd
+} // namespace at

--- a/module-cellular/test/CMakeLists.txt
+++ b/module-cellular/test/CMakeLists.txt
@@ -21,9 +21,9 @@ add_catch2_executable(
 
 add_catch2_executable(
         NAME
-        unittest_parse_CSCA
+        cellular-parse-result
         SRCS
-        unittest_parse_CSCA.cpp
+        unittest_parse_result.cpp
         LIBS
         module-cellular
 )

--- a/module-cellular/test/mock/AtCommon_channel.hpp
+++ b/module-cellular/test/mock/AtCommon_channel.hpp
@@ -56,6 +56,21 @@ namespace at
         }
     };
 
+    class GenericChannel : public ChannelMock
+    {
+      public:
+        GenericChannel(at::Result::Code code, std::vector<std::string> response) : result(code, std::move(response))
+        {}
+
+      private:
+        virtual Result ResultMock()
+        {
+            return result;
+        }
+
+        const Result result;
+    };
+
     /// provides CSCS bad response
     class CSCS_badChannel : public ChannelMock
     {

--- a/module-services/service-appmgr/service-appmgr/Actions.hpp
+++ b/module-services/service-appmgr/service-appmgr/Actions.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -26,6 +26,8 @@ namespace app::manager
             Launch,
             CloseSystem,
             Call,
+            CallRejectNotEmergency,
+            CallRejectNoSim,
             Dial,
             EmergencyDial,
             ShowCallLog,

--- a/module-services/service-cellular/CellularServiceAPI.cpp
+++ b/module-services/service-cellular/CellularServiceAPI.cpp
@@ -24,16 +24,15 @@ namespace sys
 
 bool CellularServiceAPI::DialNumber(sys::Service *serv, const utils::PhoneNumber &number)
 {
-    auto msg                          = std::make_shared<CellularCallRequestMessage>(number.getView());
-    auto ret                          = sys::Bus::SendUnicast(msg, ServiceCellular::serviceName, serv, 5000);
-    CellularResponseMessage *response = reinterpret_cast<CellularResponseMessage *>(ret.second.get());
-    if ((ret.first == sys::ReturnCodes::Success) && (response->retCode == true)) {
-        return true;
-    }
-    else {
-        LOG_ERROR("Failed");
-        return false;
-    }
+    auto msg = std::make_shared<CellularCallRequestMessage>(number.getView());
+    return sys::Bus::SendUnicast(msg, ServiceCellular::serviceName, serv);
+}
+
+bool CellularServiceAPI::DialEmergencyNumber(sys::Service *serv, const utils::PhoneNumber &number)
+{
+    auto msg = std::make_shared<CellularCallRequestMessage>(number.getView(),
+                                                            CellularCallRequestMessage::RequestMode::Emergency);
+    return sys::Bus::SendUnicast(msg, ServiceCellular::serviceName, serv);
 }
 
 bool CellularServiceAPI::AnswerIncomingCall(sys::Service *serv)

--- a/module-services/service-cellular/RequestFactory.cpp
+++ b/module-services/service-cellular/RequestFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "service-cellular/RequestFactory.hpp"
@@ -15,9 +15,16 @@
 #include "service-cellular/requests/ImeiRequest.hpp"
 #include "service-cellular/requests/UssdRequest.hpp"
 
+#include <common_data/EventStore.hpp>
+#include <cmd/QECCNUM.hpp>
+
 namespace cellular
 {
-    RequestFactory::RequestFactory(const std::string &data) : request(data)
+    RequestFactory::RequestFactory(const std::string &data,
+                                   at::BaseChannel &channel,
+                                   CellularCallRequestMessage::RequestMode requestMode,
+                                   SimStatus simCardStatus)
+        : request(data), channel(channel), requestMode(requestMode), simStatus(simCardStatus)
     {
         registerRequest(ImeiRegex, ImeiRequest::create);
         registerRequest(PasswordRegistrationRegex, PasswordRegistrationRequest::create);
@@ -32,8 +39,43 @@ namespace cellular
         requestMap.emplace_back(std::make_pair(regex, callback));
     }
 
+    std::unique_ptr<IRequest> RequestFactory::emergencyCheck()
+    {
+        at::cmd::QECCNUM cmd;
+        auto qeccnumResult   = channel.cmd(cmd);
+        auto qeccnumResponse = cmd.parse(qeccnumResult);
+
+        auto isSimEmergency =
+            std::find(qeccnumResponse.eccNumbersSim.begin(), qeccnumResponse.eccNumbersSim.end(), request) !=
+            qeccnumResponse.eccNumbersSim.end();
+        auto isNoSimEmergency =
+            std::find(qeccnumResponse.eccNumbersNoSim.begin(), qeccnumResponse.eccNumbersNoSim.end(), request) !=
+            qeccnumResponse.eccNumbersNoSim.end();
+
+        if (isSimEmergency || isNoSimEmergency) {
+            if (simStatus == SimStatus::SimInsterted || isNoSimEmergency) {
+                return std::make_unique<CallRequest>(request);
+            }
+            else {
+                actionRequest = app::manager::actions::Action::CallRejectNoSim;
+            }
+        }
+        else if (requestMode == CellularCallRequestMessage::RequestMode::Emergency) {
+            actionRequest = app::manager::actions::Action::CallRejectNotEmergency;
+        }
+        return nullptr;
+    }
+
     std::unique_ptr<IRequest> RequestFactory::create()
     {
+        if (auto req = emergencyCheck(); req) {
+            return req;
+        }
+
+        if (actionRequest) {
+            return nullptr;
+        }
+
         std::string groupA, groupB, groupC, groupD, groupE, groupF;
         GroupMatch matchPack = {groupA, groupB, groupC, groupD, groupE, groupF};
 
@@ -76,7 +118,17 @@ namespace cellular
                 }
             }
         }
+
+        if (simStatus == SimStatus::SimSlotEmpty) {
+            actionRequest = app::manager::actions::Action::CallRejectNoSim;
+            return nullptr;
+        }
         return std::make_unique<CallRequest>(request);
+    }
+
+    std::optional<app::manager::actions::Action> &RequestFactory::getActionRequest()
+    {
+        return actionRequest;
     }
 
 } // namespace cellular

--- a/module-services/service-cellular/requests/Request.cpp
+++ b/module-services/service-cellular/requests/Request.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <string>

--- a/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
+++ b/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -23,6 +23,8 @@ namespace sys
 namespace CellularServiceAPI
 {
     bool DialNumber(sys::Service *serv, const utils::PhoneNumber &number);
+    bool DialEmergencyNumber(sys::Service *serv, const utils::PhoneNumber &number);
+
     bool AnswerIncomingCall(sys::Service *serv);
     void HangupCall(sys::Service *serv);
     /*

--- a/module-services/service-cellular/service-cellular/RequestFactory.hpp
+++ b/module-services/service-cellular/service-cellular/RequestFactory.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -8,7 +8,11 @@
 #include <map>
 #include <functional>
 
+#include <Modem/TS0710/DLC_channel.h>
+
 #include "requests/CallRequest.hpp"
+#include "service-appmgr/Actions.hpp"
+#include "CellularMessage.hpp"
 
 namespace cellular
 {
@@ -17,12 +21,29 @@ namespace cellular
     class RequestFactory
     {
       public:
-        RequestFactory(const std::string &data);
+        enum class SimStatus
+        {
+            SimInsterted,
+            SimSlotEmpty
+        };
+
+        RequestFactory(const std::string &data,
+                       at::BaseChannel &channel,
+                       CellularCallRequestMessage::RequestMode requestMode,
+                       SimStatus simCardStatus);
         std::unique_ptr<IRequest> create();
+        std::optional<app::manager::actions::Action> &getActionRequest();
 
       private:
+        void registerRequest(std::string regex, CreateCallback);
+        std::unique_ptr<IRequest> emergencyCheck();
+
         std::string request;
         std::vector<std::pair<std::string, CreateCallback>> requestMap;
-        void registerRequest(std::string regex, CreateCallback);
+        std::optional<app::manager::actions::Action> actionRequest;
+
+        at::BaseChannel &channel;
+        const CellularCallRequestMessage::RequestMode requestMode;
+        const SimStatus simStatus;
     };
 } // namespace cellular

--- a/module-services/service-cellular/service-cellular/requests/CallRequest.hpp
+++ b/module-services/service-cellular/service-cellular/requests/CallRequest.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/module-services/service-cellular/service-cellular/requests/ImeiRequest.hpp
+++ b/module-services/service-cellular/service-cellular/requests/ImeiRequest.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/module-services/service-cellular/service-cellular/requests/Request.hpp
+++ b/module-services/service-cellular/service-cellular/requests/Request.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -18,9 +18,9 @@ namespace cellular
         virtual std::string command()                              = 0;
         virtual void handle(RequestHandler &h, at::Result &result) = 0;
         virtual void setHandled(bool handled)                      = 0;
-        virtual bool isHandled() const noexcept                    = 0;
         virtual bool checkModemResponse(const at::Result &result)  = 0;
-        virtual bool isValid() const noexcept                      = 0;
+        [[nodiscard]] virtual bool isHandled() const noexcept      = 0;
+        [[nodiscard]] virtual bool isValid() const noexcept        = 0;
         virtual ~IRequest(){};
     };
 

--- a/module-services/service-cellular/tests/CMakeLists.txt
+++ b/module-services/service-cellular/tests/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.12)
 
 add_catch2_executable(
         NAME
-            cellular-mmi
+            cellular-request-factory
         SRCS
-            unittest_mmi.cpp
+        unittest_request_factory.cpp
         LIBS
             module-cellular
 )


### PR DESCRIPTION
Call requests on lock screen have to be handled
separately to allow only emergency and ICE numbers.