### PR TITLE
[EGD-5790] Fix end of line display in message thumbnail

### DIFF
--- a/module-db/Interface/SMSRecord.cpp
+++ b/module-db/Interface/SMSRecord.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SMSRecord.hpp"
@@ -205,7 +205,8 @@ bool SMSRecordInterface::Update(const SMSRecord &recUpdated)
 
 void SMSRecordInterface::UpdateThreadSummary(ThreadRecord &threadToUpdate, const SMSRecord &rec)
 {
-    threadToUpdate.snippet = rec.body.substr(0, rec.body.length() >= snippetLength ? snippetLength : rec.body.length());
+    threadToUpdate.snippet = rec.body.substr(
+        0, std::min<size_t>({snippetLength, rec.body.length(), rec.body.find("\n"), rec.body.find("\r")}));
     threadToUpdate.date    = rec.date;
     threadToUpdate.type    = rec.type;
 }

--- a/module-utils/utf8/UTF8.cpp
+++ b/module-utils/utf8/UTF8.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <cassert>
@@ -407,7 +407,7 @@ UTF8 UTF8::substr(const uint32_t begin, const uint32_t length) const
     return retString;
 }
 
-uint32_t UTF8::find(const char *s, uint32_t pos)
+uint32_t UTF8::find(const char *s, uint32_t pos) const
 {
     uint32_t stringCount;
     uint32_t stringSize;
@@ -440,7 +440,7 @@ uint32_t UTF8::find(const char *s, uint32_t pos)
     return npos;
 }
 
-uint32_t UTF8::findLast(const char *s, uint32_t pos)
+uint32_t UTF8::findLast(const char *s, uint32_t pos) const
 {
     uint32_t stringCount;
     uint32_t stringSize;

--- a/module-utils/utf8/UTF8.hpp
+++ b/module-utils/utf8/UTF8.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -146,7 +146,7 @@ class UTF8
      * @note returns npos when substring is not found
      */
 
-    uint32_t find(const char *s, uint32_t pos = 0);
+    uint32_t find(const char *s, uint32_t pos = 0) const;
     /**
      * @brief Finds last occurrence of substring in string
      * @param s string to find
@@ -154,7 +154,7 @@ class UTF8
      * @return index of first matched string
      * @note returns npos when substring is not found.
      */
-    uint32_t findLast(const char *s, uint32_t pos);
+    uint32_t findLast(const char *s, uint32_t pos) const;
     /**
      * @brief splits UTF8 sting into two strings.
      * @param idx index of character from which the division will be made.
@@ -203,7 +203,7 @@ class UTF8
      * @brief Check if string has only ASCII characters
      * @return true if there are only ASCII characters in string, false otherwise.
      */
-    bool isAscii(void)
+    bool isAscii(void) const
     {
         if (this->sizeUsed - 1 == this->length())
             return true;


### PR DESCRIPTION
Original problem was that '\n' character was displayed as `[]` in
message thumbnail. After consulting Design-Team thumbnail should not
display anything succeeding problematic character.