### PR TITLE
[EGD-5593] Change SOS button occurrences in GUI

### DIFF
--- a/module-apps/application-desktop/windows/LockedInfoWindow.cpp
+++ b/module-apps/application-desktop/windows/LockedInfoWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "LockedInfoWindow.hpp"
@@ -40,7 +40,7 @@ bool LockedInfoWindow::onInput(const InputEvent &inputEvent)
 {
     if (inputEvent.isShortPress()) {
         if (inputEvent.keyCode == KeyCode::KEY_LF && bottomBar->isActive(BottomBar::Side::LEFT)) {
-            app::manager::Controller::sendAction(application, app::manager::actions::ShowEmergencyContacts);
+            app::manager::Controller::sendAction(application, app::manager::actions::EmergencyDial);
             return true;
         }
         else if (inputEvent.keyCode == KeyCode::KEY_RF && bottomBar->isActive(BottomBar::Side::RIGHT)) {

--- a/module-apps/application-desktop/windows/PinLockBaseWindow.cpp
+++ b/module-apps/application-desktop/windows/PinLockBaseWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "application-desktop/data/AppDesktopStyle.hpp"
@@ -43,7 +43,6 @@ namespace gui
         LockWindow::restore();
         lockImage->setVisible(false);
         infoImage->setVisible(false);
-        iceBox->setVisible(false);
     }
 
     void PinLockBaseWindow::setImagesVisible(bool lockImg, bool infoImg)
@@ -54,7 +53,6 @@ namespace gui
 
     void PinLockBaseWindow::setTitleBar(bool isVisible, bool isIceActive)
     {
-        iceBox->setVisible(isIceActive);
         LockWindow::setTitleBar(isVisible);
     }
 
@@ -62,30 +60,16 @@ namespace gui
     {
         LockWindow::buildBottomBar();
         setBottomBarWidgetsActive(false, false, false);
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get("app_desktop_emergency"));
     }
 
     void PinLockBaseWindow::buildTitleBar()
     {
         using namespace style::window::pin_lock;
 
-        iceBox = new gui::HBox(this, ice::x, ice::y, ice::w, ice::h);
-        iceBox->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Center));
-        iceBox->setEdges(RectangleEdge::None);
-        iceBox->setVisible(false);
-
         auto arrow        = new gui::Image("left_label_arrow");
         arrow->activeItem = false;
         arrow->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Center));
         arrow->setMargins(Margins(0, 0, ice::margin, 0));
-        iceBox->addWidget(arrow);
-
-        auto iceText        = new gui::Text(nullptr, 0, 0, ice::text::w, ice::h);
-        iceText->activeItem = false;
-        iceText->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Center));
-        iceText->setFont(style::window::font::verysmall);
-        iceText->setText(utils::localize.get("app_desktop_emergency"));
-        iceBox->addWidget(iceText);
 
         title = new gui::Text(this, title::x, title::y, title::w, title::h);
         title->setFilled(false);

--- a/module-apps/application-desktop/windows/PinLockBaseWindow.hpp
+++ b/module-apps/application-desktop/windows/PinLockBaseWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -21,7 +21,6 @@ namespace gui
         void setImagesVisible(bool lockImg, bool infoImg);
         void setTitleBar(bool isVisible, bool isIceActive);
 
-        gui::HBox *iceBox        = nullptr;
         gui::Image *infoImage = nullptr;
         gui::Image *lockImage    = nullptr;
 

--- a/module-apps/application-desktop/windows/PinLockWindow.cpp
+++ b/module-apps/application-desktop/windows/PinLockWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 // application manager
@@ -47,7 +47,6 @@ namespace gui
 
     void PinLockWindow::invalidate() noexcept
     {
-        iceBox        = nullptr;
         title         = nullptr;
         lockImage  = nullptr;
         infoImage  = nullptr;
@@ -110,16 +109,8 @@ namespace gui
         if (!inputEvent.isShortPress()) {
             return AppWindow::onInput(inputEvent);
         }
-        // accept only LF, enter, RF, #, and numeric values;
-        if (inputEvent.is(KeyCode::KEY_LEFT) && iceBox->visible) {
-            app::manager::Controller::sendAction(application, app::manager::actions::EmergencyDial);
-            return true;
-        }
-        else if (inputEvent.is(KeyCode::KEY_LF) && bottomBar->isActive(BottomBar::Side::LEFT)) {
-            app::manager::Controller::sendAction(application, app::manager::actions::EmergencyDial);
-            return true;
-        }
-        else if (inputEvent.is(KeyCode::KEY_RF) && bottomBar->isActive(BottomBar::Side::RIGHT)) {
+        // accept only enter, RF, #, and numeric values;
+        if (inputEvent.is(KeyCode::KEY_RF) && bottomBar->isActive(BottomBar::Side::RIGHT)) {
             if (usesNumericKeys()) {
                 lock->clearAttempt();
             }


### PR DESCRIPTION
Due to the changes made in our desing 'SOS' button have to
be visible only on the unlock info screen (yet it
shouldn't be on the pin window). This PR fixes locked info
window as well as pin window.