### PR TITLE
[EGD-5290] Fix audio on voice call

### DIFF
--- a/module-audio/Audio/Stream.cpp
+++ b/module-audio/Audio/Stream.cpp
@@ -137,6 +137,15 @@ bool Stream::reserve(Span &span)
         return true;
     }
 
+    // reset data to peek end
+    _blocksUsed = 0;
+    _dataEnd    = _peekPosition;
+
+    // reserve at peek end
+    _reserveCount             = 1;
+    _writeReservationPosition = _peekPosition;
+    span                      = *++_writeReservationPosition;
+
     broadcastEvent(Event::StreamOverflow);
     return false;
 }

--- a/module-audio/Audio/test/unittest_stream.cpp
+++ b/module-audio/Audio/test/unittest_stream.cpp
@@ -203,7 +203,7 @@ TEST(Stream, Reserve)
     EXPECT_FALSE(s.reserve(span));
 
     s.commit();
-    EXPECT_EQ(s.getUsedBlockCount(), s.getBlockCount());
+    EXPECT_EQ(s.getUsedBlockCount(), 1);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Due to an error in the stream's block reservation, when the stream was
full, SAI was trying to read data to an unitialized data span randomly
disabling audio channel.

Fix the problem by overwriting data after the peek position, always
returning valid data span.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>
