### PR TITLE
[EGD-6507] Enable per-module testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ include(module-lwip/lwip-includes.cmake)
 include(SerialPort)
 include(CopyGdbInit)
 include(Utils)
+include(ModuleUtils)
 
 message("PROJECT_TARGET: ${PROJECT_TARGET}")
 message("TARGET_SOURCES: ${TARGET_SOURCES}")

--- a/cmake/modules/ModuleUtils.cmake
+++ b/cmake/modules/ModuleUtils.cmake
@@ -1,0 +1,23 @@
+macro(module_is_test_entity)
+    if(${ENABLE_TESTS})
+        if (NOT ${ARGV0} STREQUAL "")
+            set(_NAME ${ARGV0})
+        else()
+            string(REGEX MATCH "module-\([^/]*\)" _NAME ${CMAKE_CURRENT_LIST_DIR})
+            set(_NAME ${CMAKE_MATCH_1})
+        endif()
+
+        if(${_NAME} STREQUAL "")
+            message(FATAL_ERROR "Can't determine module name to enable testing.")
+        endif()
+
+        add_test_entity(NAME ${_NAME})
+
+        enable_entity_coverage(
+            NAME
+                ${_NAME}
+            COVERAGE_PATH
+                .*/module-${_NAME}/.*
+        )
+    endif()
+endmacro()

--- a/cmake/modules/PureCoverage.cmake
+++ b/cmake/modules/PureCoverage.cmake
@@ -80,3 +80,37 @@ if(COVERAGE_ENABLE)
         DEPENDENCIES ""
     )
 endif()
+
+function(enable_entity_coverage)
+    if(COVERAGE_ENABLE)
+        cmake_parse_arguments(
+            _ARGS
+            ""
+            "NAME;COVERAGE_PATH"
+            ""
+            ${ARGN}
+        )
+
+        message("Enabling coverage reporting for test entity: ${_ARGS_NAME} (${PROJECT_NAME})")
+
+        if(_ARGS_COVERAGE_PATH)
+            set(GCOVR_ADDITIONAL_ARGS ${GCOVR_ADDITIONAL_ARGS} -f ${_ARGS_COVERAGE_PATH})
+        endif()
+
+        setup_target_for_coverage_gcovr_html(
+            NAME coverage-${_ARGS_NAME}-html
+            EXECUTABLE ;
+            DEPENDENCIES ""
+        )
+
+        setup_target_for_coverage_gcovr_xml(
+            NAME coverage-${_ARGS_NAME}
+            EXECUTABLE ;
+            DEPENDENCIES ""
+        )
+
+        add_dependencies(coverage-${_ARGS_NAME}-html check-${_ARGS_NAME})
+        add_dependencies(coverage-${_ARGS_NAME} check-${_ARGS_NAME})
+        add_dependencies(check-${_ARGS_NAME} coverage-cleanup)
+    endif()
+endfunction(enable_entity_coverage)

--- a/module-apps/CMakeLists.txt
+++ b/module-apps/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required(VERSION 3.14)
 project(module-apps VERSION 1.0
         DESCRIPTION "Library with all applications.")
 
+module_is_test_entity()
+
 if(${PROJECT_TARGET} STREQUAL "TARGET_RT1051")
     include(targets/Target_RT1051.cmake)
 elseif(${PROJECT_TARGET} STREQUAL "TARGET_Linux")

--- a/module-audio/Audio/test/CMakeLists.txt
+++ b/module-audio/Audio/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
-# audio tests
 
