### PR TITLE
[EGD-5703] Fix SimCard topBar icon on Desktop

### DIFF
--- a/module-apps/Application.cpp
+++ b/module-apps/Application.cpp
@@ -10,6 +10,7 @@
 #include "module-apps/popups/data/PhoneModeParams.hpp"
 #include "module-sys/Timers/TimerFactory.hpp" // for Timer
 #include "TopBar.hpp"
+#include "TopBar/Time.hpp"
 #include "popups/TetheringConfirmationPopup.hpp"
 #include "Translator.hpp"                // for KeyInputSim...
 #include "common_data/EventStore.hpp"    // for Battery
@@ -96,8 +97,11 @@ namespace app
           settings(std::make_unique<settings::Settings>(this)), phoneMode{mode}
     {
         topBarManager->enableIndicators({gui::top_bar::Indicator::Time});
-        topBarManager->set(utils::dateAndTimeSettings.isTimeFormat12() ? gui::top_bar::TimeMode::Time12h
-                                                                       : gui::top_bar::TimeMode::Time24h);
+        using TimeMode = gui::top_bar::TimeConfiguration::TimeMode;
+        auto modifier  = std::make_shared<gui::top_bar::TimeConfiguration>(
+            utils::dateAndTimeSettings.isTimeFormat12() ? TimeMode::Time12h : TimeMode::Time24h);
+        topBarManager->set(gui::top_bar::Indicator::Time, std::move(modifier));
+
         bus.channels.push_back(sys::BusChannel::ServiceCellularNotifications);
 
         longPressTimer = sys::TimerFactory::createPeriodicTimer(this,

--- a/module-apps/TopBarManager.cpp
+++ b/module-apps/TopBarManager.cpp
@@ -16,8 +16,8 @@ namespace app
         return topBarConfiguration;
     }
 
-    void TopBarManager::set(gui::top_bar::TimeMode timeMode)
+    void TopBarManager::set(gui::top_bar::Indicator indicator, std::shared_ptr<StatusBarVisitor> config)
     {
-        topBarConfiguration.setTimeMode(timeMode);
+        topBarConfiguration.setIndicatorModifier(indicator, std::move(config));
     }
 } // namespace app

--- a/module-apps/TopBarManager.hpp
+++ b/module-apps/TopBarManager.hpp
@@ -12,7 +12,7 @@ namespace app
       public:
         void enableIndicators(const gui::top_bar::Indicators &indicators);
         [[nodiscard]] auto getConfiguration() const noexcept -> const gui::top_bar::Configuration &;
-        void set(gui::top_bar::TimeMode timeMode);
+        void set(gui::top_bar::Indicator indicator, std::shared_ptr<StatusBarVisitor> config);
 
       private:
         gui::top_bar::Configuration topBarConfiguration;

--- a/module-apps/application-desktop/ApplicationDesktop.cpp
+++ b/module-apps/application-desktop/ApplicationDesktop.cpp
@@ -44,6 +44,7 @@
 #include <module-apps/messages/AppMessage.hpp>
 #include <SystemManager/messages/SystemManagerMessage.hpp>
 #include <service-db/DBCalllogMessage.hpp>
+#include <module-gui/gui/widgets/TopBar/SIM.hpp>
 
 #include <cassert>
 namespace app
@@ -80,6 +81,8 @@ namespace app
                                          Indicator::Battery,
                                          Indicator::SimCard,
                                          Indicator::NetworkAccessTechnology});
+        topBarManager->set(Indicator::SimCard,
+                           std::make_shared<SIMConfiguration>(SIMConfiguration::DisplayMode::OnlyInactiveState));
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
 
         addActionReceiver(app::manager::actions::RequestPin, [this](auto &&data) {

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -69,9 +69,6 @@ namespace gui
             }
         };
 
-        applyToTopBar(
-            [this](top_bar::Configuration configuration) { return configureTopBar(std::move(configuration)); });
-
         setVisibleState();
     }
 
