### PR TITLE
[EGD-5893] Disable optimization for os

### DIFF
--- a/module-os/CMakeLists.txt
+++ b/module-os/CMakeLists.txt
@@ -4,7 +4,6 @@ project(module-os VERSION 1.0
         DESCRIPTION "OS module library")
 
 set(SOURCES
-
         ${CMAKE_CURRENT_SOURCE_DIR}/RTOSWrapper/ccondition_variable.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/RTOSWrapper/cevent_groups.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/RTOSWrapper/cmem_pool.cpp
@@ -17,7 +16,6 @@ set(SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/RTOSWrapper/ctickhook.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/RTOSWrapper/ctimer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/RTOSWrapper/cworkqueue.cpp
-
 
         ${CMAKE_CURRENT_SOURCE_DIR}/FreeRTOS/application.c
         ${CMAKE_CURRENT_SOURCE_DIR}/FreeRTOS/event_groups.c
@@ -44,7 +42,6 @@ else()
             ${CMAKE_CURRENT_SOURCE_DIR}/FreeRTOS/tasks.c
             )
 endif()
-
 
 if(${PROJECT_TARGET} STREQUAL "TARGET_RT1051")
     include(targets/Target_RT1051.cmake)
@@ -74,7 +71,12 @@ target_compile_definitions(${PROJECT_NAME}
         CPP_FREERTOS_CONDITION_VARIABLES
 )
 
-if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+# enforce no optimization for RelWithDebInfo configuration to debug system memory
+if (${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
+        target_compile_options (${PROJECT_NAME} PRIVATE "-O0")
+endif ()
+
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug" OR ${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
 	target_compile_definitions(${PROJECT_NAME} PRIVATE DEBUG_FREERTOS)
 endif ()
 


### PR DESCRIPTION
Disable FreeRTOS optimization for RelWithDebInfo configuration in order
to be able to analyze system memory (heap and tasks' stacks).

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>
