### PR TITLE
[EGD-6220] Fix Calllog persistent DB entry

### DIFF
--- a/image/user/db/calllog_002.sql
+++ b/image/user/db/calllog_002.sql
@@ -2,5 +2,5 @@
 -- For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 BEGIN TRANSACTION;
-INSERT OR REPLACE INTO calls ("_id","number","e164number","presentation","date","duration","type","name","contactId","isRead") VALUES (1,'500466048','+48500466048',1,'2020-09-14 11:21:02',0,1,'alek',4,1);
+INSERT OR REPLACE INTO calls ("_id","number","e164number","presentation","date","duration","type","name","contactId","isRead") VALUES (1,'500466048','+48500466048',1,'1616406388',0,1,'alek',4,1);
 COMMIT;


### PR DESCRIPTION
Date entries are stored in DB as `int`s. String version is obsoleted