### PR TITLE
[EGD-5638] Use ignore_paths in license checker hook mode

### DIFF
--- a/config/license_header_check.sh
+++ b/config/license_header_check.sh
@@ -38,7 +38,6 @@ declare -A FileTypes=(
             ["shell"]="sh;bashChecker;"
             ["sqlite"]="sql;sqlChecker;"
         )
-declare -a paths_to_ignore
 
 function addEmptyLine() {
     LINE=$1
@@ -161,8 +160,6 @@ function excludePathFromFind(){
         path=${ignore_paths[$I]}
         if [[ -d ${path} ]]; then
             NOT_PATH="${NOT_PATH} -not ( -path ${path%*/} -prune )"
-        else
-            paths_to_ignore+=("${path}")
         fi
         I=$(( $I + 1 ))
     done
@@ -170,12 +167,12 @@ function excludePathFromFind(){
 
 function findFiles() {
     # find files except submodule directories
-    readarray -d '' FILES_TO_CHECK < <(find . ${NOT_PATH} -iname \"*.${FILE_EXT}\" -printf \"%P\0\")
+    readarray -d '' FILES_TO_CHECK < <(find . ${NOT_PATH} -iname "*.${FILE_EXT}" -printf "%P\0")
 }
 
 function shouldnt_ignore() {
     FILE=$1
-    for el in ${paths_to_ignore[@]}; do
+    for el in ${ignore_paths[@]}; do
         if [[ ${FILE}  =~ ^${el}.* ]]; then
             echo -e "${ORANGE}Ignore: ${FILE} checking due to: $el match!\e[0m"
             return 1
@@ -205,14 +202,10 @@ function hookMain() {
     parseArgs $@
     readarray -d '' FILES_TO_CHECK < <( ${GET_FILES_CMD} )
 
-    NOT_PATH=""
-    excludePathFromFind
-
     for FILE_TYPE in "${!FileTypes[@]}" 
     do
         echo "=== ${FILE_TYPE} ==="
         extractValues ${FILE_TYPE}
-        findFiles
         I=0
         while [[ $I -lt ${#FILES_TO_CHECK[@]} ]]
         do


### PR DESCRIPTION
License checker script should check against all excluded files,
not just directories.

Fix find command used to list file types present in the repo.