### PR TITLE
[EGD-6347] Refactored phone modes handling in applications

### DIFF
--- a/module-apps/Application.hpp
+++ b/module-apps/Application.hpp
@@ -48,6 +48,7 @@ namespace gui
 namespace gui
 {
     class Item;
+    class PopupRequestParams;
 }
 namespace gui
 {
@@ -188,6 +189,7 @@ namespace app
 
         Application(std::string name,
                     std::string parent                  = "",
+                    sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                     StartInBackground startInBackground = {false},
                     uint32_t stackDepth                 = 4096,
                     sys::ServicePriority priority       = sys::ServicePriority::Idle);
@@ -326,7 +328,7 @@ namespace app
         /// Handle the change of phone mode and tethering mode
         /// @param mode new phone mode
         /// @param tethering new tethering mode
-        void handlePhoneModeChanged(sys::phone_modes::PhoneMode mode, sys::phone_modes::Tethering tethering);
+        void handlePhoneModeChanged(sys::phone_modes::PhoneMode mode);
 
         /// @ingrup AppWindowStack
         WindowsStack windowsStack;
@@ -334,6 +336,7 @@ namespace app
 
         /// Method used to attach popups windows to application
         void attachPopups(const std::vector<gui::popup::ID> &popupsList);
+        void showPopup(gui::popup::ID id, const gui::PopupRequestParams *params);
         void abortPopup(gui::popup::ID id);
 
       public:
@@ -391,7 +394,7 @@ namespace app
 
         /// application's settings
         std::unique_ptr<settings::Settings> settings;
-        std::unique_ptr<sys::phone_modes::Observer> phoneModeObserver;
+        sys::phone_modes::PhoneMode phoneMode;
 
       public:
         void setLockScreenPasscodeOn(bool screenPasscodeOn) noexcept;
@@ -414,21 +417,5 @@ namespace app
 
       private:
         ApplicationName targetAppName;
-    };
-
-    class PopupRequestParams : public manager::actions::ActionParams
-    {
-      public:
-        explicit PopupRequestParams(gui::popup::ID popupId)
-            : manager::actions::ActionParams{"Popup request parameters"}, popupId{popupId}
-        {}
-
-        [[nodiscard]] auto getPopupId() const noexcept
-        {
-            return popupId;
-        }
-
-      private:
-        gui::popup::ID popupId;
     };
 } /* namespace app */

--- a/module-apps/ApplicationLauncher.hpp
+++ b/module-apps/ApplicationLauncher.hpp
@@ -65,12 +65,12 @@ namespace app
             return (preventAutoLocking == PreventAutoLocking::True);
         }
 
-        virtual bool run(sys::Service *caller = nullptr)
+        virtual bool run(sys::phone_modes::PhoneMode mode, sys::Service *caller = nullptr)
         {
             return false;
         }
 
-        virtual bool runBackground(sys::Service *caller = nullptr)
+        virtual bool runBackground(sys::phone_modes::PhoneMode mode, sys::Service *caller = nullptr)
         {
             return false;
         }
@@ -89,17 +89,17 @@ namespace app
             : ApplicationLauncher(name, std::move(manifest), isCloseable, preventBlocking)
         {}
 
-        bool run(sys::Service *caller) override
+        bool run(sys::phone_modes::PhoneMode mode, sys::Service *caller) override
         {
             parent = (caller == nullptr ? "" : caller->GetName());
-            handle = std::make_shared<T>(name, parent);
+            handle = std::make_shared<T>(name, parent, mode);
             return sys::SystemManager::RunApplication(handle, caller);
         }
 
-        bool runBackground(sys::Service *caller) override
+        bool runBackground(sys::phone_modes::PhoneMode mode, sys::Service *caller) override
         {
             parent = (caller == nullptr ? "" : caller->GetName());
-            handle = std::make_shared<T>(name, parent, true);
+            handle = std::make_shared<T>(name, parent, mode, true);
             return sys::SystemManager::RunApplication(handle, caller);
         }
     };

--- a/module-apps/application-alarm-clock/ApplicationAlarmClock.cpp
+++ b/module-apps/application-alarm-clock/ApplicationAlarmClock.cpp
@@ -19,9 +19,10 @@ namespace app
 
     ApplicationAlarmClock::ApplicationAlarmClock(std::string name,
                                                  std::string parent,
+                                                 sys::phone_modes::PhoneMode mode,
                                                  uint32_t stackDepth,
                                                  sys::ServicePriority priority)
-        : Application(name, parent, false, stackDepth, priority)
+        : Application(name, parent, mode, false, stackDepth, priority)
     {
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
     }

--- a/module-apps/application-alarm-clock/ApplicationAlarmClock.hpp
+++ b/module-apps/application-alarm-clock/ApplicationAlarmClock.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -14,8 +14,9 @@ namespace app
       public:
         ApplicationAlarmClock(std::string name,
                               std::string parent,
-                              uint32_t stackDepth           = 4096,
-                              sys::ServicePriority priority = sys::ServicePriority::Idle);
+                              sys::phone_modes::PhoneMode mode = sys::phone_modes::PhoneMode::Connected,
+                              uint32_t stackDepth              = 4096,
+                              sys::ServicePriority priority    = sys::ServicePriority::Idle);
 
         sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;
 
@@ -36,7 +37,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch}};
+            return {{manager::actions::Launch, manager::actions::PhoneModeChanged}};
         }
     };
 } // namespace app

--- a/module-apps/application-antenna/ApplicationAntenna.cpp
+++ b/module-apps/application-antenna/ApplicationAntenna.cpp
@@ -36,8 +36,11 @@ namespace app
 
     inline constexpr auto antennaApplicationStackSize = 1024 * 3;
 
