### PR TITLE
[EGD-6074] Add system message and window for BT initialization error

### DIFF
--- a/module-apps/application-settings-new/ApplicationSettings.cpp
+++ b/module-apps/application-settings-new/ApplicationSettings.cpp
@@ -47,6 +47,7 @@
 #include <service-bluetooth/messages/BondedDevices.hpp>
 #include <service-bluetooth/messages/Connect.hpp>
 #include <service-bluetooth/messages/DeviceName.hpp>
+#include <service-bluetooth/messages/InitializationResult.hpp>
 #include <service-bluetooth/messages/Passkey.hpp>
 #include <service-bluetooth/messages/ResponseVisibleDevices.hpp>
 #include <service-bluetooth/messages/Unpair.hpp>
@@ -253,6 +254,26 @@ namespace app
                                  returnToPreviousWindow();
                                  return true;
                              }}));
+
+            return sys::MessageNone{};
+        });
+
+        connect(typeid(::message::bluetooth::InitializationResult), [&](sys::Message *msg) {
+            auto initializationResultMsg = static_cast<::message::bluetooth::InitializationResult *>(msg);
+            if (initializationResultMsg->isSucceed()) {
+                return sys::MessageNone{};
+            }
+            switchWindow(gui::window::name::dialog_confirm,
+                         gui::ShowMode::GUI_SHOW_INIT,
+                         std::make_unique<gui::DialogMetadataMessage>(
+                             gui::DialogMetadata{utils::localize.get("app_settings_bt"),
+                                                 "info_big_circle_W_G",
+                                                 utils::localize.get("app_settings_bluetooth_init_error_message"),
+                                                 "",
+                                                 [=]() -> bool {
+                                                     switchWindow(gui::window::name::bluetooth);
+                                                     return true;
+                                                 }}));
 
             return sys::MessageNone{};
         });

--- a/module-services/service-bluetooth/service-bluetooth/messages/InitializationResult.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/messages/InitializationResult.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "service-bluetooth/BluetoothMessage.hpp"
+
+namespace message::bluetooth
+{
+    class InitializationResult : public BluetoothMessage
+    {
+      public:
+        explicit InitializationResult(bool succeed) : succeed(succeed)
+        {}
+        [[nodiscard]] auto isSucceed() const noexcept -> bool
+        {
+            return succeed;
+        }
+
+      private:
+        const bool succeed;
+    };
+} // namespace message::bluetooth


### PR DESCRIPTION
Purpose of added system message is to sent information about bluetooth
initialization result from bluetooth service to application settings.
Added window will print error if initialization fails.
Further integration in service bluetooth is required.