### PR TITLE
[EGD-6222] Fix the App Calendar memory leaks

### DIFF
--- a/module-apps/application-calendar/ApplicationCalendar.cpp
+++ b/module-apps/application-calendar/ApplicationCalendar.cpp
@@ -167,14 +167,13 @@ namespace app
             "",
             [=]() -> bool {
                 LOG_DEBUG("Switch to new event window");
-                std::unique_ptr<EventRecordData> eventData = std::make_unique<EventRecordData>();
-                eventData->setDescription(style::window::calendar::new_event);
                 auto event       = std::make_shared<EventsRecord>();
                 event->date_from = dateFilter;
                 event->date_till = dateFilter + std::chrono::hours(utils::time::Locale::max_hour_24H_mode) +
                                    std::chrono::minutes(utils::time::Locale::max_minutes);
-                eventData->setData(event);
 
+                auto eventData = std::make_unique<EventRecordData>(std::move(event));
+                eventData->setDescription(style::window::calendar::new_event);
                 switchWindow(
                     style::window::calendar::name::new_edit_event, gui::ShowMode::GUI_SHOW_INIT, std::move(eventData));
                 return true;

--- a/module-apps/application-calendar/data/CalendarData.hpp
+++ b/module-apps/application-calendar/data/CalendarData.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -18,16 +18,10 @@ class EventRecordData : public gui::SwitchData
     std::shared_ptr<EventsRecord> record;
 
   public:
-    EventRecordData() = default;
-    EventRecordData(std::shared_ptr<EventsRecord> record) : record{std::move(record)} {};
-    virtual ~EventRecordData() = default;
+    explicit EventRecordData(std::shared_ptr<EventsRecord> record) : record{std::move(record)} {};
     std::shared_ptr<EventsRecord> getData()
     {
         return record;
-    };
-    virtual void setData(std::shared_ptr<EventsRecord> rec)
-    {
-        record = std::move(rec);
     };
 };
 

--- a/module-apps/application-calendar/data/dateCommon.hpp
+++ b/module-apps/application-calendar/data/dateCommon.hpp
@@ -246,8 +246,8 @@ inline TimePoint TimePointFromYearMonthDay(const calendar::YearMonthDay &ymd)
 inline time_t TimePointToMin(const TimePoint &tp)
 {
     auto time     = TimePointToTimeT(tp);
-    auto duration = new utils::time::Duration(time);
-    auto minutes  = duration->getMinutes();
+    auto duration = utils::time::Duration(time);
+    auto minutes  = duration.getMinutes();
     return minutes;
 }
 

--- a/module-apps/application-calendar/models/DayEventsModel.cpp
+++ b/module-apps/application-calendar/models/DayEventsModel.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DayEventsModel.hpp"
@@ -70,7 +70,6 @@ auto DayEventsModel::handleQueryResponse(db::QueryResult *queryResult) -> bool
             return false;
         }
 
-        auto records = response->getResult();
         if (auto app = dynamic_cast<app::ApplicationCalendar *>(application); app != nullptr) {
             if (response->getCountResult() == 0) {
                 LOG_DEBUG("Empty records");
@@ -80,6 +79,7 @@ auto DayEventsModel::handleQueryResponse(db::QueryResult *queryResult) -> bool
                 }
             }
             auto eventShift = app->getEventShift();
