### PR TITLE
[EGD-6314] phone mode widget visibility

### DIFF
--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -38,8 +38,7 @@ namespace app
                                          Indicator::Time,
                                          Indicator::Battery,
                                          Indicator::SimCard,
-                                         Indicator::NetworkAccessTechnology,
-                                         Indicator::PhoneMode});
+                                         Indicator::NetworkAccessTechnology});
         addActionReceiver(manager::actions::Call, [this](auto &&data) {
             switchWindow(window::name_call, std::forward<decltype(data)>(data));
             return actionHandled();

--- a/module-apps/application-call/windows/EmergencyCallWindow.cpp
+++ b/module-apps/application-call/windows/EmergencyCallWindow.cpp
@@ -27,6 +27,13 @@ namespace gui
         numberDescriptionLabel->setText(utils::localize.get("app_call_emergency_text"));
     }
 
+    top_bar::Configuration EmergencyCallWindow::configureTopBar(top_bar::Configuration appConfiguration)
+    {
+        appConfiguration.disable(top_bar::Indicator::NetworkAccessTechnology);
+        appConfiguration.enable(top_bar::Indicator::PhoneMode);
+        return appConfiguration;
+    }
+
     bool EmergencyCallWindow::onInput(const InputEvent &inputEvent)
     {
         if (inputEvent.isShortPress()) {

--- a/module-apps/application-call/windows/EmergencyCallWindow.hpp
+++ b/module-apps/application-call/windows/EmergencyCallWindow.hpp
@@ -17,6 +17,7 @@ namespace gui
         bool onInput(const InputEvent &inputEvent) override;
 
         void buildInterface() override;
+        top_bar::Configuration configureTopBar(top_bar::Configuration appConfiguration) override;
     };
 
 } /* namespace gui */

--- a/module-apps/application-call/windows/EnterNumberWindow.cpp
+++ b/module-apps/application-call/windows/EnterNumberWindow.cpp
@@ -42,6 +42,13 @@ namespace gui
         setFocusItem(newContactIcon);
     }
 
+    top_bar::Configuration EnterNumberWindow::configureTopBar(top_bar::Configuration appConfiguration)
+    {
+        appConfiguration.enable(top_bar::Indicator::PhoneMode);
+        appConfiguration.disable(top_bar::Indicator::NetworkAccessTechnology);
+        return appConfiguration;
+    }
+
     bool EnterNumberWindow::addNewContact()
     {
         interface->handleAddContactEvent(enteredNumber);

--- a/module-apps/application-call/windows/EnterNumberWindow.hpp
+++ b/module-apps/application-call/windows/EnterNumberWindow.hpp
@@ -22,6 +22,8 @@ namespace gui
 
         void buildInterface() override;
 
+        top_bar::Configuration configureTopBar(top_bar::Configuration appConfiguration) override;
+
         auto addNewContact() -> bool;
     };
 

--- a/module-apps/application-desktop/ApplicationDesktop.cpp
+++ b/module-apps/application-desktop/ApplicationDesktop.cpp
@@ -49,8 +49,7 @@ namespace app
                                          Indicator::Time,
                                          Indicator::Battery,
                                          Indicator::SimCard,
-                                         Indicator::NetworkAccessTechnology,
-                                         Indicator::PhoneMode});
+                                         Indicator::NetworkAccessTechnology});
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
 
         addActionReceiver(app::manager::actions::RequestPin, [this](auto &&data) {

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -75,6 +75,8 @@ namespace gui
         auto app            = getAppDesktop();
         const auto isLocked = app->lockHandler.isScreenLocked();
         appConfiguration.setIndicator(top_bar::Indicator::Lock, isLocked);
+        appConfiguration.disable(top_bar::Indicator::NetworkAccessTechnology);
+        appConfiguration.enable(top_bar::Indicator::PhoneMode);
         return appConfiguration;
     }
 

--- a/module-apps/application-onboarding/ApplicationOnBoarding.cpp
+++ b/module-apps/application-onboarding/ApplicationOnBoarding.cpp
@@ -37,8 +37,7 @@ namespace app
                                          Indicator::Time,
                                          Indicator::Battery,
                                          Indicator::SimCard,
-                                         Indicator::NetworkAccessTechnology,
-                                         Indicator::PhoneMode});
+                                         Indicator::NetworkAccessTechnology});
 
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
     }

--- a/module-gui/gui/widgets/TopBar.cpp
+++ b/module-gui/gui/widgets/TopBar.cpp
@@ -151,9 +151,12 @@ namespace gui::top_bar
         }
 
         // phone mode and NAT are mutually exclusive.
+        if (config.isEnabled(Indicator::NetworkAccessTechnology)) {
+            config.disable(Indicator::PhoneMode);
+        }
+
         if (config.isEnabled(Indicator::PhoneMode)) {
             phoneMode->setPhoneMode(config.getPhoneMode());
-            config.disable(Indicator::NetworkAccessTechnology);
         }
 
         using namespace utils::time;


### PR DESCRIPTION
Phone mode widget will be visible only on main screen, while entering
numbers and emergency mode. Also it will be disabled whenever NAT
widget is enabled.