### PR TITLE
[EGD-6191] Fix harness call tests

### DIFF
--- a/module-services/service-desktop/endpoints/developerMode/DeveloperModeHelper.cpp
+++ b/module-services/service-desktop/endpoints/developerMode/DeveloperModeHelper.cpp
@@ -119,6 +119,20 @@ auto DeveloperModeHelper::processPut(Context &context) -> ProcessResult
         }
         code = toCode(owner->bus.sendUnicast(std::move(msg), "ServiceDesktop"));
     }
+    else if (auto switchData = body[json::developerMode::switchApplication].object_items(); !switchData.empty()) {
+        auto msg = std::make_shared<app::manager::SwitchRequest>(
+            owner->GetName(),
+            switchData[json::developerMode::switchData::applicationName].string_value(),
+            switchData[json::developerMode::switchData::windowName].string_value(),
+            nullptr);
+        code = toCode(owner->bus.sendUnicast(std::move(msg), "ApplicationManager"));
+    }
+    else if (auto switchData = body[json::developerMode::switchWindow].object_items(); !switchData.empty()) {
+        auto msg = std::make_shared<app::AppSwitchWindowMessage>(
+            switchData[json::developerMode::switchData::windowName].string_value(), "", nullptr);
+        code = toCode(owner->bus.sendUnicast(
+            std::move(msg), switchData[json::developerMode::switchData::applicationName].string_value()));
+    }
 
     else {
         context.setResponseStatus(http::Code::BadRequest);

--- a/module-services/service-desktop/endpoints/developerMode/DeveloperModeHelper.hpp
+++ b/module-services/service-desktop/endpoints/developerMode/DeveloperModeHelper.hpp
@@ -58,6 +58,13 @@ namespace parserFSM
         inline constexpr auto getInfo                = "getInfo";
         inline constexpr auto tethering              = "tethering";
         inline constexpr auto usbSecurityStatus      = "usbSecurityStatus";
+        inline constexpr auto switchApplication      = "switchApplication";
+        inline constexpr auto switchWindow           = "switchWindow";
+        namespace switchData
+        {
+            inline constexpr auto applicationName = "applicationName";
+            inline constexpr auto windowName      = "windowName";
+        } // namespace switchData
         /// values for getInfo cmd
         inline constexpr auto simStateInfo      = "simState";
         inline constexpr auto cellularStateInfo = "cellularState";

--- a/test/README.md
+++ b/test/README.md
@@ -22,10 +22,6 @@ As for now, it consists of the following methods that can be used during writing
 
    returns a `CDCSerial` object - wrapper for Python's `Serial`
    
-* `get_window_name()`
-
-   returns current application(window) name
-   
 * `with_phone_unlocked(func)`
 
     decorator allowing to call a function with an unlocked operating system

--- a/test/pytest/conftest.py
+++ b/test/pytest/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 import time
@@ -159,6 +159,36 @@ def phone_in_desktop(harness):
     # assert that we are in ApplicationDesktop
     assert harness.get_application_name() == "ApplicationDesktop"
 
+@pytest.fixture(scope='function')
+def phone_ends_test_in_desktop(harness):
+    yield
+    target_application = "ApplicationDesktop"
+    target_window     = "MainWindow"
+    log.info(f"returning to {target_window} of {target_application} ...")
+    time.sleep(1)
+
+    if harness.get_application_name() != target_application :
+        body = {"switchApplication" : {"applicationName": target_application, "windowName" : target_window }}
+        harness.endpoint_request("developerMode", "put", body)
+        time.sleep(1)
+
+        max_retry_counter = 5
+        while harness.get_application_name() != target_application:
+            max_retry_counter -= 1
+            if max_retry_counter == 0:
+                break
+
+            log.info(f"Not in {target_application}, {max_retry_counter} attempts left...")
+            time.sleep(1)
+    else :
+        # switching window in case ApplicationDesktop is not on MainWindow:
+        body = {"switchWindow" : {"applicationName": target_application, "windowName" : target_window }}
+        harness.endpoint_request("developerMode", "put", body)
+        time.sleep(1)
+
+    # assert that we are in ApplicationDesktop
+    assert harness.get_application_name() == target_application
+    time.sleep(1)
 
 def pytest_configure(config):
     config.addinivalue_line("markers",

--- a/test/pytest/module_apps/call_utils.py
+++ b/test/pytest/module_apps/call_utils.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+import time
+from harness import log
+from harness.interface.defs import key_codes
+
+def get_calllog_count(harness):
+    body = {"count": True}
+    return harness.endpoint_request("calllog", "get", body)["body"]["count"]
+
+def select_call_button(harness, call_duration):
+    # call
+    log.info("Call duration = {}s, calling...".format(call_duration))
+    harness.connection.send_key_code(key_codes["fnLeft"])
+    time.sleep(call_duration)
+    # hang up
+    log.info("Hanging up...")
+    harness.connection.send_key_code(key_codes["fnRight"])

--- a/test/pytest/test_auto_lock.py
+++ b/test/pytest/test_auto_lock.py
@@ -2,9 +2,9 @@
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 import pytest
-from harness.interface.defs import status
+from harness.interface.defs import status, key_codes
 from harness.interface.CDCSerial import Keytype
-from harness.interface.defs import key_codes
+from harness import log
 import time
 import random
 
@@ -14,6 +14,12 @@ def change_auto_lock_timer(harness, value: str):
     ret = harness.endpoint_request("developerMode", "put", body)
     assert ret["status"] == status["OK"]
 
+@pytest.fixture(scope='function')
+def phone_ends_with_default_auto_lock(harness):
+    yield
+    timeout = str(30000)
+    log.info("Setting back default timeout to {}ms".format(timeout))
+    change_auto_lock_timer(harness, timeout)
 
 app_navigation_to_name_mapping = {
     "messages": "ApplicationMessages",
@@ -79,6 +85,7 @@ def get_dom(harness):
 
 @pytest.mark.skip("not fully implemented - should work after EGD-5884")
 @pytest.mark.rt1051
+@pytest.mark.usefixtures("phone_ends_with_default_auto_lock")
 @pytest.mark.usefixtures("phone_unlocked")
 def test_auto_lock(harness):
     # change timer lock value
@@ -107,6 +114,7 @@ def test_auto_lock(harness):
 
 
 @pytest.mark.rt1051
+@pytest.mark.usefixtures("phone_ends_with_default_auto_lock")
 @pytest.mark.usefixtures("phone_unlocked")
 def test_no_auto_lock_for_meditation_app(harness):
     # change timer lock value

--- a/test/pytest/test_call.py
+++ b/test/pytest/test_call.py
@@ -3,27 +3,18 @@
 import time
 import pytest
 
-from harness.interface.defs import key_codes
-
-
-def get_calllog_count(harness):
-    body = {"count": True}
-    return harness.endpoint_request("calllog", "get", body)["body"]["count"]
-
+from module_apps.call_utils import get_calllog_count, select_call_button
 
 @pytest.mark.rt1051
+@pytest.mark.usefixtures("phone_ends_test_in_desktop")
 @pytest.mark.usefixtures("phone_unlocked")
 @pytest.mark.usefixtures("usb_unlocked")
-
 def test_call(harness, phone_number, call_duration):
     count_before = get_calllog_count(harness)
     # enter number
     harness.send_number(str(phone_number))
     # call
-    harness.connection.send_key_code(key_codes["fnLeft"])
-    time.sleep(call_duration)
-    # hang up
-    harness.connection.send_key_code(key_codes["fnRight"])
+    select_call_button(harness, call_duration)
     count_after = get_calllog_count(harness)
 
     assert count_before + 1 == count_after

--- a/test/pytest/test_call_back.py
+++ b/test/pytest/test_call_back.py
@@ -4,14 +4,10 @@ import time
 import pytest
 
 from harness.interface.defs import key_codes
-
-
-def get_calllog_count(harness):
-    body = {"count": True}
-    return harness.endpoint_request("calllog", "get", body)["body"]["count"]
-
+from module_apps.call_utils import get_calllog_count, select_call_button
 
 @pytest.mark.rt1051
+@pytest.mark.usefixtures("phone_ends_test_in_desktop")
 @pytest.mark.usefixtures("phone_in_desktop")
 @pytest.mark.usefixtures("phone_unlocked")
 def test_call(harness, call_duration):
@@ -25,15 +21,8 @@ def test_call(harness, call_duration):
         assert harness.connection.get_application_name() == "ApplicationCallLog"
 
     # call
-    harness.connection.send_key_code(key_codes["fnLeft"])
-    time.sleep(call_duration)
-    # hang up
-    harness.connection.send_key_code(key_codes["fnRight"])
+    select_call_button(harness, call_duration)
     count_after = get_calllog_count(harness)
-
-    for _ in range(3):
-        harness.connection.send_key_code(key_codes["fnRight"])
-        time.sleep(1)
 
     assert count_before + 1 == count_after
     time.sleep(2)  # needed to restore after call


### PR DESCRIPTION
* This PR provides a fix for the bug reported in [EGD-6081].
The solution adds the `tear_down`-like fixture called after the
problematic tests, that enforce focus on `ApplicationDesktop'`s
main window.
* Additionally a similar solution was added to the `test_auto_lock`
to restore the original (30s) lock timeout.

[EGD-6081]: https://appnroll.atlassian.net/browse/EGD-6081