### PR TITLE
[EGD-5918] The system should crash on init failure

### DIFF
--- a/module-services/service-db/ServiceDB.hpp
+++ b/module-services/service-db/ServiceDB.hpp
@@ -108,6 +108,7 @@ namespace sys
 #if ENABLE_FILEINDEXER_SERVICE
             manifest.dependencies = {service::name::file_indexer.data()};
 #endif
+            manifest.timeout = std::chrono::minutes{1};
             return manifest;
         }
     };

--- a/module-sys/SystemManager/SystemManager.cpp
+++ b/module-sys/SystemManager/SystemManager.cpp
@@ -149,6 +149,7 @@ namespace sys
             const auto startTimeout = service.get().getStartTimeout().count();
             if (const auto success = RunSystemService(service.get().create(), this, startTimeout); !success) {
                 LOG_FATAL("Unable to start service: %s", service.get().getName().c_str());
+                throw SystemInitialisationError{"System startup failed: unable to start a system service."};
             }
         });
     }

--- a/module-sys/SystemManager/SystemManager.hpp
+++ b/module-sys/SystemManager/SystemManager.hpp
@@ -12,6 +12,7 @@
 #define SYSTEMMANAGER_SYSTEMMANAGER_HPP_
 
 #include <functional>
+#include <stdexcept>
 #include "thread.hpp"
 #include "condition_variable.hpp"
 #include "mutex.hpp"
@@ -45,6 +46,12 @@ namespace sys
         Update,
         Reboot,
         None,
+    };
+
+    class SystemInitialisationError : public std::runtime_error
+    {
+      public:
+        using std::runtime_error::runtime_error;
     };
 
     class SystemManagerCmd : public DataMessage


### PR DESCRIPTION
ServiceDB init process times out. Its timeout should be extended.