-    ApplicationAntenna::ApplicationAntenna(std::string name, std::string parent, StartInBackground startInBackground)
-        : Application(name, parent, startInBackground, antennaApplicationStackSize)
+    ApplicationAntenna::ApplicationAntenna(std::string name,
+                                           std::string parent,
+                                           sys::phone_modes::PhoneMode mode,
+                                           StartInBackground startInBackground)
+        : Application(name, parent, mode, startInBackground, antennaApplicationStackSize)
     {
         bus.channels.push_back(sys::BusChannel::AntennaNotifications);
         appTimer = sys::TimerFactory::createPeriodicTimer(

--- a/module-apps/application-antenna/ApplicationAntenna.hpp
+++ b/module-apps/application-antenna/ApplicationAntenna.hpp
@@ -40,6 +40,7 @@ namespace app
       public:
         ApplicationAntenna(std::string name                    = name_antenna,
                            std::string parent                  = {},
+                           sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                            StartInBackground startInBackground = {false});
         virtual ~ApplicationAntenna();
 
@@ -73,7 +74,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch}};
+            return {{manager::actions::Launch, manager::actions::PhoneModeChanged}};
         }
     };
 } /* namespace app */

--- a/module-apps/application-calculator/ApplicationCalculator.cpp
+++ b/module-apps/application-calculator/ApplicationCalculator.cpp
@@ -9,8 +9,9 @@ namespace app
 {
     ApplicationCalculator::ApplicationCalculator(std::string name,
                                                  std::string parent,
+                                                 sys::phone_modes::PhoneMode mode,
                                                  StartInBackground startInBackground)
-        : Application(name, parent, startInBackground, stack_size)
+        : Application(name, parent, mode, startInBackground, stack_size)
     {}
 
     sys::MessagePointer ApplicationCalculator::DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp)

--- a/module-apps/application-calculator/ApplicationCalculator.hpp
+++ b/module-apps/application-calculator/ApplicationCalculator.hpp
@@ -15,6 +15,7 @@ namespace app
       public:
         ApplicationCalculator(std::string name                    = name_calculator,
                               std::string parent                  = {},
+                              sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                               StartInBackground startInBackground = {false});
         ~ApplicationCalculator() override = default;
 
@@ -35,7 +36,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch}};
+            return {{manager::actions::Launch, manager::actions::PhoneModeChanged}};
         }
     };
 } /* namespace app */

--- a/module-apps/application-calendar/ApplicationCalendar.cpp
+++ b/module-apps/application-calendar/ApplicationCalendar.cpp
@@ -44,10 +44,11 @@ namespace app
 
     ApplicationCalendar::ApplicationCalendar(std::string name,
                                              std::string parent,
+                                             sys::phone_modes::PhoneMode mode,
                                              StartInBackground startInBackground,
                                              uint32_t stackDepth,
                                              sys::ServicePriority priority)
-        : Application(name, parent, startInBackground, stackDepth, priority)
+        : Application(name, parent, mode, startInBackground, stackDepth, priority)
     {
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
         addActionReceiver(manager::actions::ShowReminder, [this](auto &&data) {

--- a/module-apps/application-calendar/ApplicationCalendar.hpp
+++ b/module-apps/application-calendar/ApplicationCalendar.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -25,6 +25,7 @@ namespace app
       public:
         ApplicationCalendar(std::string name,
                             std::string parent,
+                            sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                             StartInBackground startInBackground = {false},
                             uint32_t stackDepth                 = 8192,
                             sys::ServicePriority priority       = sys::ServicePriority::Idle);
@@ -65,7 +66,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch, manager::actions::ShowReminder}};
+            return {{manager::actions::Launch, manager::actions::ShowReminder, manager::actions::PhoneModeChanged}};
         }
     };
 } /* namespace app */

--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -30,8 +30,11 @@
 
 namespace app
 {
-    ApplicationCall::ApplicationCall(std::string name, std::string parent, StartInBackground startInBackground)
-        : Application(name, parent, startInBackground, app::call_stack_size)
+    ApplicationCall::ApplicationCall(std::string name,
+                                     std::string parent,
+                                     sys::phone_modes::PhoneMode mode,
+                                     StartInBackground startInBackground)
+        : Application(name, parent, mode, startInBackground, app::call_stack_size)
     {
         using namespace gui::top_bar;
         topBarManager->enableIndicators({Indicator::Signal,

--- a/module-apps/application-call/ApplicationCall.hpp
+++ b/module-apps/application-call/ApplicationCall.hpp
@@ -82,6 +82,7 @@ namespace app
       public:
         ApplicationCall(std::string name                    = name_call,
                         std::string parent                  = {},
+                        sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                         StartInBackground startInBackground = {false});
         sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;
         sys::ReturnCodes InitHandler() override;
@@ -131,7 +132,8 @@ namespace app
                      manager::actions::EmergencyDial,
                      manager::actions::NotAnEmergencyNotification,
                      manager::actions::NoSimNotification,
-                     manager::actions::CallRejectedByOfflineNotification}};
+                     manager::actions::CallRejectedByOfflineNotification,
+                     manager::actions::PhoneModeChanged}};
         }
     };
 } /* namespace app */

--- a/module-apps/application-calllog/ApplicationCallLog.cpp
+++ b/module-apps/application-calllog/ApplicationCallLog.cpp
@@ -22,8 +22,11 @@ using namespace calllog;
 
 namespace app
 {
-    ApplicationCallLog::ApplicationCallLog(std::string name, std::string parent, StartInBackground startInBackground)
-        : Application(name, parent, startInBackground, 4096)
+    ApplicationCallLog::ApplicationCallLog(std::string name,
+                                           std::string parent,
+                                           sys::phone_modes::PhoneMode mode,
+                                           StartInBackground startInBackground)
+        : Application(name, parent, mode, startInBackground, 4096)
     {
         addActionReceiver(manager::actions::ShowCallLog, [this](auto &&data) {
             switchWindow(gui::name::window::main_window, std::move(data));

--- a/module-apps/application-calllog/ApplicationCallLog.hpp
+++ b/module-apps/application-calllog/ApplicationCallLog.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -17,6 +17,7 @@ namespace app
       public:
         ApplicationCallLog(std::string name                    = CallLogAppStr,
                            std::string parent                  = {},
+                           sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                            StartInBackground startInBackground = {false});
         ~ApplicationCallLog() override;
 
@@ -41,7 +42,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch, manager::actions::ShowCallLog}};
+            return {{manager::actions::Launch, manager::actions::ShowCallLog, manager::actions::PhoneModeChanged}};
         }
     };
 } /* namespace app */

