### PR TITLE
[EGD-6150] Clean bottom bar after unpairing the last device from the list

### DIFF
--- a/module-apps/application-settings-new/windows/AllDevicesWindow.cpp
+++ b/module-apps/application-settings-new/windows/AllDevicesWindow.cpp
@@ -74,6 +74,8 @@ namespace gui
                                              return (bd_addr_to_str(device.address) == addressOfSelectedDevice);
                                          }),
                           devices.end());
+            bottomBar->setActive(BottomBar::Side::LEFT, false);
+            bottomBar->setActive(BottomBar::Side::CENTER, false);
             refreshOptionsList();
             bluetoothSettingsModel->requestDeviceUnpair(addressOfSelectedDevice);
             return true;

--- a/module-apps/application-settings-new/windows/AllDevicesWindow.hpp
+++ b/module-apps/application-settings-new/windows/AllDevicesWindow.hpp
@@ -24,10 +24,10 @@ namespace gui
 
         Image *leftArrowImage = nullptr;
         Image *crossImage     = nullptr;
-        std::vector<Devicei> devices;
+        std::vector<Devicei> devices{};
         std::string addressOfConnectedDevice;
         std::string addressOfSelectedDevice;
-        std::unique_ptr<BluetoothSettingsModel> bluetoothSettingsModel;
+        std::unique_ptr<BluetoothSettingsModel> bluetoothSettingsModel{};
     };
 
 } // namespace gui


### PR DESCRIPTION
FORGET and CONNECT/DISCONNECT buttons were not removed after
the last device was removed from the list in All Devices window.