### PR TITLE
[EGD-5042] Fix options distances in SMS and Settings options

### DIFF
--- a/module-apps/options/OptionStyle.hpp
+++ b/module-apps/options/OptionStyle.hpp
@@ -37,6 +37,7 @@ namespace gui::option
     {
         inline constexpr gui::Length option_left_margin  = 10;
         inline constexpr gui::Length option_right_margin = 10;
+        inline constexpr gui::Length option_bottom_margin  = style::margins::big;
         inline constexpr gui::Length option_right_min_size = 150;
         inline constexpr uint32_t optionsListTopMargin   = 10U;
         inline constexpr uint32_t optionsListX           = style::window::default_left_margin;

--- a/module-apps/options/type/OptionChangePin.cpp
+++ b/module-apps/options/type/OptionChangePin.cpp
@@ -12,6 +12,7 @@ auto gui::option::ChangePin::build() const -> gui::ListItem *
     auto optionItem = new gui::ListItem();
     optionItem->setEdges(RectangleEdge::None);
     optionItem->setMinimumSize(style::window::default_body_width, style::window::label::big_h);
+    optionItem->setMargins(Margins(0, 0, 0, window::option_bottom_margin));
 
     auto optionBodyHBox = new gui::HBox(optionItem, 0, 0, 0, 0);
     auto font           = FontManager::getInstance().getFont(style::window::font::medium);

--- a/module-apps/options/type/OptionSetting.cpp
+++ b/module-apps/options/type/OptionSetting.cpp
@@ -11,6 +11,7 @@ namespace gui::option
     {
         auto optionItem = new gui::ListItem();
         optionItem->setMinimumSize(style::window::default_body_width, style::window::label::big_h);
+        optionItem->setMargins(Margins(0, 0, 0, window::option_bottom_margin));
         optionItem->activatedCallback    = activatedCallback;
         optionItem->focusChangedCallback = focusChangedCallback;
 

--- a/module-apps/options/type/OptionSimple.cpp
+++ b/module-apps/options/type/OptionSimple.cpp
@@ -17,6 +17,7 @@ namespace gui::option
     {
         auto optionItem = new gui::ListItem();
         optionItem->setMinimumSize(style::window::default_body_width, style::window::label::big_h);
+        optionItem->setMargins(Margins(0, 0, 0, window::option_bottom_margin));
 
         auto optionBodyHBox = new gui::HBox(optionItem, 0, 0, 0, 0);
         optionBodyHBox->setEdges(RectangleEdge::None);


### PR DESCRIPTION
According to most recent design, options should be separated
with 8px.