@@ -117,6 +114,8 @@ namespace gui
 
     void DesktopMainWindow::setVisibleState()
     {
+        applyToTopBar(
+            [this](top_bar::Configuration configuration) { return configureTopBar(std::move(configuration)); });
         if (auto app = getAppDesktop(); app->lockHandler.isScreenLocked()) {
             bottomBar->setText(BottomBar::Side::CENTER, utils::translate("app_desktop_unlock"));
             bottomBar->setActive(BottomBar::Side::RIGHT, false);

--- a/module-apps/windows/AppWindow.cpp
+++ b/module-apps/windows/AppWindow.cpp
@@ -5,6 +5,7 @@
 #include "Application.hpp"
 #include "InputEvent.hpp"
 #include "TopBar.hpp"
+#include "TopBar/Time.hpp"
 #include <Style.hpp>
 #include <application-desktop/ApplicationDesktop.hpp>
 #include <i18n/i18n.hpp>
@@ -116,8 +117,10 @@ namespace gui
     bool AppWindow::updateTime()
     {
         applyToTopBar([](top_bar::Configuration configuration) {
-            configuration.setTimeMode(utils::dateAndTimeSettings.isTimeFormat12() ? gui::top_bar::TimeMode::Time12h
-                                                                                  : (gui::top_bar::TimeMode::Time24h));
+            using TimeMode = gui::top_bar::TimeConfiguration::TimeMode;
+            auto modifier  = std::make_shared<gui::top_bar::TimeConfiguration>(
+                utils::dateAndTimeSettings.isTimeFormat12() ? TimeMode::Time12h : TimeMode::Time24h);
+            configuration.setIndicatorModifier(gui::top_bar::Indicator::Time, std::move(modifier));
             return configuration;
         });
         if (topBar == nullptr) {

--- a/module-gui/gui/widgets/TopBar.hpp
+++ b/module-gui/gui/widgets/TopBar.hpp
@@ -29,6 +29,8 @@ namespace gui
 
 class UTF8;
 
+class StatusBarVisitor;
+
 namespace gui::top_bar
 {
 
@@ -45,12 +47,7 @@ namespace gui::top_bar
 
     using Indicators        = std::vector<Indicator>;
     using IndicatorStatuses = std::map<Indicator, bool>;
-
-    enum class TimeMode
-    {
-        Time12h, /// 12h time format
-        Time24h  /// 24h time format
-    };
+    using IndicatorsModifiers = std::map<Indicator, std::shared_ptr<StatusBarVisitor>>;
 
     /// Carries the top bar configuration.
     class Configuration
@@ -61,7 +58,7 @@ namespace gui::top_bar
         void enable(Indicator indicator);
 
         /// Enable number of specified indicators
-        /// @param indicators vectior of indicators to enable
+        /// @param indicators vector of indicators to enable
         void enable(const Indicators &indicators);
 
         /// Disable specified indicator
@@ -73,17 +70,14 @@ namespace gui::top_bar
         /// @param enabled desired status to be set (true=enabled, false=disabled)
         void setIndicator(Indicator indicator, bool enabled);
 
-        /// Set time mode (12h/24h)
-        /// @param timeMode desired time mode configuration
-        void setTimeMode(TimeMode timeMode);
-
         /// Set phone mode (connected/dnd/offline)
         /// @param phoneMode desired phone mode configuration
         void setPhoneMode(sys::phone_modes::PhoneMode phoneMode);
 
-        /// Return the time mode configuration
-        /// @return cuurent time mode configuration
-        [[nodiscard]] auto getTimeMode() const noexcept -> TimeMode;
+        /// Set a configuration modifier to the specified indicator
+        /// @param indicator indicator type
+        /// @param config desired indicator's configuration
+        void setIndicatorModifier(Indicator indicator, std::shared_ptr<StatusBarVisitor> config);
 
         /// Get the phone mode configuration
         /// @return phone mode
@@ -98,6 +92,10 @@ namespace gui::top_bar
         /// @return indicator statuses
         [[nodiscard]] auto getIndicatorsConfiguration() const noexcept -> const IndicatorStatuses &;
 
+        /// Return the indicator modifiers
+        /// @return indicator modifiers
+        [[nodiscard]] auto getIndicatorsModifiers() const noexcept -> const IndicatorsModifiers &;
+
       private:
         /// Current indicator statuses
         IndicatorStatuses indicatorStatuses = {{Indicator::Signal, false},
@@ -108,11 +106,11 @@ namespace gui::top_bar
                                                {Indicator::SimCard, false},
                                                {Indicator::NetworkAccessTechnology, false}};
 
-        /// Time mode
-        TimeMode mTimeMode = TimeMode::Time12h;
-
         /// Phone mode
         sys::phone_modes::PhoneMode mPhoneMode = sys::phone_modes::PhoneMode::Connected;
+
+        /// Indicator modifiers:
+        IndicatorsModifiers indicatorsModifiers;
     };
 
     /// Top bar widget class.
@@ -196,6 +194,11 @@ namespace gui::top_bar
         /// @param indicator indicator id
         /// @param enabled enable or disable the specified indicator
         void setIndicatorStatus(Indicator indicator, bool enabled);
+
+        /// Applies a modifier to specified indicator
+        /// @param indicator indicator id
+        /// @param modifier pointer to modifier
+        void setIndicatorModifier(Indicator indicator, StatusBarVisitor &modifier);
 
         /// Pointer to widget showing digital clock
         Time *time = nullptr;

--- a/module-gui/gui/widgets/TopBar/SIM.cpp
+++ b/module-gui/gui/widgets/TopBar/SIM.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SIM.hpp"
@@ -39,5 +39,38 @@ namespace gui::top_bar
             set(simunknown);
             break;
         }
+    }
+
+    void SIM::show()
+    {
+        bool isVisible = !(mode == SIMConfiguration::DisplayMode::OnlyInactiveState &&
+                           (current == GSM::SIM::SIM1 || current == GSM::SIM::SIM2));
+        StatusBarWidgetBase<Image>::setVisible(isVisible);
+    }
+
+    void SIM::acceptStatusBarVisitor(StatusBarVisitor &visitor)
+    {
+        visitor.visit(*this);
+    }
+
+    SIMConfiguration::SIMConfiguration(DisplayMode mode) : mode{mode}
+    {}
+
+    void SIMConfiguration::visit(gui::top_bar::SIM &widget) const
+    {
+        widget.mode = getMode();
+    }
+
+    SIMConfiguration::DisplayMode SIMConfiguration::getMode() const noexcept
+    {
+        return mode;
+    }
+
+    SIMDevelopersMode::SIMDevelopersMode(Item *parent, uint32_t x, uint32_t y) : SIM(parent, x, y)
+    {}
+
+    void SIMDevelopersMode::show()
+    {
+        StatusBarWidgetBase<Image>::setVisible(true);
     }
 }; // namespace gui::top_bar

--- a/module-gui/gui/widgets/TopBar/SIM.hpp
+++ b/module-gui/gui/widgets/TopBar/SIM.hpp
@@ -9,14 +9,47 @@
 
 namespace gui::top_bar
 {
+    class SIMConfiguration : public StatusBarVisitor
+    {
+      public:
+        enum class DisplayMode
+        {
+            AnyState,
+            OnlyInactiveState
+        };
+
+        explicit SIMConfiguration(DisplayMode mode);
+
+        [[nodiscard]] DisplayMode getMode() const noexcept;
+
+        void visit([[maybe_unused]] gui::top_bar::SIM &widget) const override;
+
+      private:
+        DisplayMode mode;
+    };
+
     class SIM : public StatusBarWidgetBase<Image>
     {
         Store::GSM::SIM current = Store::GSM::SIM::SIM_UNKNOWN;
+        SIMConfiguration::DisplayMode mode = SIMConfiguration::DisplayMode::AnyState;
+        friend class SIMConfiguration;
 
       public:
         SIM(Item *parent, uint32_t x, uint32_t y);
 
         /// check if sim set in state -> if not -> show new sim
         void update(const Store::GSM::SIM &state);
+
+        void show() override;
+
+        void acceptStatusBarVisitor(StatusBarVisitor &visitor) override;
+    };
+
+    class SIMDevelopersMode : public SIM
+    {
+      public:
+        SIMDevelopersMode(Item *parent, uint32_t x, uint32_t y);
+
+        void show() override;
     };
 } // namespace gui::top_bar

--- a/module-gui/gui/widgets/TopBar/StatusBarWidgetBase.hpp
+++ b/module-gui/gui/widgets/TopBar/StatusBarWidgetBase.hpp
@@ -3,6 +3,33 @@
 
 #pragma once
 
+#include <log/log.hpp>
+
+namespace gui::top_bar
+{
+    class SIM;
+    class Time;
+} // namespace gui::top_bar
+
+class StatusBarVisitor
+{
+    void logError() const
+    {
+        LOG_ERROR("Invalid widget visited");
+    }
+
+  public:
+    virtual void visit([[maybe_unused]] gui::top_bar::SIM &widget) const
+    {
+        logError();
+    }
+    virtual void visit([[maybe_unused]] gui::top_bar::Time &widget) const
+    {
+        logError();
+    }
+    virtual ~StatusBarVisitor() = default;
+};
+
 template <typename ItemPolicy> class StatusBarWidgetBase : public ItemPolicy
 {
   public:
@@ -22,5 +49,10 @@ template <typename ItemPolicy> class StatusBarWidgetBase : public ItemPolicy
     virtual bool isVisible()
     {
         return ItemPolicy::visible;
+    }
+
+    virtual void acceptStatusBarVisitor([[maybe_unused]] StatusBarVisitor &visitor)
+    {
+        LOG_ERROR("Invalid visitor");
     }
 };

--- a/module-gui/gui/widgets/TopBar/Time.cpp
+++ b/module-gui/gui/widgets/TopBar/Time.cpp
@@ -3,7 +3,6 @@
 
 #include "Time.hpp"
 #include "time/time_conversion.hpp"
-#include <Utils.hpp>
 #include "Style.hpp"
 
 namespace gui::top_bar
@@ -29,5 +28,26 @@ namespace gui::top_bar
     void Time::setFormat(const std::string &format)
     {
         _time.set_format(format);
+    }
+
+    void Time::acceptStatusBarVisitor(StatusBarVisitor &visitor)
+    {
+        visitor.visit(*this);
+    }
+
+    TimeConfiguration::TimeConfiguration(TimeMode mode) : mode{mode}
+    {}
+
+    TimeConfiguration::TimeMode TimeConfiguration::getMode() const noexcept
+    {
+        return mode;
+    }
+
+    void TimeConfiguration::visit(gui::top_bar::Time &widget) const
+    {
+        using namespace utils::time;
+        getMode() == TimeConfiguration::TimeMode::Time12h
+            ? widget.setFormat(Locale::format(Locale::TimeFormat::FormatTime12H))
+            : widget.setFormat(Locale::format(Locale::TimeFormat::FormatTime24H));
     }
 } // namespace gui::top_bar

