### PR TITLE
[EGD-6281] Fix microphone mute

### DIFF
--- a/module-audio/Audio/Operation/RouterOperation.cpp
+++ b/module-audio/Audio/Operation/RouterOperation.cpp
@@ -82,7 +82,9 @@ namespace audio
 
         // enable audio connections
         inputConnection->enable();
-        outputConnection->enable();
+        if (!IsMuted()) {
+            outputConnection->enable();
+        }
 
         return audio::RetCode::Success;
     }
@@ -152,10 +154,10 @@ namespace audio
             SwitchToPriorityProfile();
             break;
         case EventType::CallMute:
-            Mute(true);
+            Mute();
             break;
         case EventType::CallUnmute:
-            Mute(false);
+            Unmute();
             break;
         default:
             return RetCode::UnsupportedEvent;
@@ -203,15 +205,21 @@ namespace audio
         return RetCode::Success;
     }
 
-    bool RouterOperation::Mute(bool enable)
+    void RouterOperation::Mute()
     {
-        if (enable == true) {
-            outputConnection->disable();
-        }
-        else {
-            outputConnection->enable();
-        }
-        return true;
+        outputConnection->disable();
+        mute = Mute::Enabled;
+    }
+
+    void RouterOperation::Unmute()
+    {
+        outputConnection->enable();
+        mute = Mute::Disabled;
+    }
+
+    auto RouterOperation::IsMuted() const noexcept -> bool
+    {
+        return mute == RouterOperation::Mute::Enabled;
     }
 
     Position RouterOperation::GetPosition()

--- a/module-audio/Audio/Operation/RouterOperation.hpp
+++ b/module-audio/Audio/Operation/RouterOperation.hpp
@@ -27,6 +27,11 @@ namespace audio
         using AudioCallback =
             std::function<std::int32_t(const void *inputBuffer, void *outputBuffer, unsigned long framesPerBuffer)>;
         static const std::size_t INPUT_BUFFER_START_SIZE = 1024;
+        enum class Mute : bool
+        {
+            Enabled,
+            Disabled
+        };
 
       public:
         RouterOperation(const char *file, AudioServiceMessage::Callback callback);
@@ -48,8 +53,11 @@ namespace audio
         static constexpr auto maximumBlockSize = 64U;
         static constexpr Endpoint::Capabilities routerCapabilities{.minBlockSize = minimumBlockSize,
                                                                    .maxBlockSize = maximumBlockSize};
+        Mute mute = Mute::Disabled;
 
-        bool Mute(bool enable);
+        void Mute();
+        void Unmute();
+        [[nodiscard]] auto IsMuted() const noexcept -> bool;
 
         std::unique_ptr<Stream> dataStreamOut;
         std::unique_ptr<Stream> dataStreamIn;


### PR DESCRIPTION
Fix microphone mute during the phone call.
Previously phone would unmute on:
- connecting/disconnecting a jack
- turning loudspeaker on/off
- switching to the bt device.