### PR TITLE
[EGD-6013] Fix no copy syscall

### DIFF
--- a/board/rt1051/newlib/io_syscalls.cpp
+++ b/board/rt1051/newlib/io_syscalls.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 #include <errno.h>
 #include <stdio.h>
@@ -149,5 +149,21 @@ extern "C"
     void __env_unlock(struct _reent *reent)
     {
         utils::internal::syscalls::env_unlock(reent->_errno);
+    }
+    ssize_t readlink(const char *path, char *buf, size_t buflen)
+    {
+        return syscalls::readlink(_REENT->_errno, path, buf, buflen);
+    }
+    int symlink(const char *name1, const char *name2)
+    {
+        return syscalls::symlink(_REENT->_errno, name1, name2);
+    }
+    long fpathconf(int fd, int name)
+    {
+        return syscalls::fpathconf(_REENT->_errno, fd, name);
+    }
+    long pathconf(const char *path, int name)
+    {
+        return syscalls::pathconf(_REENT->_errno, path, name);
     }
 }

--- a/module-vfs/drivers/include/purefs/fs/drivers/filesystem_littlefs.hpp
+++ b/module-vfs/drivers/include/purefs/fs/drivers/filesystem_littlefs.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -37,6 +37,7 @@ namespace purefs::fs::drivers
         auto unlink(fsmount mnt, std::string_view name) noexcept -> int override;
         auto rename(fsmount mnt, std::string_view oldname, std::string_view newname) noexcept -> int override;
         auto mkdir(fsmount mnt, std::string_view path, int mode) noexcept -> int override;
+        auto fchmod(fsfile zfile, mode_t mode) noexcept -> int override;
 
         /** Directory support API */
         auto diropen(fsmount mnt, std::string_view path) noexcept -> fsdir override;

--- a/module-vfs/drivers/src/purefs/fs/filesystem_littlefs.cpp
+++ b/module-vfs/drivers/src/purefs/fs/filesystem_littlefs.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <purefs/fs/drivers/filesystem_littlefs.hpp>
@@ -446,6 +446,13 @@ namespace purefs::fs::drivers
     auto filesystem_littlefs::dirclose(fsdir dirstate) noexcept -> int
     {
         return invoke_lfs(dirstate, ::lfs_dir_close);
+    }
+
+    auto filesystem_littlefs::fchmod(fsfile zfile, mode_t mode) noexcept -> int
+    {
+        // Littlefs doesn't support chmod() so we need that path exists
+        struct stat filestat;
+        return fstat(zfile, filestat);
     }
 
 } // namespace purefs::fs::drivers

--- a/module-vfs/include/internal/newlib/vfs_io_syscalls.hpp
+++ b/module-vfs/include/internal/newlib/vfs_io_syscalls.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -43,5 +43,9 @@ namespace vfsn::internal::syscalls
               const void *data);
     int umount(int &_errno_, const char *special_file);
     int statvfs(int &_errno_, const char *path, struct statvfs *buf);
+    ssize_t readlink(int &_errno_, const char *path, char *buf, size_t buflen);
+    int symlink(int &_errno_, const char *name1, const char *name2);
+    long fpathconf(int &_errno, int fd, int name);
+    long pathconf(int &_errno, const char *path, int name);
 
 } // namespace vfsn::internal::syscalls

--- a/module-vfs/src/newlib/vfs_io_syscalls.cpp
+++ b/module-vfs/src/newlib/vfs_io_syscalls.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <errno.h>
@@ -362,6 +362,40 @@ namespace vfsn::internal::syscalls
                          fstype ? fstype : "",
                          rwflag,
                          data);
+    }
+
+    ssize_t readlink(int &_errno_, const char *path, char *buf, size_t buflen)
+    {
+        // Symlinks are not supported. According to man(2) symlink EINVAL when is not symlink.
+        _errno_ = EINVAL;
+        return -1;
+    }
+
+    int symlink(int &_errno_, const char *name1, const char *name2)
+    {
+        return invoke_fs(_errno_, &purefs::fs::filesystem::symlink, name1, name2);
+    }
+
+    long fpathconf(int &_errno, int fd, int name)
+    {
+        if (name == _PC_PATH_MAX) {
+            return PATH_MAX;
+        }
+        else {
+            _errno = EINVAL;
+            return -1;
+        }
+    }
+
+    long pathconf(int &_errno, const char *path, int name)
+    {
+        if (name == _PC_PATH_MAX) {
+            return PATH_MAX;
+        }
+        else {
+            _errno = EINVAL;
+            return -1;
+        }
     }
 
 } // namespace vfsn::internal::syscalls


### PR DESCRIPTION
Due to lack of some filesystem syscalls std::filesystem::copy
functions family doesn't work. This path add missing syscalls
in the FS layer.