### PR TITLE
[EGD-6341] Fix battery critical level

### DIFF
--- a/module-services/service-evtmgr/battery-level-check/BatteryLevelCheck.cpp
+++ b/module-services/service-evtmgr/battery-level-check/BatteryLevelCheck.cpp
@@ -15,7 +15,7 @@ namespace battery_level_check
 {
     namespace
     {
-        unsigned int batteryLevelCritical = 0;
+        unsigned int batteryLevelCritical = 10;
 
         constexpr auto batteryShutdownLevel = 5;
 


### PR DESCRIPTION
Critical level is set to
default instead of zero
before DB query