### PR TITLE
[EGD-5848] Fix bluetooth pairing key import

### DIFF
--- a/module-bluetooth/Bluetooth/BluetoothWorker.cpp
+++ b/module-bluetooth/Bluetooth/BluetoothWorker.cpp
@@ -48,7 +48,6 @@ namespace
 
         [[nodiscard]] auto operator()()
         {
-            bluetooth::KeyStorage::settings = settings;
             bluetooth::GAP::registerScan();
 
             auto settingsName = std::get<std::string>(settings->getValue(bluetooth::Settings::DeviceName));

--- a/module-services/service-bluetooth/ServiceBluetooth.cpp
+++ b/module-services/service-bluetooth/ServiceBluetooth.cpp
@@ -23,11 +23,13 @@
 #include <service-desktop/service-desktop/Constants.hpp>
 #include <service-bluetooth/messages/SetDeviceName.hpp>
 #include <BtCommand.hpp>
+#include <BtKeysStorage.hpp>
 
 ServiceBluetooth::ServiceBluetooth() : sys::Service(service::name::bluetooth)
 {
     auto settings  = std::make_unique<settings::Settings>(this);
     settingsHolder = std::make_shared<bluetooth::SettingsHolder>(std::move(settings));
+    bluetooth::KeyStorage::settings = settingsHolder;
     LOG_INFO("[ServiceBluetooth] Initializing");
 }
 


### PR DESCRIPTION
After BT refactor settings init for key storage has been moved,
thus in the initial phase settings were unavailable and btstack
couldn't import keys from storage