### PR TITLE
[EGD-6338] Fix NAT widget visibility

### DIFF
--- a/module-apps/application-calendar/windows/EventReminderWindow.cpp
+++ b/module-apps/application-calendar/windows/EventReminderWindow.cpp
@@ -44,11 +44,7 @@ namespace gui
     top_bar::Configuration EventReminderWindow::configureTopBar(top_bar::Configuration appConfiguration)
     {
         using namespace top_bar;
-        appConfiguration.enable({Indicator::Signal,
-                                 Indicator::Time,
-                                 Indicator::Battery,
-                                 Indicator::SimCard,
-                                 Indicator::NetworkAccessTechnology});
+        appConfiguration.enable({Indicator::Signal, Indicator::Time, Indicator::Battery, Indicator::SimCard});
         return appConfiguration;
     }
 

--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -37,11 +37,7 @@ namespace app
         : Application(name, parent, mode, startInBackground, app::call_stack_size)
     {
         using namespace gui::top_bar;
-        topBarManager->enableIndicators({Indicator::Signal,
-                                         Indicator::Time,
-                                         Indicator::Battery,
-                                         Indicator::SimCard,
-                                         Indicator::NetworkAccessTechnology});
+        topBarManager->enableIndicators({Indicator::Signal, Indicator::Time, Indicator::Battery, Indicator::SimCard});
         addActionReceiver(manager::actions::Call, [this](auto &&data) {
             switchWindow(window::name_call, std::forward<decltype(data)>(data));
             return actionHandled();

--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -154,6 +154,12 @@ namespace gui
         erase();
     }
 
+    top_bar::Configuration CallWindow::configureTopBar(top_bar::Configuration appConfiguration)
+    {
+        appConfiguration.enable(top_bar::Indicator::NetworkAccessTechnology);
+        return appConfiguration;
+    }
+
     void CallWindow::setState(State state)
     {
         auto prevState = getState();

--- a/module-apps/application-call/windows/CallWindow.hpp
+++ b/module-apps/application-call/windows/CallWindow.hpp
@@ -70,6 +70,8 @@ namespace gui
         void rebuild() override;
         void buildInterface() override;
         void destroyInterface() override;
+        top_bar::Configuration configureTopBar(top_bar::Configuration appConfiguration) override;
+
         bool handleDigit(const uint32_t digit);
         void connectTimerOnExit();
         void runCallTimer();

--- a/module-apps/application-call/windows/EmergencyCallWindow.cpp
+++ b/module-apps/application-call/windows/EmergencyCallWindow.cpp
@@ -29,7 +29,6 @@ namespace gui
 
     top_bar::Configuration EmergencyCallWindow::configureTopBar(top_bar::Configuration appConfiguration)
     {
-        appConfiguration.disable(top_bar::Indicator::NetworkAccessTechnology);
         appConfiguration.enable(top_bar::Indicator::PhoneMode);
         return appConfiguration;
     }

--- a/module-apps/application-call/windows/EnterNumberWindow.cpp
+++ b/module-apps/application-call/windows/EnterNumberWindow.cpp
@@ -45,7 +45,6 @@ namespace gui
     top_bar::Configuration EnterNumberWindow::configureTopBar(top_bar::Configuration appConfiguration)
     {
         appConfiguration.enable(top_bar::Indicator::PhoneMode);
-        appConfiguration.disable(top_bar::Indicator::NetworkAccessTechnology);
         return appConfiguration;
     }
 

--- a/module-apps/application-desktop/ApplicationDesktop.cpp
+++ b/module-apps/application-desktop/ApplicationDesktop.cpp
@@ -48,11 +48,7 @@ namespace app
           lockHandler(this), dbNotificationHandler(this)
     {
         using namespace gui::top_bar;
-        topBarManager->enableIndicators({Indicator::Signal,
-                                         Indicator::Time,
-                                         Indicator::Battery,
-                                         Indicator::SimCard,
-                                         Indicator::NetworkAccessTechnology});
+        topBarManager->enableIndicators({Indicator::Signal, Indicator::Time, Indicator::Battery, Indicator::SimCard});
         topBarManager->set(Indicator::SimCard,
                            std::make_shared<SIMConfiguration>(SIMConfiguration::DisplayMode::OnlyInactiveState));
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);

--- a/module-apps/application-desktop/windows/PostUpdateWindow.cpp
+++ b/module-apps/application-desktop/windows/PostUpdateWindow.cpp
@@ -60,7 +60,6 @@ top_bar::Configuration PostUpdateWindow::configureTopBar(top_bar::Configuration 
     appConfiguration.enable(top_bar::Indicator::Time);
     appConfiguration.disable(top_bar::Indicator::Lock);
     appConfiguration.disable(top_bar::Indicator::Battery);
-    appConfiguration.disable(top_bar::Indicator::NetworkAccessTechnology);
     appConfiguration.disable(top_bar::Indicator::Signal);
     appConfiguration.disable(top_bar::Indicator::SimCard);
     return appConfiguration;

--- a/module-apps/application-desktop/windows/UpdateProgress.cpp
+++ b/module-apps/application-desktop/windows/UpdateProgress.cpp
@@ -73,7 +73,6 @@ namespace gui
         appConfiguration.enable(top_bar::Indicator::Time);
         appConfiguration.disable(top_bar::Indicator::Lock);
         appConfiguration.disable(top_bar::Indicator::Battery);
-        appConfiguration.disable(top_bar::Indicator::NetworkAccessTechnology);
         appConfiguration.disable(top_bar::Indicator::Signal);
         appConfiguration.disable(top_bar::Indicator::SimCard);
         return appConfiguration;

--- a/module-apps/application-onboarding/ApplicationOnBoarding.cpp
+++ b/module-apps/application-onboarding/ApplicationOnBoarding.cpp
@@ -38,11 +38,7 @@ namespace app
         : Application(std::move(name), std::move(parent), mode, startInBackground, OnBoardingStackSize)
     {
         using namespace gui::top_bar;
-        topBarManager->enableIndicators({Indicator::Signal,
-                                         Indicator::Time,
-                                         Indicator::Battery,
-                                         Indicator::SimCard,
-                                         Indicator::NetworkAccessTechnology});
+        topBarManager->enableIndicators({Indicator::Signal, Indicator::Time, Indicator::Battery, Indicator::SimCard});
 
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
         bus.channels.push_back(sys::BusChannel::PhoneLockChanges);

--- a/module-apps/popups/PowerOffWindow.cpp
+++ b/module-apps/popups/PowerOffWindow.cpp
@@ -19,7 +19,6 @@ namespace gui
         appConfiguration.enable(top_bar::Indicator::Time);
         appConfiguration.disable(top_bar::Indicator::Lock);
         appConfiguration.disable(top_bar::Indicator::Battery);
-        appConfiguration.disable(top_bar::Indicator::NetworkAccessTechnology);
         appConfiguration.disable(top_bar::Indicator::Signal);
         appConfiguration.disable(top_bar::Indicator::SimCard);
         return appConfiguration;

--- a/module-gui/gui/widgets/TopBar.cpp
+++ b/module-gui/gui/widgets/TopBar.cpp
@@ -22,9 +22,9 @@ namespace gui::top_bar
 {
     using namespace style::header::status_bar;
 
-    constexpr auto batteryWidgetAsText = true;
+    constexpr auto batteryWidgetAsText = false;
     using BatteryType                  = std::conditional<batteryWidgetAsText, BatteryText, BatteryBar>::type;
-    constexpr auto signalWidgetAsText  = true;
+    constexpr auto signalWidgetAsText  = false;
     using SignalType = std::conditional<signalWidgetAsText, SignalStrengthText, SignalStrengthBar>::type;
     constexpr auto simWidgetInDevelopersMode = false;
     using SimType = std::conditional<simWidgetInDevelopersMode, SIMDevelopersMode, SIM>::type;


### PR DESCRIPTION
Make sure that NAT (Network Access Technology) widget is visible on top
bar ONLY during call.