### PR TITLE
[EGD-5703] Fix in displaying sim card icon

### DIFF
--- a/module-apps/TopBarManager.cpp
+++ b/module-apps/TopBarManager.cpp
@@ -14,4 +14,9 @@ namespace app
     {
         return topBarConfiguration;
     }
+
+    void TopBarManager::setIndicatorFlag(gui::top_bar::Indicator indicator, int flag)
+    {
+        topBarConfiguration.setIndicatorFlag(indicator, flag);
+    }
 } // namespace app

--- a/module-apps/TopBarManager.hpp
+++ b/module-apps/TopBarManager.hpp
@@ -11,6 +11,7 @@ namespace app
     {
       public:
         void enableIndicators(const gui::top_bar::Indicators &indicators);
+        void setIndicatorFlag(gui::top_bar::Indicator indicator, int flag);
         [[nodiscard]] auto getConfiguration() const noexcept -> const gui::top_bar::Configuration &;
 
       private:

--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -38,6 +38,7 @@ namespace app
                                          Indicator::Battery,
                                          Indicator::SimCard,
                                          Indicator::NetworkAccessTechnology});
+        topBarManager->setIndicatorFlag(Indicator::SimCard, static_cast<int>(gui::SIM::SimIndicatorFlag::SIM_SHOW_ALL));
         addActionReceiver(manager::actions::Call, [this](auto &&data) {
             switchWindow(window::name_call, std::forward<decltype(data)>(data));
             return actionHandled();

--- a/module-gui/gui/widgets/TopBar.cpp
+++ b/module-gui/gui/widgets/TopBar.cpp
@@ -56,6 +56,14 @@ namespace gui::top_bar
         indicatorStatuses[indicator] = enabled;
     }
 
+    void Configuration::setIndicatorFlag(Indicator indicator, int flag)
+    {
+        indicatorFlags[indicator] = flag;
+    }
+    auto Configuration::getIndicatorFlag(Indicator indicator) -> int
+    {
+        return (indicatorFlags.count(indicator) == 0 ? 0 : indicatorFlags[indicator]);
+    }
     auto Configuration::isEnabled(Indicator indicator) const -> bool
     {
         return indicatorStatuses.at(indicator);
@@ -181,7 +189,8 @@ namespace gui::top_bar
             sim->setVisible(false);
             return;
         }
-        sim->show(Store::GSM::get()->sim);
+        int flag = configuration.getIndicatorFlag(Indicator::SimCard);
+        sim->show(Store::GSM::get()->sim, static_cast<SIM::SimIndicatorFlag>(flag));
     }
 
     bool TopBar::updateSignalStrength()

--- a/module-gui/gui/widgets/TopBar.hpp
+++ b/module-gui/gui/widgets/TopBar.hpp
@@ -29,9 +29,10 @@ namespace gui::top_bar
         SimCard,
         NetworkAccessTechnology
     };
+
     using Indicators        = std::vector<Indicator>;
     using IndicatorStatuses = std::map<Indicator, bool>;
-
+    using IndicatorFlags    = std::map<Indicator, int>;
     /**
      * Carries the top bar configuration.
      */
@@ -42,7 +43,9 @@ namespace gui::top_bar
         void enable(const Indicators &indicators);
         void disable(Indicator indicator);
         void set(Indicator indicator, bool enabled);
+        void setIndicatorFlag(Indicator indicator, int flag);
         [[nodiscard]] auto isEnabled(Indicator indicator) const -> bool;
+        [[nodiscard]] auto getIndicatorFlag(Indicator indicator) -> int;
         [[nodiscard]] auto getIndicatorsConfiguration() const noexcept -> const IndicatorStatuses &;
 
       private:
@@ -52,6 +55,7 @@ namespace gui::top_bar
                                                {Indicator::Battery, false},
                                                {Indicator::SimCard, false},
                                                {Indicator::NetworkAccessTechnology, false}};
+        IndicatorFlags indicatorFlags;
     };
 
     /// Header of most of design Windows

--- a/module-gui/gui/widgets/TopBar/SIM.cpp
+++ b/module-gui/gui/widgets/TopBar/SIM.cpp
@@ -12,17 +12,18 @@ namespace gui
         set(simunknown);
     }
 
-    void SIM::show(Store::GSM::SIM state)
+    void SIM::show(Store::GSM::SIM state, SimIndicatorFlag flag)
     {
         if (state == current) {
             return;
         }
+        setVisible(true);
         switch (state) {
         case GSM::SIM::SIM1:
-            set(sim1);
+            setSimWithNumber(sim1, flag);
             break;
         case GSM::SIM::SIM2:
-            set(sim2);
+            setSimWithNumber(sim2, flag);
             break;
         case GSM::SIM::SIM_FAIL:
             set(simfailed);
@@ -32,6 +33,15 @@ namespace gui
         case GSM::SIM::SIM_UNKNOWN:
             set(simunknown);
             break;
+        }
+    }
+    void SIM::setSimWithNumber(const char *sim, SimIndicatorFlag flag)
+    {
+        if (flag == SimIndicatorFlag::SIM_SHOW_ALL) {
+            set(sim);
+        }
+        else {
+            setVisible(false);
         }
     }
 }; // namespace gui

--- a/module-gui/gui/widgets/TopBar/SIM.hpp
+++ b/module-gui/gui/widgets/TopBar/SIM.hpp
@@ -13,6 +13,11 @@ namespace gui
         Store::GSM::SIM current = Store::GSM::SIM::SIM_UNKNOWN;
 
       public:
+        enum class SimIndicatorFlag
+        {
+            SIM_NO_FLAGS = 0, ///> default action, only sim blocked and sim error is displayed
+            SIM_SHOW_ALL = 1  ///> includes sim1 and sim2 icon
+        };
         /// create first image (sim unknown) and set it
         const unsigned int w   = 24;
         const unsigned int h   = 30;
@@ -22,7 +27,10 @@ namespace gui
         const char *simfailed  = "simfail";    // sim - notification for sim failure
 
         /// check if sim set in state -> if not -> show new sim
-        void show(Store::GSM::SIM state);
+        void show(Store::GSM::SIM state, SimIndicatorFlag flag = SimIndicatorFlag::SIM_NO_FLAGS);
         SIM(Item *parent, uint32_t x, uint32_t y);
+
+      private:
+        void setSimWithNumber(const char *sim, SimIndicatorFlag flag);
     };
 } // namespace gui


### PR DESCRIPTION
Fix in displaying sim card icon. Icon with active sim card |1|2| should not be displayed on application desktop. Only in case of problems (? - sim is not working,X - sim is blocked) user should see the icon.