### PR TITLE
[EGD-6118] BT low power initial implementation

### DIFF
--- a/module-bluetooth/Bluetooth/btstack_config.h
+++ b/module-bluetooth/Bluetooth/btstack_config.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
 //
 // btstack_config.h for generic POSIX H4 port
 //
@@ -32,7 +35,7 @@
 #define ENABLE_LOG_DEBUG
 #define ENABLE_SCO_OVER_HCI
 #define ENABLE_SDP_DES_DUMP
-// #define ENABLE_EHCILL
+#define ENABLE_EHCILL
 
 // BTstack configuration. buffers, sizes, ...
 #define HCI_INCOMING_PRE_BUFFER_SIZE 14 // sizeof benep heade, avoid memcpy

--- a/module-bluetooth/Bluetooth/glucode/btstack_uart_block_rt1051.cpp
+++ b/module-bluetooth/Bluetooth/glucode/btstack_uart_block_rt1051.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <bsp/bluetooth/Bluetooth.hpp>
@@ -86,6 +86,17 @@ extern "C"
         BlueKitchen::getInstance()->write(buffer, length);
     }
 
+    static int btstack_uart_rt1051_get_supported_sleep_modes(void)
+    {
+        return BTSTACK_UART_SLEEP_MASK_RTS_HIGH_WAKE_ON_CTS_PULSE;
+    }
+
+    static void btstack_uart_rt1051_set_sleep(btstack_uart_sleep_mode_t sleep_mode)
+    {}
+
+    static void btstack_uart_rt1051_set_wakeup_handler(void (*the_wakeup_handler)(void))
+    {}
+
     static const btstack_uart_block_t btstack_uart_posix = {
         /* int  (*init)(hci_transport_config_uart_t * config); */ uart_rt1051_init,
         /* int  (*open)(void); */ uart_rt1051_open,
@@ -97,9 +108,9 @@ extern "C"
         /* int  (*set_flowcontrol)(int flowcontrol); */ NULL, // uart_rt1051_set_flowcontrol,
         /* void (*receive_block)(uint8_t *buffer, uint16_t len); */ uart_rt1051_receive_block,
         /* void (*send_block)(const uint8_t *buffer, uint16_t length); */ uart_rt1051_send_block,
-        /* int (*get_supported_sleep_modes); */ NULL,
-        /* void (*set_sleep)(btstack_uart_sleep_mode_t sleep_mode); */ NULL,
-        /* void (*set_wakeup_handler)(void (*handler)(void)); */ NULL,
+        /* int (*get_supported_sleep_modes); */ &btstack_uart_rt1051_get_supported_sleep_modes,
+        /* void (*set_sleep)(btstack_uart_sleep_mode_t sleep_mode); */ &btstack_uart_rt1051_set_sleep,
+        /* void (*set_wakeup_handler)(void (*handler)(void)); */ &btstack_uart_rt1051_set_wakeup_handler,
     };
 
     const btstack_uart_block_t *btstack_uart_block_rt1051_instance()

--- a/module-bsp/board/rt1051/bluetooth/BlueKitchen.cpp
+++ b/module-bsp/board/rt1051/bluetooth/BlueKitchen.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "bsp/bluetooth/Bluetooth.hpp"
@@ -23,8 +23,7 @@ BlueKitchen::BlueKitchen()
     write_done_cb = NULL;
 }
 
-BlueKitchen::~BlueKitchen()
-{}
+BlueKitchen::~BlueKitchen() = default;
 
 BlueKitchen *BlueKitchen::getInstance()
 {

--- a/module-bsp/board/rt1051/bluetooth/BluetoothCommon.cpp
+++ b/module-bsp/board/rt1051/bluetooth/BluetoothCommon.cpp
@@ -37,8 +37,7 @@ BluetoothCommon::BluetoothCommon()
     GPIO_PinInit(BSP_BLUETOOTH_SHUTDOWN_PORT, BSP_BLUETOOTH_SHUTDOWN_PIN, &gpio_init_structure);
 }
 
-BluetoothCommon::~BluetoothCommon()
-{}
+BluetoothCommon::~BluetoothCommon() = default;
 
 void BluetoothCommon::open()
 {


### PR DESCRIPTION
The `Pure`'s power consumption was measured in three variants:
 * BT off
 * BT on (master)
 * BT on (EGD-6118)

Measurement results (respectively):
* idle [mA]:
   - 78-81
   - 83-85
   - 78-81

* BT headphones connected [mA]
   - (no measurement)
   - 85-87
   - 82-85

* music play [mA] (may be not precise)
   - 90-100
   - 98-105
   - 101-115