--- a/module-apps/application-clock/ApplicationClock.cpp
+++ b/module-apps/application-clock/ApplicationClock.cpp
@@ -21,10 +21,11 @@ namespace app
 {
     ApplicationClock::ApplicationClock(std::string name,
                                        std::string parent,
+                                       sys::phone_modes::PhoneMode mode,
                                        StartInBackground startInBackground,
                                        uint32_t stackDepth,
                                        sys::ServicePriority priority)
-        : Application(name, parent, startInBackground, stackDepth, priority)
+        : Application(name, parent, mode, startInBackground, stackDepth, priority)
     {
         timerClock = sys::TimerFactory::createPeriodicTimer(
             this, "Clock", std::chrono::milliseconds{1000}, [&](sys::Timer &) { timerClockCallback(); });

--- a/module-apps/application-clock/ApplicationClock.hpp
+++ b/module-apps/application-clock/ApplicationClock.hpp
@@ -21,6 +21,7 @@ namespace app
       public:
         ApplicationClock(std::string name                    = name_clock,
                          std::string parent                  = {},
+                         sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                          StartInBackground startInBackground = {false},
                          uint32_t stackDepth                 = 4096,
                          sys::ServicePriority priority       = sys::ServicePriority::Idle);
@@ -42,7 +43,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch}};
+            return {{manager::actions::Launch, manager::actions::PhoneModeChanged}};
         }
     };
 } /* namespace app */

--- a/module-apps/application-desktop/ApplicationDesktop.cpp
+++ b/module-apps/application-desktop/ApplicationDesktop.cpp
@@ -72,8 +72,11 @@ namespace app
         }
     } // namespace
 
-    ApplicationDesktop::ApplicationDesktop(std::string name, std::string parent, StartInBackground startInBackground)
-        : Application(name, parent, startInBackground), lockHandler(this)
+    ApplicationDesktop::ApplicationDesktop(std::string name,
+                                           std::string parent,
+                                           sys::phone_modes::PhoneMode mode,
+                                           StartInBackground startInBackground)
+        : Application(name, parent, mode, startInBackground), lockHandler(this)
     {
         using namespace gui::top_bar;
         topBarManager->enableIndicators({Indicator::Signal,

--- a/module-apps/application-desktop/ApplicationDesktop.hpp
+++ b/module-apps/application-desktop/ApplicationDesktop.hpp
@@ -56,6 +56,7 @@ namespace app
 
         ApplicationDesktop(std::string name                    = name_desktop,
                            std::string parent                  = {},
+                           sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                            StartInBackground startInBackground = {false});
         virtual ~ApplicationDesktop();
         sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;
@@ -131,7 +132,8 @@ namespace app
                      manager::actions::DisplayCMEError,
                      manager::actions::DisplayLowBatteryScreen,
                      manager::actions::SystemBrownout,
-                     manager::actions::DisplayLogoAtExit}};
+                     manager::actions::DisplayLogoAtExit,
+                     manager::actions::PhoneModeChanged}};
         }
     };
 

--- a/module-apps/application-meditation/ApplicationMeditation.cpp
+++ b/module-apps/application-meditation/ApplicationMeditation.cpp
@@ -12,8 +12,9 @@ namespace app
 {
     ApplicationMeditation::ApplicationMeditation(std::string name,
                                                  std::string parent,
+                                                 sys::phone_modes::PhoneMode mode,
                                                  StartInBackground startInBackground)
-        : Application{name, parent, startInBackground}, state{std::make_unique<gui::OptionsData>()}
+        : Application{name, parent, mode, startInBackground}, state{std::make_unique<gui::OptionsData>()}
     {}
 
     auto ApplicationMeditation::InitHandler() -> sys::ReturnCodes

--- a/module-apps/application-meditation/ApplicationMeditation.hpp
+++ b/module-apps/application-meditation/ApplicationMeditation.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -17,6 +17,7 @@ namespace app
       public:
         explicit ApplicationMeditation(std::string name                    = name_meditation,
                                        std::string parent                  = {},
+                                       sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                                        StartInBackground startInBackground = {false});
 
         auto InitHandler() -> sys::ReturnCodes override;
@@ -32,7 +33,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch}};
+            return {{manager::actions::Launch, manager::actions::PhoneModeChanged}};
         }
     };
 } // namespace app

--- a/module-apps/application-messages/ApplicationMessages.cpp
+++ b/module-apps/application-messages/ApplicationMessages.cpp
@@ -41,8 +41,11 @@ namespace app
 {
     static constexpr auto messagesStackDepth = 1024 * 6; // 6Kb stack size
 
-    ApplicationMessages::ApplicationMessages(std::string name, std::string parent, StartInBackground startInBackground)
-        : Application(name, parent, startInBackground, messagesStackDepth), AsyncCallbackReceiver{this}
+    ApplicationMessages::ApplicationMessages(std::string name,
+                                             std::string parent,
+                                             sys::phone_modes::PhoneMode mode,
+                                             StartInBackground startInBackground)
+        : Application(name, parent, mode, startInBackground, messagesStackDepth), AsyncCallbackReceiver{this}
     {
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
         addActionReceiver(manager::actions::CreateSms, [this](auto &&data) {

--- a/module-apps/application-messages/ApplicationMessages.hpp
+++ b/module-apps/application-messages/ApplicationMessages.hpp
@@ -40,6 +40,7 @@ namespace app
       public:
         ApplicationMessages(std::string name                    = name_messages,
                             std::string parent                  = {},
+                            sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                             StartInBackground startInBackground = {false});
 
         sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;
@@ -87,7 +88,8 @@ namespace app
                      manager::actions::CreateSms,
                      manager::actions::ShowSmsTemplates,
                      manager::actions::SmsRejectNoSim,
-                     manager::actions::SMSRejectedByOfflineNotification}};
+                     manager::actions::SMSRejectedByOfflineNotification,
+                     manager::actions::PhoneModeChanged}};
         }
     };
 } /* namespace app */

