### PR TITLE
[EGD-5963] Unify type of UUID field in all endpoints

### DIFF
--- a/module-services/service-desktop/parser/MessageHandler.cpp
+++ b/module-services/service-desktop/parser/MessageHandler.cpp
@@ -10,7 +10,6 @@
 #include <log/log.hpp>
 
 #include <bits/exception.h>
-#include <cinttypes>
 #include <memory>
 
 namespace sys
@@ -40,7 +39,7 @@ void MessageHandler::processMessage()
 {
     auto context = ContextFactory::create(messageJson);
 
-    LOG_DEBUG("[MsgHandler]\nmethod: %d\nendpoint: %d\nuuid: %" PRIu32 "\nbody: %s\n",
+    LOG_DEBUG("[MsgHandler]\nmethod: %d\nendpoint: %d\nuuid: %d\nbody: %s\n",
               static_cast<int>(context->getMethod()),
               static_cast<int>(context->getEndpoint()),
               context->getUuid(),

--- a/module-services/service-desktop/tests/test-contacts.cpp
+++ b/module-services/service-desktop/tests/test-contacts.cpp
@@ -171,9 +171,10 @@ TEST_CASE("Endpoint Contacts Test")
     {
         auto count       = 29; // requested number of record to return
         auto endpoint    = 7;
-        auto uuid        = "1103";
+        auto uuid        = 1103;
         auto totalCount  = contactsDb->contacts.count();
-        auto testMessage = "{\"endpoint\":" + std::to_string(endpoint) + ", \"method\":1, \"uuid\":" + uuid +
+        auto testMessage = "{\"endpoint\":" + std::to_string(endpoint) +
+                           ", \"method\":1, \"uuid\":" + std::to_string(uuid) +
                            ", \"body\":{\"limit\":" + std::to_string(count) + ", \"offset\":20}}";
         std::string err;
         auto msgJson = json11::Json::parse(testMessage, err);
@@ -191,7 +192,7 @@ TEST_CASE("Endpoint Contacts Test")
         auto retJson = json11::Json::parse(msg.substr(10), err); // string length and go to real data
 
         REQUIRE(err.empty());
-        REQUIRE(uuid == retJson[parserFSM::json::uuid].string_value());
+        REQUIRE(uuid == retJson[parserFSM::json::uuid].int_value());
         REQUIRE(endpoint == retJson[parserFSM::json::endpoint].int_value());
 
         auto body = retJson[parserFSM::json::body];

--- a/module-services/service-desktop/tests/unittest.cpp
+++ b/module-services/service-desktop/tests/unittest.cpp
@@ -247,15 +247,15 @@ TEST_CASE("Context class test")
         REQUIRE(context.getUuid() == 12345);
         REQUIRE(context.getEndpoint() == EndpointType::contacts);
         REQUIRE(context.createSimpleResponse() ==
-                R"(#000000061{"body": null, "endpoint": 7, "status": 200, "uuid": "12345"})");
+                R"(#000000061{"body": null, "endpoint": 7, "status": 200, "uuid": 12345})");
 
         context.setResponseBody(context.getBody());
         REQUIRE(context.createSimpleResponse() ==
-                R"(#000000073{"body": {"test": "test"}, "endpoint": 7, "status": 200, "uuid": "12345"})");
+                R"(#000000073{"body": {"test": "test"}, "endpoint": 7, "status": 200, "uuid": 12345})");
     }
     SECTION("Invalid message")
     {
-        auto testMessage = R"({"endpoint":25, "method":8, "uuid":"0", "body":{"te":"test"}})";
+        auto testMessage = R"({"endpoint":25, "method":8, "uuid":0, "body":{"te":"test"}})";
         std::string err;
         auto msgJson = json11::Json::parse(testMessage, err);
         REQUIRE(err.empty());
@@ -285,7 +285,7 @@ TEST_CASE("Endpoint Factory test")
 
     SECTION("Wrong endpoint")
     {
-        auto testMessage = R"({"endpoint":25, "method":8, "uuid":"12345", "body":{"te":"test"}})";
+        auto testMessage = R"({"endpoint":25, "method":8, "uuid":12345, "body":{"te":"test"}})";
         std::string err;
         auto msgJson = json11::Json::parse(testMessage, err);
         REQUIRE(err.empty());
@@ -314,7 +314,7 @@ TEST_CASE("Secured Endpoint Factory test")
 
     SECTION("Secured endpoint")
     {
-        auto testMessage = R"({"endpoint":25, "method":8, "uuid":"12345", "body":{"te":"test"}})";
+        auto testMessage = R"({"endpoint":25, "method":8, "uuid":12345, "body":{"te":"test"}})";
         std::string err;
         auto msgJson = json11::Json::parse(testMessage, err);
         REQUIRE(err.empty());


### PR DESCRIPTION
UUID is no longer stored as a string, since we are not
going to use 128b UUID.