### PR TITLE
[EGD-5948] Fix build pure image for all target

### DIFF
--- a/cmake/modules/DiskImage.cmake
+++ b/cmake/modules/DiskImage.cmake
@@ -12,7 +12,7 @@ add_custom_command(
     )
 
 add_custom_target(
-    disk_image 
+    disk_image ALL
     DEPENDS ${DISK_IMAGE}
     )
 
@@ -20,7 +20,6 @@ if (${PROJECT_TARGET} STREQUAL "TARGET_Linux")
     add_dependencies(disk_image ${CMAKE_PROJECT_NAME})
     add_dependencies(check disk_image)
 else()
-    message("!!!!!!!!!!!!!!!!!!!!!!!!")
     add_dependencies(disk_image ${BIN_FILE}-target)
 endif()
 


### PR DESCRIPTION
Currently image is generated as a separate rule, but we need
to build image for the all targets.