### PR TITLE
[EGD-2514] Fix clock does not refresh

### DIFF
--- a/module-apps/Application.cpp
+++ b/module-apps/Application.cpp
@@ -150,7 +150,7 @@ namespace app
             else if (suspendInProgress) {
                 message->setCommandType(service::gui::DrawMessage::Type::SUSPEND);
             }
-            sys::Bus::SendUnicast(message, service::name::gui, this);
+            sys::Bus::SendUnicast(std::move(message), service::name::gui, this);
         }
 
         if (suspendInProgress)

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -77,14 +77,8 @@ namespace gui
     {
         auto app            = getAppDesktop();
         const auto isLocked = app->lockHandler.isScreenLocked();
-        updateTopBarConfiguration(isLocked, appConfiguration);
+        appConfiguration.set(top_bar::Indicator::Lock, isLocked);
         return appConfiguration;
-    }
-
-    void DesktopMainWindow::updateTopBarConfiguration(bool isScreenLocked, top_bar::Configuration &configuration)
-    {
-        configuration.set(top_bar::Indicator::Lock, isScreenLocked);
-        configuration.set(top_bar::Indicator::Time, !isScreenLocked);
     }
 
     DesktopMainWindow::DesktopMainWindow(app::Application *app) : AppWindow(app, app::window::name::desktop_main_window)
@@ -101,10 +95,8 @@ namespace gui
     void DesktopMainWindow::setVisibleState()
     {
         auto app = getAppDesktop();
-        applyToTopBar([isLocked = app->lockHandler.isScreenLocked()](top_bar::Configuration configuration) {
-            updateTopBarConfiguration(isLocked, configuration);
-            return configuration;
-        });
+        applyToTopBar(
+            [this](top_bar::Configuration configuration) { return configureTopBar(std::move(configuration)); });
 
         if (app->lockHandler.isScreenLocked()) {
             bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("app_desktop_unlock"));

--- a/module-apps/application-desktop/windows/DesktopMainWindow.hpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.hpp
@@ -88,7 +88,6 @@ namespace gui
 
       private:
         void invalidate() noexcept;
-        static void updateTopBarConfiguration(bool isScreenLocked, top_bar::Configuration &configuration);
 
         gui::KeyInputMappedTranslation translator;
     };

--- a/module-services/service-appmgr/model/ApplicationManager.cpp
+++ b/module-services/service-appmgr/model/ApplicationManager.cpp
@@ -34,9 +34,12 @@ namespace app::manager
 {
     namespace
     {
-        static constexpr auto default_application_locktime_ms = 30000;
-        static constexpr auto shutdown_delay_ms               = 500;
-    }; // namespace
+        constexpr auto default_application_locktime_ms = 30000;
+        constexpr auto shutdown_delay_ms               = 500;
+
+        constexpr auto timerBlock         = "BlockTimer";
+        constexpr auto timerShutdownDelay = "ShutdownDelay";
+    } // namespace
 
     ApplicationManagerBase::ApplicationManagerBase(std::vector<std::unique_ptr<app::ApplicationLauncher>> &&launchers)
         : applications{std::move(launchers)}
@@ -102,8 +105,8 @@ namespace app::manager
                                            const ApplicationName &_rootApplicationName)
         : Service{serviceName}, ApplicationManagerBase(std::move(launchers)), rootApplicationName{_rootApplicationName},
           blockingTimer{std::make_unique<sys::Timer>(
-              "BlockTimer", this, std::numeric_limits<sys::ms>::max(), sys::Timer::Type::SingleShot)},
-          shutdownDelay{std::make_unique<sys::Timer>("ShutdownDelay", this, shutdown_delay_ms)},
+              timerBlock, this, std::numeric_limits<sys::ms>::max(), sys::Timer::Type::SingleShot)},
+          shutdownDelay{std::make_unique<sys::Timer>(timerShutdownDelay, this, shutdown_delay_ms)},
           settings(std::make_unique<settings::Settings>(this))
     {
         registerMessageHandlers();

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "service-evtmgr/BatteryMessages.hpp"
@@ -151,7 +151,7 @@ sys::MessagePointer EventManager::DataReceivedHandler(sys::DataMessage *msgl, sy
     }
     else if (msgl->messageType == MessageType::EVMMinuteUpdated && msgl->sender == this->GetName()) {
 
-        // HandleAlarmTrigger(msgl);
+        HandleAlarmTrigger(msgl);
 
         handled = true;
     }
@@ -372,3 +372,6 @@ bool EventManager::processKeypadBacklightRequest(bsp::keypad_backlight::Action a
     }
     return response;
 }
+
+void EventManager::GetNextAlarmTimestamp(time_t timestamp)
+{}


### PR DESCRIPTION
There was no refresh trigger that would cause items like clock
to display its up-to-date state while user is being inactive.
This PR solves that issue providing timer-based refresh trigger
that is dependent on user activity.