### PR TITLE
[EGD-5686] Change image script for gen RT1051 imgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,8 @@ if (${PROJECT_TARGET} STREQUAL "TARGET_Linux")
 		OUTPUT ${FAT_IMAGE}
                 DEPENDS genlittlefs
 		DEPENDS assets
-		COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/generate_fatfs_image.sh ${FAT_IMAGE} ${CMAKE_BINARY_DIR}
+                DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate_purephone_image.sh
+		COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/generate_purephone_image.sh ${FAT_IMAGE} ${CMAKE_BINARY_DIR}
 		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 		COMMENT "Generate ${FAT_IMAGE}"
 	)

--- a/generate_purephone_image.sh
+++ b/generate_purephone_image.sh
@@ -1,29 +1,28 @@
 #!/bin/bash -e
-# Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 usage() {
 cat << ==usage
-Usage: $(basename $0) [image_dir] [assets_root_dir]
-	image_dir Target disk image
-	asset_root_dir Asset root directory
+Usage: $(basename $0) [image_path] [build_dir]
+	image_path Destination image path name for. ex PurePhone.img
+	build_dir  PurePhone build dir for ex. build-rt1051-RelWithDebInfo
 ==usage
 }
 
-ASSETS_DIR="assets country-codes.db Luts.bin"
-
-TEST_ITEMS="testfiles"
+ASSETS_DIR="assets country-codes.db Luts.bin boot.bin"
 
 if [ $# -ne 2 ]; then
 	echo "Error! Invalid argument count"
 	usage
 	exit -1
 fi
+
 IMAGE_NAME=$(realpath $1)
 SRC_DATA=$(realpath $2)
 
 if [ ! -d "$SRC_DATA" ]; then
-	echo "Error! asset_root_dir is not a directory"
+	echo "Error! build_dir is not a directory"
 	usage
 	exit -1
 fi
@@ -53,19 +52,22 @@ fi
 SDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 GENLFS=$(find $SDIR -type f -iname genlittlefs -executable -print -quit)
 if [ -z ${GENLFS} ]; then
-    echo "Unable to find genlilttlefs..."
+    echo "Error: Unable to find genlilttlefs..."
     exit -1
 fi
 
+#Number of sectors in the phone EMMC card
+DEVICE_BLK_COUNT=30621696
+DEVICE_BLK_SIZE=512
 # Partition sizes in sector 512 units
 PART1_START=2048
 PART1_SIZE=2097152
 PART2_START=$(($PART1_START + $PART1_SIZE))
 PART2_SIZE=$PART1_SIZE
 PART3_START=$(($PART2_START + $PART2_SIZE))
-PART3_SIZE=29358080
+PART3_SIZE=$(($DEVICE_BLK_COUNT - $PART1_SIZE - $PART2_SIZE - $PART1_START))
 
-truncate -s 16G $IMAGE_NAME
+truncate -s $(($DEVICE_BLK_COUNT * $DEVICE_BLK_SIZE)) $IMAGE_NAME
 sfdisk $IMAGE_NAME << ==sfdisk
 label: dos
 label-id: 0x09650eb4
@@ -76,25 +78,28 @@ unit: sectors
 /dev/sdx3 : start=    $PART3_START,  size=    $PART3_SIZE, type=9e
 ==sfdisk
 
-PART1="$IMAGE_NAME@@$(($PART1_START*512))"
-PART2="$IMAGE_NAME@@$(($PART2_START*512))"
-mformat -i "$PART1" -F -T $PART1_SIZE -M 512 -v MUDITAOS
-mformat -i "$PART2" -F -T $PART2_SIZE -M 512 -v RECOVER
+
+# Format FAT partitions
+PART1="$IMAGE_NAME@@$(($PART1_START * $DEVICE_BLK_SIZE))"
+PART2="$IMAGE_NAME@@$(($PART2_START * $DEVICE_BLK_SIZE))"
+mformat -i "$PART1" -F -T $PART1_SIZE -M $DEVICE_BLK_SIZE -v MUDITAOS
+mformat -i "$PART2" -F -T $PART2_SIZE -M $DEVICE_BLK_SIZE -v RECOVER
+
+#Copy FAT data
 mmd -i "$PART1" ::/current
 cd "$SRC_DATA"
 for i in $ASSETS_DIR; do
+    if [ -f "$i" -o -d "$i" ]; then
 	mcopy -s -i "$PART1" $i ::/current/
+    else 
+        echo "Warning! Unable to copy item: $i"
+    fi
 done
 mcopy -s -i "$PART1" .boot.json ::
 mcopy -s -i "$PART1" .boot.json.crc32 ::
 mmd -i "$PART1" ::/current/sys
 mcopy -s -i "$PART1" data ::/current/sys
-
-# Testing parts of files
-for i in $TEST_ITEMS; do
-	mcopy -s -i "$PART1" $i ::/current
-done
-mcopy -s -i "$PART1" sys/updates ::
+mmd -i "$PART1" ::/updates
 
 #Littlefs generate image
 $GENLFS --image=$IMAGE_NAME --block_size=32768  --overwrite  --partition_num=3 -- user/*


### PR DESCRIPTION
After this patch emulator flash gen script also will be able to generate
images for generate disk images for flashing RT1051 using dd command.

For flashing Phone user need to switch bootloader into the MSC mode
and then write image using following command:

sudo dd if=test.image of=/dev/<mscdisk> status=progress  conv=sparse

where <mscdisk> is a pure phone disk device.