### PR TITLE
[EGD-5722] Fix color test scheme change

### DIFF
--- a/module-gui/gui/core/DrawCommand.cpp
+++ b/module-gui/gui/core/DrawCommand.cpp
@@ -33,7 +33,7 @@ namespace gui
 {
     void Clear::draw(Context *ctx) const
     {
-        ctx->fill(ColorFullWhite.intensity);
+        ctx->fill(renderer::PixelRenderer::getColor(gui::ColorFullWhite.intensity));
     }
 
     void DrawLine::draw(Context *ctx) const
@@ -248,7 +248,9 @@ namespace gui
 
                 offsetRowContext += vecOffset;
                 if (vecColor != alphaColor) {
-                    std::memset(ctxData + offsetRowContext, vecColor, std::min(ctx->getW(), vecLength));
+                    std::memset(ctxData + offsetRowContext,
+                                renderer::PixelRenderer::getColor(vecColor),
+                                std::min(ctx->getW(), vecLength));
                 }
                 offsetRowContext += vecLength;
             }


### PR DESCRIPTION
This PR fixes problem with full white color not being changed by Color Test window
caused by changes in other PR.
It changes draw commands (Clear and vector images) to use colors from global color scheme.  