### PR TITLE
[EGD-5977] Fix empty BT devices list after pairing

### DIFF
--- a/module-bluetooth/Bluetooth/interface/profiles/GAP/GAP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/GAP/GAP.cpp
@@ -46,7 +46,6 @@ namespace bluetooth
     void GAP::stopScan()
     {
         gap_inquiry_stop();
-        devices.clear();
         LOG_INFO("Scan stopped!");
     }
 
@@ -87,6 +86,7 @@ namespace bluetooth
     auto GAP::startScan() -> int
     {
         LOG_INFO("Starting inquiry scan..");
+        devices.clear();
         return gap_inquiry_start(inquiryIntervalSeconds);
     }
 


### PR DESCRIPTION
After changing flow of settings windows, the stopScan command
is being executed right after executing pairing, so cleaning the
scan devices list is being done on scan start