+            auto records    = response->getResult();
             if (eventShift) {
                 for (auto &record : records) {
                     record.date_from += std::chrono::hours(eventShift);

--- a/module-apps/application-calendar/models/NewEditEventModel.hpp
+++ b/module-apps/application-calendar/models/NewEditEventModel.hpp
@@ -3,51 +3,49 @@
 
 #pragma once
 #include "Application.hpp"
-#include <application-calendar/widgets/CalendarDateItem.hpp>
-#include <application-calendar/widgets/CalendarTimeItem.hpp>
-#include "application-calendar/widgets/CalendarStyle.hpp"
-#include "application-calendar/widgets/TextWithLabelItem.hpp"
-#include "application-calendar/widgets/SeveralOptionsItem.hpp"
 #include "InternalModel.hpp"
 #include <ListItemProvider.hpp>
+#include <application-calendar/widgets/CalendarListItem.hpp>
+#include <application-calendar/data/CalendarData.hpp>
 
 namespace gui
 {
-    class NewEventCheckBoxWithLabel; // fw declaration
-}
+    class TextWithLabelItem;
+    class NewEventCheckBoxWithLabel;
+    class CalendarDateItem;
+    class CalendarTimeItem;
+    class SeveralOptionsItem;
+} // namespace gui
 
 class NewEditEventModel : public app::InternalModel<gui::CalendarListItem *>, public gui::ListItemProvider
 {
     app::Application *application = nullptr;
-    bool mode24H                  = false;
 
+    TimePoint startTimeBuffer;
+    TimePoint endTimeBuffer;
+
+    gui::TextWithLabelItem *eventNameInput              = nullptr;
     gui::NewEventCheckBoxWithLabel *allDayEventCheckBox = nullptr;
-
     gui::CalendarDateItem *dateItem  = nullptr;
     gui::CalendarTimeItem *startTime = nullptr;
     gui::CalendarTimeItem *endTime   = nullptr;
+    gui::SeveralOptionsItem *reminder                   = nullptr;
+    gui::SeveralOptionsItem *repeat                     = nullptr;
 
-    gui::SeveralOptionsItem *reminder      = nullptr;
-    gui::SeveralOptionsItem *repeat        = nullptr;
-    gui::TextWithLabelItem *eventNameInput = nullptr;
+    void createData(bool allDayEvent);
+    void createTimeItems();
+    void eraseTimeItems();
+    void clearData();
 
   public:
-    NewEditEventModel(app::Application *app, bool mode24H = false);
+    explicit NewEditEventModel(app::Application *app);
 
     void loadData(std::shared_ptr<EventsRecord> record);
     void loadRepeat(const std::shared_ptr<EventsRecord> &record);
-    void loadDataWithoutTimeItem();
-    void reloadDataWithTimeItem();
     void saveData(std::shared_ptr<EventsRecord> event, EventAction action);
 
     [[nodiscard]] unsigned int getMinimalItemHeight() const override;
     [[nodiscard]] unsigned int requestRecordsCount() override;
     gui::ListItem *getItem(gui::Order order) override;
     void requestRecords(const uint32_t offset, const uint32_t limit) override;
-
-    uint32_t getRepeatOptionValue();
-    void setRepeatOptionValue(const uint32_t &value);
-
-  private:
-    void createData(bool allDayEvent);
 };

--- a/module-apps/application-calendar/widgets/CalendarTimeItem.cpp
+++ b/module-apps/application-calendar/widgets/CalendarTimeItem.cpp
@@ -14,7 +14,9 @@ namespace gui
     CalendarTimeItem::CalendarTimeItem(const std::string &description,
                                        TimeWidget::Type type,
                                        const std::function<void(const UTF8 &text)> &bottomBarTemporaryMode,
-                                       const std::function<void()> &bottomBarRestoreFromTemporaryMode)
+                                       const std::function<void()> &bottomBarRestoreFromTemporaryMode,
+                                       TimePoint dateFrom,
+                                       TimePoint dateTill)
     {
         setMinimumSize(style::window::default_body_width, date_and_time::height);
         setEdges(RectangleEdge::None);
@@ -24,6 +26,10 @@ namespace gui
         vBox->setEdges(RectangleEdge::None);
 
         timeWidget = new TimeWidget(vBox, description, type, bottomBarTemporaryMode, bottomBarRestoreFromTemporaryMode);
+        timeWidget->loadData(std::chrono::hours(TimePointToHour24H(dateFrom)),
+                             std::chrono::minutes(TimePointToMin(dateFrom)),
+                             std::chrono::hours(TimePointToHour24H(dateTill)),
+                             std::chrono::minutes(TimePointToMin(dateTill)));
 
         onLoadCallback = [&](std::shared_ptr<EventsRecord> event) {
             timeWidget->loadData(std::chrono::hours(TimePointToHour24H(event->date_from)),
@@ -42,6 +48,13 @@ namespace gui
             return false;
         };
         passDefaultCallbacksFromListItem(this, vBox);
+    }
+
+    auto CalendarTimeItem::getFromTillDate() const -> std::shared_ptr<utils::time::FromTillDate>
+    {
+        auto fromTillDate = std::make_shared<utils::time::FromTillDate>();
+        timeWidget->saveData(fromTillDate);
+        return fromTillDate;
     }
 
     void CalendarTimeItem::setConnectionToSecondItem(CalendarTimeItem *item)

--- a/module-apps/application-calendar/widgets/CalendarTimeItem.hpp
+++ b/module-apps/application-calendar/widgets/CalendarTimeItem.hpp
@@ -15,10 +15,13 @@ namespace gui
         CalendarTimeItem(const std::string &description,
                          TimeWidget::Type type,
                          const std::function<void(const UTF8 &text)> &bottomBarTemporaryMode,
-                         const std::function<void()> &bottomBarRestoreFromTemporaryMode);
+                         const std::function<void()> &bottomBarRestoreFromTemporaryMode,
+                         TimePoint dateFrom,
+                         TimePoint dateTill);
 
         void setConnectionToSecondItem(CalendarTimeItem *item);
         void setConnectionToDateItem(CalendarDateItem *item);
