### PR TITLE
[EGD-6024] Fix refreshing bt devices list after disconnect

### DIFF
--- a/module-apps/application-settings-new/models/BluetoothSettingsModel.cpp
+++ b/module-apps/application-settings-new/models/BluetoothSettingsModel.cpp
@@ -86,6 +86,4 @@ void BluetoothSettingsModel::requestConnection(std::string addr)
 void BluetoothSettingsModel::requestDisconnection()
 {
     application->bus.sendUnicast(std::make_shared<message::bluetooth::Disconnect>(), service::name::bluetooth);
-    application->bus.sendUnicast(std::make_shared<::message::bluetooth::RequestBondedDevices>(),
-                                 service::name::bluetooth);
 }

--- a/module-apps/application-settings-new/windows/AllDevicesWindow.cpp
+++ b/module-apps/application-settings-new/windows/AllDevicesWindow.cpp
@@ -93,6 +93,7 @@ namespace gui
                     LOG_DEBUG("Device: %s", device.name.c_str());
                     if (isConnected) {
                         bluetoothSettingsModel->requestDisconnection();
+                        addressOfConnectedDevice.clear();
                         refreshOptionsList();
                     }
                     else {


### PR DESCRIPTION
After pushing Disconnect button, list was not refreshing
in a proper way, a disconnect button was nat changed to connect.