### PR TITLE
[EGD-5805] Charging plugged & not charging - topbar icon change

### DIFF
--- a/module-bsp/board/linux/battery-charger/battery_charger.cpp
+++ b/module-bsp/board/linux/battery-charger/battery_charger.cpp
@@ -63,7 +63,7 @@ namespace bsp::battery_charger
                         else {
                             // second 100% in a row
                             if (plugged && Store::Battery::get().level == fullBattery) {
-                                Store::Battery::modify().state = Store::Battery::State::PluggedNotCharging;
+                                Store::Battery::modify().state = Store::Battery::State::ChargingDone;
                             }
                         }
                         targetQueueHandle = IRQQueueHandle;

--- a/module-gui/gui/widgets/TopBar.hpp
+++ b/module-gui/gui/widgets/TopBar.hpp
@@ -83,8 +83,6 @@ namespace gui::top_bar
         Label *networkAccessTechnologyLabel    = nullptr;
         SignalStrengthWidgetBase *signalWidget = nullptr;
         Image *lock;
-        std::map<const Store::Battery::State, Image *> batteryChargings = {
-            {Store::Battery::State::Charging, nullptr}, {Store::Battery::State::PluggedNotCharging, nullptr}};
         gui::SIM *sim                    = nullptr;
         BatteryWidgetBase *batteryWidget = nullptr;
         Configuration configuration;

--- a/module-gui/gui/widgets/TopBar/BatteryWidgetBar.cpp
+++ b/module-gui/gui/widgets/TopBar/BatteryWidgetBar.cpp
@@ -59,7 +59,7 @@ namespace gui
         img->set(batteryCharging);
     }
 
-    void BatteryWidgetBar::showBatteryPluggedNotCharging()
+    void BatteryWidgetBar::showBatteryChargingDone()
     {
         img->set(batteryChargingReady);
     }

--- a/module-gui/gui/widgets/TopBar/BatteryWidgetBar.hpp
+++ b/module-gui/gui/widgets/TopBar/BatteryWidgetBar.hpp
@@ -15,7 +15,7 @@ namespace gui
 
       private:
         void showBatteryLevel(std::uint32_t percentage) override;
-        void showBatteryPluggedNotCharging() override;
+        void showBatteryChargingDone() override;
         void showBatteryCharging() override;
 
         Image *img = nullptr;

--- a/module-gui/gui/widgets/TopBar/BatteryWidgetBase.cpp
+++ b/module-gui/gui/widgets/TopBar/BatteryWidgetBase.cpp
@@ -18,13 +18,15 @@ namespace gui
             setVisible(true);
             switch (batteryContext.state) {
             case Store::Battery::State::Discharging:
+                [[fallthrough]];
+            case Store::Battery::State::PluggedNotCharging:
                 showBatteryLevel(batteryContext.level);
                 break;
             case Store::Battery::State::Charging:
                 showBatteryCharging();
                 break;
-            case Store::Battery::State::PluggedNotCharging:
-                showBatteryPluggedNotCharging();
+            case Store::Battery::State::ChargingDone:
+                showBatteryChargingDone();
                 break;
             }
         }

--- a/module-gui/gui/widgets/TopBar/BatteryWidgetBase.hpp
+++ b/module-gui/gui/widgets/TopBar/BatteryWidgetBase.hpp
@@ -13,7 +13,7 @@ namespace gui
     class BatteryWidgetBase : public HBox
     {
         virtual void showBatteryLevel(std::uint32_t percentage) = 0;
-        virtual void showBatteryPluggedNotCharging()            = 0;
+        virtual void showBatteryChargingDone()                  = 0;
         virtual void showBatteryCharging()                      = 0;
 
       public:

--- a/module-gui/gui/widgets/TopBar/BatteryWidgetText.cpp
+++ b/module-gui/gui/widgets/TopBar/BatteryWidgetText.cpp
@@ -29,7 +29,7 @@ namespace gui
         label->setText(utils::localize.get("topbar_battery_charging"));
     }
 
-    void BatteryWidgetText::showBatteryPluggedNotCharging()
+    void BatteryWidgetText::showBatteryChargingDone()
     {
         label->setText(utils::localize.get("topbar_battery_plugged"));
     }

--- a/module-gui/gui/widgets/TopBar/BatteryWidgetText.hpp
+++ b/module-gui/gui/widgets/TopBar/BatteryWidgetText.hpp
@@ -15,7 +15,7 @@ namespace gui
 
       private:
         void showBatteryLevel(std::uint32_t percentage) override;
-        void showBatteryPluggedNotCharging() override;
+        void showBatteryChargingDone() override;
         void showBatteryCharging() override;
         Label *label = nullptr;
     };

--- a/module-utils/common_data/EventStore.hpp
+++ b/module-utils/common_data/EventStore.hpp
@@ -25,6 +25,7 @@ namespace Store
         {
             Discharging,
             Charging,
+            ChargingDone,
             PluggedNotCharging,
         } state            = State::Discharging;
         unsigned int level = 0;


### PR DESCRIPTION
Fix icons behavior in topbar. When plugged and no charging regular dischrging icon is displayed. Changed according to designers.