--- a/module-apps/application-music-player/ApplicationMusicPlayer.cpp
+++ b/module-apps/application-music-player/ApplicationMusicPlayer.cpp
@@ -18,8 +18,9 @@ namespace app
 
     ApplicationMusicPlayer::ApplicationMusicPlayer(std::string name,
                                                    std::string parent,
+                                                   sys::phone_modes::PhoneMode mode,
                                                    StartInBackground startInBackground)
-        : Application(std::move(name), std::move(parent), startInBackground, applicationMusicPlayerStackSize)
+        : Application(std::move(name), std::move(parent), mode, startInBackground, applicationMusicPlayerStackSize)
     {
         LOG_INFO("ApplicationMusicPlayer::create");
         connect(typeid(AudioStartPlaybackResponse), [&](sys::Message *msg) {

--- a/module-apps/application-music-player/ApplicationMusicPlayer.hpp
+++ b/module-apps/application-music-player/ApplicationMusicPlayer.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -31,6 +31,7 @@ namespace app
       public:
         explicit ApplicationMusicPlayer(std::string name                    = name_music_player,
                                         std::string parent                  = {},
+                                        sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                                         StartInBackground startInBackground = {false});
 
         sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl,
@@ -60,7 +61,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch}};
+            return {{manager::actions::Launch, manager::actions::PhoneModeChanged}};
         }
     };
 } /* namespace app */

--- a/module-apps/application-notes/ApplicationNotes.cpp
+++ b/module-apps/application-notes/ApplicationNotes.cpp
@@ -27,8 +27,11 @@ namespace app
         constexpr auto NotesStackSize = 4096U;
     } // namespace
 
-    ApplicationNotes::ApplicationNotes(std::string name, std::string parent, StartInBackground startInBackground)
-        : Application(std::move(name), std::move(parent), startInBackground, NotesStackSize)
+    ApplicationNotes::ApplicationNotes(std::string name,
+                                       std::string parent,
+                                       sys::phone_modes::PhoneMode mode,
+                                       StartInBackground startInBackground)
+        : Application(std::move(name), std::move(parent), mode, startInBackground, NotesStackSize)
     {
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
     }

--- a/module-apps/application-notes/ApplicationNotes.hpp
+++ b/module-apps/application-notes/ApplicationNotes.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -25,6 +25,7 @@ namespace app
       public:
         explicit ApplicationNotes(std::string name                    = name_notes,
                                   std::string parent                  = {},
+                                  sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                                   StartInBackground startInBackground = {false});
 
         sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;
@@ -40,7 +41,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch}};
+            return {{manager::actions::Launch, manager::actions::PhoneModeChanged}};
         }
     };
 } // namespace app

--- a/module-apps/application-onboarding/ApplicationOnBoarding.cpp
+++ b/module-apps/application-onboarding/ApplicationOnBoarding.cpp
@@ -30,8 +30,9 @@ namespace app
 
     ApplicationOnBoarding::ApplicationOnBoarding(std::string name,
                                                  std::string parent,
+                                                 sys::phone_modes::PhoneMode mode,
                                                  StartInBackground startInBackground)
-        : Application(std::move(name), std::move(parent), startInBackground, OnBoardingStackSize)
+        : Application(std::move(name), std::move(parent), mode, startInBackground, OnBoardingStackSize)
     {
         using namespace gui::top_bar;
         topBarManager->enableIndicators({Indicator::Signal,

--- a/module-apps/application-onboarding/ApplicationOnBoarding.hpp
+++ b/module-apps/application-onboarding/ApplicationOnBoarding.hpp
@@ -27,6 +27,7 @@ namespace app
       public:
         explicit ApplicationOnBoarding(std::string name                    = name_onboarding,
                                        std::string parent                  = {},
+                                       sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                                        StartInBackground startInBackground = {false});
 
         sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;
@@ -44,7 +45,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch}};
+            return {{manager::actions::Launch, manager::actions::PhoneModeChanged}};
         }
     };
 } // namespace app

--- a/module-apps/application-phonebook/ApplicationPhonebook.cpp
+++ b/module-apps/application-phonebook/ApplicationPhonebook.cpp
@@ -21,8 +21,9 @@ namespace app
 {
     ApplicationPhonebook::ApplicationPhonebook(std::string name,
                                                std::string parent,
+                                               sys::phone_modes::PhoneMode mode,
                                                StartInBackground startInBackground)
-        : Application(name, parent, startInBackground, phonebook_stack_size)
+        : Application(name, parent, mode, startInBackground, phonebook_stack_size)
     {
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
         addActionReceiver(manager::actions::ShowContacts, [this](auto &&data) {

--- a/module-apps/application-phonebook/ApplicationPhonebook.hpp
+++ b/module-apps/application-phonebook/ApplicationPhonebook.hpp
@@ -32,6 +32,7 @@ namespace app
       public:
         ApplicationPhonebook(std::string name                    = name_phonebook,
                              std::string parent                  = {},
+                             sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                              StartInBackground startInBackground = {false});
         ~ApplicationPhonebook() override = default;
 
@@ -59,7 +60,8 @@ namespace app
                      manager::actions::AddContact,
                      manager::actions::EditContact,
                      manager::actions::ShowContactDetails,
-                     manager::actions::ShowEmergencyContacts}};
+                     manager::actions::ShowEmergencyContacts,
+                     manager::actions::PhoneModeChanged}};
         }
     };
 } // namespace app

--- a/module-apps/application-settings-new/ApplicationSettings.cpp
+++ b/module-apps/application-settings-new/ApplicationSettings.cpp
@@ -96,8 +96,9 @@ namespace app
 
     ApplicationSettingsNew::ApplicationSettingsNew(std::string name,
                                                    std::string parent,
+                                                   sys::phone_modes::PhoneMode mode,
                                                    StartInBackground startInBackground)
