### PR TITLE
[EGD-5973] Reduce audio stack usage

### DIFF
--- a/module-apps/application-music-player/ApplicationMusicPlayer.cpp
+++ b/module-apps/application-music-player/ApplicationMusicPlayer.cpp
@@ -14,10 +14,12 @@
 
 namespace app
 {
+    constexpr std::size_t applicationMusicPlayerStackSize = 4 * 1024;
+
     ApplicationMusicPlayer::ApplicationMusicPlayer(std::string name,
                                                    std::string parent,
                                                    StartInBackground startInBackground)
-        : Application(std::move(name), std::move(parent), startInBackground, 4096)
+        : Application(std::move(name), std::move(parent), startInBackground, applicationMusicPlayerStackSize)
     {
         LOG_INFO("ApplicationMusicPlayer::create");
         connect(typeid(AudioStartPlaybackResponse), [&](sys::Message *msg) {

--- a/module-audio/Audio/AudioCommon.cpp
+++ b/module-audio/Audio/AudioCommon.cpp
@@ -61,6 +61,11 @@ namespace audio
         return false;
     }
 
+    const std::string dbPath(const DbPathElement &element)
+    {
+        return dbPath(element.setting, element.playbackType, element.profileType, element.phoneMode);
+    }
+
     const std::string dbPath(const Setting &setting,
                              const PlaybackType &playbackType,
                              const Profile::Type &profileType,

--- a/module-audio/Audio/AudioCommon.hpp
+++ b/module-audio/Audio/AudioCommon.hpp
@@ -61,9 +61,19 @@ namespace audio
         Last = Alarm,
     };
 
+    struct DbPathElement
+    {
+        Setting setting;
+        PlaybackType playbackType;
+        Profile::Type profileType;
+        std::optional<sys::phone_modes::PhoneMode> phoneMode = std::nullopt;
+    };
+
     [[nodiscard]] const std::string str(const PlaybackType &playbackType) noexcept;
 
     [[nodiscard]] const std::string str(const Setting &setting) noexcept;
+
+    [[nodiscard]] const std::string dbPath(const DbPathElement &element);
 
     [[nodiscard]] const std::string dbPath(const Setting &setting,
                                            const PlaybackType &playbackType,

--- a/module-audio/Audio/decoder/DecoderWorker.cpp
+++ b/module-audio/Audio/decoder/DecoderWorker.cpp
@@ -5,7 +5,7 @@
 #include "Audio/decoder/Decoder.hpp"
 
 audio::DecoderWorker::DecoderWorker(Stream *audioStreamOut, Decoder *decoder, EndOfFileCallback endOfFileCallback)
-    : sys::Worker(DecoderWorker::workerName, DecoderWorker::workerPriority), audioStreamOut(audioStreamOut),
+    : sys::Worker(DecoderWorker::workerName, DecoderWorker::workerPriority, stackDepth), audioStreamOut(audioStreamOut),
       decoder(decoder), endOfFileCallback(endOfFileCallback),
       bufferSize(audioStreamOut->getBlockSize() / sizeof(BufferInternalType))
 {}

--- a/module-audio/Audio/decoder/DecoderWorker.hpp
+++ b/module-audio/Audio/decoder/DecoderWorker.hpp
@@ -30,6 +30,8 @@ namespace audio
         auto disablePlayback() -> bool;
 
       private:
+        static constexpr std::size_t stackDepth = 2 * 1024;
+
         virtual auto handleMessage(uint32_t queueID) -> bool override;
         void pushAudioData();
         bool stateChangeWait();


### PR DESCRIPTION
    Verify stack usage of:
     - ServiceAudio
     - application music player
     - decoder worker
    Change if possible to a realistic value keeping a 30% margin.
    Stack usage reduction is limited due to an extensive stack usage of
    every call to the filesystem, which uses around 2 kB of stack.
