### PR TITLE
[EGD-6000] Fix stack usage for service time

### DIFF
--- a/module-services/service-time/ServiceTime.cpp
+++ b/module-services/service-time/ServiceTime.cpp
@@ -19,7 +19,7 @@
 
 namespace stm
 {
-    ServiceTime::ServiceTime() : sys::Service(service::name::service_time), calendarEvents(this)
+    ServiceTime::ServiceTime() : sys::Service(service::name::service_time, "", StackDepth), calendarEvents(this)
     {
         LOG_INFO("[ServiceTime] Initializing");
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);

--- a/module-services/service-time/ServiceTime.hpp
+++ b/module-services/service-time/ServiceTime.hpp
@@ -29,6 +29,7 @@ namespace stm
     class ServiceTime : public sys::Service
     {
       private:
+        static constexpr auto StackDepth = 1300;
         CalendarTimeEvents calendarEvents;
 
       public:


### PR DESCRIPTION
Currently service time waste a lot of stack. This
patch reduce stack usage of the service time stack