### PR TITLE
[EGD-5941] Add tool to analyze stack usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,11 @@ add_compile_options( ${TARGET_COMPILE_OPTIONS}
                      # warning flags
                      -Wall -Wextra -Werror -Wno-unused-parameter -Wno-deprecated-declarations)
 
+option (GENERATE_STACK_USAGE "Generate stack usage report" OFF)
+if (GENERATE_STACK_USAGE)
+    add_compile_options (-fstack-usage)
+endif ()
+
 target_compile_features(${PROJECT_NAME} PUBLIC
         ${TARGET_COMPILE_FEATURES})
 

--- a/tools/stack-usage.sh
+++ b/tools/stack-usage.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+
+# make sure, that GENERATE_STACK_USAGE option has been enabled in cmake configuration
+
+builddir=$1
+minsize=$2
+pattern=$3
+
+if [ -z "$builddir" ]; then
+    echo "usage $0 builddir [minsize] [file name pattern]"
+    exit 1
+fi
+
+if [ -z $minsize ]; then
+    minsize=0
+fi
+
+if [ -n "$pattern" ]; then
+    FILTER="| egrep $pattern"
+fi
+
+eval find $builddir -name "*.su" $FILTER | xargs awk '{if ( $(NF-1) > '$minsize') print $(NF-1)" "$0}' | sort -n


### PR DESCRIPTION
Add a script to determine a stack usage of code components.
The GENERATE_STACK_USAGE option must be used in the build configuration.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>
