### PR TITLE
[EGD-4884] fix no mixed text input case

### DIFF
--- a/enabled_unittests
+++ b/enabled_unittests
@@ -139,7 +139,8 @@ TESTS_LIST["catch2-gui-text"]="
     Text ctor;
     Text drawLines;
     Text buildDrawList;
-    handle input mode ABC/abc/1234;
+    handle input mode ABC/abc/1234/Abc;
+    handle input mode Abc;
     handle longpress for digit in ABC mode;
     handle text expand;
     handle newline;
@@ -152,6 +153,7 @@ TESTS_LIST["catch2-gui-text"]="
     RichText newline and empty lines tests;
     TextBlock Ctor/Dtor ;
     Text block - set/update/get text;
+    Text block - set/update/get text with navigation and max length;
     Text block - remove text;
     Text block - get width;
     Text BlockCursor Ctor/Dtor ;

--- a/module-apps/application-messages/widgets/SMSInputWidget.cpp
+++ b/module-apps/application-messages/widgets/SMSInputWidget.cpp
@@ -70,7 +70,7 @@ namespace gui
                     ->setBottomBarText(utils::localize.get("sms_reply"), BottomBar::Side::CENTER);
 
                 inputText->setInputMode(new InputMode(
-                    {InputMode::ABC, InputMode::abc, InputMode::digit},
+                    {InputMode::ABC, InputMode::abc, InputMode::digit, InputMode::Abc},
                     [=](const UTF8 &Text) { application->getCurrentWindow()->bottomBarTemporaryMode(Text); },
                     [=]() { application->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); },
                     [=]() { application->getCurrentWindow()->selectSpecialCharacter(); }));

--- a/module-apps/application-messages/windows/NewMessage.cpp
+++ b/module-apps/application-messages/windows/NewMessage.cpp
@@ -245,7 +245,7 @@ namespace gui
         message->setMaximumSize(body->getWidth(), body->getHeight());
         message->setEdges(gui::RectangleEdge::Bottom);
         message->setInputMode(new InputMode(
-            {InputMode::ABC, InputMode::abc, InputMode::digit},
+            {InputMode::ABC, InputMode::abc, InputMode::Abc, InputMode::digit},
             [=](const UTF8 &text) { bottomBarTemporaryMode(text); },
             [=]() { bottomBarRestoreFromTemporaryMode(); },
             [=]() { selectSpecialCharacter(); }));

--- a/module-apps/application-notes/windows/NoteEditWindow.cpp
+++ b/module-apps/application-notes/windows/NoteEditWindow.cpp
@@ -69,7 +69,7 @@ namespace app::notes
         edit->setEdges(gui::RectangleEdge::None);
         edit->setFont(::style::window::font::medium);
         edit->setInputMode(new InputMode(
-            {InputMode::ABC, InputMode::abc, InputMode::digit},
+            {InputMode::ABC, InputMode::abc, InputMode::digit, InputMode::Abc},
             [=](const UTF8 &text) { bottomBarTemporaryMode(text); },
             [=]() { bottomBarRestoreFromTemporaryMode(); },
             [=]() { selectSpecialCharacter(); }));

--- a/module-apps/windows/AppWindow.hpp
+++ b/module-apps/windows/AppWindow.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/module-gui/gui/input/Translator.hpp
+++ b/module-gui/gui/input/Translator.hpp
@@ -15,15 +15,6 @@
 
 namespace gui
 {
-
-    // TODO if neccessary `custom` keymap can be added her
-    enum class Keymaps
-    {
-        ABC,
-        abc,
-        digit,
-    };
-
     class KeyBaseTranslation
     {
       public:

--- a/module-gui/gui/widgets/InputMode.cpp
+++ b/module-gui/gui/widgets/InputMode.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <InputMode.hpp>
@@ -11,6 +11,7 @@ const std::map<InputMode::Mode, std::string> input_mode = {
     {InputMode::digit, "numeric"},
     {InputMode::ABC, "upper"},
     {InputMode::abc, "lower"},
+    {InputMode::Abc, "lower"},
     {InputMode::phone, "phone"},
 };
 
@@ -23,6 +24,8 @@ static std::string getInputName(InputMode::Mode m)
         return "ABC";
     case InputMode::abc:
         return "abc";
+    case InputMode::Abc:
+        return "Abc";
     case InputMode::phone:
         return "phone";
     default:

--- a/module-gui/gui/widgets/InputMode.hpp
+++ b/module-gui/gui/widgets/InputMode.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -17,6 +17,7 @@ class InputMode
         digit,
         abc,
         ABC,
+        Abc,
         phone,
     };
 

--- a/module-gui/gui/widgets/Text.hpp
+++ b/module-gui/gui/widgets/Text.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -182,6 +182,9 @@ namespace gui
 
       private:
         gui::KeyInputMappedTranslation translator;
+        /// wraps UTF8 char retrieval with additional text analysis (in case of `Abc` InputMode )that provides
+        /// basic capitalization rules enforcement
+        uint32_t getCharCode(const InputEvent &inputEvent);
 
       public:
         TextChangedCallback textChangedCallback;

--- a/module-gui/gui/widgets/TextBlock.cpp
+++ b/module-gui/gui/widgets/TextBlock.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TextBlock.hpp"
@@ -45,9 +45,17 @@ namespace gui
         return text;
     }
 
