### PR TITLE
[EGD-4651] Fix CrashDump submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -83,4 +83,4 @@
 	shallow = true
 [submodule "module-utils/CrashDebug"]
 	path = module-utils/CrashDebug
-	url = git@github.com:adamgreen/CrashDebug.git
+	url = https://github.com/adamgreen/CrashDebug.git


### PR DESCRIPTION
git:protocol requires proper credential, prevents some script to be run
correctly