### PR TITLE
[EGD-5059] Fix SMS thread UX issues

### DIFF
--- a/module-apps/application-messages/data/MessagesStyle.hpp
+++ b/module-apps/application-messages/data/MessagesStyle.hpp
@@ -62,12 +62,13 @@ namespace style
         namespace smsInput
         {
             inline constexpr gui::Length min_h                   = 40;
-            inline constexpr gui::Length default_input_w         = 395;
+            inline constexpr gui::Length default_input_w         = 385;
             inline constexpr gui::Length default_input_h         = 30;
             inline constexpr gui::Length bottom_padding          = 5;
             inline constexpr gui::Length max_input_h             = default_input_h * 4 + bottom_padding;
-            inline constexpr gui::Length reply_bottom_margin     = 5;
+            inline constexpr gui::Length reply_bottom_margin     = 8;
             inline constexpr gui::Length new_sms_vertical_spacer = 25;
+            inline constexpr gui::Length new_sms_left_margin     = 10;
         } // namespace smsInput
 
         namespace smsOutput

--- a/module-apps/application-messages/widgets/SMSInputWidget.cpp
+++ b/module-apps/application-messages/widgets/SMSInputWidget.cpp
@@ -21,7 +21,8 @@ namespace gui
     SMSInputWidget::SMSInputWidget(app::Application *application) : application(application)
     {
         setMinimumSize(style::window::default_body_width, style::messages::smsInput::min_h);
-        setMargins(Margins(0, style::messages::smsInput::new_sms_vertical_spacer, 0, 0));
+        setMargins(Margins(
+            style::messages::smsInput::new_sms_left_margin, style::messages::smsInput::new_sms_vertical_spacer, 0, 0));
         setEdges(gui::RectangleEdge::None);
 
         body = new HBox(this, 0, 0, 0, 0);
@@ -29,7 +30,6 @@ namespace gui
         body->setMaximumSize(style::window::default_body_width, style::messages::smsInput::max_input_h);
 
         deleteByList = false;
-
         inputText = new gui::Text(body, 0, 0, 0, 0, "", ExpandMode::Up);
         inputText->setMaximumSize(style::messages::smsInput::default_input_w, style::messages::smsInput::max_input_h);
         inputText->setMinimumSize(style::messages::smsInput::default_input_w,
@@ -99,6 +99,16 @@ namespace gui
         };
 
         dimensionChangedCallback = [&](gui::Item &, const BoundingBox &newDim) -> bool {
+            if (newDim.w == style::listview::item_width_with_scroll - style::messages::smsInput::new_sms_left_margin) {
+                inputText->setMinimumWidth(style::messages::smsInput::default_input_w);
+                inputText->setMaximumWidth(style::messages::smsInput::default_input_w);
+            }
+            else {
+                inputText->setMinimumWidth(style::messages::smsInput::default_input_w +
+                                           style::listview::scroll::item_margin);
+                inputText->setMaximumWidth(style::messages::smsInput::default_input_w +
+                                           style::listview::scroll::item_margin);
+            }
             body->setArea({0, 0, newDim.w, newDim.h});
             return true;
         };

--- a/module-gui/gui/widgets/BottomBar.cpp
+++ b/module-gui/gui/widgets/BottomBar.cpp
@@ -20,7 +20,7 @@ namespace gui
     BottomBar::BottomBar()
     {
 
-        Padding margins{20, 0, 20, 0};
+        Padding margins{style::window::bottomBar::leftMargin, 0, style::window::bottomBar::rightMargin, 0};
         left   = prepareLabel(Side::LEFT);
         center = prepareLabel(Side::CENTER);
         right  = prepareLabel(Side::RIGHT);
@@ -36,12 +36,12 @@ namespace gui
         setFillColor(ColorFullWhite);
         setBorderColor(ColorNoColor);
         setFilled(true);
-        setSize(480, 50);
+        setSize(style::window::bottomBar::w, style::window::bottomBar::h);
     }
     BottomBar::BottomBar(Item *parent, uint32_t x, uint32_t y, uint32_t w, uint32_t h) : Rect{parent, x, y, w, h}
     {
 
-        Padding margins{20, 0, 20, 0};
+        Padding margins{style::window::bottomBar::leftMargin, 0, style::window::bottomBar::rightMargin, 0};
         left   = prepareLabel(Side::LEFT);
         center = prepareLabel(Side::CENTER);
         right  = prepareLabel(Side::RIGHT);
@@ -57,7 +57,7 @@ namespace gui
         setFillColor(ColorFullWhite);
         setBorderColor(ColorNoColor);
         setFilled(true);
-        setSize(480, 50);
+        setSize(style::window::bottomBar::w, style::window::bottomBar::h);
         updateDrawArea();
     }
     BottomBar::~BottomBar()

--- a/module-gui/gui/widgets/Style.hpp
+++ b/module-gui/gui/widgets/Style.hpp
@@ -84,6 +84,14 @@ namespace style
         /// minimal label decoration for Option
         void decorateOption(gui::Label *el);
 
+        namespace bottomBar
+        {
+            inline constexpr auto leftMargin  = 30U;
+            inline constexpr auto rightMargin = 30U;
+
+            inline constexpr auto h = 54U;
+            inline constexpr auto w = window_width;
+        } // namespace bottomBar
     }; // namespace window
 
     namespace settings


### PR DESCRIPTION
This PR correct following global UX issues that were noticed in SMS
threads:
- invalid Nav-bar margins (30px instead of 20px)
- invalid NAv-bar hight (54px instead of 50 px)

This PR corrects following SMS threads UX issues:
- invalid inputText's left margin (10px instead of 0px)