+        auto getFromTillDate() const -> std::shared_ptr<utils::time::FromTillDate>;
 
       private:
         TimeWidget *timeWidget = nullptr;

--- a/module-apps/application-calendar/widgets/NewEventCheckBoxWithLabel.hpp
+++ b/module-apps/application-calendar/widgets/NewEventCheckBoxWithLabel.hpp
@@ -3,13 +3,14 @@
 
 #pragma once
 #include "CheckBoxWithLabelItem.hpp"
-#include "application-calendar/models/NewEditEventModel.hpp"
+#include <widgets/DateWidget.hpp>
 
 namespace gui
 {
     class NewEventCheckBoxWithLabel : public CheckBoxWithLabelItem
     {
-        NewEditEventModel *model = nullptr;
+        using OnCheckCallback     = std::function<void(bool)>;
+        OnCheckCallback onCheck   = nullptr;
         app::Application *app    = nullptr;
         gui::DateWidget *dateItem = nullptr;
         void applyCallbacks() override;
@@ -17,10 +18,14 @@ namespace gui
       public:
         NewEventCheckBoxWithLabel(app::Application *application,
                                   const std::string &description,
-                                  NewEditEventModel *model  = nullptr);
-        virtual ~NewEventCheckBoxWithLabel() override = default;
+                                  OnCheckCallback onCheck);
 
         void setConnectionToDateItem(gui::DateWidget *item);
     };
+
+    namespace allDayEvents
+    {
+        bool isAllDayEvent(TimePoint start, TimePoint end);
+    }
 
 } /* namespace gui */

--- a/module-apps/application-calendar/windows/AllEventsWindow.cpp
+++ b/module-apps/application-calendar/windows/AllEventsWindow.cpp
@@ -74,12 +74,6 @@ namespace gui
 
     bool AllEventsWindow::onInput(const gui::InputEvent &inputEvent)
     {
-        if (inputEvent.keyCode == gui::KeyCode::KEY_RF &&
-            inputEvent.state == gui::InputEvent::State::keyReleasedShort) {
-            LOG_DEBUG("Switch to desktop");
-            app::manager::Controller::switchBack(application);
-        }
-
         if (AppWindow::onInput(inputEvent)) {
             return true;
         }
@@ -88,26 +82,18 @@ namespace gui
             return false;
         }
 
-        if (inputEvent.keyCode == gui::KeyCode::KEY_LEFT) {
+        if (inputEvent.is(gui::KeyCode::KEY_LEFT)) {
             LOG_DEBUG("Switch to new event window");
-            std::unique_ptr<EventRecordData> data = std::make_unique<EventRecordData>();
-            data->setDescription(style::window::calendar::new_event);
             auto event       = std::make_shared<EventsRecord>();
             event->date_from = dateFilter;
             event->date_till = dateFilter + std::chrono::hours(utils::time::Locale::max_hour_24H_mode) +
                                std::chrono::minutes(utils::time::Locale::max_minutes);
-            data->setData(event);
+            auto data = std::make_unique<EventRecordData>(std::move(event));
+            data->setDescription(style::window::calendar::new_event);
             application->switchWindow(
                 style::window::calendar::name::new_edit_event, gui::ShowMode::GUI_SHOW_INIT, std::move(data));
             return true;
         }
-
-        if (inputEvent.keyCode == gui::KeyCode::KEY_LF) {
-            application->switchWindow(gui::name::window::main_window);
-            LOG_DEBUG("Switch to month view - main window");
-            return true;
-        }
-
         return false;
     }
 

--- a/module-apps/application-calendar/windows/DayEventsWindow.cpp
+++ b/module-apps/application-calendar/windows/DayEventsWindow.cpp
@@ -95,16 +95,14 @@ namespace gui
             return false;
         }
 
