### PR TITLE
[EGD-6108] Fix phonebook leak of DialogMetadata

### DIFF
--- a/module-apps/application-phonebook/windows/PhonebookContactOptions.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookContactOptions.cpp
@@ -106,7 +106,7 @@ namespace gui
         meta->title     = cont.getFormattedName();
         meta->icon      = "phonebook_contact_delete_trashcan";
         application->switchWindow(gui::window::name::dialog_yes_no,
-                                  std::make_unique<gui::DialogMetadataMessage>(std::move(*meta.release())));
+                                  std::make_unique<gui::DialogMetadataMessage>(std::move(*meta)));
         return true;
     }
 
@@ -129,7 +129,7 @@ namespace gui
         meta->title     = cont.getFormattedName();
         meta->icon      = "phonebook_contact_delete_trashcan";
         application->switchWindow(gui::window::name::dialog_yes_no,
-                                  std::make_unique<DialogMetadataMessage>(std::move(*meta.release())));
+                                  std::make_unique<DialogMetadataMessage>(std::move(*meta)));
         return true;
     }
 
@@ -154,7 +154,7 @@ namespace gui
         };
         meta.title = contact->getFormattedName(ContactRecord::NameFormatType::Title);
         application->switchWindow(gui::window::name::dialog_confirm,
-                                  std::make_unique<gui::DialogMetadataMessage>(meta));
+                                  std::make_unique<gui::DialogMetadataMessage>(std::move(meta)));
         return true;
     }
 } // namespace gui

--- a/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
@@ -226,7 +226,7 @@ namespace gui
         meta->title = duplicatedNumber.getFormatted();
         meta->icon  = "info_big_circle_W_G";
         application->switchWindow(gui::window::name::dialog_yes_no,
-                                  std::make_unique<gui::DialogMetadataMessage>(std::move(*meta.release())));
+                                  std::make_unique<gui::DialogMetadataMessage>(std::move(*meta)));
     }
 
     void PhonebookNewContact::showDialogDuplicatedSpeedDialNumber()
@@ -257,7 +257,7 @@ namespace gui
         metadata->iconText = contact->speeddial;
 
         application->switchWindow(gui::window::name::dialog_yes_no_icon_txt,
-                                  std::make_unique<gui::DialogMetadataMessage>(std::move(*metadata.release())));
+                                  std::make_unique<gui::DialogMetadataMessage>(std::move(*metadata)));
     }
 
 } // namespace gui

--- a/module-apps/messages/DialogMetadataMessage.hpp
+++ b/module-apps/messages/DialogMetadataMessage.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -14,7 +14,7 @@ namespace gui
         DialogMetadata metadata;
 
       public:
-        DialogMetadataMessage(DialogMetadata metadata) : metadata(metadata)
+        explicit DialogMetadataMessage(DialogMetadata metadata) : metadata(std::move(metadata))
         {}
         [[nodiscard]] const DialogMetadata &get() const
         {


### PR DESCRIPTION
The leaks were caused by releases on `unique_ptr` - reviewer
(my) mistake