### PR TITLE
[EGD-5609] Fix lfs partition erase size bug

### DIFF
--- a/host-tools/genlittlefs/lfs_ioaccess.c
+++ b/host-tools/genlittlefs/lfs_ioaccess.c
@@ -171,6 +171,7 @@ struct lfs_ioaccess_context *lfs_ioaccess_open(struct lfs_config *cfg,
     }
     ret->file_des = open(filename, O_RDWR);
     if (ret->file_des < 0) {
+        free((void *)ret->empty_flash_mem);
         free(ret);
         return NULL;
     }
@@ -178,6 +179,7 @@ struct lfs_ioaccess_context *lfs_ioaccess_open(struct lfs_config *cfg,
     int err = fstat(ret->file_des, &statbuf);
     if (err < 0) {
         close(ret->file_des);
+        free((void *)ret->empty_flash_mem);
         free(ret);
         return NULL;
     }
@@ -186,6 +188,7 @@ struct lfs_ioaccess_context *lfs_ioaccess_open(struct lfs_config *cfg,
         err = ioctl(ret->file_des, BLKGETSIZE64, &blk_size);
         if (err < 0) {
             close(ret->file_des);
+            free((void *)ret->empty_flash_mem);
             free(ret);
             return NULL;
         }
@@ -199,6 +202,7 @@ struct lfs_ioaccess_context *lfs_ioaccess_open(struct lfs_config *cfg,
     if (partition) {
         if (partition->end > statbuf.st_size) {
             close(ret->file_des);
+            free((void *)ret->empty_flash_mem);
             free(ret);
             errno = E2BIG;
             return NULL;

--- a/host-tools/genlittlefs/mklfs.c
+++ b/host-tools/genlittlefs/mklfs.c
@@ -308,6 +308,7 @@ int main(int argc, char **argv)
         err = ftruncate(fds, lopts.filesystem_size);
         if (err) {
             perror("Unable to truncate file");
+            close(fds);
             free(lopts.src_dirs);
             return EXIT_FAILURE;
         }
@@ -364,6 +365,7 @@ int main(int argc, char **argv)
             return EXIT_FAILURE;
         }
     }
+    const lfs_ssize_t used_blocks = lfs_fs_size(&lfs);
     err = lfs_unmount(&lfs);
     if (err < 0) {
         fprintf(stderr, "lfs umount error: error=%d\n", err);
@@ -375,11 +377,12 @@ int main(int argc, char **argv)
     lfs_ioaccess_close(ioctx);
     printf("Littlefs summary:\n"
            "     Directories created: %lu, Files added: %lu, Transferred %lu kbytes.\n"
-           "     Littlefs block size: %i blocks count: %i.\n",
+           "     Littlefs block size: %i blocks: %i/%i.\n",
            prog_summary.directories_added,
            prog_summary.files_added,
            prog_summary.bytes_transferred / 1024UL,
            cfg.block_size,
+           used_blocks,
            cfg.block_count);
     return EXIT_SUCCESS;
 }

--- a/module-vfs/src/newlib/vfs_io_syscalls.cpp
+++ b/module-vfs/src/newlib/vfs_io_syscalls.cpp
@@ -355,7 +355,13 @@ namespace vfsn::internal::syscalls
               unsigned long int rwflag,
               const void *data)
     {
-        return invoke_fs(_errno_, &purefs::fs::filesystem::mount, special_file, dir, fstype, rwflag, data);
+        return invoke_fs(_errno_,
+                         &purefs::fs::filesystem::mount,
+                         special_file ? special_file : "",
+                         dir ? dir : "",
+                         fstype ? fstype : "",
+                         rwflag,
+                         data);
     }
 
 } // namespace vfsn::internal::syscalls

--- a/module-vfs/src/purefs/blkdev/partition_parser.cpp
+++ b/module-vfs/src/purefs/blkdev/partition_parser.cpp
@@ -94,13 +94,13 @@ namespace purefs::blkdev::internal
 
     auto partition_parser::check_partition(const std::shared_ptr<disk> disk, const partition &part) -> bool
     {
-        auto sector_size        = disk->get_info(info_type::sector_size);
-        unsigned long this_size = disk->get_info(info_type::sector_count) * sector_size;
-        const auto poffset      = part.start_sector * sector_size;
-        const auto psize        = part.num_sectors * sector_size;
-        const auto pnext        = part.start_sector * sector_size + poffset;
-        if ((poffset + psize > this_size) ||                                      // oversized
-            (pnext < static_cast<unsigned long>(part.start_sector * sector_size)) // going backward
+        auto sector_size     = disk->get_info(info_type::sector_size);
+        const auto this_size = uint64_t(disk->get_info(info_type::sector_count)) * uint64_t(sector_size);
+        const auto poffset   = uint64_t(part.start_sector) * uint64_t(sector_size);
+        const auto psize     = uint64_t(part.num_sectors) * uint64_t(sector_size);
+        const auto pnext     = uint64_t(part.start_sector) * uint64_t(sector_size) + poffset;
+        if ((poffset + psize > this_size) ||                    // oversized
+            (pnext < uint64_t(part.start_sector) * sector_size) // going backward
         ) {
             LOG_WARN("Part %d looks strange: start_sector %u offset %u next %u\n",
                      unsigned(part.mbr_number),

--- a/module-vfs/src/purefs/fs/filesystem.cpp
+++ b/module-vfs/src/purefs/fs/filesystem.cpp
@@ -55,7 +55,7 @@ namespace purefs::fs
         cpp_freertos::LockGuard _lck(*m_lock);
         const auto it = m_fstypes.find(std::string(fsname));
         if (it == std::end(m_fstypes)) {
-            LOG_ERROR("VFS: filesystem %.*s doesn't exists in manager.", int(fsname.length()), fsname.data());
+            LOG_ERROR("VFS: filesystem %s doesn't exists in manager.", std::string(fsname).c_str());
             return -ENOENT;
         }
         if (it->second->mount_count() > 0) {
@@ -74,7 +74,7 @@ namespace purefs::fs
     {
         // Sanity check input data
         if (target.size() <= 1 || target[0] != '/') {
-            LOG_ERROR("VFS: Invalid target mountpoint path %.*s", int(target.length()), target.data());
+            LOG_ERROR("VFS: Invalid target mountpoint path %s", std::string(target).c_str());
             return -EINVAL;
         }
         if (flags & ~(mount_flags::remount | mount_flags::read_only)) {


### PR DESCRIPTION
Storing LFS erase size in the boot byte is not possible
because Linux kernel is unable to detect the partitions
after change boot bytes to values other than 0x80 or 0x00

In this patch LFS_BLOCK_SIZE is moved to the second
MBR bootcode AREA