-    UTF8 TextBlock::getText(uint32_t start_position) const
+    UTF8 TextBlock::getText(uint32_t start_position, NavigationDirection direction, unsigned maxLength) const
     {
-        return text.substr(start_position, text.length() - start_position);
+        start_position = std::min<uint32_t>(start_position, text.length());
+        if (direction == NavigationDirection::LEFT) {
+            unsigned fromPos = start_position > maxLength ? start_position - maxLength : 0;
+            return text.substr(fromPos, start_position - fromPos);
+        }
+        else {
+            auto length = std::min<unsigned>(text.length() - start_position, maxLength);
+            return text.substr(start_position, length);
+        }
     }
 
     const TextFormat *TextBlock::getFormat() const

--- a/module-gui/gui/widgets/TextBlock.hpp
+++ b/module-gui/gui/widgets/TextBlock.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -37,7 +37,9 @@ namespace gui
         TextBlock(const TextBlock &);
 
         const UTF8 &getText() const;
-        UTF8 getText(uint32_t start_position) const;
+        UTF8 getText(uint32_t start_position,
+                     NavigationDirection direction = NavigationDirection::RIGHT,
+                     unsigned maxCharCount         = std::numeric_limits<unsigned>::max()) const;
         auto getFormat() const -> const TextFormat *;
         void setText(const UTF8 text);
         void insertChar(const uint32_t value, const uint32_t pos);

--- a/module-gui/gui/widgets/TextBlockCursor.cpp
+++ b/module-gui/gui/widgets/TextBlockCursor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TextBlockCursor.hpp"
@@ -294,12 +294,12 @@ namespace gui
         return *currentBlock();
     }
 
-    auto BlockCursor::getText() -> std::string
+    auto BlockCursor::getText(NavigationDirection direction, unsigned maxLength) -> std::string
     {
         if (currentBlock() == blocksEnd()) {
             return "";
         }
-        return currentBlock()->getText(getPosition());
+        return currentBlock()->getText(getPosition(), direction, maxLength);
     }
 
     auto BlockCursor::getUTF8Text() -> UTF8

--- a/module-gui/gui/widgets/TextBlockCursor.hpp
+++ b/module-gui/gui/widgets/TextBlockCursor.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -159,7 +159,8 @@ namespace gui
         virtual void addChar(uint32_t utf_val);
         void addTextBlock(TextBlock &&);
 
-        [[nodiscard]] auto getText() -> std::string;
+        [[nodiscard]] auto getText(NavigationDirection direction = NavigationDirection::RIGHT,
+                                   unsigned maxLength            = std::numeric_limits<unsigned>::max()) -> std::string;
         auto getUTF8Text() -> UTF8;
 
         /// iterable

--- a/module-gui/gui/widgets/TextConstants.hpp
+++ b/module-gui/gui/widgets/TextConstants.hpp
@@ -67,4 +67,11 @@ namespace gui
         CantAdd
     };
 
+    namespace textCapitalization
+    {
+        constexpr auto checkDepth           = 3;
+        const std::string uppercaseTriggers = ".!?";
+        const std::string neutralChars      = " ";
+    } // namespace textCapitalization
+
 } // namespace gui

--- a/module-gui/gui/widgets/TextLineCursor.cpp
+++ b/module-gui/gui/widgets/TextLineCursor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TextLineCursor.hpp"

--- a/module-gui/gui/widgets/TextLineCursor.hpp
+++ b/module-gui/gui/widgets/TextLineCursor.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/module-gui/test/test-catch-text/test-gui-TextBlock.cpp
+++ b/module-gui/test/test-catch-text/test-gui-TextBlock.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -113,6 +113,120 @@ TEST_CASE("Text block - set/update/get text")
         auto local_update_text = starting_text + starting_text;
         block.setText(local_update_text);
         REQUIRE(block.length() == local_update_text.length());
