### PR TITLE
[EGD-6304] Popup overall fixes

### DIFF
--- a/module-apps/application-meditation/windows/MeditationTimerWindow.cpp
+++ b/module-apps/application-meditation/windows/MeditationTimerWindow.cpp
@@ -59,27 +59,28 @@ void MeditationTimerWindow::destroyInterface()
 void MeditationTimerWindow::onBeforeShow(ShowMode mode, SwitchData *data)
 {
     auto timerData = dynamic_cast<MeditationTimerData *>(data);
-    assert(timerData);
-    setVisiblePreparation();
-    meditationTime = timerData->getMeditationTime();
-    meditationIntervalPeriod = timerData->getMeditationIntervals();
+    if (timerData != nullptr) {
+        setVisiblePreparation();
+        meditationTime           = timerData->getMeditationTime();
+        meditationIntervalPeriod = timerData->getMeditationIntervals();
 
-    auto onPreparation = [&]() -> void {
-        setVisibleRunning();
-        auto onMeditationEnd = [&]() -> void {
-            setVisibleMeditationEnd();
+        auto onPreparation = [&]() -> void {
+            setVisibleRunning();
+            auto onMeditationEnd = [&]() -> void {
+                setVisibleMeditationEnd();
+                application->refreshWindow(RefreshModes::GUI_REFRESH_FAST);
+            };
+            timer->registerTimeoutCallback(onMeditationEnd);
+            timer->reset(meditationTime, meditationIntervalPeriod);
+            timer->start();
             application->refreshWindow(RefreshModes::GUI_REFRESH_FAST);
         };
-        timer->registerTimeoutCallback(onMeditationEnd);
-        timer->reset(meditationTime, meditationIntervalPeriod);
-        timer->start();
-        application->refreshWindow(RefreshModes::GUI_REFRESH_FAST);
-    };
 
-    timer->registerTimeoutCallback(onPreparation);
-    timer->setCounterVisible(timerData->isCounterEnabled());
-    timer->reset(timerData->getPreparationTime());
-    timer->start();
+        timer->registerTimeoutCallback(onPreparation);
+        timer->setCounterVisible(timerData->isCounterEnabled());
+        timer->reset(timerData->getPreparationTime());
+        timer->start();
+    }
 }
 
 auto MeditationTimerWindow::onInput(const InputEvent &inputEvent) -> bool

--- a/module-audio/Audio/Audio.cpp
+++ b/module-audio/Audio/Audio.cpp
@@ -124,6 +124,7 @@ namespace audio
             LOG_ERROR("Operation STOP failure: %s", audio::str(retStop).c_str());
         }
 
+        muted    = Muted::False;
         auto ret = Operation::Create(Operation::Type::Idle);
         if (ret) {
             currentState     = State::Idle;
@@ -154,6 +155,7 @@ namespace audio
 
     audio::RetCode Audio::Mute()
     {
+        muted = Muted::True;
         return SetOutputVolume(0);
     }
 

--- a/module-audio/Audio/Audio.hpp
+++ b/module-audio/Audio/Audio.hpp
@@ -19,6 +19,12 @@ namespace audio
 
     class Audio
     {
+        enum class Muted : bool
+        {
+            True,
+            False
+        };
+
       public:
         enum class State
         {
@@ -59,6 +65,11 @@ namespace audio
         Gain GetInputGain()
         {
             return currentOperation->GetInputGain();
+        }
+
+        [[nodiscard]] auto IsMuted() const noexcept
+        {
+            return muted == Muted::True;
         }
 
         const Operation &GetCurrentOperation() const
@@ -103,6 +114,7 @@ namespace audio
       private:
         void UpdateProfiles();
 
+        Muted muted = Muted::False;
         AudioSinkState audioSinkState;
 
         std::shared_ptr<BluetoothStreamData> btData;

--- a/module-services/service-audio/service-audio/AudioMessage.hpp
+++ b/module-services/service-audio/service-audio/AudioMessage.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -262,14 +262,19 @@ class AudioKeyPressedRequest : public AudioMessage
 class AudioKeyPressedResponse : public sys::DataMessage
 {
   public:
+    enum class ShowPopup : bool
+    {
+        True,
+        False
+    };
     AudioKeyPressedResponse(audio::RetCode retCode,
                             const audio::Volume &volume,
-                            const bool muted,
+                            const ShowPopup showPopup,
                             const std::pair<audio::Profile::Type, audio::PlaybackType> &context)
-        : sys::DataMessage(MessageType::AudioMessage), volume(volume), muted(muted), context(context)
+        : sys::DataMessage(MessageType::AudioMessage), volume(volume), showPopup(showPopup), context(context)
     {}
 
     const audio::Volume volume{};
-    const bool muted = false;
+    const ShowPopup showPopup = ShowPopup::False;
     std::pair<audio::Profile::Type, audio::PlaybackType> context;
 };

--- a/module-services/service-audio/service-audio/ServiceAudio.hpp
+++ b/module-services/service-audio/service-audio/ServiceAudio.hpp
@@ -72,8 +72,6 @@ class ServiceAudio : public sys::Service
                      const std::string                       = "",
                      const audio::PlaybackType &playbackType = audio::PlaybackType::None)
         -> std::unique_ptr<AudioResponseMessage>;
-    auto HandleStop(const std::vector<audio::PlaybackType> &stopTypes, const audio::Token &token, bool &muted)
-        -> std::unique_ptr<AudioResponseMessage>;
     auto HandleStop(const std::vector<audio::PlaybackType> &stopTypes, const audio::Token &token)
         -> std::unique_ptr<AudioResponseMessage>;
     auto HandleSendEvent(std::shared_ptr<audio::Event> evt) -> std::unique_ptr<AudioResponseMessage>;
@@ -84,6 +82,7 @@ class ServiceAudio : public sys::Service
     void HandleNotification(const AudioNotificationMessage::Type &type, const audio::Token &token);
     auto HandleKeyPressed(const int step) -> std::unique_ptr<AudioKeyPressedResponse>;
     void HandlePhoneModeChange(sys::phone_modes::PhoneMode phoneMode, sys::phone_modes::Tethering tetheringMode);
+    void MuteCurrentOperation();
     void VibrationUpdate(const audio::PlaybackType &type               = audio::PlaybackType::None,
                          std::optional<audio::AudioMux::Input *> input = std::nullopt);
     auto GetVibrationType(const audio::PlaybackType &type) -> VibrationType;


### PR DESCRIPTION
Removed duplicated mode observer from application
that was introduced during the rebase in this commit
21efa6425052de570c49ba12442e49a8f481363b.
Fixed mute logic according to the design.
Fixed switching back to the meditation window.