### PR TITLE
[EGD-5703] Fix in displaying sim card icon

### DIFF
--- a/module-apps/TopBarManager.cpp
+++ b/module-apps/TopBarManager.cpp
@@ -16,6 +16,11 @@ namespace app
         return topBarConfiguration;
     }
 
+    void TopBarManager::setIndicatorFlag(gui::top_bar::Indicator indicator, int flag)
+    {
+        topBarConfiguration.setIndicatorFlag(indicator, flag);
+    }
+
     void TopBarManager::set(gui::top_bar::TimeMode timeMode)
     {
         topBarConfiguration.set(timeMode);

--- a/module-apps/TopBarManager.hpp
+++ b/module-apps/TopBarManager.hpp
@@ -11,6 +11,7 @@ namespace app
     {
       public:
         void enableIndicators(const gui::top_bar::Indicators &indicators);
+        void setIndicatorFlag(gui::top_bar::Indicator indicator, int flag);
         [[nodiscard]] auto getConfiguration() const noexcept -> const gui::top_bar::Configuration &;
         void set(gui::top_bar::TimeMode timeMode);
 

--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -26,6 +26,7 @@
 #include <cassert>
 #include <module-apps/application-phonebook/data/PhonebookItemData.hpp>
 #include <module-services/service-db/service-db/DBServiceAPI.hpp>
+#include <module-gui/gui/widgets/TopBar/SIM.hpp>
 
 namespace app
 {
@@ -38,6 +39,8 @@ namespace app
                                          Indicator::Battery,
                                          Indicator::SimCard,
                                          Indicator::NetworkAccessTechnology});
+        topBarManager->setIndicatorFlag(Indicator::SimCard,
+                                        static_cast<int>(gui::top_bar::SIM::SimIndicatorFlag::SIM_SHOW_ALL));
         addActionReceiver(manager::actions::Call, [this](auto &&data) {
             switchWindow(window::name_call, std::forward<decltype(data)>(data));
             return actionHandled();

--- a/module-gui/gui/widgets/TopBar.cpp
+++ b/module-gui/gui/widgets/TopBar.cpp
@@ -170,6 +170,15 @@ namespace gui::top_bar
         }
     }
 
+    void Configuration::setIndicatorFlag(Indicator indicator, int flag)
+    {
+        indicatorFlags[indicator] = flag;
+    }
+    auto Configuration::getIndicatorFlag(Indicator indicator) -> int
+    {
+        return (indicatorFlags.count(indicator) == 0 ? 0 : indicatorFlags[indicator]);
+    }
+
     bool TopBar::updateBattery()
     {
         if (battery == nullptr) {
@@ -187,8 +196,12 @@ namespace gui::top_bar
 
     void TopBar::showSim(bool enabled)
     {
-        sim->update(Store::GSM::get()->sim);
-        enabled ? sim->show() : sim->hide();
+        if (!enabled) {
+            sim->setVisible(false);
+            return;
+        }
+        int flag = configuration.getIndicatorFlag(Indicator::SimCard);
+        sim->update(Store::GSM::get()->sim, static_cast<SIM::SimIndicatorFlag>(flag));
     }
 
     bool TopBar::updateSim()

--- a/module-gui/gui/widgets/TopBar.hpp
+++ b/module-gui/gui/widgets/TopBar.hpp
@@ -38,6 +38,7 @@ namespace gui::top_bar
     };
     using Indicators        = std::vector<Indicator>;
     using IndicatorStatuses = std::map<Indicator, bool>;
+    using IndicatorFlags    = std::map<Indicator, int>;
 
     enum class TimeMode
     {
@@ -57,7 +58,9 @@ namespace gui::top_bar
         void set(Indicator indicator, bool enabled);
         void set(TimeMode timeMode);
         [[nodiscard]] auto getTimeMode() const noexcept -> TimeMode;
+        void setIndicatorFlag(Indicator indicator, int flag);
         [[nodiscard]] auto isEnabled(Indicator indicator) const -> bool;
+        [[nodiscard]] auto getIndicatorFlag(Indicator indicator) -> int;
         [[nodiscard]] auto getIndicatorsConfiguration() const noexcept -> const IndicatorStatuses &;
 
       private:
@@ -67,6 +70,8 @@ namespace gui::top_bar
                                                {Indicator::Battery, false},
                                                {Indicator::SimCard, false},
                                                {Indicator::NetworkAccessTechnology, false}};
+
+        IndicatorFlags indicatorFlags;
         TimeMode timeMode                   = TimeMode::Time12h;
     };
 

--- a/module-gui/gui/widgets/TopBar/SIM.cpp
+++ b/module-gui/gui/widgets/TopBar/SIM.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SIM.hpp"
@@ -17,18 +17,18 @@ namespace gui::top_bar
         set(simunknown);
     }
 
-    void SIM::update(const Store::GSM::SIM &state)
+    void SIM::update(const Store::GSM::SIM &state, SimIndicatorFlag flag)
     {
         if (state == current) {
             return;
         }
-        current = state;
-        switch (current) {
+        setVisible(true);
+        switch (state) {
         case GSM::SIM::SIM1:
-            set(sim1);
+            setSimWithNumber(sim1, flag);
             break;
         case GSM::SIM::SIM2:
-            set(sim2);
+            setSimWithNumber(sim2, flag);
             break;
         case GSM::SIM::SIM_FAIL:
             set(simfailed);
@@ -40,4 +40,13 @@ namespace gui::top_bar
             break;
         }
     }
-}; // namespace gui::top_bar
+    void SIM::setSimWithNumber(const char *sim, SimIndicatorFlag flag)
+    {
+        if (flag == SimIndicatorFlag::SIM_SHOW_ALL) {
+            set(sim);
+        }
+        else {
+            setVisible(false);
+        }
+    }
+}; // namespace gui

--- a/module-gui/gui/widgets/TopBar/SIM.hpp
+++ b/module-gui/gui/widgets/TopBar/SIM.hpp
@@ -14,9 +14,17 @@ namespace gui::top_bar
         Store::GSM::SIM current = Store::GSM::SIM::SIM_UNKNOWN;
 
       public:
+        enum class SimIndicatorFlag
+        {
+            SIM_NO_FLAGS = 0, ///> default action, only sim blocked and sim error is displayed
+            SIM_SHOW_ALL = 1  ///> includes sim1 and sim2 icon
+        };
         SIM(Item *parent, uint32_t x, uint32_t y);
 
         /// check if sim set in state -> if not -> show new sim
-        void update(const Store::GSM::SIM &state);
+        void update(const Store::GSM::SIM &state, SimIndicatorFlag flag = SimIndicatorFlag::SIM_NO_FLAGS);
+
+      private:
+        void setSimWithNumber(const char *sim, SimIndicatorFlag flag);
     };
 } // namespace gui::top_bar


### PR DESCRIPTION
Fix in displaying sim card icon. Icon with active sim card |1|2|
should not be displayed on application desktop. Only in case of
problems (? - sim is not working,X - sim is blocked) user
should see the icon.