### PR TITLE
[EGD-5394] Eink - reuse temperature for waveforms

### DIFF
--- a/module-services/service-eink/EinkDisplay.cpp
+++ b/module-services/service-eink/EinkDisplay.cpp
@@ -232,6 +232,11 @@ namespace service::eink
         displayMode = mode;
     }
 
+    std::int32_t EinkDisplay::getLastTemperature() const noexcept
+    {
+        return currentWaveform.temperature;
+    }
+
     ::gui::Size EinkDisplay::getSize() const noexcept
     {
         return size;

--- a/module-services/service-eink/EinkDisplay.hpp
+++ b/module-services/service-eink/EinkDisplay.hpp
@@ -35,6 +35,7 @@ namespace service::eink
         bool setWaveform(EinkWaveforms_e mode, std::int32_t temperature);
         void setMode(EinkDisplayColorMode_e mode) noexcept;
 
+        std::int32_t getLastTemperature() const noexcept;
         ::gui::Size getSize() const noexcept;
 
       private:

--- a/module-services/service-eink/ServiceEink.hpp
+++ b/module-services/service-eink/ServiceEink.hpp
@@ -31,13 +31,21 @@ namespace service::eink
             Running,
             Suspended
         };
+
+        /// It takes 25ms to get a new measurement
+        enum class WaveformTemperature
+        {
+            KEEP_CURRENT,
+            MEASURE_NEW,
+        };
+
         void setState(State state) noexcept;
         bool isInState(State state) const noexcept;
 
         void enterActiveMode();
         void suspend();
         void updateDisplay(std::uint8_t *frameBuffer, ::gui::RefreshModes refreshMode);
-        void prepareDisplay(::gui::RefreshModes refreshMode);
+        void prepareDisplay(::gui::RefreshModes refreshMode, WaveformTemperature behaviour);
 
         sys::MessagePointer handleEinkModeChangedMessage(sys::Message *message);
         sys::MessagePointer handleImageMessage(sys::Message *message);


### PR DESCRIPTION
Do not waste time right before refresh of the eink display to measure new temperature.
Assume that the measurement from early frame prepare stage is valid.
It has only to be valid for _time of rendering the frame_, which is less than a 1000ms.

**Currently sometimes (?) messages are handled in such an order, that any gain is lost.**