### PR TITLE
[EGD-5522] Remount fs R/W for backup or update

### DIFF
--- a/board/linux/libiosyscalls/src/syscalls_posix.cpp
+++ b/board/linux/libiosyscalls/src/syscalls_posix.cpp
@@ -625,8 +625,14 @@ extern "C"
         const char *special_file, const char *dir, const char *fstype, unsigned long int rwflag, const void *data)
     {
         if (vfs::redirect_to_image(dir)) {
-            TRACE_SYSCALLN("(%s, %s, %s, %08lx, %p) -> VFS", special_file, dir, fstype, rwflag, data);
-            return vfs::invoke_fs(&fs::mount, special_file, dir, fstype, rwflag, data);
+            TRACE_SYSCALLN("(%s, %s, %s, %08lx, %p) -> VFS",
+                           special_file ? special_file : "(null)",
+                           dir ? dir : "(null)",
+                           fstype ? fstype : "(null)",
+                           rwflag,
+                           data);
+            return vfs::invoke_fs(
+                &fs::mount, special_file ? special_file : "", dir ? dir : "", fstype ? fstype : "", rwflag, data);
         }
         else {
             TRACE_SYSCALLN("(%s, %s, %s, %08lx,%p) -> linux fs", special_file, dir, fstype, rwflag, data);

--- a/module-vfs/src/purefs/vfs_subsystem.cpp
+++ b/module-vfs/src/purefs/vfs_subsystem.cpp
@@ -109,7 +109,7 @@ namespace purefs::subsystem
         }
         err = fs_core->register_filesystem("littlefs", std::make_shared<fs::drivers::filesystem_littlefs>());
         if (err) {
-            LOG_FATAL("Unable to register vfat filesystem with error %i", err);
+            LOG_FATAL("Unable to register lfs filesystem with error %i", err);
             return {};
         }
 


### PR DESCRIPTION
After setting vFAT to be read only by default backup,
update and factory reset procedures need to remount R/W
first.