--- a/module-gui/gui/widgets/TopBar/Time.hpp
+++ b/module-gui/gui/widgets/TopBar/Time.hpp
@@ -9,13 +9,35 @@
 
 namespace gui::top_bar
 {
+
+    /// Sets time mode (12h/24h) for Time widget
+    class TimeConfiguration : public StatusBarVisitor
+    {
+      public:
+        enum class TimeMode
+        {
+            Time12h, /// 12h time format
+            Time24h  /// 24h time format
+        };
+
+        explicit TimeConfiguration(TimeMode mode);
+
+        [[nodiscard]] TimeMode getMode() const noexcept;
+        void visit(gui::top_bar::Time &widget) const override;
+
+      private:
+        TimeMode mode;
+    };
+
     class Time : public StatusBarWidgetBase<Label>
     {
         utils::time::Timestamp _time;
+        void setFormat(const std::string &format);
+        friend class TimeConfiguration;
 
       public:
         Time(Item *parent, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
         void update();
-        void setFormat(const std::string &format);
+        void acceptStatusBarVisitor(StatusBarVisitor &visitor) override;
     };
 } // namespace gui::top_bar


### PR DESCRIPTION
In initial design a `TobBar`'s SimCard icon with number is supposed
to display on the home screen only if there are two cards inserted.
Because of the hardware limitations (there is no way of telling if
there is a single or two cards inserted) the established consensus is
that home screen should not display SimCard widget unless it's
indication error state.

Although in the task description there is only home screen mentioned,
the behaviour was established for all `ApplicationDesktop`'s windows.