+# audio tests
 add_catch2_executable(
     NAME
         audio-test

--- a/module-audio/CMakeLists.txt
+++ b/module-audio/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required(VERSION 3.12)
 project(module-audio VERSION 1.0
         DESCRIPTION "Audio module library")
 
+module_is_test_entity()
+
 set(SOURCES
         "${CMAKE_CURRENT_SOURCE_DIR}/Audio/Audio.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/Audio/AudioCommon.cpp"

--- a/module-bluetooth/CMakeLists.txt
+++ b/module-bluetooth/CMakeLists.txt
@@ -5,6 +5,8 @@ project(module-bluetooth VERSION 1.0 DESCRIPTION "Bluetooth module library")
 
 set(CMAKE_CXX_STANDARD 17)
 
+module_is_test_entity()
+
 set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Bluetooth/audio/BluetoothAudioDevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Bluetooth/BluetoothWorker.cpp

--- a/module-cellular/CMakeLists.txt
+++ b/module-cellular/CMakeLists.txt
@@ -5,6 +5,8 @@ project(module-cellular VERSION 1.0
 
 include(SerialPort)
 
+module_is_test_entity()
+
 set(SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/Modem/ATParser.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/Modem/ATStream.cpp

--- a/module-db/CMakeLists.txt
+++ b/module-db/CMakeLists.txt
@@ -3,6 +3,8 @@
 project(module-db VERSION 1.0
         DESCRIPTION "Database module library")
 
+module_is_test_entity()
+
 include(thirdparty)
 
 set (SQLITE3_SOURCE Database/sqlite3.c)

--- a/module-gui/CMakeLists.txt
+++ b/module-gui/CMakeLists.txt
@@ -1,8 +1,9 @@
 ﻿cmake_minimum_required(VERSION 3.12)
 
-
 project(module-gui VERSION 1.0
         DESCRIPTION "GUI library dedicated for pure phone.")
+
+module_is_test_entity()
 
 if( NOT ${PROJECT_TARGET} STREQUAL "TARGET_Linux")
     include(targets/Target_Cross.cmake)
@@ -10,7 +11,6 @@ else()
 	set(CMAKE_CXX_STANDARD 17)
     include(targets/Target_Linux.cmake)
 endif()
-
 
 add_library(${PROJECT_NAME} STATIC ${SOURCES} ${BOARD_SOURCES})
 include(gui/CMakeLists.txt)

--- a/module-services/CMakeLists.txt
+++ b/module-services/CMakeLists.txt
@@ -3,6 +3,8 @@
 project(module-services VERSION 1.0
         DESCRIPTION "Library with all services.")
 
+module_is_test_entity()
+
 include(${CMAKE_SOURCE_DIR}/module-lwip/lwip-includes.cmake)
 
 if(${PROJECT_TARGET} STREQUAL "TARGET_RT1051")

--- a/module-sys/CMakeLists.txt
+++ b/module-sys/CMakeLists.txt
@@ -3,6 +3,8 @@
 project(module-sys VERSION 1.0
         DESCRIPTION "Core module library")
 
+module_is_test_entity()
+
 set(BUS_IMPL_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/Service/details/bus/Bus.cpp
 )

--- a/module-utils/CMakeLists.txt
+++ b/module-utils/CMakeLists.txt
@@ -11,6 +11,8 @@ if(${CMAKE_VERSION} VERSION_LESS 3.12)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 endif()
 
+module_is_test_entity()
+
 if(${PROJECT_TARGET} STREQUAL "TARGET_Linux")
 	include(targets/Target_Linux.cmake)
 else()

--- a/module-vfs/CMakeLists.txt
+++ b/module-vfs/CMakeLists.txt
@@ -3,8 +3,9 @@ cmake_minimum_required(VERSION 3.12)
 project(module-vfs VERSION 1.0
         DESCRIPTION "VFS module library")
 
-add_subdirectory(thirdparty/lfsfs)
+module_is_test_entity()
 
+add_subdirectory(thirdparty/lfsfs)
 
 set(FF_FAT_SOURCES_THIRDPARTY
         ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/fatfs/source/ff.c

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,12 @@ list(APPEND CMAKE_MODULE_PATH "${CATCH2_PATH}/contrib/")
 add_subdirectory(googletest)
 add_subdirectory(${CATCH2_PATH})
 
+define_property(
+    DIRECTORY PROPERTY TEST_ENTITY INHERITED
+    BRIEF_DOCS "Test entity of the directory"
+    FULL_DOCS "Add directory to a test entity to group tests defined in the directory and its subdirectories"
+)
+
 include(CMakeParseArguments)
 include(GoogleTest)
 include(Catch)
@@ -31,6 +37,8 @@ function(add_gtest_executable)
     if(NOT _TEST_ARGS_SRCS)
 	message(FATAL_ERROR "You must provide test sources for ${_TESTNAME}")
     endif(NOT _TEST_ARGS_SRCS)
+
+    get_directory_property(_TEST_ENTITY TEST_ENTITY)
 
     add_executable(${_TESTNAME} EXCLUDE_FROM_ALL ${_TEST_ARGS_SRCS})
 
@@ -65,7 +73,11 @@ function(add_gtest_executable)
 
     add_dependencies(unittests ${_TESTNAME})
     add_dependencies(check ${_TESTNAME})
-    
+
+    if(_TEST_ENTITY)
+        add_dependencies(unittests-${_TEST_ENTITY} ${_TESTNAME})
+    endif()
+
     gtest_add_tests(${_TESTNAME} "" AUTO)
 endfunction()
 
@@ -84,8 +96,10 @@ function(add_catch2_executable)
     set(_TESTNAME "catch2-${_TEST_ARGS_NAME}")
 
     if(NOT _TEST_ARGS_SRCS)
-	    message(FATAL_ERROR "You must provide test sources for ${_TESTNAME}")
+        message(FATAL_ERROR "You must provide test sources for ${_TESTNAME}")
     endif(NOT _TEST_ARGS_SRCS)
+
+    get_directory_property(_TEST_ENTITY TEST_ENTITY)
 
     add_executable(${_TESTNAME} EXCLUDE_FROM_ALL ${_TEST_ARGS_SRCS})
 
@@ -117,7 +131,40 @@ function(add_catch2_executable)
 
     add_dependencies(unittests ${_TESTNAME})
     add_dependencies(check ${_TESTNAME})
-    catch_discover_tests(${_TESTNAME} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+    if(_TEST_ENTITY)
+        add_dependencies(unittests-${_TEST_ENTITY} ${_TESTNAME})
+    endif()
+
+    catch_discover_tests(${_TESTNAME}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        PROPERTIES LABELS ${_TEST_ENTITY}
+    )
+endfunction()
+
+function(add_test_entity)
+    cmake_parse_arguments(
+        _ARGS
+        ""
+        "NAME"
+        ""
+        ${ARGN}
+    )
+
+    if(NOT _ARGS_NAME)
+        message(FATAL_ERROR "You must provide a test entity name")
+    endif(NOT _ARGS_NAME)
+
+    message("Adding test entity: ${_ARGS_NAME}")
+
+    set_directory_properties(PROPERTIES
+        TEST_ENTITY ${_ARGS_NAME}
+        LABELS ${_ARGS_NAME}
+    )
+
+    add_custom_target(unittests-${_ARGS_NAME})
+    add_custom_target(check-${_ARGS_NAME} ${CMAKE_CTEST_COMMAND} -L ${_ARGS_NAME})
+    add_dependencies(check-${_ARGS_NAME} unittests-${_ARGS_NAME})
 endfunction()
 
 set(_CATCH_DISCOVER_TESTS_SCRIPT ${_CATCH_DISCOVER_TESTS_SCRIPT} PARENT_SCOPE)


### PR DESCRIPTION
Add per-module:
 - test build
 - test execution
 - coverage reporting (xml/html).

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>