### PR TITLE
[EGD-5926] Unmount VFS partitions on close

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -179,5 +179,8 @@ int main()
     LOG_PRINTF("Launching PurePhone \n");
     LOG_PRINTF("commit: %s tag: %s branch: %s\n", GIT_REV, GIT_TAG, GIT_BRANCH);
     cpp_freertos::Thread::StartScheduler();
+
+    purefs::subsystem::unmount_all();
+
     return 0;
 }


### PR DESCRIPTION
There is no shutdown procedure reflecting sysInit,
but filesystems can be unmounted directly before returning
from main()