-        : Application(std::move(name), std::move(parent), startInBackground), AsyncCallbackReceiver{this}
+        : Application(std::move(name), std::move(parent), mode, startInBackground), AsyncCallbackReceiver{this}
     {
         if ((Store::GSM::SIM::SIM1 == selectedSim || Store::GSM::SIM::SIM2 == selectedSim) &&
             Store::GSM::get()->sim == selectedSim) {
@@ -537,8 +538,10 @@ namespace app
         windowsFactory.attach(gui::window::name::connection_frequency, [](Application *app, const std::string &name) {
             return std::make_unique<gui::ConnectionFrequencyWindow>(app, static_cast<ApplicationSettingsNew *>(app));
         });
-        attachPopups(
-            {gui::popup::ID::Volume, gui::popup::ID::TetheringPhoneModeChangeProhibited, gui::popup::ID::Tethering});
+        attachPopups({gui::popup::ID::Volume,
+                      gui::popup::ID::TetheringPhoneModeChangeProhibited,
+                      gui::popup::ID::Tethering,
+                      gui::popup::ID::PhoneModes});
     }
 
     void ApplicationSettingsNew::destroyUserInterface()

--- a/module-apps/application-settings-new/ApplicationSettings.hpp
+++ b/module-apps/application-settings-new/ApplicationSettings.hpp
@@ -180,6 +180,7 @@ namespace app
       public:
         explicit ApplicationSettingsNew(std::string name                    = name_settings_new,
                                         std::string parent                  = {},
+                                        sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                                         StartInBackground startInBackground = {false});
         ~ApplicationSettingsNew() override;
         auto DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) -> sys::MessagePointer override;
@@ -256,7 +257,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch}};
+            return {{manager::actions::Launch, manager::actions::PhoneModeChanged}};
         }
     };
 } /* namespace app */

--- a/module-apps/application-settings/ApplicationSettings.cpp
+++ b/module-apps/application-settings/ApplicationSettings.cpp
@@ -41,8 +41,11 @@ namespace gui::window::name
 
 namespace app
 {
-    ApplicationSettings::ApplicationSettings(std::string name, std::string parent, StartInBackground startInBackground)
-        : Application(name, parent, startInBackground)
+    ApplicationSettings::ApplicationSettings(std::string name,
+                                             std::string parent,
+                                             sys::phone_modes::PhoneMode mode,
+                                             StartInBackground startInBackground)
+        : Application(name, parent, mode, startInBackground)
     {
         bus.channels.push_back(sys::BusChannel::AntennaNotifications);
         addActionReceiver(manager::actions::SelectSimCard, [this](auto &&data) {

--- a/module-apps/application-settings/ApplicationSettings.hpp
+++ b/module-apps/application-settings/ApplicationSettings.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #ifndef MODULE_APPS_APPLICATION_SETTINGS_APPLICATIONSETTINGS_HPP_
@@ -35,6 +35,7 @@ namespace app
       public:
         ApplicationSettings(std::string name                    = name_settings,
                             std::string parent                  = {},
+                            sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                             StartInBackground startInBackground = {false});
         virtual ~ApplicationSettings();
         sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;
@@ -64,7 +65,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch, manager::actions::SelectSimCard}};
+            return {{manager::actions::Launch, manager::actions::SelectSimCard, manager::actions::PhoneModeChanged}};
         }
     };
 } /* namespace app */

--- a/module-apps/application-special-input/ApplicationSpecialInput.cpp
+++ b/module-apps/application-special-input/ApplicationSpecialInput.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationSpecialInput.hpp"
@@ -14,8 +14,9 @@ namespace
 
 ApplicationSpecialInput::ApplicationSpecialInput(std::string name,
                                                  std::string parent,
+                                                 sys::phone_modes::PhoneMode mode,
                                                  StartInBackground startInBackground)
-    : Application(name, parent, startInBackground, SpecialInputAppStackDepth)
+    : Application(name, parent, mode, startInBackground, SpecialInputAppStackDepth)
 {
     addActionReceiver(manager::actions::ShowSpecialInput, [this](auto &&data) {
         switchWindow(app::char_select, std::move(data));

--- a/module-apps/application-special-input/ApplicationSpecialInput.hpp
+++ b/module-apps/application-special-input/ApplicationSpecialInput.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -21,6 +21,7 @@ namespace app
 
         ApplicationSpecialInput(std::string name                    = special_input,
                                 std::string parent                  = {},
+                                sys::phone_modes::PhoneMode mode    = sys::phone_modes::PhoneMode::Connected,
                                 StartInBackground startInBackground = {true});
         virtual ~ApplicationSpecialInput() = default;
 
@@ -39,7 +40,7 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::ShowSpecialInput}};
+            return {{manager::actions::ShowSpecialInput, manager::actions::PhoneModeChanged}};
         }
     };
 }; // namespace app

--- a/module-apps/popups/TetheringPhoneModePopup.cpp
+++ b/module-apps/popups/TetheringPhoneModePopup.cpp
@@ -4,7 +4,7 @@
 #include "TetheringPhoneModePopup.hpp"
 #include "DialogMetadataMessage.hpp"
 #include "Application.hpp"
-#include "SystemManager/messages/TetheringPhoneModeChangeProhibitedMessage.hpp"
+#include "data/PopupRequestParams.hpp"
 #include <service-appmgr/Controller.hpp>
 
 namespace gui
@@ -20,7 +20,7 @@ namespace gui
         metadata.text   = utils::translateI18("tethering_phone_mode_change_prohibited");
         metadata.icon   = "info_big_circle_W_G";
         metadata.action = [this]() {
-            auto params = std::make_unique<app::PopupRequestParams>(gui::popup::ID::TetheringPhoneModeChangeProhibited);
+            auto params = std::make_unique<gui::PopupRequestParams>(gui::popup::ID::TetheringPhoneModeChangeProhibited);
             app::manager::Controller::sendAction(application, app::manager::actions::AbortPopup, std::move(params));
             return true;
         };

--- a/module-apps/popups/data/PhoneModeParams.hpp
+++ b/module-apps/popups/data/PhoneModeParams.hpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "popups/Popups.hpp"
+
+#include <service-appmgr/Actions.hpp>
+#include <module-sys/PhoneModes/Common.hpp>
+
+namespace gui
+{
+    class PhoneModeParams : public app::manager::actions::ActionParams
+    {
+      public:
+        explicit PhoneModeParams(sys::phone_modes::PhoneMode mode) : phoneMode{mode}
+        {}
+
+        [[nodiscard]] auto getPhoneMode() const noexcept
+        {
+            return phoneMode;
+        }
+
+      private:
+        sys::phone_modes::PhoneMode phoneMode;
+    };
+} // namespace gui