-        if (inputEvent.keyCode == gui::KeyCode::KEY_LEFT) {
+        if (inputEvent.is(gui::KeyCode::KEY_LEFT)) {
             LOG_DEBUG("Switch to new window - edit window");
-            std::unique_ptr<EventRecordData> data = std::make_unique<EventRecordData>();
+            auto event       = std::make_shared<EventsRecord>();
+            event->date_from = filterFrom;
+            event->date_till = filterFrom + std::chrono::hours(utils::time::Locale::max_hour_24H_mode) +
+                               std::chrono::minutes(utils::time::Locale::max_minutes);
+            auto data = std::make_unique<EventRecordData>(std::move(event));
             data->setDescription(style::window::calendar::new_event);
-            auto rec       = new EventsRecord();
-            rec->date_from = filterFrom;
-            rec->date_till = filterFrom + std::chrono::hours(utils::time::Locale::max_hour_24H_mode) +
-                             std::chrono::minutes(utils::time::Locale::max_minutes);
-            auto event = std::make_shared<EventsRecord>(*rec);
-            data->setData(event);
             application->switchWindow(
                 style::window::calendar::name::new_edit_event, gui::ShowMode::GUI_SHOW_INIT, std::move(data));
             return true;

--- a/module-apps/widgets/TimeWidget.cpp
+++ b/module-apps/widgets/TimeWidget.cpp
@@ -209,12 +209,12 @@ namespace gui
         this->dateItem = item;
     }
 
-    bool TimeWidget::isPm(const std::string &text)
+    bool TimeWidget::isPm(const std::string &text) const
     {
         return !(text == timeConstants::before_noon);
     }
 
-    bool TimeWidget::validateHour()
+    bool TimeWidget::validateHour() const
     {
         if (type == Type::End) {
             if (secondItem == nullptr) {
@@ -282,7 +282,7 @@ namespace gui
     void TimeWidget::validateHourFor12hMode(std::chrono::hours start_hour,
                                             std::chrono::minutes end_hour,
                                             uint32_t start_minutes,
-                                            uint32_t end_minutes)
+                                            uint32_t end_minutes) const
     {
         if (start_hour > end_hour || (start_hour == end_hour && start_minutes > end_minutes)) {
             auto hour = start_hour.count() + 1;
@@ -314,7 +314,7 @@ namespace gui
     void TimeWidget::validateHourFor24hMode(std::chrono::hours start_hour,
                                             std::chrono::minutes end_hour,
                                             uint32_t start_minutes,
-                                            uint32_t end_minutes)
+                                            uint32_t end_minutes) const
     {
         if (start_hour > end_hour || (start_hour == end_hour && start_minutes > end_minutes)) {
             auto hour = start_hour.count() + 1;
@@ -417,7 +417,7 @@ namespace gui
         }
     }
 
-    bool TimeWidget::saveData(std::shared_ptr<utils::time::FromTillDate> fromTillDate)
+    bool TimeWidget::saveData(std::shared_ptr<utils::time::FromTillDate> fromTillDate) const
     {
         if (!validateHour()) {
             return false;

--- a/module-apps/widgets/TimeWidget.hpp
+++ b/module-apps/widgets/TimeWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -35,7 +35,7 @@ namespace gui
                       const std::chrono::minutes &minutesFrom,
                       const std::chrono::hours &hoursTill,
                       const std::chrono::minutes &minutesTill);
-        bool saveData(std::shared_ptr<utils::time::FromTillDate> fromTillDate);
+        bool saveData(std::shared_ptr<utils::time::FromTillDate> fromTillDate) const;
         virtual ~TimeWidget() override = default;
 
         void setConnectionToSecondItem(TimeWidget *item);
@@ -63,15 +63,15 @@ namespace gui
         void setTime(int keyValue, Label &item);
         void onInputCallback(Label &timeInput);
         void clearInput(Label &timeInput);
-        bool isPm(const std::string &text);
-        bool validateHour();
+        inline bool isPm(const std::string &text) const;
+        bool validateHour() const;
         void validateHourFor12hMode(std::chrono::hours start_hour,
                                     std::chrono::minutes end_hour,
                                     uint32_t start_minutes,
-                                    uint32_t end_minutes);
+                                    uint32_t end_minutes) const;
         void validateHourFor24hMode(std::chrono::hours start_hour,
                                     std::chrono::minutes end_hour,
                                     uint32_t start_minutes,
-                                    uint32_t end_minutes);
+                                    uint32_t end_minutes) const;
     };
 } /* namespace gui */

--- a/module-services/service-time/timeEvents/CalendarTimeEvents.cpp
+++ b/module-services/service-time/timeEvents/CalendarTimeEvents.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <service-time/CalendarTimeEvents.hpp>
@@ -84,10 +84,9 @@ namespace stm
 
     void CalendarTimeEvents::invokeEvent()
     {
-        std::unique_ptr<EventRecordData> eventData = std::make_unique<EventRecordData>();
-        eventData->setDescription(style::window::calendar::name::event_reminder_window);
         auto event = std::make_shared<EventsRecord>(eventRecord);
-        eventData->setData(event);
+        auto eventData = std::make_unique<EventRecordData>(std::move(event));
+        eventData->setDescription(style::window::calendar::name::event_reminder_window);
 
         app::manager::Controller::sendAction(service(), app::manager::actions::ShowReminder, std::move(eventData));
     }


### PR DESCRIPTION
This PR fixes:
 -several explicit uses of `new` that were not matched by `delete`
 -dangling `CalendarTimeItem`s
 -reset of focus on the `allDayEventCheckBox` check/uncheck
 -exiting the app form `allEventsWindow` on `KEY_RF`