### PR TITLE
 [EGD-6112] Fix Service-desktop crashes during DOM dump

### DIFF
--- a/module-services/service-desktop/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/service-desktop/ServiceDesktop.hpp
@@ -23,8 +23,8 @@ namespace settings
 
 namespace sdesktop
 {
-    inline constexpr auto service_stack             = 4096;
-    inline constexpr auto worker_stack              = 1024;
+    inline constexpr auto service_stack             = 5120;
+    inline constexpr auto worker_stack              = 8704;
     inline constexpr auto cdc_queue_len             = 32;
     inline constexpr auto cdc_queue_object_size     = 1024;
     inline constexpr auto irq_queue_object_size     = sizeof(bsp::USBDeviceStatus);


### PR DESCRIPTION
 service_stack new size  5120;
 worker_stack  new size  8704;