### PR TITLE
[EGD-4852] Add sleep mode for GSM modem

### DIFF
--- a/module-bsp/bsp/cellular/bsp_cellular.cpp
+++ b/module-bsp/bsp/cellular/bsp_cellular.cpp
@@ -36,4 +36,9 @@ namespace bsp{
         return driverLPUART;
     }
 
+    [[nodiscard]] auto Cellular::GetLastCommunicationTimestamp() const noexcept -> TickType_t
+    {
+    	return lastCommunicationTimestamp;
+    }
+
 }

--- a/module-bsp/bsp/cellular/bsp_cellular.hpp
+++ b/module-bsp/bsp/cellular/bsp_cellular.hpp
@@ -56,9 +56,11 @@ namespace cellular
         virtual bsp::cellular::antenna GetAntenna() = 0;
 
         [[nodiscard]] auto GetCellularDevice() const noexcept -> std::shared_ptr<devices::Device>;
+        [[nodiscard]] auto GetLastCommunicationTimestamp() const noexcept -> TickType_t;
 
     protected:
         bool isInitialized = false;
+        TickType_t lastCommunicationTimestamp;
         std::shared_ptr<drivers::DriverLPUART> driverLPUART;
     };
     namespace cellular

--- a/module-cellular/Modem/TS0710/TS0710.cpp
+++ b/module-cellular/Modem/TS0710/TS0710.cpp
@@ -597,6 +597,12 @@ void TS0710::RegisterCellularDevice(void)
     auto deviceRegistrationMsg = std::make_shared<sys::DeviceRegistrationMessage>(pv_cellular->GetCellularDevice());
     pv_parent->bus.sendUnicast(std::move(deviceRegistrationMsg), service::name::system_manager);
 }
+
+[[nodiscard]] auto TS0710::GetLastCommunicationTimestamp() const noexcept -> TickType_t
+{
+    return pv_cellular->GetLastCommunicationTimestamp();
+}
+
 TS0710::ConfState TS0710::SetupEchoCanceller(EchoCancellerStrength strength)
 {
 

--- a/module-cellular/Modem/TS0710/TS0710.h
+++ b/module-cellular/Modem/TS0710/TS0710.h
@@ -441,6 +441,7 @@ class TS0710
     void EnterSleepMode(void);
     void ExitSleepMode(void);
     void RegisterCellularDevice(void);
+    [[nodiscard]] auto GetLastCommunicationTimestamp() const noexcept -> TickType_t;
 };
 
 #endif //_TS0710_H

--- a/module-services/service-cellular/CellularCall.cpp
+++ b/module-services/service-cellular/CellularCall.cpp
@@ -39,6 +39,9 @@ namespace CellularCall
         if (!call.isValid()) {
             LOG_ERROR("startCallAction failed");
             clear();
+            if (cpuSentinel) {
+                cpuSentinel->ReleaseMinimumFrequency();
+            }
             return false;
         }
 
@@ -60,6 +63,10 @@ namespace CellularCall
         if (!isValid()) {
             LOG_ERROR("Trying to update invalid call");
             return false;
+        }
+
+        if (cpuSentinel) {
+            cpuSentinel->ReleaseMinimumFrequency();
         }
 
         if (isActiveCall) {

--- a/module-services/service-cellular/service-cellular/ServiceCellular.hpp
+++ b/module-services/service-cellular/service-cellular/ServiceCellular.hpp
@@ -55,6 +55,14 @@ namespace packet_data
     class PacketData;
     class PDPContext;
 } // namespace packet_data
+
+namespace constants
+{
+    using namespace std::chrono_literals;
+    inline constexpr std::chrono::milliseconds sleepTimerInterval{500ms};
+    inline constexpr std::chrono::milliseconds enterSleepModeTime{5s};
+} // namespace constants
+
 class ServiceCellular : public sys::Service
 {
 
@@ -171,6 +179,11 @@ class ServiceCellular : public sys::Service
     sys::TimerHandle callStateTimer;
     sys::TimerHandle stateTimer;
     sys::TimerHandle ussdTimer;
+
+    // used to enter modem sleep mode
+    sys::TimerHandle sleepTimer;
+
+    void SleepTimerHandler();
     void CallStateTimerHandler();
     DLC_channel::Callback_t notificationCallback = nullptr;
 


### PR DESCRIPTION
When the GSM modem is idle and there is no communication,
it enters the sleep mode, where the power consumption
is significantly reduced.