### PR TITLE
[EGD-4604] Fix incorrect message UCS2 decode

### DIFF
--- a/enabled_unittests
+++ b/enabled_unittests
@@ -288,12 +288,14 @@ TESTS_LIST["catch2-utils-ucs2"]="
     UCS2 to UTF8 conversion;
     UCS2 from UTF8 emoji 😁;
     UCS2 from UTF8 emoji 🍣;
+    UCS2 text with emojis int the middle from UTF8 code;
     UTF8 to UCS2 conversion;
     TEST special input characters from UTF8;
     TEST special input characters from std::string;
     UTF8 emoji 🍣 from UCS2 code;
     UTF8 emoji 😁 and text ęą from UCS2 code;
     UTF8 emoji 😁 and text abc from UCS2 code;
+    UTF8 text with emojis int the middle from UCS2 code;
     UCS2 to UTF8 long string conversion;
     UTF8 to UCS2 long string conversion;
 "

--- a/module-utils/test/unittest_ucs2.cpp
+++ b/module-utils/test/unittest_ucs2.cpp
@@ -47,6 +47,18 @@ TEST_CASE("UCS2 from UTF8 emoji 🍣")
     REQUIRE(ucs2.str() == str);
 }
 
+TEST_CASE("UCS2 text with emojis int the middle from UTF8 code")
+{
+    UTF8 utf8("ęą😁ęą🍣ęą");
+    UCS2 ucs2 = UCS2(utf8);
+    std::string expected("01190105" //ęą
+                         "D83DDE01" // 😁
+                         "01190105" // ęą
+                         "D83CDF63" // 🍣
+                         "01190105");
+    REQUIRE(ucs2.str() == expected);
+}
+
 TEST_CASE("UTF8 to UCS2 conversion")
 {
     UTF8 utf8("Test");
@@ -88,6 +100,17 @@ TEST_CASE("UTF8 emoji 😁 and text abc from UCS2 code")
 {
     UCS2 ucs2(std::string("D83CDF63006100620063"));
     UTF8 utf8("🍣abc");
+    REQUIRE(ucs2.toUTF8() == utf8);
+}
+
+TEST_CASE("UTF8 text with emojis int the middle from UCS2 code")
+{
+    UCS2 ucs2(std::string("01190105" //ęą
+                          "D83DDE01" // 😁
+                          "01190105" // ęą
+                          "D83CDF63" // 🍣
+                          "01190105"));
+    UTF8 utf8("ęą😁ęą🍣ęą");
     REQUIRE(ucs2.toUTF8() == utf8);
 }
 


### PR DESCRIPTION
The problem could be noticed in a incoming message that contained
emojis. All emojis we pushed to the front of a message, due to
separation on decoding of `uint32_t` chars 'larger' than `0xffff`