### PR TITLE
[EGD-3685] Fix timers starting without callback

### DIFF
--- a/module-services/service-evtmgr/vibra/Vibra.cpp
+++ b/module-services/service-evtmgr/vibra/Vibra.cpp
@@ -16,8 +16,11 @@ namespace vibra_handle
         vibratorTimerPause =
             std::make_unique<sys::Timer>("VibraPauseTimer", parent, bsp::vibrator::defaultVibraPauseMs);
 
-        vibratorTimerOneshot->setInterval(bsp::vibrator::defaultVibraPulseMs);
-        vibratorTimerPause->setInterval(bsp::vibrator::defaultVibraPauseMs);
+        vibratorTimerOneshot->connect(nullTimerCallback);
+        vibratorTimerPause->connect(nullTimerCallback);
+
+        vibratorTimerOneshot->stop();
+        vibratorTimerPause->stop();
     }
 
     void Vibra::intPulse(bool repetitive)

--- a/module-services/service-evtmgr/vibra/Vibra.hpp
+++ b/module-services/service-evtmgr/vibra/Vibra.hpp
@@ -36,5 +36,6 @@ namespace vibra_handle
         int repetitions = 1;
 
         void intPulse(bool repetitive);
+        std::function<void(sys::Timer &)> nullTimerCallback{};
     };
 } // namespace vibra_handle


### PR DESCRIPTION
Fixed null-callback timer in Vibra starting automatically on creation