### PR TITLE
[EGD-3633] Fix new message recipient

### DIFF
--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -474,7 +474,7 @@
   "app_music_player_music_empty_window_notification": "Press Music Library to choose\n a song from the library",
   "app_special_input_window": "Special characters",
   "app_emoji_input_window": "Emoji",
-  "sms_add_rec_num": "Add contact",
+  "sms_add_rec_num": "Add recipient or type a number",
   "sms_title_message": "New message",
   "sms_call_text": "Call ",
   "sms_resend_failed": "Send again",

--- a/module-gui/gui/widgets/Text.cpp
+++ b/module-gui/gui/widgets/Text.cpp
@@ -179,6 +179,7 @@ namespace gui
     void Text::clear()
     {
         buildDocument("");
+        onTextChanged();
     }
 
     bool Text::isEmpty()


### PR DESCRIPTION
Known issues with recipient field fixed:
- on contact, clearing there was leftover data
- on contact, one could keep adding numbers to visible name
- on contact, to delete it one had to delete each visible name char
- `select` in center button was not restored in some edge cases
- wrong recipient label