--- a/module-apps/popups/data/PopupRequestParams.hpp
+++ b/module-apps/popups/data/PopupRequestParams.hpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "popups/Popups.hpp"
+
+#include <service-appmgr/Actions.hpp>
+#include <module-sys/PhoneModes/Common.hpp>
+
+namespace gui
+{
+    class PopupRequestParams : public app::manager::actions::ActionParams
+    {
+      public:
+        explicit PopupRequestParams(gui::popup::ID popupId)
+            : app::manager::actions::ActionParams{"Popup request parameters"}, popupId{popupId}
+        {}
+
+        [[nodiscard]] auto getPopupId() const noexcept
+        {
+            return popupId;
+        }
+
+      private:
+        gui::popup::ID popupId;
+    };
+
+    class PhoneModePopupRequestParams : public PopupRequestParams
+    {
+      public:
+        explicit PhoneModePopupRequestParams(sys::phone_modes::PhoneMode mode)
+            : PopupRequestParams{gui::popup::ID::PhoneModes}, phoneMode{mode}
+        {}
+
+        [[nodiscard]] auto getPhoneMode() const noexcept
+        {
+            return phoneMode;
+        }
+
+      private:
+        sys::phone_modes::PhoneMode phoneMode;
+    };
+} // namespace gui

--- a/module-services/service-antenna/ServiceAntenna.cpp
+++ b/module-services/service-antenna/ServiceAntenna.cpp
@@ -78,15 +78,14 @@ ServiceAntenna::ServiceAntenna()
     bus.channels.push_back(sys::BusChannel::PhoneModeChanges);
 
     phoneModeObserver->connect(this);
-    phoneModeObserver->subscribe(
-        [=]([[maybe_unused]] sys::phone_modes::PhoneMode mode, sys::phone_modes::Tethering tethering) {
-            if (mode == sys::phone_modes::PhoneMode::Offline) {
-                this->handleLockRequest(antenna::lockState::locked);
-            }
-            else {
-                this->handleLockRequest(antenna::lockState::unlocked);
-            }
-        });
+    phoneModeObserver->subscribe([this](sys::phone_modes::PhoneMode mode) {
+        if (mode == sys::phone_modes::PhoneMode::Offline) {
+            handleLockRequest(antenna::lockState::locked);
+        }
+        else {
+            handleLockRequest(antenna::lockState::unlocked);
+        }
+    });
 }
 
 ServiceAntenna::~ServiceAntenna()

--- a/module-services/service-appmgr/model/ApplicationHandle.cpp
+++ b/module-services/service-appmgr/model/ApplicationHandle.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <service-appmgr/model/ApplicationHandle.hpp>
@@ -58,14 +58,14 @@ namespace app::manager
         return manifest.contains(action);
     }
 
-    void ApplicationHandle::run(sys::Service *caller)
+    void ApplicationHandle::run(sys::phone_modes::PhoneMode mode, sys::Service *caller)
     {
-        launcher->run(caller);
+        launcher->run(mode, caller);
     }
 
-    void ApplicationHandle::runInBackground(sys::Service *caller)
+    void ApplicationHandle::runInBackground(sys::phone_modes::PhoneMode mode, sys::Service *caller)
     {
-        launcher->runBackground(caller);
+        launcher->runBackground(mode, caller);
     }
 
     void ApplicationHandle::close() noexcept

--- a/module-services/service-appmgr/service-appmgr/Actions.hpp
+++ b/module-services/service-appmgr/service-appmgr/Actions.hpp
@@ -60,6 +60,7 @@ namespace app::manager
             DisplayLogoAtExit,
             SMSRejectedByOfflineNotification,
             CallRejectedByOfflineNotification,
+            PhoneModeChanged,
             ShowPopup,
             AbortPopup,
             UserAction // The last enumerator in the Action enum.

--- a/module-services/service-appmgr/service-appmgr/model/ApplicationHandle.hpp
+++ b/module-services/service-appmgr/service-appmgr/model/ApplicationHandle.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -24,8 +24,8 @@ namespace app::manager
         explicit ApplicationHandle(std::unique_ptr<app::ApplicationLauncher> &&_launcher);
 
         void setState(State state) noexcept;
-        void run(sys::Service *caller);
-        void runInBackground(sys::Service *caller);
+        void run(sys::phone_modes::PhoneMode mode, sys::Service *caller);
+        void runInBackground(sys::phone_modes::PhoneMode mode, sys::Service *caller);
         void close() noexcept;
 
         auto valid() const noexcept -> bool;

--- a/module-services/service-appmgr/service-appmgr/model/ApplicationManager.hpp
+++ b/module-services/service-appmgr/service-appmgr/model/ApplicationManager.hpp
@@ -68,6 +68,7 @@ namespace app::manager
         auto getLaunchingApplication() const noexcept -> ApplicationHandle *;
         auto getPreviousApplication() const noexcept -> ApplicationHandle *;
         auto getApplication(const ApplicationName &name) const noexcept -> ApplicationHandle *;
