### PR TITLE
[EGD-6219] Add GDB macro to print memory

### DIFF
--- a/.gdb_macros
+++ b/.gdb_macros
@@ -1,0 +1,30 @@
+define xac
+    dont-repeat
+    set $addr = (char *)($arg0)
+    set $endaddr = $addr + $arg1
+    while $addr < $endaddr
+        printf "%p: ", $addr
+        set $lineendaddr = $addr + 8
+        if $lineendaddr > $endaddr
+            set $lineendaddr = $endaddr
+        end
+        set $a = $addr
+        while $a < $lineendaddr
+            printf "0x%02x ", *(unsigned char *)$a
+            set $a++
+        end
+        printf "'"
+        set $a = $addr
+        while $a < $lineendaddr
+            printf "%c", *(char *)$a
+            set $a++
+        end
+        printf "'\n"
+        set $addr = $addr + 8
+    end
+end
+
+document xac
+usage: xac address count
+end
+

--- a/.gdbinit
+++ b/.gdbinit
@@ -1,2 +1,4 @@
+source .gdb_macros
+
 handle all nostop pass
 handle SIGUSR1 nostop noprint

--- a/.gdbinit-1051
+++ b/.gdbinit-1051
@@ -1,3 +1,5 @@
+source .gdb_macros
+
 set pagination off
 target remote localhost:2331
 source tools/gdb_crash_extend.py


### PR DESCRIPTION
Added GDB macro to print out the content
of the memory range in hex/ASCII format.