### PR TITLE
[EGD-5519] Lockscreen does not ask for pin after reset solved

### DIFF
--- a/image/user/db/settings_v2_002.sql
+++ b/image/user/db/settings_v2_002.sql
@@ -14,7 +14,7 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('gs_time_date_format', '1'),
     ('gs_active_sim', 'SIM1'),
     ('gs_lock_pass_hash', '3333'),
-    ('gs_lock_screen_passcode_on', '1'),
+    ('gs_lock_screen_passcode_is_on', '1'),
     ('gs_lock_time', '30000'),
     ('gs_display_language', 'English'),
     ('gs_input_language', 'English');
@@ -22,3 +22,4 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('bt_device_visibility', '0'),
     ('bt_device_name', 'PurePhone'),
     ('bt_bonded_devices', '');
+

--- a/module-apps/Application.cpp
+++ b/module-apps/Application.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Application.hpp"
@@ -501,7 +501,7 @@ namespace app
 
         settings->registerValueChange(
             settings::SystemProperties::lockScreenPasscodeIsOn,
-            [this](const std::string &value) { setLockScreenPasscodeOn(utils::getNumericValue<bool>(value)); },
+            [this](const std::string &value) { lockScreenPasscodeIsOn = utils::getNumericValue<bool>(value); },
             settings::SettingsScope::Global);
         return sys::ReturnCodes::Success;
     }


### PR DESCRIPTION
Name of parameter for lockscreen mode on/off updated in sql script.
Register on param lockscreen only reacts on value change.