### PR TITLE
[EGD-5541] Sim card check refactor

### DIFF
--- a/module-apps/application-messages/ApplicationMessages.cpp
+++ b/module-apps/application-messages/ApplicationMessages.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationMessages.hpp"
@@ -31,6 +31,8 @@
 #include <module-db/queries/messages/threads/QueryThreadRemove.hpp>
 #include <module-db/queries/phonebook/QueryContactGetByID.hpp>
 
+#include <service-cellular/CellularMessage.hpp>
+
 #include <cassert>
 #include <time/time_conversion.hpp>
 #include <messages/OptionsWindow.hpp>
@@ -49,6 +51,14 @@ namespace app
             switchWindow(gui::name::window::sms_templates, std::move(data));
             return msgHandled();
         });
+        addActionReceiver(manager::actions::SmsRejectNoSim, [this](auto &&data) {
+            auto action = [this]() {
+                returnToPreviousWindow();
+                return true;
+            };
+            showNotification(action);
+            return msgHandled();
+        });
     }
 
     // Invoked upon receiving data message
@@ -59,7 +69,6 @@ namespace app
         if (reinterpret_cast<sys::ResponseMessage *>(retMsg.get())->retCode == sys::ReturnCodes::Success) {
             return retMsg;
         }
-
         if (msgl->messageType == MessageType::DBServiceNotification) {
             auto msg = dynamic_cast<db::NotificationMessage *>(msgl);
             if (msg != nullptr) {
@@ -367,14 +376,6 @@ namespace app
     {
         if (!sendSms(number, body)) {
             return false;
-        }
-
-        if (!Store::GSM::get()->simCardInserted()) {
-            auto action = [=]() -> bool {
-                returnToPreviousWindow();
-                return true;
-            };
-            return showNotification(action);
         }
 
         return true;

--- a/module-apps/application-messages/ApplicationMessages.hpp
+++ b/module-apps/application-messages/ApplicationMessages.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -81,7 +81,10 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch, manager::actions::CreateSms, manager::actions::ShowSmsTemplates}};
+            return {{manager::actions::Launch,
+                     manager::actions::CreateSms,
+                     manager::actions::ShowSmsTemplates,
+                     manager::actions::SmsRejectNoSim}};
         }
     };
 } /* namespace app */

--- a/module-apps/application-messages/windows/NewMessage.cpp
+++ b/module-apps/application-messages/windows/NewMessage.cpp
@@ -126,16 +126,6 @@ namespace gui
             LOG_ERROR("Failed to send the SMS.");
             return false;
         }
-        if (!Store::GSM::get()->simCardInserted()) {
-            auto action = [this, number]() {
-                if (!switchToThreadWindow(number.getView())) {
-                    LOG_ERROR("switchToThreadWindow failed");
-                }
-                return true;
-            };
-            app->showNotification(action, true);
-            return true;
-        }
         return switchToThreadWindow(number.getView());
     }
 

--- a/module-services/service-appmgr/model/ApplicationManager.cpp
+++ b/module-services/service-appmgr/model/ApplicationManager.cpp
@@ -299,6 +299,7 @@ namespace app::manager
         connect(typeid(CellularNotAnEmergencyNotification), convertibleToActionHandler);
         connect(typeid(sys::CriticalBatteryLevelNotification), convertibleToActionHandler);
         connect(typeid(sys::SystemBrownoutMesssage), convertibleToActionHandler);
+        connect(typeid(CellularSmsNoSimRequestMessage), convertibleToActionHandler);
     }
 
     sys::ReturnCodes ApplicationManager::SwitchPowerModeHandler(const sys::ServicePowerMode mode)

--- a/module-services/service-appmgr/service-appmgr/Actions.hpp
+++ b/module-services/service-appmgr/service-appmgr/Actions.hpp
@@ -50,6 +50,7 @@ namespace app::manager
             ShowMMIResult,
             ShowMMIResponse,
             ShowMMIPush,
+            SmsRejectNoSim,
             DisplayCMEError,
             DisplayLowBatteryNotification,
             SystemBrownout,

--- a/module-services/service-cellular/service-cellular/CellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/CellularMessage.hpp
@@ -27,7 +27,7 @@
 class CellularMessage : public sys::DataMessage
 {
   public:
-    CellularMessage(MessageType messageType) : sys::DataMessage(messageType){};
+    explicit CellularMessage(MessageType messageType) : sys::DataMessage(messageType){};
 };
 
 class CellularCallMessage : public CellularMessage
@@ -298,6 +298,19 @@ class CellularCallRequestMessage : public CellularMessage
     {}
     utils::PhoneNumber::View number;
     RequestMode requestMode = RequestMode::Normal;
+};
+
+class CellularSmsNoSimRequestMessage : public CellularMessage, public app::manager::actions::ConvertibleToAction
+{
+  public:
+    CellularSmsNoSimRequestMessage() : CellularMessage{MessageType::MessageTypeUninitialized}
+    {}
+
+    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+    {
+        return std::make_unique<app::manager::ActionRequest>(
+            sender, app::manager::actions::SmsRejectNoSim, std::make_unique<app::manager::actions::ActionParams>());
+    }
 };
 
 class CellularSimMessage : public CellularMessage


### PR DESCRIPTION
Moved checking for a SIM card logic from application level to service cellular.
Provided an action in response to application messages.