+        auto getRunningApplications() noexcept -> std::vector<ApplicationHandle *>;
         auto getApplications() const noexcept -> const ApplicationsContainer &
         {
             return applications.getAll();
@@ -84,6 +85,8 @@ namespace app::manager
 
       private:
         using ApplicationsStack = std::deque<ApplicationName>;
+
+        auto getStackOfUniqueApplications() const -> ApplicationsStack;
 
         State state = State::Running;
         ApplicationsStack stack;
@@ -120,6 +123,9 @@ namespace app::manager
         auto handleHomeAction(ActionEntry &action) -> ActionProcessStatus;
         auto handleLaunchAction(ActionEntry &action) -> ActionProcessStatus;
         auto handlePopupAction(ActionEntry &action) -> ActionProcessStatus;
+        auto handlePhoneModeChangedAction(ActionEntry &action) -> ActionProcessStatus;
+        void handlePhoneModeChanged(sys::phone_modes::PhoneMode phoneMode);
+        void changePhoneMode(sys::phone_modes::PhoneMode phoneMode, const ApplicationHandle *app);
         auto handleCustomAction(ActionEntry &action) -> ActionProcessStatus;
         auto handleSwitchApplication(SwitchRequest *msg, bool closeCurrentlyFocusedApp = true) -> bool;
         auto handleCloseConfirmation(CloseConfirmation *msg) -> bool;

--- a/module-services/service-audio/ServiceAudio.cpp
+++ b/module-services/service-audio/ServiceAudio.cpp
@@ -165,9 +165,7 @@ ServiceAudio::ServiceAudio()
     bus.channels.push_back(sys::BusChannel::PhoneModeChanges);
 
     phoneModeObserver->connect(this);
-    phoneModeObserver->subscribe([&](sys::phone_modes::PhoneMode phoneMode, sys::phone_modes::Tethering tetheringMode) {
-        HandlePhoneModeChange(phoneMode, tetheringMode);
-    });
+    phoneModeObserver->subscribe([&](sys::phone_modes::PhoneMode phoneMode) { HandlePhoneModeChange(phoneMode); });
 
     connect(typeid(BluetoothDeviceVolumeChanged),
             [this](sys::Message *msg) -> sys::MessagePointer { return handleVolumeChangedOnBluetoothDevice(msg); });
@@ -546,8 +544,7 @@ auto ServiceAudio::HandleKeyPressed(const int step) -> std::unique_ptr<AudioKeyP
         audio::RetCode::Success, newVolume, AudioKeyPressedResponse::ShowPopup::True, context);
 }
 
