### PR TITLE
[EGD-5594] Fix sending multiple cmux frames

### DIFF
--- a/module-cellular/Modem/TS0710/TS0710_Frame.h
+++ b/module-cellular/Modem/TS0710/TS0710_Frame.h
@@ -78,7 +78,6 @@ class TS0710_Frame
             FCS = 0xFF - FCS;
             ret.push_back(FCS);
             ret.push_back(TS0710_FLAG);
-
             return ret;
         }
 


### PR DESCRIPTION
Sending multiple cmux frames was broken. Sending at command
longer than 127 bytes caused the modem to freeze.