### PR TITLE
[EGD-6239] Fix Linux Release build on gcc-10

### DIFF
--- a/board/linux/libiosyscalls/src/syscalls_posix_dirent.cpp
+++ b/board/linux/libiosyscalls/src/syscalls_posix_dirent.cpp
@@ -214,7 +214,7 @@ extern "C"
                 entry->d_ino    = stdata.st_ino;
                 entry->d_type   = S_ISREG(stdata.st_mode) ? DT_REG : DT_DIR;
                 entry->d_reclen = fname.size();
-                std::strncpy(entry->d_name, fname.c_str(), sizeof(entry->d_name));
+                std::strncpy(entry->d_name, fname.c_str(), sizeof(entry->d_name) - 1);
                 *result = entry;
                 return 0;
             }

--- a/module-bsp/board/linux/battery-charger/battery_charger.cpp
+++ b/module-bsp/board/linux/battery-charger/battery_charger.cpp
@@ -40,7 +40,7 @@ namespace bsp::battery_charger
             // Open FIFO for write only
             int fd = open(batteryFIFO, O_RDONLY | O_NONBLOCK);
 
-            xQueueHandle targetQueueHandle;
+            xQueueHandle targetQueueHandle = nullptr;
 
             while (true) {
                 std::uint8_t buff[fifoBuffSize];

--- a/module-services/service-evtmgr/battery-level-check/BatteryLevelCheck.cpp
+++ b/module-services/service-evtmgr/battery-level-check/BatteryLevelCheck.cpp
@@ -7,6 +7,8 @@
 #include <agents/settings/SystemSettings.hpp>
 #include <common_data/EventStore.hpp>
 #include <Utils.hpp>
+
+#define BOOST_SML_CFG_DISABLE_MIN_SIZE // GCC10 fix
 #include <module-utils/sml/include/boost/sml.hpp>
 
 namespace battery_level_check


### PR DESCRIPTION
strncpy() was provided with size equal to a buffer size, not leaving
buffer space for a trailing zero.