-void ServiceAudio::HandlePhoneModeChange(sys::phone_modes::PhoneMode phoneMode,
-                                         sys::phone_modes::Tethering tetheringMode)
+void ServiceAudio::HandlePhoneModeChange(sys::phone_modes::PhoneMode phoneMode)
 {
     LOG_INFO("Phone mode changed to %s", utils::enumToString(phoneMode).c_str());
     for (auto &input : audioMux.GetAllInputs()) {

--- a/module-services/service-audio/service-audio/ServiceAudio.hpp
+++ b/module-services/service-audio/service-audio/ServiceAudio.hpp
@@ -81,7 +81,7 @@ class ServiceAudio : public sys::Service
     auto HandleGetFileTags(const std::string &fileName) -> std::unique_ptr<AudioResponseMessage>;
     void HandleNotification(const AudioNotificationMessage::Type &type, const audio::Token &token);
     auto HandleKeyPressed(const int step) -> std::unique_ptr<AudioKeyPressedResponse>;
-    void HandlePhoneModeChange(sys::phone_modes::PhoneMode phoneMode, sys::phone_modes::Tethering tetheringMode);
+    void HandlePhoneModeChange(sys::phone_modes::PhoneMode phoneMode);
     void MuteCurrentOperation();
     void VibrationUpdate(const audio::PlaybackType &type               = audio::PlaybackType::None,
                          std::optional<audio::AudioMux::Input *> input = std::nullopt);

--- a/module-sys/PhoneModes/Common.hpp
+++ b/module-sys/PhoneModes/Common.hpp
@@ -23,27 +23,38 @@ namespace sys::phone_modes
     class PhoneModeChanged : public DataMessage
     {
       public:
-        PhoneModeChanged(PhoneMode phoneMode, Tethering tetheringMode)
-            : DataMessage{MessageType::MessageTypeUninitialized}, phoneMode{phoneMode}, tethering{tetheringMode}
+        explicit PhoneModeChanged(PhoneMode phoneMode)
+            : DataMessage{MessageType::MessageTypeUninitialized}, phoneMode{phoneMode}
         {}
 
         [[nodiscard]] auto getPhoneMode() const noexcept
         {
             return phoneMode;
         }
+
+      private:
+        PhoneMode phoneMode;
+    };
+
+    class TetheringChanged : public DataMessage
+    {
+      public:
+        explicit TetheringChanged(Tethering tetheringMode)
+            : DataMessage{MessageType::MessageTypeUninitialized}, tethering{tetheringMode}
+        {}
+
         [[nodiscard]] auto getTetheringMode() const noexcept
         {
             return tethering;
         }
 
       private:
-        PhoneMode phoneMode;
         Tethering tethering;
     };
 
-    class PhoneModeChangedSuccessfully : public ResponseMessage
+    class ChangedSuccessfully : public ResponseMessage
     {};
 
-    class PhoneModeChangeFailed : public ResponseMessage
+    class ChangeFailed : public ResponseMessage
     {};
 } // namespace sys::phone_modes

--- a/module-sys/PhoneModes/Observer.hpp
+++ b/module-sys/PhoneModes/Observer.hpp
@@ -18,12 +18,21 @@ namespace sys::phone_modes
     class Observer
     {
       public:
-        using OnChangeCallback   = std::function<void(PhoneMode, Tethering)>;
+        using OnPhoneModeChangedCallback = std::function<void(PhoneMode)>;
+        using OnTetheringChangedCallback = std::function<void(Tethering)>;
         using OnCompleteCallback = std::function<void()>;
         using OnErrorCallback    = std::function<void(const std::exception &)>;
+        struct OnFinishedCallbacks
+        {
+            OnCompleteCallback onComplete;
+            OnErrorCallback onError;
+        };
 
         void connect(Service *owner);
-        void subscribe(OnChangeCallback &&onChange,
+        void subscribe(OnPhoneModeChangedCallback &&onChange,
+                       OnCompleteCallback &&onComplete = {},
+                       OnErrorCallback &&onError       = {}) noexcept;
+        void subscribe(OnTetheringChangedCallback &&onChange,
                        OnCompleteCallback &&onComplete = {},
                        OnErrorCallback &&onError       = {}) noexcept;
 
@@ -33,11 +42,12 @@ namespace sys::phone_modes
 
       private:
         sys::MessagePointer handlePhoneModeChange(PhoneModeChanged *message);
-        void onPhoneModeChanged();
+        sys::MessagePointer handleTetheringChange(TetheringChanged *message);
 
-        OnChangeCallback onChangeCallback;
-        OnCompleteCallback onCompleteCallback;
-        OnErrorCallback onErrorCallback;
+        OnPhoneModeChangedCallback onPhoneModeChangedCallback;
+        OnTetheringChangedCallback onTetheringChangedCallback;
+        OnFinishedCallbacks onPhoneModeChangeFinished;
+        OnFinishedCallbacks onTetheringChangeFinished;
         PhoneMode phoneMode     = PhoneMode::Connected;
         Tethering tetheringMode = Tethering::Off;
     };

--- a/module-sys/PhoneModes/Subject.cpp
+++ b/module-sys/PhoneModes/Subject.cpp
@@ -21,18 +21,22 @@ namespace sys::phone_modes
 
     bool Subject::setMode(PhoneMode _phoneMode, Tethering _tetheringMode)
     {
-        const bool changed = changePhoneMode(_phoneMode) || changeTetheringMode(_tetheringMode);
-        if (changed) {
-            notifyChange();
+        const bool phoneModeChanged = changePhoneMode(_phoneMode);
+        if (phoneModeChanged) {
+            notifyPhoneModeChange();
         }
-        return changed;
+        const bool tetheringChanged = changeTetheringMode(_tetheringMode);
+        if (tetheringChanged) {
+            notifyTetheringChange();
+        }
+        return phoneModeChanged || tetheringChanged;
     }
 
     bool Subject::setPhoneMode(PhoneMode mode)
     {
         const auto changed = changePhoneMode(mode);
         if (changed) {
-            notifyChange();
+            notifyPhoneModeChange();
         }
         return changed;
     }
@@ -46,7 +50,7 @@ namespace sys::phone_modes
     {
         const auto changed = changeTetheringMode(mode);
         if (changed) {
-            notifyChange();
+            notifyTetheringChange();
         }
         return changed;
     }
@@ -56,13 +60,18 @@ namespace sys::phone_modes
         return std::exchange(tetheringMode, mode) != mode;
     }
 
-    void Subject::notifyChange()
+    void Subject::notifyPhoneModeChange()
     {
-        LOG_INFO("Phone modes changed: Phone mode: [%s]; Tethering: [%s]. Notifying phone modes observers.",
-                 magic_enum::enum_name(phoneMode).data(),
+        LOG_INFO("Phone mode changed to: [%s]. Notifying phone modes observers.",
+                 magic_enum::enum_name(phoneMode).data());
+        owner->bus.sendMulticast(std::make_shared<PhoneModeChanged>(phoneMode), BusChannel::PhoneModeChanges);
+    }
+
+    void Subject::notifyTetheringChange()
+    {
+        LOG_INFO("Tethering mode changed to: [%s]. Notifying phone modes observers.",
                  magic_enum::enum_name(tetheringMode).data());
-        auto message = std::make_shared<PhoneModeChanged>(phoneMode, tetheringMode);
-        owner->bus.sendMulticast(std::move(message), BusChannel::PhoneModeChanges);
+        owner->bus.sendMulticast(std::make_shared<TetheringChanged>(tetheringMode), BusChannel::PhoneModeChanges);
     }
     bool Subject::isTetheringEnabled() const noexcept
     {

--- a/module-sys/PhoneModes/Subject.hpp
+++ b/module-sys/PhoneModes/Subject.hpp
@@ -42,9 +42,10 @@ namespace sys::phone_modes
         bool isTetheringEnabled() const noexcept;
 
       private:
-        void notifyChange();
         bool changePhoneMode(PhoneMode mode) noexcept;
+        void notifyPhoneModeChange();
         bool changeTetheringMode(Tethering mode) noexcept;
+        void notifyTetheringChange();
 
         Service *owner;
         PhoneMode phoneMode     = PhoneMode::Connected;

--- a/module-sys/SystemManager/messages/TetheringPhoneModeChangeProhibitedMessage.hpp
+++ b/module-sys/SystemManager/messages/TetheringPhoneModeChangeProhibitedMessage.hpp
@@ -19,7 +19,7 @@ namespace sys
 
         std::unique_ptr<app::manager::ActionRequest> toAction() const override
         {
-            auto params = std::make_unique<app::PopupRequestParams>(gui::popup::ID::TetheringPhoneModeChangeProhibited);
+            auto params = std::make_unique<gui::PopupRequestParams>(gui::popup::ID::TetheringPhoneModeChangeProhibited);
             return std::make_unique<app::manager::ActionRequest>(
                 sender, app::manager::actions::ShowPopup, std::move(params));
         }

--- a/module-sys/SystemManager/messages/TetheringQuestionRequest.hpp
+++ b/module-sys/SystemManager/messages/TetheringQuestionRequest.hpp
@@ -5,6 +5,8 @@
 
 #include <module-sys/Service/Message.hpp>
 
+#include <module-apps/popups/data/PopupRequestParams.hpp>
+
 #include <service-appmgr/Actions.hpp>
 #include <service-appmgr/messages/ActionRequest.hpp>
 
@@ -18,7 +20,7 @@ namespace sys
 
         std::unique_ptr<app::manager::ActionRequest> toAction() const override
         {
-            auto params = std::make_unique<app::PopupRequestParams>(gui::popup::ID::Tethering);
+            auto params = std::make_unique<gui::PopupRequestParams>(gui::popup::ID::Tethering);
             return std::make_unique<app::manager::ActionRequest>(
                 sender, app::manager::actions::ShowPopup, std::move(params));
         }
@@ -32,7 +34,7 @@ namespace sys
 
         std::unique_ptr<app::manager::ActionRequest> toAction() const override
         {
-            auto params = std::make_unique<app::PopupRequestParams>(gui::popup::ID::Tethering);
+            auto params = std::make_unique<gui::PopupRequestParams>(gui::popup::ID::Tethering);
             return std::make_unique<app::manager::ActionRequest>(
                 sender, app::manager::actions::AbortPopup, std::move(params));
         }


### PR DESCRIPTION
PhoneModeObserver doesn't work properly in applications.
Applications have to handle the phone mode changes via AppMgr.
Phone mode and tethering handlers separated.