### PR TITLE
[EGD-5596] Fix fread() handling of EOF

### DIFF
--- a/board/linux/libiosyscalls/src/syscalls_stdio.cpp
+++ b/board/linux/libiosyscalls/src/syscalls_stdio.cpp
@@ -454,7 +454,7 @@ extern "C"
                 char *p = reinterpret_cast<char *>(__ptr);
                 do {
                     auto res       = vfs::invoke_fs(&fs::read, fx->fd, p, __size);
-                    const auto eof = res > 0 && size_t(res) < __size;
+                    const auto eof = res >= 0 && size_t(res) < __size;
                     fx->error      = errno;
                     if (res < 0 || eof)
                         break;


### PR DESCRIPTION
iosyscalls' fread() should interpret zero bytes read as EOF.