### PR TITLE
[EGD-5927] Redirect access to '/lib' in emulator

### DIFF
--- a/board/linux/libiosyscalls/src/iosyscalls.cpp
+++ b/board/linux/libiosyscalls/src/iosyscalls.cpp
@@ -21,6 +21,7 @@ namespace
 
     constexpr const char *LINUX_PATHS[]{"/dev/",
                                         "/etc/",
+                                        "/lib",
                                         "/usr/share",
                                         "/run/user",
                                         "/home",


### PR DESCRIPTION
Sanitizer was trying to access libraries after all objects
got deleted and hung in a nested bug state.