### PR TITLE
[EGD-5132] Change time synchronization logic

### DIFF
--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -1086,11 +1086,6 @@ sys::MessagePointer ServiceCellular::DataReceivedHandler(sys::DataMessage *msgl,
         }
         break;
     }
-    case MessageType::EVMTimeUpdated: {
-        auto channel = cmux->get(TS0710::Channel::Commands);
-        channel->cmd(at::AT::DISABLE_TIME_ZONE_REPORTING);
-        channel->cmd(at::AT::DISABLE_TIME_ZONE_UPDATE);
-    } break;
     case MessageType::CellularSimResponse: {
         responseMsg = std::make_shared<CellularResponseMessage>(handleSimResponse(msgl));
     } break;


### PR DESCRIPTION
Until now first network time update has been disabling
periodic time update. Now the time is updated periodically.