### PR TITLE
[EGD-6190] Fix Bluetooth DMA transmission

### DIFF
--- a/module-bluetooth/Bluetooth/glucode/BluetoothRunLoop.cpp
+++ b/module-bluetooth/Bluetooth/glucode/BluetoothRunLoop.cpp
@@ -137,16 +137,6 @@ namespace bluetooth
     }
     auto RunLoop::process() -> bool
     {
-
-        btstack_data_source_t *ds;
-        btstack_data_source_t *next;
-        for (ds = reinterpret_cast<btstack_data_source_t *>(data_sources); ds != nullptr; ds = next) {
-            next = reinterpret_cast<btstack_data_source_t *>(
-                ds->item.next); // cache pointer to next data_source to allow data source to remove itself
-            if ((ds->flags & DATA_SOURCE_CALLBACK_POLL) != 0) {
-                ds->process(ds, DATA_SOURCE_CALLBACK_POLL);
-            }
-        }
         // process registered function calls on run loop thread
         while (true) {
             function_call_t message = {nullptr, nullptr};

--- a/module-bsp/board/rt1051/bluetooth/BluetoothCommon.cpp
+++ b/module-bsp/board/rt1051/bluetooth/BluetoothCommon.cpp
@@ -174,6 +174,8 @@ BTdev::Error BluetoothCommon::set_baudrate(uint32_t bd)
         LOG_ERROR("BT error: baudrate [%lu] set err: %d", bd, err);
         ret = ErrorBSP;
     }
+    BSP_BLUETOOTH_UART_BASE->FIFO |= LPUART_FIFO_RXFLUSH_MASK; // flush fifo
+    BSP_BLUETOOTH_UART_BASE->FIFO &= ~LPUART_FIFO_RXFE_MASK;   // disable fifo
     return ret;
 }
 


### PR DESCRIPTION
Enabled previously FIFO buffer without proper handling caused
ignoring one byte. Disabling FIFO fixes this issue