### PR TITLE
[EGD-6308] Add block CPU frequency decreasing for connected USB

### DIFF
--- a/module-services/service-desktop/service-desktop/WorkerDesktop.hpp
+++ b/module-services/service-desktop/service-desktop/WorkerDesktop.hpp
@@ -8,6 +8,7 @@
 #include "Service/Message.hpp"
 #include "Service/Service.hpp"
 #include "Service/Worker.hpp"
+#include "Service/CpuSentinel.hpp"
 #include "parser/ParserFSM.hpp"
 #include "endpoints/EndpointFactory.hpp"
 #include "bsp/usb/usb.hpp"
@@ -68,4 +69,6 @@ class WorkerDesktop : public sys::Worker, public bsp::USBDeviceListener
     const sdesktop::USBSecurityModel &securityModel;
     sys::Service *ownerService = nullptr;
     parserFSM::StateMachine parser;
+
+    std::shared_ptr<sys::CpuSentinel> cpuSentinel;
 };


### PR DESCRIPTION
While the USB cable is connected, the battery charging works,
so in this case energy saving is not critical
and for a more stable transmission, we block decreasing
the CPU frequency below 132 MHz.