+    }
+}
+
+TEST_CASE("Text block - set/update/get text with navigation and max length")
+{
+    using namespace gui;
+    const std::string starting_text = "some starting text";
+    auto &fontmanager               = mockup::fontManager();
+    REQUIRE(fontmanager.getFont(0) != nullptr);
+    auto block = TextBlock(starting_text, fontmanager.getFont(0), TextBlock::End::None);
+
+    SECTION("get forward/back on empty text with invalid starting pos and length")
+    {
+        auto emptyTextBlock     = TextBlock("", fontmanager.getFont(0), TextBlock::End::None);
+        const auto starting_pos = 10;
+        REQUIRE(emptyTextBlock.getText(starting_pos, NavigationDirection::RIGHT) == std::string{});
+        REQUIRE(emptyTextBlock.getText(starting_pos, NavigationDirection::LEFT) == std::string{});
+    }
+
+    SECTION("get forward full")
+    {
+        const auto starting_pos = 0;
+        REQUIRE(block.getText(starting_pos, NavigationDirection::RIGHT, starting_text.size()) == starting_text);
+    }
+
+    SECTION("get forward full with overflowing max length")
+    {
+        const auto starting_pos = 0;
+        REQUIRE(block.getText(starting_pos, NavigationDirection::RIGHT) == starting_text);
+    }
+
+    SECTION("get forward with non-zero starting position")
+    {
+        const auto starting_pos = 5;
+        REQUIRE(block.getText(starting_pos, NavigationDirection::RIGHT, starting_text.size() - starting_pos) ==
+                starting_text.substr(starting_pos));
+    }
+
+    SECTION("get forward with non-zero starting position with overflowing max length")
+    {
+        const auto starting_pos = 5;
+        REQUIRE(block.getText(starting_pos, NavigationDirection::RIGHT) == starting_text.substr(starting_pos));
+    }
+
+    SECTION("get forward from the end of text")
+    {
+        const auto starting_pos = starting_text.size();
+        REQUIRE(block.getText(starting_pos, NavigationDirection::RIGHT) == std::string{});
+    }
+
+    SECTION("get forward with overflowing starting position")
+    {
+        const auto starting_pos = starting_text.size() + 10;
+        REQUIRE(block.getText(starting_pos, NavigationDirection::RIGHT) == std::string{});
+    }
+
+    SECTION("get back only first char ")
+    {
+        const auto starting_pos = 1;
+        REQUIRE(block.getText(starting_pos, NavigationDirection::LEFT) == std::string{starting_text.front()});
+    }
+
+    SECTION("get back only last char")
+    {
+        const auto starting_pos = starting_text.size();
+        const auto length       = 1;
+        REQUIRE(block.getText(starting_pos, NavigationDirection::LEFT, length) == std::string{starting_text.back()});
+    }
+
+    SECTION("get back full")
+    {
+        const auto starting_pos = starting_text.size();
+        REQUIRE(block.getText(starting_pos, NavigationDirection::LEFT, starting_text.size()) == starting_text);
+    }
+
+    SECTION("get back full with overflowing max length")
+    {
+        const auto starting_pos = starting_text.size();
+        REQUIRE(block.getText(starting_pos, NavigationDirection::LEFT) == starting_text);
+    }
+
+    SECTION("get back with non-zero starting position")
+    {
+        const auto starting_pos = 5;
+        REQUIRE(block.getText(starting_pos, NavigationDirection::LEFT, starting_text.size() - starting_pos) ==
+                starting_text.substr(0, starting_pos));
+    }
+
+    SECTION("get back with non-zero starting position with overflowing max length")
+    {
+        const auto starting_pos = 5;
+        REQUIRE(block.getText(starting_pos, NavigationDirection::LEFT) == starting_text.substr(0, starting_pos));
+    }
+
+    SECTION("get back with overflowing starting position")
+    {
+        const auto starting_pos = starting_text.size() + 10;
+        const auto length       = 10;
+        REQUIRE(block.getText(starting_pos, NavigationDirection::LEFT, length) ==
+                starting_text.substr(starting_text.size() - length));
+    }
+
+    SECTION("get back with overflowing starting position with overflowing max length")
+    {
+        const auto starting_pos = starting_text.size() + 10;
+        REQUIRE(block.getText(starting_pos, NavigationDirection::LEFT) == starting_text);
+    }
+
+    SECTION("get forward and get back gives whole text")
+    {
+        const auto starting_pos = 10;
+        auto leftHandSide       = block.getText(starting_pos, NavigationDirection::LEFT);
+        auto rightHandSide      = block.getText(starting_pos, NavigationDirection::RIGHT);
+        REQUIRE(leftHandSide + rightHandSide == starting_text);
     }
 }
 


### PR DESCRIPTION
This PR provided proposition to solve `Abc` case gap in `Text`'s
input modes. The solution will need refinement in the future
with specific functionality design as at this point it is
based on fixed sets of characters that cause uppercase or
are ignored.