### PR TITLE
[EGD-5789] Fix loudspeaker in-call logic

### DIFF
--- a/module-audio/Audio/Operation/RouterOperation.cpp
+++ b/module-audio/Audio/Operation/RouterOperation.cpp
@@ -144,9 +144,11 @@ namespace audio
             SwitchToPriorityProfile();
             break;
         case EventType::CallLoudspeakerOn:
+            SetProfileAvailability({Profile::Type::RoutingEarspeaker}, false);
             SwitchProfile(Profile::Type::RoutingLoudspeaker);
             break;
         case EventType::CallLoudspeakerOff:
+            SetProfileAvailability({Profile::Type::RoutingEarspeaker}, true);
             SwitchToPriorityProfile();
             break;
         case EventType::CallMute:


### PR DESCRIPTION
In some cases loudspeaker state night have not
been passed properly ignoring users choice.