### PR TITLE
[EGD-5911] Allow configuring worker stack size

### DIFF
--- a/module-sys/Service/Worker.cpp
+++ b/module-sys/Service/Worker.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Worker.hpp"
@@ -76,13 +76,14 @@ namespace sys
         vTaskDelete(nullptr);
     }
 
-    Worker::Worker(sys::Service *service) : name(service->GetName()), priority(service->GetPriority())
+    Worker::Worker(sys::Service *service, std::uint16_t stackDepth)
+        : name(service->GetName()), priority(service->GetPriority()), stackDepth(stackDepth)
     {
         constructName();
     }
 
-    Worker::Worker(std::string workerNamePrefix, UBaseType_t priority)
-        : name(std::move(workerNamePrefix)), priority(priority)
+    Worker::Worker(std::string workerNamePrefix, UBaseType_t priority, std::uint16_t stackDepth)
+        : name(std::move(workerNamePrefix)), priority(priority), stackDepth(stackDepth)
     {
         constructName();
     }
@@ -211,7 +212,8 @@ namespace sys
         runnerTask = xTaskGetCurrentTaskHandle();
 
         BaseType_t task_error = 0;
-        task_error = xTaskCreate(Worker::taskAdapter, name.c_str(), defaultStackSize, this, priority, &taskHandle);
+        task_error            = xTaskCreate(
+            Worker::taskAdapter, name.c_str(), stackDepth / sizeof(StackType_t), this, priority, &taskHandle);
 
         if (task_error != pdPASS) {
             LOG_ERROR("Failed to start the task");

--- a/module-sys/Service/Worker.hpp
+++ b/module-sys/Service/Worker.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -100,7 +100,7 @@ namespace sys
         WorkerQueue &getControlQueue() const;
 
         static constexpr std::size_t controlMessagesCount = static_cast<std::size_t>(ControlMessage::MessageCount);
-        static constexpr std::size_t defaultStackSize     = 2048;
+        static constexpr std::size_t defaultStackSize     = 8192;
         static constexpr TickType_t defaultJoinTimeout    = portMAX_DELAY;
         static constexpr auto controlQueueNamePrefix      = "wctrl";
 
@@ -132,13 +132,14 @@ namespace sys
 
         static unsigned int count;
         const UBaseType_t priority;
+        std::uint16_t stackDepth = defaultStackSize;
 
         QueueSetHandle_t queueSet = nullptr;
         std::vector<std::shared_ptr<WorkerQueue>> queues;
 
       public:
-        Worker(sys::Service *service);
-        Worker(std::string workerNamePrefix, const UBaseType_t priority);
+        Worker(sys::Service *service, std::uint16_t stackDepth = defaultStackSize);
+        Worker(std::string workerNamePrefix, const UBaseType_t priority, std::uint16_t stackDepth = defaultStackSize);
 
         virtual ~Worker();
 


### PR DESCRIPTION
Allow configuring stack size of a worker by a child class for a better
system heap utilization control.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>
