### PR TITLE
[EGD-4851] Add URC support in sleep mode

### DIFF
--- a/module-cellular/at/Commands.hpp
+++ b/module-cellular/at/Commands.hpp
@@ -38,7 +38,7 @@ namespace at
         RI_PIN_OFF_CALL,            /// Turn off RI pin for incoming calls
         RI_PIN_PULSE_SMS,           /// Turn on RI pin for incoming sms
         RI_PIN_OFF_SMS,             /// Turn off RI pin for incoming sms
-        RI_PIN_OFF_OTHER,           /// Turn off RI pin for other URCs
+        RI_PIN_PULSE_OTHER,         /// Turn on RI pin for other incoming URCs
         URC_DELAY_ON,               /// Enable delay the output of URC indication until ring indicator pulse ends
         URC_UART1,                  /// Route URCs to UART1
         AT_PIN_READY_LOGIC,         /// Configure AP_Ready pin logic ( enable, logic level 1, 200ms )
@@ -154,7 +154,7 @@ namespace at
             {AT::RI_PIN_OFF_CALL, {"AT+QCFG=\"urc/ri/ring\",\"off\""}},
             {AT::RI_PIN_PULSE_SMS, {"AT+QCFG=\"urc/ri/smsincoming\",\"pulse\",450"}},
             {AT::RI_PIN_OFF_SMS, {"AT+QCFG=\"urc/ri/smsincoming\",\"off\""}},
-            {AT::RI_PIN_OFF_OTHER, {"AT+QCFG=\"urc/ri/other\",\"off\""}},
+            {AT::RI_PIN_PULSE_OTHER, {"AT+QCFG=\"urc/ri/other\",\"pulse\""}},
             {AT::URC_DELAY_ON, {"AT+QCFG=\"urc/delay\",1"}},
             {AT::URC_UART1, {"AT+QURCCFG=\"urcport\",\"uart1\""}},
             {AT::AT_PIN_READY_LOGIC, {"AT+QCFG=\"apready\",1,1,200"}},

--- a/module-cellular/at/src/Commands.cpp
+++ b/module-cellular/at/src/Commands.cpp
@@ -15,7 +15,7 @@ namespace at
             ret.push_back(AT::URC_NOTIF_CHANNEL);
             ret.push_back(AT::RI_PIN_AUTO_CALL);
             ret.push_back(AT::RI_PIN_PULSE_SMS);
-            ret.push_back(AT::RI_PIN_OFF_OTHER);
+            ret.push_back(AT::RI_PIN_PULSE_OTHER);
             ret.push_back(AT::URC_DELAY_ON);
             ret.push_back(AT::URC_UART1);
             ret.push_back(AT::AT_PIN_READY_LOGIC);

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -579,6 +579,9 @@ void ServiceCellular::registerMessageHandlers()
     connect(typeid(CellularSimNotReadyNotification),
             [&](sys::Message *request) -> sys::MessagePointer { return handleSimNotReadyNotification(request); });
 
+    connect(typeid(CellularUrcIncomingNotification),
+            [&](sys::Message *request) -> sys::MessagePointer { return handleUrcIncomingNotification(request); });
+
     handle_CellularGetChannelMessage();
 }
 
@@ -2507,6 +2510,12 @@ auto ServiceCellular::handleNetworkStatusUpdateNotification(sys::Message *msg) -
 auto ServiceCellular::handleSimNotReadyNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
     return std::make_shared<CellularResponseMessage>(false);
+}
+
+auto ServiceCellular::handleUrcIncomingNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
+{
+    cmux->ExitSleepMode();
+    return std::make_shared<CellularResponseMessage>(true);
 }
 
 auto ServiceCellular::handleCellularSetFlightModeMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>

--- a/module-services/service-cellular/service-cellular/CellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/CellularMessage.hpp
@@ -95,6 +95,7 @@ class CellularNotificationMessage : public CellularMessage
         PowerDownDeregistering,   // modem informed it has started to disconnect from network
         PowerDownDeregistered,    // modem informed it has disconnected from network
         SMSDone,                  // SMS initialization finished
+        NewIncomingUrc,           // phone received new URC from network and we need to wake up modem and host
     };
 
     // TODO check and fix all CellularNotificationMessage constructors
@@ -1019,6 +1020,14 @@ class CellularSimNotReadyNotification : public CellularNotificationMessage
   public:
     explicit CellularSimNotReadyNotification(const std::string &data = "")
         : CellularNotificationMessage(CellularNotificationMessage::Type::SIM_NOT_READY, data)
+    {}
+};
+
+class CellularUrcIncomingNotification : public CellularNotificationMessage
+{
+  public:
+    explicit CellularUrcIncomingNotification(const std::string &data = "")
+        : CellularNotificationMessage(CellularNotificationMessage::Type::NewIncomingUrc, data)
     {}
 };
 

--- a/module-services/service-cellular/service-cellular/ServiceCellular.hpp
+++ b/module-services/service-cellular/service-cellular/ServiceCellular.hpp
@@ -361,7 +361,7 @@ class ServiceCellular : public sys::Service
     auto handleSignalStrengthUpdateNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>;
     auto handleNetworkStatusUpdateNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>;
     auto handleSimNotReadyNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>;
-
+    auto handleUrcIncomingNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>;
     auto handleCellularSetFlightModeMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>;
 };
 

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -33,6 +33,7 @@
 #include <service-db/DBNotificationMessage.hpp>
 #include <service-desktop/Constants.hpp>
 #include <service-desktop/DesktopMessages.hpp>
+#include <service-cellular/ServiceCellular.hpp>
 #include <cassert>
 #include <list>
 #include <tuple>
@@ -193,8 +194,8 @@ sys::MessagePointer EventManager::DataReceivedHandler(sys::DataMessage *msgl, sy
         }
     }
     else if (msgl->messageType == MessageType::EVMRingIndicator) {
-        auto msg = std::make_shared<sys::CpuFrequencyMessage>(sys::CpuFrequencyMessage::Action::Increase);
-        bus.sendUnicast(msg, service::name::system_manager);
+        auto msg = std::make_shared<CellularUrcIncomingNotification>();
+        bus.sendUnicast(std::move(msg), ServiceCellular::serviceName);
     }
 
     if (handled) {


### PR DESCRIPTION
When URCs come from the network and GSM is in sleep mode,
we wake up the modem to properly handle the incoming data.