### PR TITLE
EGD-6527 Uniform access to translations and API and headers cleanup

### DIFF
--- a/module-apps/application-alarm-clock/ApplicationAlarmClock.cpp
+++ b/module-apps/application-alarm-clock/ApplicationAlarmClock.cpp
@@ -101,7 +101,7 @@ namespace app
                 return std::make_unique<alarmClock::CustomRepeatWindow>(app, std::move(presenter));
             });
         windowsFactory.attach(
-            utils::localize.get("app_alarm_clock_options_title"),
+            utils::translate("app_alarm_clock_options_title"),
             [](Application *app, const std::string &name) { return std::make_unique<gui::OptionWindow>(app, name); });
 
         windowsFactory.attach(

--- a/module-apps/application-alarm-clock/data/AlarmsData.cpp
+++ b/module-apps/application-alarm-clock/data/AlarmsData.cpp
@@ -1,7 +1,8 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlarmsData.hpp"
+#include <map>
 
 static const std::map<WeekDayIso, const char *> weekDaysAbbreviation = {{WeekDayIso::Monday, "common_mon"},
                                                                         {WeekDayIso::Tuesday, "common_tue"},
@@ -22,7 +23,7 @@ std::string CustomRepeatValueParser::getWeekDaysText() const
     std::string weekDaysText;
     for (auto const &[key, val] : weekDaysAbbreviation) {
         if (weekDayData->getData(static_cast<uint32_t>(key))) {
-            weekDaysText += utils::localize.get(val) + ", ";
+            weekDaysText += utils::translate(val) + ", ";
         }
     }
     if (!weekDaysText.empty()) {

--- a/module-apps/application-alarm-clock/models/AlarmsModel.cpp
+++ b/module-apps/application-alarm-clock/models/AlarmsModel.cpp
@@ -57,7 +57,7 @@ namespace app::alarmClock
         };
         item->inputCallback = [this, record = record.get()](gui::Item &, const gui::InputEvent &event) {
             if (event.isShortPress() && event.is(gui::KeyCode::KEY_LF)) {
-                application->switchWindow(utils::localize.get("app_alarm_clock_options_title"),
+                application->switchWindow(utils::translate("app_alarm_clock_options_title"),
                                           std::make_unique<gui::OptionsWindowOptions>(
                                               alarmsListOptions(application, *record, *alarmsRepository)));
             }

--- a/module-apps/application-alarm-clock/models/CustomRepeatModel.cpp
+++ b/module-apps/application-alarm-clock/models/CustomRepeatModel.cpp
@@ -38,7 +38,7 @@ namespace app::alarmClock
     void CustomRepeatModel::createData(const WeekDaysRepeatData &data)
     {
         for (auto const &[key, dayName] : gui::CustomCheckBoxWithLabel::weekDays) {
-            internalData.push_back(new gui::CustomCheckBoxWithLabel(application, utils::localize.get(dayName), data));
+            internalData.push_back(new gui::CustomCheckBoxWithLabel(application, utils::translate(dayName), data));
         }
 
         for (auto &item : internalData) {

--- a/module-apps/application-alarm-clock/widgets/AlarmItem.cpp
+++ b/module-apps/application-alarm-clock/widgets/AlarmItem.cpp
@@ -58,10 +58,10 @@ namespace gui
             onOffImage->switchState(ButtonState::Off);
         }
         if (alarm->repeat == static_cast<uint32_t>(AlarmRepeat::everyday)) {
-            periodLabel->setText(utils::localize.get("app_alarm_clock_repeat_everyday"));
+            periodLabel->setText(utils::translate("app_alarm_clock_repeat_everyday"));
         }
         else if (alarm->repeat == static_cast<uint32_t>(AlarmRepeat::weekDays)) {
-            periodLabel->setText(utils::localize.get("app_alarm_clock_repeat_week_days"));
+            periodLabel->setText(utils::translate("app_alarm_clock_repeat_week_days"));
         }
         else if (alarm->repeat != static_cast<uint32_t>(AlarmRepeat::never)) {
             periodLabel->setText(CustomRepeatValueParser(alarm->repeat).getWeekDaysText());

--- a/module-apps/application-alarm-clock/widgets/AlarmOptionsItem.cpp
+++ b/module-apps/application-alarm-clock/widgets/AlarmOptionsItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlarmOptionsItem.hpp"
@@ -83,13 +83,13 @@ namespace gui
         optionsNames.clear();
         switch (itemName) {
         case AlarmOptionItemName::Sound:
-            descriptionLabel->setText(utils::localize.get("app_alarm_clock_sound"));
+            descriptionLabel->setText(utils::translate("app_alarm_clock_sound"));
             break;
         case AlarmOptionItemName::Snooze:
-            descriptionLabel->setText(utils::localize.get("app_alarm_clock_snooze"));
+            descriptionLabel->setText(utils::translate("app_alarm_clock_snooze"));
             break;
         case AlarmOptionItemName::Repeat:
-            descriptionLabel->setText(utils::localize.get("app_alarm_clock_repeat"));
+            descriptionLabel->setText(utils::translate("app_alarm_clock_repeat"));
             break;
         }
         if (itemName == AlarmOptionItemName::Sound) {
@@ -98,16 +98,16 @@ namespace gui
             }
         }
         else if (itemName == AlarmOptionItemName::Snooze) {
-            optionsNames.push_back(utils::localize.get("app_alarm_clock_snooze_5_min"));
-            optionsNames.push_back(utils::localize.get("app_alarm_clock_snooze_10_min"));
-            optionsNames.push_back(utils::localize.get("app_alarm_clock_snooze_15_min"));
-            optionsNames.push_back(utils::localize.get("app_alarm_clock_snooze_30_min"));
+            optionsNames.push_back(utils::translate("app_alarm_clock_snooze_5_min"));
+            optionsNames.push_back(utils::translate("app_alarm_clock_snooze_10_min"));
+            optionsNames.push_back(utils::translate("app_alarm_clock_snooze_15_min"));
+            optionsNames.push_back(utils::translate("app_alarm_clock_snooze_30_min"));
         }
         else if (itemName == AlarmOptionItemName::Repeat) {
-            optionsNames.push_back(utils::localize.get("app_alarm_clock_repeat_never"));
-            optionsNames.push_back(utils::localize.get("app_alarm_clock_repeat_everyday"));
-            optionsNames.push_back(utils::localize.get("app_alarm_clock_repeat_week_days"));
-            optionsNames.push_back(utils::localize.get("app_alarm_clock_repeat_custom"));
+            optionsNames.push_back(utils::translate("app_alarm_clock_repeat_never"));
+            optionsNames.push_back(utils::translate("app_alarm_clock_repeat_everyday"));
+            optionsNames.push_back(utils::translate("app_alarm_clock_repeat_week_days"));
+            optionsNames.push_back(utils::translate("app_alarm_clock_repeat_custom"));
         }
     }
 
@@ -121,10 +121,10 @@ namespace gui
                 rightArrow->setVisible(true);
                 hBox->resizeItems();
                 if (itemName == AlarmOptionItemName::Sound) {
-                    bottomBarTemporaryMode(utils::localize.get("app_alarm_clock_play_pause"));
+                    bottomBarTemporaryMode(utils::translate("app_alarm_clock_play_pause"));
                 }
                 if (itemName == AlarmOptionItemName::Repeat && actualVectorIndex == optionsNames.size() - 1) {
-                    bottomBarTemporaryMode(utils::localize.get("app_alarm_clock_edit"));
+                    bottomBarTemporaryMode(utils::translate("app_alarm_clock_edit"));
                 }
             }
             else {
@@ -151,7 +151,7 @@ namespace gui
                 if (actualVectorIndex >= optionsNames.size()) {
                     actualVectorIndex = optionsNames.size() - 1;
                     if (itemName == AlarmOptionItemName::Repeat) {
-                        bottomBarTemporaryMode(utils::localize.get("app_alarm_clock_edit"));
+                        bottomBarTemporaryMode(utils::translate("app_alarm_clock_edit"));
                     }
                 }
                 else if (itemName == AlarmOptionItemName::Repeat) {
@@ -167,7 +167,7 @@ namespace gui
                     actualVectorIndex = 0;
                 }
                 if (actualVectorIndex == optionsNames.size() - 1 && itemName == AlarmOptionItemName::Repeat) {
-                    bottomBarTemporaryMode(utils::localize.get("app_alarm_clock_edit"));
+                    bottomBarTemporaryMode(utils::translate("app_alarm_clock_edit"));
                 }
                 else if (itemName == AlarmOptionItemName::Repeat) {
                     bottomBarRestoreFromTemporaryMode();
@@ -213,8 +213,7 @@ namespace gui
                     alarm->repeat = actualVectorIndex;
                 }
                 else if (alarm->repeat == optionsNames.size() - 1 ||
-                         optionsNames[optionsNames.size() - 1] ==
-                             utils::localize.get("app_alarm_clock_repeat_custom")) {
+                         optionsNames[optionsNames.size() - 1] == utils::translate("app_alarm_clock_repeat_custom")) {
                     alarm->repeat = static_cast<uint32_t>(AlarmRepeat::never);
                 }
                 break;
@@ -252,7 +251,7 @@ namespace gui
                 if (alarm->repeat < optionsNames.size() - 1) {
                     actualVectorIndex = alarm->repeat;
                     if (alarm->repeat == static_cast<uint32_t>(AlarmRepeat::never)) {
-                        optionsNames[optionsNames.size() - 1] = utils::localize.get("app_alarm_clock_repeat_custom");
+                        optionsNames[optionsNames.size() - 1] = utils::translate("app_alarm_clock_repeat_custom");
                     }
                     bottomBarRestoreFromTemporaryMode();
                 }
@@ -262,19 +261,19 @@ namespace gui
                         actualVectorIndex = static_cast<uint32_t>(AlarmRepeat::everyday);
                         alarm->repeat     = actualVectorIndex;
                         bottomBarRestoreFromTemporaryMode();
-                        optionsNames[optionsNames.size() - 1] = utils::localize.get("app_alarm_clock_repeat_custom");
+                        optionsNames[optionsNames.size() - 1] = utils::translate("app_alarm_clock_repeat_custom");
                     }
                     else if (parser.isCustomValueWeekDays()) {
                         actualVectorIndex = static_cast<uint32_t>(AlarmRepeat::weekDays);
                         alarm->repeat     = actualVectorIndex;
                         bottomBarRestoreFromTemporaryMode();
-                        optionsNames[optionsNames.size() - 1] = utils::localize.get("app_alarm_clock_repeat_custom");
+                        optionsNames[optionsNames.size() - 1] = utils::translate("app_alarm_clock_repeat_custom");
                     }
                     else {
                         actualVectorIndex                     = optionsNames.size() - 1;
                         optionsNames[optionsNames.size() - 1] = parser.getWeekDaysText();
                         if (this->focus) {
-                            bottomBarTemporaryMode(utils::localize.get("app_alarm_clock_edit"));
+                            bottomBarTemporaryMode(utils::translate("app_alarm_clock_edit"));
                         }
                     }
                 }

--- a/module-apps/application-alarm-clock/widgets/AlarmTimeItem.cpp
+++ b/module-apps/application-alarm-clock/widgets/AlarmTimeItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlarmTimeItem.hpp"
@@ -155,17 +155,17 @@ namespace gui
             mode12hInput->setFont(style::window::font::largelight);
             mode12hInput->setPenFocusWidth(style::window::default_border_focus_w);
             mode12hInput->setPenWidth(style::window::default_border_rect_no_focus);
-            mode12hInput->setText(utils::localize.get(utils::time::Locale::getAM()));
+            mode12hInput->setText(utils::translate(utils::time::Locale::getAM()));
             mode12hInput->inputCallback = [&](Item &item, const InputEvent &event) {
                 if (event.state != gui::InputEvent::State::keyReleasedShort) {
                     return false;
                 }
                 if (event.keyCode == gui::KeyCode::KEY_LF) {
-                    if (mode12hInput->getText() == utils::localize.get(utils::time::Locale::getAM())) {
-                        mode12hInput->setText(utils::localize.get(utils::time::Locale::getPM()));
+                    if (mode12hInput->getText() == utils::translate(utils::time::Locale::getAM())) {
+                        mode12hInput->setText(utils::translate(utils::time::Locale::getPM()));
                     }
                     else {
-                        mode12hInput->setText(utils::localize.get(utils::time::Locale::getAM()));
+                        mode12hInput->setText(utils::translate(utils::time::Locale::getAM()));
                     }
                     return true;
                 }
@@ -173,7 +173,7 @@ namespace gui
             };
             mode12hInput->focusChangedCallback = [&](Item &item) {
                 if (item.focus) {
-                    bottomBarTemporaryMode(utils::localize.get("common_switch"));
+                    bottomBarTemporaryMode(utils::translate("common_switch"));
                 }
                 else {
                     bottomBarRestoreFromTemporaryMode();
@@ -190,10 +190,10 @@ namespace gui
                 hourInput->setText(TimePointToHourString12H(alarm->time));
                 minuteInput->setText(TimePointToMinutesString(alarm->time));
                 if (date::is_am(TimePointToHourMinSec(alarm->time).hours())) {
-                    mode12hInput->setText(utils::localize.get(utils::time::Locale::getAM()));
+                    mode12hInput->setText(utils::translate(utils::time::Locale::getAM()));
                 }
                 else {
-                    mode12hInput->setText(utils::localize.get(utils::time::Locale::getPM()));
+                    mode12hInput->setText(utils::translate(utils::time::Locale::getPM()));
                 }
             };
         }
@@ -210,7 +210,7 @@ namespace gui
 
     bool AlarmTimeItem::isPm(const std::string &text) const
     {
-        return !(text == utils::localize.get(utils::time::Locale::getAM()));
+        return !(text == utils::translate(utils::time::Locale::getAM()));
     }
 
     void AlarmTimeItem::validateHour()

--- a/module-apps/application-alarm-clock/widgets/CustomCheckBoxWithLabel.cpp
+++ b/module-apps/application-alarm-clock/widgets/CustomCheckBoxWithLabel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CustomCheckBoxWithLabel.hpp"
@@ -90,7 +90,7 @@ namespace gui
     void CustomCheckBoxWithLabel::setCheckBoxes()
     {
         for (auto const &[key, dayName] : weekDays) {
-            if (descriptionLabel->getText() == utils::localize.get(dayName)) {
+            if (descriptionLabel->getText() == utils::translate(dayName)) {
                 checkBox->setImageVisible(checkBoxData.getData(static_cast<uint32_t>(key)));
             }
         }

--- a/module-apps/application-alarm-clock/windows/AlarmClockMainWindow.cpp
+++ b/module-apps/application-alarm-clock/windows/AlarmClockMainWindow.cpp
@@ -33,11 +33,11 @@ namespace app::alarmClock
         AppWindow::buildInterface();
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::Switch));
-        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::Switch));
+        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate(style::strings::common::options));
 
-        setTitle(utils::localize.get("app_alarm_clock_title_main"));
+        setTitle(utils::translate("app_alarm_clock_title_main"));
         leftArrowImage = new gui::Image(
             this, style::alarmClock::window::arrow_x, style::alarmClock::window::arrow_y, 0, 0, "arrow_left");
         plusSignImage =
@@ -62,7 +62,7 @@ namespace app::alarmClock
                                       style::window_width,
                                       style::window_height - ::style::header::height - ::style::footer::height,
                                       "phonebook_empty_grey_circle_W_G",
-                                      utils::localize.get("app_alarm_clock_no_alarms_information"));
+                                      utils::translate("app_alarm_clock_no_alarms_information"));
         emptyListIcon->focusChangedCallback = [this](gui::Item &) {
             onEmptyList();
             return true;

--- a/module-apps/application-alarm-clock/windows/AlarmClockOptions.cpp
+++ b/module-apps/application-alarm-clock/windows/AlarmClockOptions.cpp
@@ -16,7 +16,7 @@ namespace app::alarmClock
                        std::function<bool(gui::Item &)> onClickCallback,
                        std::list<gui::Option> &options)
         {
-            options.emplace_back(utils::localize.get(translationId), onClickCallback);
+            options.emplace_back(utils::translate(translationId), onClickCallback);
         }
 
         void removeAlarm(const AlarmsRecord &record,
@@ -24,9 +24,9 @@ namespace app::alarmClock
                          AbstractAlarmsRepository &alarmsRepository)
         {
             auto metaData = std::make_unique<gui::DialogMetadataMessage>(
-                gui::DialogMetadata{utils::localize.get("app_alarm_clock_title_main"),
+                gui::DialogMetadata{utils::translate("app_alarm_clock_title_main"),
                                     "phonebook_contact_delete_trashcan",
-                                    utils::localize.get("app_alarm_clock_delete_confirmation"),
+                                    utils::translate("app_alarm_clock_delete_confirmation"),
                                     "",
                                     [record, application, &alarmsRepository] {
                                         alarmsRepository.remove(record, [application](bool) {

--- a/module-apps/application-alarm-clock/windows/CustomRepeatWindow.cpp
+++ b/module-apps/application-alarm-clock/windows/CustomRepeatWindow.cpp
@@ -20,10 +20,10 @@ namespace app::alarmClock
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::save));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::save));
 
-        setTitle(utils::localize.get("app_calendar_custom_repeat_title"));
+        setTitle(utils::translate("app_calendar_custom_repeat_title"));
         list = new gui::ListView(this,
                                  style::alarmClock::window::listView_x,
                                  style::alarmClock::window::listView_y,

--- a/module-apps/application-alarm-clock/windows/NewEditAlarmWindow.cpp
+++ b/module-apps/application-alarm-clock/windows/NewEditAlarmWindow.cpp
@@ -23,8 +23,8 @@ namespace app::alarmClock
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::save));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::save));
 
         list = new gui::ListView(this,
                                  style::alarmClock::window::listView_x,
@@ -40,10 +40,10 @@ namespace app::alarmClock
     {
         switch (alarmAction) {
         case AlarmAction::Add:
-            setTitle(utils::localize.get("app_alarm_clock_new_alarm_title"));
+            setTitle(utils::translate("app_alarm_clock_new_alarm_title"));
             break;
         case AlarmAction::Edit:
-            setTitle(utils::localize.get("app_alarm_clock_edit_alarm_title"));
+            setTitle(utils::translate("app_alarm_clock_edit_alarm_title"));
             break;
         }
 

--- a/module-apps/application-antenna/windows/AlgoParamsWindow.cpp
+++ b/module-apps/application-antenna/windows/AlgoParamsWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlgoParamsWindow.hpp"
@@ -36,10 +36,10 @@ namespace gui
         bottomBar->setActive(BottomBar::Side::LEFT, true);
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::open));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("app_desktop_tools_antenna"));
+        setTitle(utils::translate("app_desktop_tools_antenna"));
 
         lowBandBox  = new gui::VBox(this,
                                    antenna::algo_window::leftColumnXPos,

--- a/module-apps/application-antenna/windows/AntennaMainWindow.cpp
+++ b/module-apps/application-antenna/windows/AntennaMainWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 /*
@@ -45,10 +45,10 @@ namespace gui
 
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::open));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("app_desktop_tools_antenna"));
+        setTitle(utils::translate("app_desktop_tools_antenna"));
 
         for (auto title : titlesText) {
             titles.push_back(addLabel(title, [=](gui::Item &item) { return true; }));

--- a/module-apps/application-antenna/windows/ScanModesWindow.cpp
+++ b/module-apps/application-antenna/windows/ScanModesWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ScanModesWindow.hpp"
@@ -34,10 +34,10 @@ namespace gui
         bottomBar->setActive(BottomBar::Side::LEFT, true);
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::open));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("app_desktop_tools_antenna"));
+        setTitle(utils::translate("app_desktop_tools_antenna"));
 
         modeButtonParams.insert(std::pair<uint32_t, std::string>(scanModes::Auto, "AUTO"));
         modeButtonParams.insert(std::pair<uint32_t, std::string>(scanModes::GSM_only, "GSM only"));

--- a/module-apps/application-calculator/data/CalculatorInputProcessorText.cpp
+++ b/module-apps/application-calculator/data/CalculatorInputProcessorText.cpp
@@ -61,7 +61,7 @@ bool calc::InputProcessorText::handle(const gui::InputEvent &event)
 
     if (event.keyCode == gui::KeyCode::KEY_LF) {
         if (!isPreviousNumberDecimal()) {
-            writeEquation(lastCharIsSymbol, utils::localize.get("app_calculator_decimal_separator"));
+            writeEquation(lastCharIsSymbol, utils::translate("app_calculator_decimal_separator"));
         }
         return true;
     }
@@ -138,7 +138,7 @@ bool calc::InputProcessorText::isPreviousNumberDecimal() const
         else {
             lastNumber = input.substr(*it, std::string::npos);
         }
-        return lastNumber.find(utils::localize.get("app_calculator_decimal_separator")) != std::string::npos;
+        return lastNumber.find(utils::translate("app_calculator_decimal_separator")) != std::string::npos;
     }
     return false;
 }
@@ -149,7 +149,7 @@ bool calc::InputProcessorText::decimalLimitReached() const
         return false;
 
     const auto &txt          = std::string{inputField->getText()};
-    const auto separator_pos = txt.find_last_of(utils::localize.get("app_calculator_decimal_separator"));
+    const auto separator_pos = txt.find_last_of(utils::translate("app_calculator_decimal_separator"));
 
     if ((txt.size() - separator_pos) > DecimalDigitsLimit)
         return true;

--- a/module-apps/application-calculator/data/CalculatorUtility.cpp
+++ b/module-apps/application-calculator/data/CalculatorUtility.cpp
@@ -25,14 +25,14 @@ namespace calc
             if (output.length() > CalculatorConstants::maxStringLength) {
                 output = getValueThatFitsOnScreen(result);
             }
-            if (utils::localize.get("app_calculator_decimal_separator") == symbols::strings::comma) {
+            if (utils::translate("app_calculator_decimal_separator") == symbols::strings::comma) {
                 output.replace(output.find(symbols::strings::full_stop),
                                std::size(std::string_view(symbols::strings::full_stop)),
                                symbols::strings::comma);
             }
             return Result{source, output, false};
         }
-        return Result{source, utils::localize.get("app_calculator_error"), true};
+        return Result{source, utils::translate("app_calculator_error"), true};
     }
 
     std::string Calculator::prepareEquationForParser(std::string input)

--- a/module-apps/application-calculator/tests/CalculatorInput_tests.cpp
+++ b/module-apps/application-calculator/tests/CalculatorInput_tests.cpp
@@ -19,7 +19,7 @@ SCENARIO("Input Processor tests")
 
     GIVEN("An empty input")
     {
-        utils::localize.setDisplayLanguage("English");
+        utils::setDisplayLanguage("English");
 
         auto inputField = gui::Text{};
         auto processor  = calc::InputProcessorText{gsl::make_strict_not_null(&inputField)};

--- a/module-apps/application-calculator/tests/CalculatorUtility_tests.cpp
+++ b/module-apps/application-calculator/tests/CalculatorUtility_tests.cpp
@@ -9,7 +9,7 @@
 TEST_CASE("Calculator utilities")
 {
     auto calculator = calc::Calculator();
-    utils::localize.setDisplayLanguage("English");
+    utils::setDisplayLanguage("English");
 
     SECTION("Empty input")
     {
@@ -87,7 +87,7 @@ TEST_CASE("Calculator utilities")
 
     SECTION("Fraction with comma")
     {
-        utils::localize.setDisplayLanguage("Polski");
+        utils::setDisplayLanguage("Polski");
         auto result = calculator.calculate("15,5+12,056");
         REQUIRE(result.value == "27,556");
         REQUIRE(result.equation == "15.5+12.056");
@@ -97,7 +97,7 @@ TEST_CASE("Calculator utilities")
     SECTION("Division by 0")
     {
         auto result = calculator.calculate("15+5÷0");
-        REQUIRE(result.value == utils::localize.get("app_calculator_error"));
+        REQUIRE(result.value == utils::translate("app_calculator_error"));
         REQUIRE(result.equation == "15+5/0");
         REQUIRE(result.isError);
     }
@@ -105,7 +105,7 @@ TEST_CASE("Calculator utilities")
     SECTION("Division 0 by 0")
     {
         auto result = calculator.calculate("0÷0");
-        REQUIRE(result.value == utils::localize.get("app_calculator_error"));
+        REQUIRE(result.value == utils::translate("app_calculator_error"));
         REQUIRE(result.equation == "0/0");
         REQUIRE(result.isError);
     }
@@ -113,7 +113,7 @@ TEST_CASE("Calculator utilities")
     SECTION("Result exceeds maximum number")
     {
         auto result = calculator.calculate("1.79769e+308×2");
-        REQUIRE(result.value == utils::localize.get("app_calculator_error"));
+        REQUIRE(result.value == utils::translate("app_calculator_error"));
         REQUIRE(result.equation == "1.79769e+308*2");
         REQUIRE(result.isError);
     }

--- a/module-apps/application-calculator/windows/CalculatorMainWindow.cpp
+++ b/module-apps/application-calculator/windows/CalculatorMainWindow.cpp
@@ -18,14 +18,14 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_calculator_title_main"));
+        setTitle(utils::translate("app_calculator_title_main"));
 
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setActive(gui::BottomBar::Side::LEFT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::calculator::equals));
-        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::localize.get(style::calculator::decimal_separator));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::calculator::equals));
+        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate(style::calculator::decimal_separator));
         bottomBar->setFont(BottomBar::Side::LEFT, style::window::font::largelight);
 
         mathOperationInput = new gui::Text(this,

--- a/module-apps/application-calendar/ApplicationCalendar.cpp
+++ b/module-apps/application-calendar/ApplicationCalendar.cpp
@@ -167,7 +167,7 @@ namespace app
         auto metaData = std::make_unique<gui::DialogMetadataMessage>(gui::DialogMetadata{
             title,
             "phonebook_empty_grey_circle_W_G",
-            utils::localize.get("app_calendar_no_events_information"),
+            utils::translate("app_calendar_no_events_information"),
             "",
             [=]() -> bool {
                 LOG_DEBUG("Switch to new event window");

--- a/module-apps/application-calendar/models/AllEventsModel.cpp
+++ b/module-apps/application-calendar/models/AllEventsModel.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AllEventsModel.hpp"
@@ -77,7 +77,7 @@ auto AllEventsModel::handleQueryResponse(db::QueryResult *queryResult) -> bool
 
         if (app->getEquivalentToEmptyWindow() == EquivalentWindow::AllEventsWindow) {
             auto filter = TimePointNow();
-            app->switchToNoEventsWindow(utils::localize.get("app_calendar_title_main"), filter);
+            app->switchToNoEventsWindow(utils::translate("app_calendar_title_main"), filter);
         }
     }
     auto eventShift = app->getEventShift();

--- a/module-apps/application-calendar/models/CustomRepeatModel.cpp
+++ b/module-apps/application-calendar/models/CustomRepeatModel.cpp
@@ -33,19 +33,19 @@ gui::ListItem *CustomRepeatModel::getItem(gui::Order order)
 void CustomRepeatModel::createData(const std::shared_ptr<WeekDaysRepeatData> &data)
 {
     internalData.push_back(
-        new gui::CheckBoxWithLabelItem(application, utils::localize.get(style::strings::common::Monday), data));
+        new gui::CheckBoxWithLabelItem(application, utils::translate(style::strings::common::Monday), data));
     internalData.push_back(
-        new gui::CheckBoxWithLabelItem(application, utils::localize.get(style::strings::common::Tuesday), data));
+        new gui::CheckBoxWithLabelItem(application, utils::translate(style::strings::common::Tuesday), data));
     internalData.push_back(
-        new gui::CheckBoxWithLabelItem(application, utils::localize.get(style::strings::common::Wednesday), data));
+        new gui::CheckBoxWithLabelItem(application, utils::translate(style::strings::common::Wednesday), data));
     internalData.push_back(
-        new gui::CheckBoxWithLabelItem(application, utils::localize.get(style::strings::common::Thursday), data));
+        new gui::CheckBoxWithLabelItem(application, utils::translate(style::strings::common::Thursday), data));
     internalData.push_back(
-        new gui::CheckBoxWithLabelItem(application, utils::localize.get(style::strings::common::Friday), data));
+        new gui::CheckBoxWithLabelItem(application, utils::translate(style::strings::common::Friday), data));
     internalData.push_back(
-        new gui::CheckBoxWithLabelItem(application, utils::localize.get(style::strings::common::Saturday), data));
+        new gui::CheckBoxWithLabelItem(application, utils::translate(style::strings::common::Saturday), data));
     internalData.push_back(
-        new gui::CheckBoxWithLabelItem(application, utils::localize.get(style::strings::common::Sunday), data));
+        new gui::CheckBoxWithLabelItem(application, utils::translate(style::strings::common::Sunday), data));
 
     for (auto &item : internalData) {
         item->deleteByList = false;

--- a/module-apps/application-calendar/models/NewEditEventModel.cpp
+++ b/module-apps/application-calendar/models/NewEditEventModel.cpp
@@ -47,13 +47,13 @@ void NewEditEventModel::createData(bool allDayEvent)
     assert(app != nullptr);
 
     eventNameInput = new gui::TextWithLabelItem(
-        utils::localize.get("app_calendar_new_edit_event_name"),
+        utils::translate("app_calendar_new_edit_event_name"),
         [app](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text); },
         [app]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); },
         [app]() { app->getCurrentWindow()->selectSpecialCharacter(); });
 
     allDayEventCheckBox = new gui::NewEventCheckBoxWithLabel(
-        application, utils::localize.get("app_calendar_new_edit_event_allday"), [this](bool isChecked) {
+        application, utils::translate("app_calendar_new_edit_event_allday"), [this](bool isChecked) {
             isChecked ? createTimeItems() : eraseTimeItems();
             const auto it = std::find(std::begin(internalData), std::end(internalData), allDayEventCheckBox);
             list->rebuildList(gui::listview::RebuildType::OnPageElement, std::distance(std::begin(internalData), it));
@@ -63,13 +63,13 @@ void NewEditEventModel::createData(bool allDayEvent)
 
     reminder = new gui::SeveralOptionsItem(
         application,
-        utils::localize.get("app_calendar_event_detail_reminder"),
+        utils::translate("app_calendar_event_detail_reminder"),
         [app](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text, false); },
         [app]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); });
 
     repeat = new gui::SeveralOptionsItem(
         application,
-        utils::localize.get("app_calendar_event_detail_repeat"),
+        utils::translate("app_calendar_event_detail_repeat"),
         [app](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text, false); },
         [app]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); });
 
@@ -196,8 +196,8 @@ void NewEditEventModel::createTimeItems()
         }
     };
 
-    create(startTime, utils::localize.get("app_calendar_new_edit_event_start"), gui::TimeWidget::Type::Start);
-    create(endTime, utils::localize.get("app_calendar_new_edit_event_end"), gui::TimeWidget::Type::End);
+    create(startTime, utils::translate("app_calendar_new_edit_event_start"), gui::TimeWidget::Type::Start);
+    create(endTime, utils::translate("app_calendar_new_edit_event_end"), gui::TimeWidget::Type::End);
 
     startTime->setConnectionToSecondItem(endTime);
     endTime->setConnectionToSecondItem(startTime);

--- a/module-apps/application-calendar/widgets/CheckBoxWithLabelItem.cpp
+++ b/module-apps/application-calendar/widgets/CheckBoxWithLabelItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CheckBoxWithLabelItem.hpp"
@@ -90,25 +90,25 @@ namespace gui
 
     void CheckBoxWithLabelItem::setCheckBoxes()
     {
-        if (descriptionLabel->getText() == utils::localize.get(style::strings::common::Monday)) {
+        if (descriptionLabel->getText() == utils::translate(style::strings::common::Monday)) {
             checkBox->setImageVisible(checkBoxData->getData(date::Monday.iso_encoding() - 1));
         }
-        else if (descriptionLabel->getText() == utils::localize.get(style::strings::common::Tuesday)) {
+        else if (descriptionLabel->getText() == utils::translate(style::strings::common::Tuesday)) {
             checkBox->setImageVisible(checkBoxData->getData(date::Tuesday.iso_encoding() - 1));
         }
-        else if (descriptionLabel->getText() == utils::localize.get(style::strings::common::Wednesday)) {
+        else if (descriptionLabel->getText() == utils::translate(style::strings::common::Wednesday)) {
             checkBox->setImageVisible(checkBoxData->getData(date::Wednesday.iso_encoding() - 1));
         }
-        else if (descriptionLabel->getText() == utils::localize.get(style::strings::common::Thursday)) {
+        else if (descriptionLabel->getText() == utils::translate(style::strings::common::Thursday)) {
             checkBox->setImageVisible(checkBoxData->getData(date::Thursday.iso_encoding() - 1));
         }
-        else if (descriptionLabel->getText() == utils::localize.get(style::strings::common::Friday)) {
+        else if (descriptionLabel->getText() == utils::translate(style::strings::common::Friday)) {
             checkBox->setImageVisible(checkBoxData->getData(date::Friday.iso_encoding() - 1));
         }
-        else if (descriptionLabel->getText() == utils::localize.get(style::strings::common::Saturday)) {
+        else if (descriptionLabel->getText() == utils::translate(style::strings::common::Saturday)) {
             checkBox->setImageVisible(checkBoxData->getData(date::Saturday.iso_encoding() - 1));
         }
-        else if (descriptionLabel->getText() == utils::localize.get(style::strings::common::Sunday)) {
+        else if (descriptionLabel->getText() == utils::translate(style::strings::common::Sunday)) {
             checkBox->setImageVisible(checkBoxData->getData(date::Sunday.iso_encoding() - 1));
         }
     }

--- a/module-apps/application-calendar/widgets/EventDetailDescriptionItem.cpp
+++ b/module-apps/application-calendar/widgets/EventDetailDescriptionItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "EventDetailDescriptionItem.hpp"
@@ -74,7 +74,7 @@ namespace gui
 
     void EventDetailDescriptionItem::descriptionHandler()
     {
-        title->setText(utils::localize.get("app_calendar_event_detail"));
+        title->setText(utils::translate("app_calendar_event_detail"));
         onLoadCallback = [&](std::shared_ptr<EventsRecord> event) {
             description->setText(event->title);
             eventTime->setText(

--- a/module-apps/application-calendar/widgets/RepeatAndReminderItem.cpp
+++ b/module-apps/application-calendar/widgets/RepeatAndReminderItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "RepeatAndReminderItem.hpp"
@@ -100,18 +100,18 @@ namespace gui
 
     void RepeatAndReminderItem::descriptionHandler()
     {
-        repeatTitle->setText(utils::localize.get("app_calendar_event_detail_repeat"));
-        reminderTitle->setText(utils::localize.get("app_calendar_event_detail_reminder"));
+        repeatTitle->setText(utils::translate("app_calendar_event_detail_repeat"));
+        reminderTitle->setText(utils::translate("app_calendar_event_detail_reminder"));
         onLoadCallback = [&](std::shared_ptr<EventsRecord> event) {
             if (event->repeat > app::ApplicationCalendar::repeatOptions.size()) {
                 repeat->setText(CustomRepeatValueParser(event->repeat).getWeekDaysText());
             }
             else {
-                repeat->setText(utils::localize.get(
-                    app::ApplicationCalendar::repeatOptions.at(static_cast<Repeat>(event->repeat))));
+                repeat->setText(
+                    utils::translate(app::ApplicationCalendar::repeatOptions.at(static_cast<Repeat>(event->repeat))));
             }
-            reminder->setText(utils::localize.get(
-                app::ApplicationCalendar::reminderOptions.at(static_cast<Reminder>(event->reminder))));
+            reminder->setText(
+                utils::translate(app::ApplicationCalendar::reminderOptions.at(static_cast<Reminder>(event->reminder))));
         };
     }
 

--- a/module-apps/application-calendar/widgets/SeveralOptionsItem.cpp
+++ b/module-apps/application-calendar/widgets/SeveralOptionsItem.cpp
@@ -79,26 +79,26 @@ namespace gui
     void SeveralOptionsItem::prepareOptionsNames()
     {
         optionsNames.clear();
-        if (descriptionLabel->getText() == utils::localize.get("app_calendar_event_detail_reminder")) {
-            optionsNames.push_back(utils::localize.get("app_calendar_reminder_never"));
-            optionsNames.push_back(utils::localize.get("app_calendar_reminder_event_time"));
-            optionsNames.push_back(utils::localize.get("app_calendar_reminder_5_min_before"));
-            optionsNames.push_back(utils::localize.get("app_calendar_reminder_15_min_before"));
-            optionsNames.push_back(utils::localize.get("app_calendar_reminder_30_min_before"));
-            optionsNames.push_back(utils::localize.get("app_calendar_reminder_1_hour_before"));
-            optionsNames.push_back(utils::localize.get("app_calendar_reminder_2_hour_before"));
-            optionsNames.push_back(utils::localize.get("app_calendar_reminder_1_day_before"));
-            optionsNames.push_back(utils::localize.get("app_calendar_reminder_2_days_before"));
-            optionsNames.push_back(utils::localize.get("app_calendar_reminder_1_week_before"));
+        if (descriptionLabel->getText() == utils::translate("app_calendar_event_detail_reminder")) {
+            optionsNames.push_back(utils::translate("app_calendar_reminder_never"));
+            optionsNames.push_back(utils::translate("app_calendar_reminder_event_time"));
+            optionsNames.push_back(utils::translate("app_calendar_reminder_5_min_before"));
+            optionsNames.push_back(utils::translate("app_calendar_reminder_15_min_before"));
+            optionsNames.push_back(utils::translate("app_calendar_reminder_30_min_before"));
+            optionsNames.push_back(utils::translate("app_calendar_reminder_1_hour_before"));
+            optionsNames.push_back(utils::translate("app_calendar_reminder_2_hour_before"));
+            optionsNames.push_back(utils::translate("app_calendar_reminder_1_day_before"));
+            optionsNames.push_back(utils::translate("app_calendar_reminder_2_days_before"));
+            optionsNames.push_back(utils::translate("app_calendar_reminder_1_week_before"));
         }
-        else if (descriptionLabel->getText() == utils::localize.get("app_calendar_event_detail_repeat")) {
-            optionsNames.push_back(utils::localize.get("app_calendar_repeat_never"));
-            optionsNames.push_back(utils::localize.get("app_calendar_repeat_daily"));
-            optionsNames.push_back(utils::localize.get("app_calendar_repeat_weekly"));
-            optionsNames.push_back(utils::localize.get("app_calendar_repeat_two_weeks"));
-            optionsNames.push_back(utils::localize.get("app_calendar_repeat_month"));
-            optionsNames.push_back(utils::localize.get("app_calendar_repeat_year"));
-            optionsNames.push_back(utils::localize.get("app_calendar_repeat_custom"));
+        else if (descriptionLabel->getText() == utils::translate("app_calendar_event_detail_repeat")) {
+            optionsNames.push_back(utils::translate("app_calendar_repeat_never"));
+            optionsNames.push_back(utils::translate("app_calendar_repeat_daily"));
+            optionsNames.push_back(utils::translate("app_calendar_repeat_weekly"));
+            optionsNames.push_back(utils::translate("app_calendar_repeat_two_weeks"));
+            optionsNames.push_back(utils::translate("app_calendar_repeat_month"));
+            optionsNames.push_back(utils::translate("app_calendar_repeat_year"));
+            optionsNames.push_back(utils::translate("app_calendar_repeat_custom"));
         }
     }
 
@@ -107,8 +107,8 @@ namespace gui
         focusChangedCallback = [&](Item &item) {
             if (item.focus) {
                 if (actualVectorIndex == optionsNames.size() - 1 &&
-                    descriptionLabel->getText() == utils::localize.get("app_calendar_event_detail_repeat")) {
-                    bottomBarTemporaryMode(utils::localize.get("app_calendar_edit"));
+                    descriptionLabel->getText() == utils::translate("app_calendar_event_detail_repeat")) {
+                    bottomBarTemporaryMode(utils::translate("app_calendar_edit"));
                 }
                 optionLabel->setMargins(gui::Margins(0, 0, 0, 0));
             }
@@ -130,8 +130,8 @@ namespace gui
                 actualVectorIndex--;
                 if (actualVectorIndex >= optionsNames.size()) {
                     actualVectorIndex = optionsNames.size() - 1;
-                    if (descriptionLabel->getText() == utils::localize.get("app_calendar_event_detail_repeat")) {
-                        bottomBarTemporaryMode(utils::localize.get("app_calendar_edit"));
+                    if (descriptionLabel->getText() == utils::translate("app_calendar_event_detail_repeat")) {
+                        bottomBarTemporaryMode(utils::translate("app_calendar_edit"));
                     }
                 }
                 else {
@@ -147,8 +147,8 @@ namespace gui
                 }
                 optionLabel->setText(optionsNames[actualVectorIndex]);
                 if (actualVectorIndex == optionsNames.size() - 1 &&
-                    descriptionLabel->getText() == utils::localize.get("app_calendar_event_detail_repeat")) {
-                    bottomBarTemporaryMode(utils::localize.get("app_calendar_edit"));
+                    descriptionLabel->getText() == utils::translate("app_calendar_event_detail_repeat")) {
+                    bottomBarTemporaryMode(utils::translate("app_calendar_edit"));
                 }
                 else {
                     bottomBarRestoreFromTemporaryMode();
@@ -156,7 +156,7 @@ namespace gui
                 return true;
             }
             if (event.keyCode == gui::KeyCode::KEY_LF && actualVectorIndex == optionsNames.size() - 1 &&
-                descriptionLabel->getText() == utils::localize.get("app_calendar_event_detail_repeat")) {
+                descriptionLabel->getText() == utils::translate("app_calendar_event_detail_repeat")) {
                 OptionParser parser;
                 auto weekDayRepeatData = std::make_unique<WeekDaysRepeatData>();
                 assert(weekDayRepeatData != nullptr);
@@ -168,26 +168,26 @@ namespace gui
         };
 
         onSaveCallback = [&](std::shared_ptr<EventsRecord> record) {
-            if (descriptionLabel->getText() == utils::localize.get("app_calendar_event_detail_repeat")) {
+            if (descriptionLabel->getText() == utils::translate("app_calendar_event_detail_repeat")) {
                 if (record->repeat < optionsNames.size() - 1 && actualVectorIndex != optionsNames.size() - 1) {
                     record->repeat = actualVectorIndex;
                 }
                 else if (record->repeat == optionsNames.size() - 1 ||
-                         optionsNames[optionsNames.size() - 1] == utils::localize.get("app_calendar_repeat_custom")) {
+                         optionsNames[optionsNames.size() - 1] == utils::translate("app_calendar_repeat_custom")) {
                     record->repeat = static_cast<uint32_t>(AlarmRepeat::never);
                 }
             }
-            else if (descriptionLabel->getText() == utils::localize.get("app_calendar_event_detail_reminder")) {
+            else if (descriptionLabel->getText() == utils::translate("app_calendar_event_detail_reminder")) {
                 record->reminder = static_cast<uint32_t>(reminderTimeOptions[actualVectorIndex]);
             }
         };
 
         onLoadCallback = [&](std::shared_ptr<EventsRecord> event) {
-            if (descriptionLabel->getText() == utils::localize.get("app_calendar_event_detail_repeat")) {
+            if (descriptionLabel->getText() == utils::translate("app_calendar_event_detail_repeat")) {
                 if (event->repeat < optionsNames.size() - 1) {
                     actualVectorIndex = event->repeat;
                     if (event->repeat == static_cast<uint32_t>(Repeat::never)) {
-                        optionsNames[optionsNames.size() - 1] = utils::localize.get("app_calendar_repeat_custom");
+                        optionsNames[optionsNames.size() - 1] = utils::translate("app_calendar_repeat_custom");
                     }
                     bottomBarRestoreFromTemporaryMode();
                 }
@@ -197,20 +197,20 @@ namespace gui
                         actualVectorIndex = static_cast<uint32_t>(Repeat::daily);
                         event->repeat     = actualVectorIndex;
                         bottomBarRestoreFromTemporaryMode();
-                        optionsNames[optionsNames.size() - 1] = utils::localize.get("app_calendar_repeat_custom");
+                        optionsNames[optionsNames.size() - 1] = utils::translate("app_calendar_repeat_custom");
                     }
                     else {
                         actualVectorIndex                     = optionsNames.size() - 1;
                         optionsNames[optionsNames.size() - 1] = parser.getWeekDaysText();
                         if (this->focus) {
-                            bottomBarTemporaryMode(utils::localize.get("app_calendar_edit"));
+                            bottomBarTemporaryMode(utils::translate("app_calendar_edit"));
                         }
                     }
                 }
                 repeatOptionValue = event->repeat;
                 optionLabel->setText(optionsNames[actualVectorIndex]);
             }
-            else if (descriptionLabel->getText() == utils::localize.get("app_calendar_event_detail_reminder")) {
+            else if (descriptionLabel->getText() == utils::translate("app_calendar_event_detail_reminder")) {
                 actualVectorIndex = std::find(reminderTimeOptions.begin(),
                                               reminderTimeOptions.end(),
                                               static_cast<Reminder>(event->reminder)) -

--- a/module-apps/application-calendar/windows/AllEventsWindow.cpp
+++ b/module-apps/application-calendar/windows/AllEventsWindow.cpp
@@ -35,11 +35,11 @@ namespace gui
         AppWindow::buildInterface();
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
-        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::localize.get("app_calendar_bar_month"));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::open));
+        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate("app_calendar_bar_month"));
 
-        setTitle(utils::localize.get("app_calendar_title_main"));
+        setTitle(utils::translate("app_calendar_title_main"));
         leftArrowImage = new gui::Image(
             this, style::window::calendar::arrow_x, style::window::calendar::arrow_y, 0, 0, "arrow_left");
         newDayEventImage =

--- a/module-apps/application-calendar/windows/CalendarEventsOptionsWindow.cpp
+++ b/module-apps/application-calendar/windows/CalendarEventsOptionsWindow.cpp
@@ -22,7 +22,7 @@ namespace gui
     auto CalendarEventsOptions::eventsOptionsList() -> std::list<gui::Option>
     {
         std::list<gui::Option> options;
-        options.emplace_back(gui::Option{utils::localize.get("app_calendar_options_edit"), [=](gui::Item &item) {
+        options.emplace_back(gui::Option{utils::translate("app_calendar_options_edit"), [=](gui::Item &item) {
                                              LOG_INFO("Switch to edit window");
                                              auto rec  = std::make_unique<EventsRecord>(*eventRecord);
                                              auto data = std::make_unique<EventRecordData>(std::move(rec));
@@ -31,7 +31,7 @@ namespace gui
                                                                        std::move(data));
                                              return true;
                                          }});
-        options.emplace_back(gui::Option{utils::localize.get("app_calendar_options_delete"),
+        options.emplace_back(gui::Option{utils::translate("app_calendar_options_delete"),
                                          [=](gui::Item &item) { return eventDelete(); }});
         return options;
     }
@@ -60,7 +60,7 @@ namespace gui
         auto metaData = std::make_unique<gui::DialogMetadataMessage>(gui::DialogMetadata{
             eventRecord->title,
             "phonebook_contact_delete_trashcan",
-            utils::localize.get("app_calendar_event_delete_confirmation"),
+            utils::translate("app_calendar_event_delete_confirmation"),
             "",
             [=]() -> bool {
                 LOG_INFO("Delete calendar event %d", static_cast<int>(eventRecord->ID));

--- a/module-apps/application-calendar/windows/CalendarMainWindow.cpp
+++ b/module-apps/application-calendar/windows/CalendarMainWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CalendarMainWindow.hpp"
@@ -151,7 +151,7 @@ namespace gui
 
         LOG_DEBUG("Start build interface for calendar main window");
 
-        setTitle(utils::localize.get("app_calendar_title_main"));
+        setTitle(utils::translate("app_calendar_title_main"));
 
         monthModel = std::make_unique<MonthModel>(actualDate);
         filterRequest();
@@ -161,9 +161,9 @@ namespace gui
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setActive(gui::BottomBar::Side::LEFT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
-        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::localize.get("app_calendar_bar_list"));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::open));
+        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate("app_calendar_bar_list"));
     }
 
     void CalendarMainWindow::destroyInterface()
@@ -228,7 +228,7 @@ namespace gui
             else {
                 auto appCalendar = dynamic_cast<app::ApplicationCalendar *>(application);
                 assert(appCalendar != nullptr);
-                appCalendar->switchToNoEventsWindow(utils::localize.get("app_calendar_title_main"), filter);
+                appCalendar->switchToNoEventsWindow(utils::translate("app_calendar_title_main"), filter);
             }
             return true;
         }

--- a/module-apps/application-calendar/windows/CustomRepeatWindow.cpp
+++ b/module-apps/application-calendar/windows/CustomRepeatWindow.cpp
@@ -30,10 +30,10 @@ namespace gui
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::save));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::save));
 
-        setTitle(utils::localize.get("app_calendar_custom_repeat_title"));
+        setTitle(utils::translate("app_calendar_custom_repeat_title"));
         list = new gui::ListView(this,
                                  style::window::calendar::listView_x,
                                  style::window::calendar::listView_y,

--- a/module-apps/application-calendar/windows/DayEventsWindow.cpp
+++ b/module-apps/application-calendar/windows/DayEventsWindow.cpp
@@ -66,8 +66,8 @@ namespace gui
         AppWindow::buildInterface();
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::open));
 
         setTitle(dayMonthTitle);
         leftArrowImage = new gui::Image(

--- a/module-apps/application-calendar/windows/EventDetailWindow.cpp
+++ b/module-apps/application-calendar/windows/EventDetailWindow.cpp
@@ -30,8 +30,8 @@ namespace gui
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setActive(gui::BottomBar::Side::LEFT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate(style::strings::common::options));
 
         bodyList = new gui::ListView(this,
                                      style::window::calendar::listView_x,

--- a/module-apps/application-calendar/windows/EventReminderWindow.cpp
+++ b/module-apps/application-calendar/windows/EventReminderWindow.cpp
@@ -57,7 +57,7 @@ namespace gui
         AppWindow::buildInterface();
 
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::ok));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::ok));
         bottomBar->setBorderColor(ColorNoColor);
 
         const uint32_t w = this->getWidth() - style::window::default_left_margin - style::window::default_right_margin;

--- a/module-apps/application-calendar/windows/NewEditEventWindow.cpp
+++ b/module-apps/application-calendar/windows/NewEditEventWindow.cpp
@@ -27,8 +27,8 @@ namespace gui
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::save));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::save));
 
         list = new gui::ListView(this,
                                  style::window::calendar::listView_x,
@@ -44,11 +44,11 @@ namespace gui
     {
         switch (eventAction) {
         case EventAction::Add: {
-            setTitle(utils::localize.get("app_calendar_new_event_title"));
+            setTitle(utils::translate("app_calendar_new_event_title"));
             break;
         }
         case EventAction::Edit:
-            setTitle(utils::localize.get("app_calendar_edit_event_title"));
+            setTitle(utils::translate("app_calendar_edit_event_title"));
             break;
         }
 

--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -60,7 +60,7 @@ namespace app
                 return true;
             };
             constexpr auto iconNoEmergency = "emergency_W_G";
-            auto textNoEmergency           = utils::localize.get("app_call_wrong_emergency");
+            auto textNoEmergency           = utils::translate("app_call_wrong_emergency");
             utils::findAndReplaceAll(textNoEmergency, "$NUMBER", data->getDescription());
             showNotification(buttonAction, iconNoEmergency, textNoEmergency);
             return actionHandled();
@@ -71,7 +71,7 @@ namespace app
                 return true;
             };
             constexpr auto iconNoSim = "info_big_circle_W_G";
-            const auto textNoSim     = utils::localize.get("app_call_no_sim");
+            const auto textNoSim     = utils::translate("app_call_no_sim");
             showNotification(buttonAction, iconNoSim, textNoSim);
             return actionHandled();
         });
@@ -81,7 +81,7 @@ namespace app
                 return true;
             };
             constexpr auto icon    = "info_big_circle_W_G";
-            const auto textOffline = utils::localize.get("app_call_offline");
+            const auto textOffline = utils::translate("app_call_offline");
             showNotification(buttonAction, icon, textOffline);
             return actionHandled();
         });

--- a/module-apps/application-call/widgets/StateIcon.hpp
+++ b/module-apps/application-call/widgets/StateIcon.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -8,6 +8,7 @@
 #include <Style.hpp>
 #include <log/log.hpp>
 #include <i18n/i18n.hpp>
+#include <map>
 
 namespace gui
 {
@@ -74,7 +75,7 @@ namespace gui
         {
             this->state = state;
             img->set(data.at(state).first);
-            label->setText(utils::localize.get(data.at(state).second));
+            label->setText(utils::translate(data.at(state).second));
             using namespace style::window;
             label->setFont(data.find(state) != data.begin() ? font::verysmallbold : font::verysmall);
         }

--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -60,9 +60,9 @@ namespace gui
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(strings::message));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(strings::message));
 
         // top circle image
         imageCircleTop = new gui::Image(this, imageCircleTop::x, imageCircleTop::y, 0, 0, imageCircleTop::name);
@@ -85,7 +85,7 @@ namespace gui
         speakerIcon                       = new SpeakerIcon(this, speakerIcon::x, speakerIcon::y);
         speakerIcon->focusChangedCallback = [=](gui::Item &item) {
             LOG_DEBUG("speakerIcon get/lost focus");
-            bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::Switch), false);
+            bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::Switch), false);
             return true;
         };
         speakerIcon->activatedCallback = [=](gui::Item &item) {
@@ -113,7 +113,7 @@ namespace gui
         microphoneIcon                       = new MicrophoneIcon(this, microphoneIcon::x, microphoneIcon::y);
         microphoneIcon->focusChangedCallback = [=](gui::Item &item) {
             LOG_DEBUG("microphoneIcon get/lost focus");
-            bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::Switch), false);
+            bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::Switch), false);
             return true;
         };
         microphoneIcon->activatedCallback = [=](gui::Item &item) {
@@ -130,7 +130,7 @@ namespace gui
         sendSmsIcon                       = new gui::SendSmsIcon(this, sendMessageIcon::x, sendMessageIcon::y);
         sendSmsIcon->focusChangedCallback = [=](gui::Item &item) {
             LOG_DEBUG("Send message get/lost focus");
-            bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(strings::message), false);
+            bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(strings::message), false);
             return true;
         };
         sendSmsIcon->activatedCallback = [=](gui::Item &item) {
@@ -162,9 +162,9 @@ namespace gui
         switch (state) {
         case State::INCOMING_CALL: {
             interface->startAudioRinging();
-            bottomBar->setText(gui::BottomBar::Side::LEFT, utils::localize.get(strings::answer), true);
-            bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(strings::reject), true);
-            durationLabel->setText(utils::localize.get(strings::iscalling));
+            bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate(strings::answer), true);
+            bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(strings::reject), true);
+            durationLabel->setText(utils::translate(strings::iscalling));
             durationLabel->setVisible(true);
             speakerIcon->setVisible(false);
             microphoneIcon->setVisible(false);
@@ -186,7 +186,7 @@ namespace gui
             bottomBar->setActive(gui::BottomBar::Side::CENTER, false);
             bottomBar->setActive(gui::BottomBar::Side::RIGHT, false);
             durationLabel->setVisible(true);
-            durationLabel->setText(utils::localize.get(strings::callended));
+            durationLabel->setText(utils::translate(strings::callended));
             sendSmsIcon->setVisible(false);
             speakerIcon->setVisible(false);
             microphoneIcon->setVisible(false);
@@ -202,7 +202,7 @@ namespace gui
             runCallTimer();
             bottomBar->setActive(gui::BottomBar::Side::LEFT, false);
             bottomBar->setActive(gui::BottomBar::Side::CENTER, false);
-            bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(strings::endcall), true);
+            bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(strings::endcall), true);
             durationLabel->setVisible(true);
             sendSmsIcon->setVisible(false);
             speakerIcon->setVisible(true);
@@ -216,8 +216,8 @@ namespace gui
             interface->startAudioRouting();
             bottomBar->setActive(gui::BottomBar::Side::LEFT, false);
             bottomBar->setActive(gui::BottomBar::Side::CENTER, false);
-            bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(strings::endcall), true);
-            durationLabel->setText(utils::localize.get(strings::calling));
+            bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(strings::endcall), true);
+            durationLabel->setText(utils::translate(strings::calling));
             durationLabel->setVisible(true);
             sendSmsIcon->setVisible(false);
             speakerIcon->setVisible(true);
@@ -274,7 +274,7 @@ namespace gui
                 numberLabel->setText(displayName);
             }
             else {
-                numberLabel->setText(utils::localize.get(strings::privateNumber));
+                numberLabel->setText(utils::translate(strings::privateNumber));
             }
 
             if (dynamic_cast<app::IncomingCallData *>(data) != nullptr) {

--- a/module-apps/application-call/windows/EmergencyCallWindow.cpp
+++ b/module-apps/application-call/windows/EmergencyCallWindow.cpp
@@ -21,10 +21,10 @@ namespace gui
         using namespace callAppStyle;
         NumberWindow::buildInterface();
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("app_phonebook_ice_contacts_title"));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate("app_phonebook_ice_contacts_title"));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        numberDescriptionLabel->setText(utils::localize.get("app_call_emergency_text"));
+        numberDescriptionLabel->setText(utils::translate("app_call_emergency_text"));
     }
 
     top_bar::Configuration EmergencyCallWindow::configureTopBar(top_bar::Configuration appConfiguration)

--- a/module-apps/application-call/windows/EnterNumberWindow.cpp
+++ b/module-apps/application-call/windows/EnterNumberWindow.cpp
@@ -34,8 +34,8 @@ namespace gui
         using namespace callAppStyle::enterNumberWindow;
         NumberWindow::buildInterface();
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("common_add"));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get("app_call_clear"));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate("common_add"));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate("app_call_clear"));
 
         newContactIcon                    = new gui::AddContactIcon(this, newContactIcon::x, newContactIcon::y);
         newContactIcon->activatedCallback = [=](gui::Item &item) { return addNewContact(); };

--- a/module-apps/application-call/windows/NumberWindow.cpp
+++ b/module-apps/application-call/windows/NumberWindow.cpp
@@ -38,10 +38,10 @@ namespace gui
         numberLabel->setText(num);
 
         if (num.empty()) {
-            bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+            bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
             return;
         }
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get("app_call_clear"));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate("app_call_clear"));
     }
 
     void NumberWindow::buildInterface()
@@ -54,7 +54,7 @@ namespace gui
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
 
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(callAppStyle::strings::call));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(callAppStyle::strings::call));
 
         numberLabel = new gui::Label(this, numberLabel::x, numberLabel::y, numberLabel::w, numberLabel::h);
         numberLabel->setPenWidth(numberLabel::borderW);

--- a/module-apps/application-calllog/ApplicationCallLog.cpp
+++ b/module-apps/application-calllog/ApplicationCallLog.cpp
@@ -94,7 +94,7 @@ namespace app
             return std::make_unique<gui::CallLogDetailsWindow>(app);
         });
         windowsFactory.attach(
-            utils::localize.get("app_phonebook_options_title"),
+            utils::translate("app_phonebook_options_title"),
             [](Application *app, const std::string &name) { return std::make_unique<gui::OptionWindow>(app, name); });
         windowsFactory.attach(calllog::settings::DialogYesNoStr, [](Application *app, const std::string &name) {
             return std::make_unique<gui::DialogYesNo>(app, name);
@@ -115,7 +115,7 @@ namespace app
         auto metaData = std::make_unique<gui::DialogMetadataMessage>(
             gui::DialogMetadata{record.name,
                                 "phonebook_contact_delete_trashcan",
-                                utils::localize.get("app_calllog_delete_call_confirmation"),
+                                utils::translate("app_calllog_delete_call_confirmation"),
                                 "",
                                 [=]() -> bool {
                                     if (DBServiceAPI::CalllogRemove(this, record.ID) == false) {

--- a/module-apps/application-calllog/widgets/CalllogItem.cpp
+++ b/module-apps/application-calllog/widgets/CalllogItem.cpp
@@ -61,7 +61,7 @@ namespace gui
     {
         this->call = call;
         if (call->presentation == PresentationType::PR_UNKNOWN) {
-            text->setText(utils::localize.get(callLogStyle::strings::privateNumber));
+            text->setText(utils::translate(callLogStyle::strings::privateNumber));
         }
         else {
             text->setText(call->name);

--- a/module-apps/application-calllog/windows/CallLogDetailsWindow.cpp
+++ b/module-apps/application-calllog/windows/CallLogDetailsWindow.cpp
@@ -77,9 +77,9 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::call));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::options));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::call));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         // NOTE: height of all labels is set using decorators
 
@@ -89,7 +89,7 @@ namespace gui
                                                         information::label::y,
                                                         information::label::w,
                                                         0,
-                                                        utils::localize.get(style::strings::common::information)));
+                                                        utils::translate(style::strings::common::information)));
         number           = decorateData(
             new gui::Label(this, information::number::x, information::number::y, information::number::w, 0));
         number->setFont(style::window::font::mediumbold);
@@ -128,12 +128,12 @@ namespace gui
 
         // focus callbacks
         rects[static_cast<uint32_t>(FocusRects::Call)]->focusChangedCallback = [=](gui::Item &item) {
-            bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::call));
+            bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::call));
             return true;
         };
 
         rects[static_cast<uint32_t>(FocusRects::Sms)]->focusChangedCallback = [=](gui::Item &item) {
-            bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::send));
+            bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::send));
             return true;
         };
 
@@ -158,7 +158,7 @@ namespace gui
 
         // Type
         typeLabel = decorateLabel(new gui::Label(
-            this, type::label::x, type::label::y, type::label::w, 0, utils::localize.get("app_calllog_type")));
+            this, type::label::x, type::label::y, type::label::w, 0, utils::translate("app_calllog_type")));
         typeData  = decorateData(new gui::Label(this, type::data::x, type::data::y, type::data::w, 0));
 
         // TODO: alek: it is used in the code at least twice, possibly create one common function for this
@@ -177,12 +177,12 @@ namespace gui
                                                      duration::label::y,
                                                      duration::label::w,
                                                      0,
-                                                     utils::localize.get("app_calllog_duration")));
+                                                     utils::translate("app_calllog_duration")));
         durationData  = decorateData(new gui::Label(this, duration::data::x, duration::data::y, duration::data::w, 0));
 
         // Date
         dateLabel = decorateLabel(new gui::Label(
-            this, date::label::x, date::label::y, date::label::w, 0, utils::localize.get("app_calllog_date")));
+            this, date::label::x, date::label::y, date::label::w, 0, utils::translate("app_calllog_date")));
         dateDay   = decorateData(new gui::Label(this, date::dataDay::x, date::dataDay::y, date::dataDay::w, 0));
         dateDate  = decorateData(new gui::Label(this, date::dataDate::x, date::dataDate::y, date::dataDate::w, 0));
     }
@@ -214,16 +214,16 @@ namespace gui
             UTF8 callTypeStr;
             switch (record.type) {
             case CallType::CT_INCOMING:
-                callTypeStr = utils::localize.get("app_calllog_incoming_call");
+                callTypeStr = utils::translate("app_calllog_incoming_call");
                 break;
             case CallType::CT_OUTGOING:
-                callTypeStr = utils::localize.get("app_calllog_outgoing_call");
+                callTypeStr = utils::translate("app_calllog_outgoing_call");
                 break;
             case CallType::CT_MISSED:
-                callTypeStr = utils::localize.get("app_calllog_missed_call");
+                callTypeStr = utils::translate("app_calllog_missed_call");
                 break;
             case CallType::CT_REJECTED:
-                callTypeStr = utils::localize.get("app_calllog_rejected_call");
+                callTypeStr = utils::translate("app_calllog_rejected_call");
                 break;
             default:
                 break;
@@ -234,8 +234,8 @@ namespace gui
 
             utils::time::Timestamp t(record.date);
             dateDay->setText(t.day() + ",");
-            dateDate->setText(t.str(utils::localize.get("locale_date_full") + ", " +
-                                    utils::localize.get("locale_12hour_min"))); // TODO: alek 12/24 h
+            dateDate->setText(t.str(utils::translate("locale_date_full") + ", " +
+                                    utils::translate("locale_12hour_min"))); // TODO: alek 12/24 h
         }
 
         if (mode == ShowMode::GUI_SHOW_INIT)
@@ -248,7 +248,7 @@ namespace gui
             rects[FocusRects::Sms]->setVisible(false);
             rects[FocusRects::Sms]->activatedCallback    = nullptr;
             rects[FocusRects::Sms]->focusChangedCallback = nullptr;
-            number->setText(utils::localize.get(callLogStyle::strings::privateNumber));
+            number->setText(utils::translate(callLogStyle::strings::privateNumber));
             bottomBar->setActive(BottomBar::Side::CENTER, false);
         }
         else {
@@ -274,7 +274,7 @@ namespace gui
             (inputEvent.keyCode == KeyCode::KEY_LF)) {
             auto app = dynamic_cast<app::ApplicationCallLog *>(application);
             assert(app != nullptr);
-            app->switchWindow(utils::localize.get("app_phonebook_options_title"),
+            app->switchWindow(utils::translate("app_phonebook_options_title"),
                               std::make_unique<gui::OptionsWindowOptions>(calllogWindowOptions(app, record)));
 
             return true;

--- a/module-apps/application-calllog/windows/CallLogMainWindow.cpp
+++ b/module-apps/application-calllog/windows/CallLogMainWindow.cpp
@@ -45,11 +45,11 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_calllog_title_main"));
+        setTitle(utils::translate("app_calllog_title_main"));
 
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::call));
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::call));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::open));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         list = new gui::ListView(this,
                                  mainWindow::x,

--- a/module-apps/application-calllog/windows/CallLogOptionsWindow.cpp
+++ b/module-apps/application-calllog/windows/CallLogOptionsWindow.cpp
@@ -28,7 +28,7 @@ std::list<gui::Option> calllogWindowOptions(app::ApplicationCallLog *app, const 
 
     // add option delete call option
     options.push_back(gui::Option(
-        utils::localize.get("app_calllog_options_delete_call"),
+        utils::translate("app_calllog_options_delete_call"),
         [=](gui::Item &item) { return app->removeCalllogEntry(record); },
         gui::option::Arrow::Disabled));
 

--- a/module-apps/application-desktop/ApplicationDesktop.cpp
+++ b/module-apps/application-desktop/ApplicationDesktop.cpp
@@ -421,9 +421,9 @@ namespace app
         auto createPinChangedSuccessfullyDialog =
             [](app::ApplicationDesktop *app) -> std::unique_ptr<gui::DialogMetadataMessage> {
             return std::make_unique<gui::DialogMetadataMessage>(
-                gui::DialogMetadata{utils::localize.get("app_desktop_sim_change_pin"),
+                gui::DialogMetadata{utils::translate("app_desktop_sim_change_pin"),
                                     "success_icon_W_G",
-                                    utils::localize.get("app_desktop_sim_pin_changed_successfully"),
+                                    utils::translate("app_desktop_sim_pin_changed_successfully"),
                                     "",
                                     [app]() {
                                         app->switchWindow(app::window::name::desktop_main_window);
@@ -459,8 +459,8 @@ namespace app
                     "",
                     "success_icon_W_G",
                     response->getSimCardLock() == CellularSimCardLockDataMessage::SimCardLock::Unlocked
-                        ? utils::localize.get("app_desktop_sim_card_unlocked")
-                        : utils::localize.get("app_desktop_sim_card_locked"),
+                        ? utils::translate("app_desktop_sim_card_unlocked")
+                        : utils::translate("app_desktop_sim_card_locked"),
                     "",
                     [this]() {
                         switchWindow(app::window::name::desktop_main_window);

--- a/module-apps/application-desktop/data/Mmi.hpp
+++ b/module-apps/application-desktop/data/Mmi.hpp
@@ -122,13 +122,13 @@ namespace mmi
 
         virtual void visit(mmiactions::MMICallForwardingResult &customResult, std::string &displayMessage)
         {
-            displayMessage += utils::localize.get("app_desktop_info_mmi_call_forwarding") + "\n";
+            displayMessage += utils::translate("app_desktop_info_mmi_call_forwarding") + "\n";
             if (customResult.getMessageType() == mmiactions::IMMICustomResultParams::MMIType::CallForwardingData) {
                 auto [voice, fax, sync, async] = customResult.getData();
-                displayMessage += utils::localize.get("app_desktop_info_mmi_common_voice") + ": " + voice + "\n" +
-                                  utils::localize.get("app_desktop_info_mmi_common_fax") + ": " + fax + "\n" +
-                                  utils::localize.get("app_desktop_info_mmi_common_sync") + ": " + sync + "\n" +
-                                  utils::localize.get("app_desktop_info_mmi_common_async") + ": " + async + "\n";
+                displayMessage += utils::translate("app_desktop_info_mmi_common_voice") + ": " + voice + "\n" +
+                                  utils::translate("app_desktop_info_mmi_common_fax") + ": " + fax + "\n" +
+                                  utils::translate("app_desktop_info_mmi_common_sync") + ": " + sync + "\n" +
+                                  utils::translate("app_desktop_info_mmi_common_async") + ": " + async + "\n";
             }
             else if (customResult.getMessageType() ==
                      mmiactions::IMMICustomResultParams::MMIType::CallForwardingNotification) {
@@ -138,7 +138,7 @@ namespace mmi
 
         virtual void visit(mmiactions::MMICallBarringResult &customResult, std::string &displayMessage)
         {
-            displayMessage += utils::localize.get("app_desktop_info_mmi_call_barring") + "\n";
+            displayMessage += utils::translate("app_desktop_info_mmi_call_barring") + "\n";
             if (customResult.getMessageType() == mmiactions::IMMICustomResultParams::MMIType::CallBarringData) {
                 displayMessage += getCustomMessagesFromDictionary(customResult.getMessages());
             }
@@ -150,7 +150,7 @@ namespace mmi
 
         virtual void visit(mmiactions::MMICallWaitingResult &customResult, std::string &displayMessage)
         {
-            displayMessage += utils::localize.get("app_desktop_info_mmi_call_waiting") + "\n";
+            displayMessage += utils::translate("app_desktop_info_mmi_call_waiting") + "\n";
             if (customResult.getMessageType() == mmiactions::IMMICustomResultParams::MMIType::CallWaitingData) {
                 displayMessage += getCustomMessagesFromDictionary(customResult.getMessages());
             }
@@ -162,19 +162,19 @@ namespace mmi
 
         virtual void visit(mmiactions::MMIClipResult &customResult, std::string &displayMessage)
         {
-            displayMessage += utils::localize.get("app_desktop_info_mmi_clip") + "\n";
+            displayMessage += utils::translate("app_desktop_info_mmi_clip") + "\n";
             displayMessage += getSelectedMessagesFromDictionary(customResult.getMessage());
         }
 
         virtual void visit(mmiactions::MMIClirResult &customResult, std::string &displayMessage)
         {
-            displayMessage += utils::localize.get("app_desktop_info_mmi_clir") + "\n";
+            displayMessage += utils::translate("app_desktop_info_mmi_clir") + "\n";
             displayMessage += getSelectedMessagesFromDictionary(customResult.getMessage());
         }
 
         virtual void visit(mmiactions::MMIImeiResult &customResult, std::string &displayMessage)
         {
-            displayMessage += utils::localize.get("app_desktop_info_mmi_imei") + "\n";
+            displayMessage += utils::translate("app_desktop_info_mmi_imei") + "\n";
             displayMessage += customResult.getImei() + "\n";
             displayMessage += getSelectedMessagesFromDictionary(customResult.getMessage());
         }
@@ -191,12 +191,12 @@ namespace mmi
                 auto it = messageDictionary.find(serviceState);
                 if (messageDictionary.end() != it) {
                     if (queryStr.empty()) {
-                        queryStr += utils::localize.get(it->second) + "\n";
+                        queryStr += utils::translate(it->second) + "\n";
                     }
                 }
                 it = messageDictionary.find(serviceClass);
                 if (messageDictionary.end() != it) {
-                    queryStr += utils::localize.get(it->second) + "\n";
+                    queryStr += utils::translate(it->second) + "\n";
                 }
             }
             return queryStr;
@@ -209,7 +209,7 @@ namespace mmi
             for (const auto &msg : msgList) {
                 auto it = messageDictionary.find(msg);
                 if (messageDictionary.end() != it) {
-                    selectedMessages += utils::localize.get(it->second) + "\n";
+                    selectedMessages += utils::translate(it->second) + "\n";
                 }
             }
             return selectedMessages;

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -97,11 +97,10 @@ namespace gui
             [this](top_bar::Configuration configuration) { return configureTopBar(std::move(configuration)); });
 
         if (app->lockHandler.isScreenLocked()) {
-            bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("app_desktop_unlock"));
+            bottomBar->setText(BottomBar::Side::CENTER, utils::translate("app_desktop_unlock"));
             bottomBar->setActive(BottomBar::Side::RIGHT, false);
-            bottomBar->setText(BottomBar::Side::LEFT,
-                               utils::localize.get("app_desktop_emergency"),
-                               app->lockHandler.isScreenBlocked());
+            bottomBar->setText(
+                BottomBar::Side::LEFT, utils::translate("app_desktop_emergency"), app->lockHandler.isScreenBlocked());
 
             inputCallback = nullptr;
             setFocusItem(nullptr);
@@ -250,15 +249,15 @@ namespace gui
         }
 
         auto onNotificationFocus = [this](bool isFocused) -> void {
-            bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("app_desktop_show"), isFocused);
-            bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get("app_desktop_clear"), isFocused);
+            bottomBar->setText(BottomBar::Side::CENTER, utils::translate("app_desktop_show"), isFocused);
+            bottomBar->setText(BottomBar::Side::RIGHT, utils::translate("app_desktop_clear"), isFocused);
             bottomBar->setActive(BottomBar::Side::LEFT, !isFocused);
         };
 
         if (app->notifications.notSeen.Calls > 0) {
             notifications->addNotification(
                 "phone",
-                utils::localize.get("app_desktop_missed_calls"),
+                utils::translate("app_desktop_missed_calls"),
                 std::to_string(app->notifications.notSeen.Calls),
                 [app]() -> bool { return app->showCalls(); },
                 [app]() -> bool { return app->clearCallsNotification(); },
@@ -267,7 +266,7 @@ namespace gui
         if (app->notifications.notSeen.SMS > 0) {
             notifications->addNotification(
                 "mail",
-                utils::localize.get("app_desktop_unread_messages"),
+                utils::translate("app_desktop_unread_messages"),
                 std::to_string(app->notifications.notSeen.SMS),
                 [this]() -> bool {
                     return app::manager::Controller::sendAction(
@@ -293,10 +292,10 @@ namespace gui
     }
     auto DesktopMainWindow::setActiveState(app::ApplicationDesktop *app) -> bool
     {
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("app_desktop_menu"));
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get("app_desktop_calls"));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate("app_desktop_menu"));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate("app_desktop_calls"));
         auto hasNotifications = !app->notifications.notSeen.areEmpty();
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get("app_desktop_clear_all"), hasNotifications);
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate("app_desktop_clear_all"), hasNotifications);
 
         inputCallback = [this, app, hasNotifications](Item &, const InputEvent &inputEvent) -> bool {
             if (!inputEvent.isShortPress()) {

--- a/module-apps/application-desktop/windows/LockWindow.cpp
+++ b/module-apps/application-desktop/windows/LockWindow.cpp
@@ -80,11 +80,11 @@ namespace gui
         if (isReach) {
             TextFormat format(FontManager::getInstance().getFont(style::window::font::medium));
             text::RichTextParser rtParser;
-            auto parsedText = rtParser.parse(utils::localize.get(value), &format, std::move(tokens));
+            auto parsedText = rtParser.parse(utils::translate(value), &format, std::move(tokens));
             text->setText(std::move(parsedText));
         }
         else {
-            text->setText(utils::localize.get(value));
+            text->setText(utils::translate(value));
         }
     }
 
@@ -102,8 +102,8 @@ namespace gui
 
     void LockWindow::buildBottomBar()
     {
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::confirm));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::confirm));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
     }
 
     auto LockWindow::getText(TextType type) noexcept -> gui::Text *

--- a/module-apps/application-desktop/windows/LockedInfoWindow.cpp
+++ b/module-apps/application-desktop/windows/LockedInfoWindow.cpp
@@ -69,8 +69,8 @@ void LockedInfoWindow::buildInterface()
     namespace lock_style = style::window::pin_lock;
     AppWindow::buildInterface();
 
-    bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get("app_desktop_emergency"));
-    bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get("common_back"));
+    bottomBar->setText(BottomBar::Side::LEFT, utils::translate("app_desktop_emergency"));
+    bottomBar->setText(BottomBar::Side::RIGHT, utils::translate("common_back"));
 
     lockImage = new gui::Image(this, lock_style::image::x, lock_style::image::y, 0, 0, "pin_lock");
     infoText  = new Text(this,
@@ -81,7 +81,7 @@ void LockedInfoWindow::buildInterface()
 
     TextFormat format(FontManager::getInstance().getFont(style::window::font::medium));
     text::RichTextParser rtParser;
-    auto parsedText = rtParser.parse(utils::localize.get("app_desktop_press_to_unlock"), &format);
+    auto parsedText = rtParser.parse(utils::translate("app_desktop_press_to_unlock"), &format);
 
     infoText->setText(std::move(parsedText));
     infoText->setAlignment(Alignment::Horizontal::Center);

--- a/module-apps/application-desktop/windows/MenuWindow.cpp
+++ b/module-apps/application-desktop/windows/MenuWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MenuWindow.hpp"
@@ -64,7 +64,7 @@ namespace gui
         desc->setPenWidth(style::window::default_border_no_focus_w);
         desc->setFont(style::window::font::verysmall);
         desc->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Bottom));
-        desc->setText(utils::localize.get(title));
+        desc->setText(utils::translate(title));
 
         if (hasNotificationsCallback != nullptr) {
             onNotificationsChangeCallback =
@@ -147,15 +147,15 @@ namespace gui
         AppWindow::buildInterface();
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::open));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         auto app = dynamic_cast<app::ApplicationDesktop *>(application);
         assert(app);
 
         mainMenu = new MenuPage(
             this,
-            utils::localize.get("app_desktop_menu_title"),
+            utils::translate("app_desktop_menu_title"),
             {
 
                 new gui::Tile{
@@ -239,7 +239,7 @@ namespace gui
 
         toolsMenu = new MenuPage(
             this,
-            utils::localize.get("app_desktop_tools_title"),
+            utils::translate("app_desktop_tools_title"),
             {
                 new gui::Tile{"menu_tools_notes_W_G",
                               "app_desktop_tools_notes",

--- a/module-apps/application-desktop/windows/MmiInternalMsgWindow.cpp
+++ b/module-apps/application-desktop/windows/MmiInternalMsgWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MmiPushWindow.hpp"
@@ -36,10 +36,10 @@ void MmiInternalMsgWindow::handleInternalMessages(mmiactions::MMIResultParams *m
     auto result = metadata->getData();
     switch (result) {
     case mmiactions::MMIResultParams::MMIResult::Success:
-        text->setText(displayMessage + utils::localize.get("app_desktop_info_mmi_result_success"));
+        text->setText(displayMessage + utils::translate("app_desktop_info_mmi_result_success"));
         break;
     case mmiactions::MMIResultParams::MMIResult::Failed:
-        text->setText(displayMessage + utils::localize.get("app_desktop_info_mmi_result_failed"));
+        text->setText(displayMessage + utils::translate("app_desktop_info_mmi_result_failed"));
         break;
     default:
         text->clear();

--- a/module-apps/application-desktop/windows/MmiPullWindow.cpp
+++ b/module-apps/application-desktop/windows/MmiPullWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MmiPullWindow.hpp"
@@ -37,8 +37,8 @@ MmiPullWindow::MmiPullWindow(app::Application *app, const std::string &name) : g
 {
     AppWindow::buildInterface();
 
-    bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("app_desktop_replay"));
-    bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+    bottomBar->setText(BottomBar::Side::CENTER, utils::translate("app_desktop_replay"));
+    bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
     text = new Text(
         this, style::desktop::text::x, style::desktop::text::y, style::desktop::text::w, style::desktop::text::h);
     text->setTextType(TextType::MultiLine);
@@ -46,7 +46,7 @@ MmiPullWindow::MmiPullWindow(app::Application *app, const std::string &name) : g
     text->setEdges(RectangleEdge::None);
     text->setFont(style::window::font::medium);
     text->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Left, gui::Alignment::Vertical::Top));
-    setTitle(utils::localize.get("app_desktop_info"));
+    setTitle(utils::translate("app_desktop_info"));
 
     InputBox = new DesktopInputWidget(application,
                                       this,

--- a/module-apps/application-desktop/windows/MmiPushWindow.cpp
+++ b/module-apps/application-desktop/windows/MmiPushWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MmiPushWindow.hpp"
@@ -31,7 +31,7 @@ namespace style::desktop
 MmiPushWindow::MmiPushWindow(app::Application *app, const std::string &name) : gui::AppWindow(app, name)
 {
     AppWindow::buildInterface();
-    bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::ok));
+    bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::ok));
     icon = new Image(this, style::desktop::image::x, style::desktop::image::y, "");
     icon->set("info_big_circle_W_G");
     text = new Text(
@@ -41,7 +41,7 @@ MmiPushWindow::MmiPushWindow(app::Application *app, const std::string &name) : g
     text->setEdges(RectangleEdge::None);
     text->setFont(style::window::font::medium);
     text->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
-    setTitle(utils::localize.get("app_desktop_info"));
+    setTitle(utils::translate("app_desktop_info"));
 }
 
 void MmiPushWindow::onBeforeShow(ShowMode mode, SwitchData *data)

--- a/module-apps/application-desktop/windows/PinLockBaseWindow.cpp
+++ b/module-apps/application-desktop/windows/PinLockBaseWindow.cpp
@@ -86,7 +86,7 @@ namespace gui
         iceText->activeItem = false;
         iceText->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Center));
         iceText->setFont(style::window::font::verysmall);
-        iceText->setText(utils::localize.get("app_desktop_emergency"));
+        iceText->setText(utils::translate("app_desktop_emergency"));
         iceBox->addWidget(iceText);
 
         title = new gui::Text(this, title::x, title::y, title::w, title::h);

--- a/module-apps/application-desktop/windows/PostUpdateWindow.cpp
+++ b/module-apps/application-desktop/windows/PostUpdateWindow.cpp
@@ -36,7 +36,7 @@ void PostUpdateWindow::onBeforeShow(ShowMode mode, SwitchData *data)
         auto *item = dynamic_cast<CurrentOsVersion *>(data);
         if (item != nullptr) {
             currentOsVersion = item->getCurrentOsVersion();
-            auto info        = utils::localize.get("app_desktop_update_success");
+            auto info        = utils::translate("app_desktop_update_success");
             utils::findAndReplaceAll(info, "$VERSION", currentOsVersion);
             infoText->setText(info);
         }
@@ -83,9 +83,9 @@ void PostUpdateWindow::buildInterface()
     namespace post_update_style = style::window::pin_lock;
     AppWindow::buildInterface();
 
-    setTitle(utils::localize.get("app_desktop_update_muditaos"));
+    setTitle(utils::translate("app_desktop_update_muditaos"));
 
-    bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("common_ok"));
+    bottomBar->setText(BottomBar::Side::CENTER, utils::translate("common_ok"));
 
     successImage =
         new gui::Image(this, post_update_style::image::x, post_update_style::image::y, 0, 0, "circle_success");

--- a/module-apps/application-desktop/windows/PowerOffWindow.cpp
+++ b/module-apps/application-desktop/windows/PowerOffWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "InputEvent.hpp"
@@ -47,8 +47,8 @@ namespace gui
             presenter->powerOff();
             return true;
         };
-        metadata.title = utils::localize.get("app_desktop_poweroff_title");
-        metadata.text  = utils::localize.get("app_desktop_poweroff_question");
+        metadata.title = utils::translate("app_desktop_poweroff_title");
+        metadata.text  = utils::translate("app_desktop_poweroff_question");
         metadata.icon  = "turn_off_W_G";
         auto msg       = std::make_unique<DialogMetadataMessage>(std::move(metadata));
         DialogYesNo::onBeforeShow(mode, msg.get());

--- a/module-apps/application-desktop/windows/Update.cpp
+++ b/module-apps/application-desktop/windows/Update.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "log/log.hpp"
@@ -46,8 +46,8 @@ namespace gui
         AppWindow::buildInterface();
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::confirm));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::confirm));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         // title label
         titleLabel = new gui::Label(this, 0, 60, 480, 40);
@@ -56,7 +56,7 @@ namespace gui
         titleLabel->setFont(style::header::font::title);
         titleLabel->setEdges(RectangleEdge::None);
         titleLabel->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
-        titleLabel->setText(utils::localize.get("app_desktop_update"));
+        titleLabel->setText(utils::translate("app_desktop_update"));
 
         // Update version information
         updateVersionInfo = new gui::Label(this, 10, 132, 480, 40);
@@ -66,7 +66,7 @@ namespace gui
         updateVersionInfo->setEdges(RectangleEdge::None);
         updateVersionInfo->setAlignment(
             gui::Alignment(gui::Alignment::Horizontal::Left, gui::Alignment::Vertical::Top));
-        updateVersionInfo->setText(utils::localize.get("app_desktop_update"));
+        updateVersionInfo->setText(utils::translate("app_desktop_update"));
 
         // Update details
         updateDetails = new gui::Label(this, 40, 172, 440, 40);
@@ -75,7 +75,7 @@ namespace gui
         updateDetails->setFont(style::window::font::verysmall);
         updateDetails->setEdges(RectangleEdge::None);
         updateDetails->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Left, gui::Alignment::Vertical::Top));
-        updateDetails->setText(utils::localize.get("app_desktop_update"));
+        updateDetails->setText(utils::translate("app_desktop_update"));
 
         // Current version information
         currentVersionInfo = new gui::Label(this, 10, 222, 480, 40);
@@ -85,7 +85,7 @@ namespace gui
         currentVersionInfo->setEdges(RectangleEdge::None);
         currentVersionInfo->setAlignment(
             gui::Alignment(gui::Alignment::Horizontal::Left, gui::Alignment::Vertical::Top));
-        currentVersionInfo->setText(utils::localize.get("app_desktop_update_current"));
+        currentVersionInfo->setText(utils::translate("app_desktop_update_current"));
 
         // Label Info
         infoLabel = new gui::Label(this, 20, 304, 440, 40);
@@ -93,7 +93,7 @@ namespace gui
         infoLabel->setBorderColor(gui::ColorNoColor);
         infoLabel->setFont(style::window::font::medium);
         infoLabel->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Bottom));
-        infoLabel->setText(utils::localize.get("app_desktop_update_apply"));
+        infoLabel->setText(utils::translate("app_desktop_update_apply"));
 
         // Details during update
         detailLabel = new gui::Label(this, 20, 354, 440, 20);
@@ -126,8 +126,8 @@ namespace gui
             selectionLabels.push_back(label);
             pinLabelX += 193;
         }
-        selectionLabels[0]->setText(utils::localize.get(style::strings::common::no));
-        selectionLabels[1]->setText(utils::localize.get(style::strings::common::yes));
+        selectionLabels[0]->setText(utils::translate(style::strings::common::no));
+        selectionLabels[1]->setText(utils::translate(style::strings::common::yes));
 
         // define navigation between labels
         selectionLabels[0]->setNavigationItem(NavigationDirection::LEFT, selectionLabels[1]);
@@ -174,7 +174,7 @@ namespace gui
                 currentVersion << GIT_REV;
                 currentVersion << ")";
 
-                updateVersion << utils::localize.get("app_desktop_update_to");
+                updateVersion << utils::translate("app_desktop_update_to");
                 updateVersion << ": ";
                 updateVersion << msg.updateStats.versionInformation[boot::json::os_version][boot::json::version_string]
                                      .string_value();
@@ -183,7 +183,7 @@ namespace gui
                                      .string_value();
                 updateVersion << ")";
 
-                updateFileDetails << utils::localize.get("app_desktop_update_size");
+                updateFileDetails << utils::translate("app_desktop_update_size");
                 updateFileDetails << ": ";
                 updateFileDetails << std::to_string(msg.updateStats.totalBytes / 1024);
                 updateFileDetails << "Kb (";
@@ -225,7 +225,7 @@ namespace gui
                 selectionLabels[1]->setVisible(false);
 
                 percentLabel->setVisible(true);
-                percentLabel->setText(utils::localize.get("app_desktop_update_start"));
+                percentLabel->setText(utils::translate("app_desktop_update_start"));
                 auto msgToSend = std::make_shared<sdesktop::UpdateOsMessage>(updateFile.c_str(), 0);
                 application->bus.sendUnicast(msgToSend, service::name::service_desktop);
 
@@ -251,7 +251,7 @@ namespace gui
                     static_cast<int>((static_cast<float>(item->getUpdateOsMessage().updateStats.currentExtractedBytes) /
                                       static_cast<float>(item->getUpdateOsMessage().updateStats.totalBytes)) *
                                      100.0);
-                ssi << utils::localize.get("app_desktop_update_unpacking");
+                ssi << utils::translate("app_desktop_update_unpacking");
                 ssi << ": ";
                 ssi << std::to_string(progressPercent);
                 ssi << " %";
@@ -262,11 +262,11 @@ namespace gui
                 percentLabel->setText(item->getUpdateOsMessage().updateStats.messageText);
             }
 
-            sizeStream << utils::localize.get("app_desktop_update_size");
+            sizeStream << utils::translate("app_desktop_update_size");
             sizeStream << ": ";
             sizeStream << std::to_string(item->getUpdateOsMessage().updateStats.fileExtractedSize);
             sizeStream << " ";
-            sizeStream << utils::localize.get("app_desktop_update_bytes");
+            sizeStream << utils::translate("app_desktop_update_bytes");
             detailLabel->setText(sizeStream.str());
             this->application->refreshWindow(gui::RefreshModes::GUI_REFRESH_FAST);
         }

--- a/module-apps/application-desktop/windows/UpdateProgress.cpp
+++ b/module-apps/application-desktop/windows/UpdateProgress.cpp
@@ -42,7 +42,7 @@ namespace gui
                     msg.updateStats.versionInformation[boot::json::os_version][boot::json::version_string]
                         .string_value();
                 if (text->getText().empty()) {
-                    text->setText(utils::localize.get("app_desktop_update_preparing") + " " + updateVersion);
+                    text->setText(utils::translate("app_desktop_update_preparing") + " " + updateVersion);
                 }
                 else {
                     text->setText(textInfo);
@@ -83,7 +83,7 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_desktop_update_muditaos"));
+        setTitle(utils::translate("app_desktop_update_muditaos"));
 
         icon = new Image(this, style::desktop::image::x, style::desktop::image::y, "circle_update");
 
@@ -151,7 +151,7 @@ namespace gui
                 progressPercent = 30;
                 break;
             case updateos::UpdateState::ExtractingFiles:
-                textInfo        = utils::localize.get("app_desktop_update_in_progress");
+                textInfo        = utils::translate("app_desktop_update_in_progress");
                 progressPercent = 40;
                 break;
             case updateos::UpdateState::ChecksumVerification:
@@ -163,7 +163,7 @@ namespace gui
                 progressPercent = 80;
                 break;
             case updateos::UpdateState::UpdatingBootloader:
-                textInfo        = utils::localize.get("app_desktop_update_ready_for_reset");
+                textInfo        = utils::translate("app_desktop_update_ready_for_reset");
                 progressPercent = 99;
                 break;
             case updateos::UpdateState::ReadyForReset:

--- a/module-apps/application-meditation/widgets/IntervalBox.cpp
+++ b/module-apps/application-meditation/widgets/IntervalBox.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "IntervalBox.hpp"
@@ -36,7 +36,7 @@ void IntervalBox::build()
                               boxStyle::topLabel::Y,
                               boxStyle::topLabel::Width,
                               boxStyle::topLabel::Height,
-                              utils::localize.get("app_meditation_interval_chime"));
+                              utils::translate("app_meditation_interval_chime"));
     topLabel->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Bottom));
     topLabel->setFont(style::window::font::verysmall);
     topLabel->setEdges(RectangleEdge::None);
@@ -156,10 +156,10 @@ bool IntervalBox::ChimeIntervalList::hasNext(Direction direction, std::chrono::m
 std::string IntervalBox::ChimeIntervalList::toPrintableInterval(std::chrono::minutes value)
 {
     if (value.count() == 0) {
-        return utils::localize.get("app_meditation_interval_none");
+        return utils::translate("app_meditation_interval_none");
     }
     const std::string toReplace = "%0";
-    std::string temp            = utils::localize.get("app_meditation_interval_every_x_minutes");
+    std::string temp            = utils::translate("app_meditation_interval_every_x_minutes");
     temp.replace(temp.find(toReplace), toReplace.size(), std::to_string(static_cast<int>(value.count())));
     return temp;
 }

--- a/module-apps/application-meditation/widgets/MeditationListItems.cpp
+++ b/module-apps/application-meditation/widgets/MeditationListItems.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MeditationListItems.hpp"
@@ -56,7 +56,7 @@ std::string PreparationTimeItem::convertToPrintable(std::chrono::seconds _durati
 }
 
 OptionItemMeditationCounter::OptionItemMeditationCounter(bool isCounterOn)
-    : MeditationListItem(utils::localize.get("app_meditation_option_show_counter"))
+    : MeditationListItem(utils::translate("app_meditation_option_show_counter"))
 {
     imageOptionOn  = new gui::Image(this,
                                    listStyle::image::X,
@@ -81,8 +81,7 @@ void OptionItemMeditationCounter::select(bool isSelected)
     imageOptionOff->setVisible(!isSelected);
 }
 
-OptionItemPreparation::OptionItemPreparation()
-    : MeditationListItem(utils::localize.get("app_meditation_preparation_time"))
+OptionItemPreparation::OptionItemPreparation() : MeditationListItem(utils::translate("app_meditation_preparation_time"))
 {
     image = new gui::Image(this,
                            listStyle::image::X,

--- a/module-apps/application-meditation/widgets/TimerProperty.cpp
+++ b/module-apps/application-meditation/widgets/TimerProperty.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TimerProperty.hpp"
@@ -48,7 +48,7 @@ void TimerProperty::build()
     timeUnitLabel->setFont(style::window::font::verysmall);
     timeUnitLabel->setAlignment(Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center));
     timeUnitLabel->setEdges(RectangleEdge::None);
-    timeUnitLabel->setText(utils::localize.get("app_meditation_minutes"));
+    timeUnitLabel->setText(utils::translate("app_meditation_minutes"));
 }
 
 bool TimerProperty::onFocus(bool isFocused)
@@ -93,10 +93,10 @@ void TimerProperty::setMeditationTime()
     const auto meditationTime = static_cast<int>(state.getTime().count());
     timeLabel->setText(utils::to_string(meditationTime));
     if (meditationTime == 1) {
-        timeUnitLabel->setText(utils::localize.get("app_meditation_minute"));
+        timeUnitLabel->setText(utils::translate("app_meditation_minute"));
     }
     else {
-        timeUnitLabel->setText(utils::localize.get("app_meditation_minutes"));
+        timeUnitLabel->setText(utils::translate("app_meditation_minutes"));
     }
 }
 

--- a/module-apps/application-meditation/windows/MeditationListViewWindows.cpp
+++ b/module-apps/application-meditation/windows/MeditationListViewWindows.cpp
@@ -30,7 +30,7 @@ void MeditationListViewWindow::buildInterface()
                              model,
                              gui::listview::ScrollBarType::Fixed);
     setFocusItem(list);
-    bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+    bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 }
 
 void MeditationListViewWindow::destroyInterface()
@@ -67,8 +67,8 @@ MeditationOptionsWindow::MeditationOptionsWindow(app::Application *app)
 void MeditationOptionsWindow::buildInterface()
 {
     MeditationListViewWindow::buildInterface();
-    setTitle(utils::localize.get("common_options"));
-    bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::Switch));
+    setTitle(utils::translate("common_options"));
+    bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::Switch));
 }
 
 PreparationTimeWindow::PreparationTimeWindow(app::Application *app)
@@ -81,6 +81,6 @@ PreparationTimeWindow::PreparationTimeWindow(app::Application *app)
 void PreparationTimeWindow::buildInterface()
 {
     MeditationListViewWindow::buildInterface();
-    setTitle(utils::localize.get("app_meditation_preparation_time"));
-    bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
+    setTitle(utils::translate("app_meditation_preparation_time"));
+    bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
 }

--- a/module-apps/application-meditation/windows/MeditationTimerWindow.cpp
+++ b/module-apps/application-meditation/windows/MeditationTimerWindow.cpp
@@ -33,7 +33,7 @@ void MeditationTimerWindow::buildInterface()
     assert(app != nullptr); // Pre-condition check.
 
     AppWindow::buildInterface();
-    setTitle(utils::localize.get("app_meditation_title_main"));
+    setTitle(utils::translate("app_meditation_title_main"));
 
     timer = new MeditationTimer(style::meditation::timer::X,
                                 style::meditation::timer::Y,
@@ -125,27 +125,27 @@ void MeditationTimerWindow::setWidgetVisible(bool tBar, bool bBar, bool counter)
 void MeditationTimerWindow::setVisibleRunning()
 {
     setWidgetVisible(false, true, true);
-    bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::pause));
-    bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::stop));
+    bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::pause));
+    bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::stop));
     meditationInfo->setVisible(false);
 }
 void MeditationTimerWindow::setVisiblePaused()
 {
     setWidgetVisible(true, true, true);
-    bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::resume));
-    bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::stop));
+    bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::resume));
+    bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::stop));
 }
 void MeditationTimerWindow::setVisiblePreparation()
 {
     setWidgetVisible(false, false, false);
     TextFormat format(FontManager::getInstance().getFont(style::window::font::biglight));
     gui::text::RichTextParser parser;
-    auto textParsed = parser.parse(utils::localize.get("app_meditation_put_down_phone_and_wait"), &format);
+    auto textParsed = parser.parse(utils::translate("app_meditation_put_down_phone_and_wait"), &format);
     meditationInfo->setText(std::move(textParsed));
     meditationInfo->setVisible(true);
 
     finished = false;
-    bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+    bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 }
 
 void MeditationTimerWindow::setVisibleMeditationEnd()
@@ -153,7 +153,7 @@ void MeditationTimerWindow::setVisibleMeditationEnd()
     setWidgetVisible(false, false, false);
     TextFormat format(FontManager::getInstance().getFont(style::window::font::biglight));
     gui::text::RichTextParser parser;
-    auto textParsed = parser.parse(utils::localize.get("app_meditation_thank_you_for_session"), &format);
+    auto textParsed = parser.parse(utils::translate("app_meditation_thank_you_for_session"), &format);
     finished        = true;
     meditationInfo->setText(std::move(textParsed));
     meditationInfo->setVisible(true);

--- a/module-apps/application-meditation/windows/MeditationWindow.cpp
+++ b/module-apps/application-meditation/windows/MeditationWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MeditationWindow.hpp"
@@ -31,14 +31,14 @@ namespace gui
     void MeditationWindow::buildInterface()
     {
         AppWindow::buildInterface();
-        setTitle(utils::localize.get("app_meditation_title_main"));
+        setTitle(utils::translate("app_meditation_title_main"));
 
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
         bottomBar->setActive(BottomBar::Side::LEFT, true);
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::options));
         bottomBar->setActive(BottomBar::Side::CENTER, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::start));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::start));
 
         timeSetter = new TimerProperty(this,
                                        style::meditation::timer::X,

--- a/module-apps/application-messages/ApplicationMessages.cpp
+++ b/module-apps/application-messages/ApplicationMessages.cpp
@@ -61,7 +61,7 @@ namespace app
                 returnToPreviousWindow();
                 return true;
             };
-            const auto notification = utils::localize.get("app_messages_no_sim");
+            const auto notification = utils::translate("app_messages_no_sim");
             showNotification(action, notification);
             return actionHandled();
         });
@@ -70,7 +70,7 @@ namespace app
                 returnToPreviousWindow();
                 return true;
             };
-            const auto notification = utils::localize.get("app_sms_offline");
+            const auto notification = utils::translate("app_sms_offline");
             showNotification(action, notification);
 
             return actionHandled();
@@ -142,7 +142,7 @@ namespace app
             return std::make_unique<gui::NewMessageWindow>(app);
         });
         windowsFactory.attach(
-            utils::localize.get("app_phonebook_options_title"),
+            utils::translate("app_phonebook_options_title"),
             [](Application *app, const std::string &name) { return std::make_unique<gui::OptionWindow>(app, name); });
         windowsFactory.attach(gui::name::window::dialog, [](Application *app, const std::string &name) {
             return std::make_unique<gui::Dialog>(app, name);
@@ -210,7 +210,7 @@ namespace app
                 auto metaData       = std::make_unique<gui::DialogMetadataMessage>(
                     gui::DialogMetadata{contact.getFormattedName(),
                                         "phonebook_contact_delete_trashcan",
-                                        utils::localize.get("app_messages_thread_delete_confirmation"),
+                                        utils::translate("app_messages_thread_delete_confirmation"),
                                         "",
                                         [this, record]() { return onRemoveSmsThreadConfirmed(*record); }});
                 switchWindow(gui::name::window::dialog_yes_no, gui::ShowMode::GUI_SHOW_INIT, std::move(metaData));
@@ -248,7 +248,7 @@ namespace app
         auto metaData = std::make_unique<gui::DialogMetadataMessage>(
             gui::DialogMetadata{record.body,
                                 "phonebook_contact_delete_trashcan",
-                                utils::localize.get("app_messages_message_delete_confirmation"),
+                                utils::translate("app_messages_message_delete_confirmation"),
                                 "",
                                 [this, record] { return onRemoveSmsConfirmed(record); }});
         switchWindow(gui::name::window::dialog_yes_no, gui::ShowMode::GUI_SHOW_INIT, std::move(metaData));
@@ -297,8 +297,8 @@ namespace app
     {
         gui::DialogMetadata meta;
         meta.icon                        = "search_big";
-        meta.text                        = utils::localize.get("app_messages_thread_no_result");
-        meta.title                       = utils::localize.get("common_results_prefix") + query;
+        meta.text                        = utils::translate("app_messages_thread_no_result");
+        meta.title                       = utils::translate("common_results_prefix") + query;
         auto data                        = std::make_unique<gui::DialogMetadataMessage>(meta);
         data->ignoreCurrentWindowOnStack = true;
         switchWindow(gui::name::window::dialog, std::make_unique<gui::DialogMetadataMessage>(meta));
@@ -409,7 +409,7 @@ namespace app
     {
         LOG_INFO("New message options for %s", requestingWindow.c_str());
         auto opts = std::make_unique<gui::OptionsWindowOptions>(newMessageWindowOptions(this, requestingWindow, text));
-        switchWindow(utils::localize.get("app_phonebook_options_title"), std::move(opts));
+        switchWindow(utils::translate("app_phonebook_options_title"), std::move(opts));
         return true;
     }
 

--- a/module-apps/application-messages/models/ThreadsModel.cpp
+++ b/module-apps/application-messages/models/ThreadsModel.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ThreadsModel.hpp"
@@ -55,7 +55,7 @@ auto ThreadsModel::getItem(gui::Order order) -> gui::ListItem *
         }
         if (event.keyCode == gui::KeyCode::KEY_LF) {
             application->switchWindow(
-                utils::localize.get("app_phonebook_options_title"),
+                utils::translate("app_phonebook_options_title"),
                 std::make_unique<gui::OptionsWindowOptions>(threadWindowOptions(app, item->getThreadItem().get())));
         }
         return false;

--- a/module-apps/application-messages/widgets/SMSInputWidget.cpp
+++ b/module-apps/application-messages/widgets/SMSInputWidget.cpp
@@ -75,9 +75,9 @@ namespace gui
             if (inputText->focus) {
 
                 application->getWindow(gui::name::window::thread_view)
-                    ->setBottomBarText(utils::localize.get("sms_reply"), BottomBar::Side::CENTER);
+                    ->setBottomBarText(utils::translate("sms_reply"), BottomBar::Side::CENTER);
 
-                if (inputText->getText() == utils::localize.get("sms_temp_reply")) {
+                if (inputText->getText() == utils::translate("sms_temp_reply")) {
                     inputText->clear();
                 }
             }
@@ -87,7 +87,7 @@ namespace gui
 
                     // Temporary solution to be fixed when proper Text Color handling will be added.
                     auto format = TextFormat(Font(27).raw(), Color(7, 0));
-                    for (auto &el : textToTextBlocks(utils::localize.get("sms_temp_reply"), format)) {
+                    for (auto &el : textToTextBlocks(utils::translate("sms_temp_reply"), format)) {
                         inputText->addText(el);
                     }
                 }
@@ -116,7 +116,7 @@ namespace gui
 
     void SMSInputWidget::handleDraftMessage()
     {
-        if (const auto &text = inputText->getText(); text.empty() || (text == utils::localize.get("sms_temp_reply"))) {
+        if (const auto &text = inputText->getText(); text.empty() || (text == utils::translate("sms_temp_reply"))) {
             clearDraftMessage();
         }
         else {

--- a/module-apps/application-messages/widgets/SMSOutputWidget.cpp
+++ b/module-apps/application-messages/widgets/SMSOutputWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <application-messages/ApplicationMessages.hpp>
@@ -87,7 +87,7 @@ namespace gui
                 LOG_INFO("Message activated!");
                 auto app = dynamic_cast<app::ApplicationMessages *>(application);
                 assert(app != nullptr);
-                app->switchWindow(utils::localize.get("app_phonebook_options_title"),
+                app->switchWindow(utils::translate("app_phonebook_options_title"),
                                   std::make_unique<gui::OptionsWindowOptions>(smsWindowOptions(app, *record)));
                 return true;
             }

--- a/module-apps/application-messages/widgets/ThreadItem.cpp
+++ b/module-apps/application-messages/widgets/ThreadItem.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ThreadItem.hpp"
@@ -30,14 +30,14 @@ namespace gui
     {
         switch (threadStruct->thread->type) {
         case SMSType::DRAFT:
-            snippetPrefix->setText(utils::localize.get("app_messages_thread_draft"));
+            snippetPrefix->setText(utils::translate("app_messages_thread_draft"));
             break;
         case SMSType::FAILED:
-            snippetPrefix->setText(utils::localize.get("app_messages_thread_not_sent"));
+            snippetPrefix->setText(utils::translate("app_messages_thread_not_sent"));
             break;
         case SMSType::OUTBOX:
         case SMSType::QUEUED:
-            snippetPrefix->setText(utils::localize.get("app_messages_thread_you"));
+            snippetPrefix->setText(utils::translate("app_messages_thread_you"));
             break;
         default:
             break;

--- a/module-apps/application-messages/windows/MessagesMainWindow.cpp
+++ b/module-apps/application-messages/windows/MessagesMainWindow.cpp
@@ -61,11 +61,11 @@ namespace gui
         bottomBar->setActive(BottomBar::Side::LEFT, true);
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::options));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::open));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("app_messages_title_main"));
+        setTitle(utils::translate("app_messages_title_main"));
 
         leftArrowImage  = new gui::Image(this, 30, 62, 0, 0, "arrow_left");
         rightArrowImage = new gui::Image(this, 480 - 30 - 13, 62, 0, 0, "arrow_right");
@@ -78,7 +78,7 @@ namespace gui
                                  style::window_width,
                                  style::window_height - style::header::height - style::footer::height,
                                  "phonebook_empty_grey_circle_W_G",
-                                 utils::localize.get("app_messages_no_messages"));
+                                 utils::translate("app_messages_no_messages"));
 
         list->setVisible(true);
         list->focusChangedCallback = [this]([[maybe_unused]] gui::Item &item) {

--- a/module-apps/application-messages/windows/NewMessage.cpp
+++ b/module-apps/application-messages/windows/NewMessage.cpp
@@ -166,7 +166,7 @@ namespace gui
         if (getFocusItem() == recipient) {
             bottomBar->setActive(BottomBar::Side::LEFT, false);
             if (recipient->getText().empty()) {
-                bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
+                bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
                 return;
             }
             bottomBar->setActive(BottomBar::Side::CENTER, false);
@@ -177,17 +177,17 @@ namespace gui
     {
         namespace msgStyle = style::messages::newMessage;
         AppWindow::buildInterface();
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::options));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("sms_title_message"));
+        setTitle(utils::translate("sms_title_message"));
 
         const uint32_t w = this->getWidth() - style::window::default_left_margin - style::window::default_right_margin;
         const uint32_t h = this->getHeight() - title->offset_h() - bottomBar->getHeight();
         body             = new gui::VBox(this, style::window::default_left_margin, (uint32_t)title->offset_h(), w, h);
 
         auto recipientLabel = new Label(body, 0, 0, body->getWidth(), msgStyle::recipientLabel::h);
-        recipientLabel->setText(utils::localize.get("sms_add_rec_num"));
+        recipientLabel->setText(utils::translate("sms_add_rec_num"));
         recipientLabel->activeItem = false;
         recipientLabel->setEdges(gui::RectangleEdge::None);
         recipientLabel->setFont(style::window::font::small);
@@ -234,7 +234,7 @@ namespace gui
         img->activeItem = false;
 
         auto labelMessage = new Label(body, 0, 0, body->getWidth(), msgStyle::messageLabel::h);
-        labelMessage->setText(utils::localize.get("app_messages_message"));
+        labelMessage->setText(utils::translate("app_messages_message"));
         labelMessage->activeItem = false;
         labelMessage->setEdges(gui::RectangleEdge::None);
         labelMessage->setFont(style::window::font::small);
@@ -260,7 +260,7 @@ namespace gui
             return true;
         };
         message->focusChangedCallback = [=](Item &) -> bool {
-            bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::send));
+            bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::send));
             bottomBar->setActive(BottomBar::Side::LEFT, true);
             return true;
         };

--- a/module-apps/application-messages/windows/OptionsMessages.cpp
+++ b/module-apps/application-messages/windows/OptionsMessages.cpp
@@ -21,7 +21,7 @@ std::list<gui::Option> smsWindowOptions(app::ApplicationMessages *app, const SMS
     std::list<gui::Option> options;
 
     if (record.type == SMSType::FAILED) {
-        options.emplace_back(utils::localize.get("sms_resend_failed"), [=, &record](gui::Item &item) {
+        options.emplace_back(utils::translate("sms_resend_failed"), [=, &record](gui::Item &item) {
             app->resendSms(record);
             app->returnToPreviousWindow();
             return true;
@@ -34,19 +34,19 @@ std::list<gui::Option> smsWindowOptions(app::ApplicationMessages *app, const SMS
         contact.isTemporary() ? gui::option::ContactOperation::Add : gui::option::ContactOperation::Details;
     options.emplace_back(gui::Option{std::make_unique<gui::option::Contact>(app, contactOperation, contact)});
 
-    options.emplace_back(UTF8(utils::localize.get("sms_forward_message")), [=](gui::Item &item) {
+    options.emplace_back(UTF8(utils::translate("sms_forward_message")), [=](gui::Item &item) {
         std::unique_ptr<gui::SwitchData> data = std::make_unique<SMSTextData>(record.body);
         app->switchWindow(gui::name::window::new_sms, std::move(data));
         return true;
     });
 
-    options.emplace_back(UTF8(utils::localize.get("sms_copy")), [=](gui::Item &item) {
+    options.emplace_back(UTF8(utils::translate("sms_copy")), [=](gui::Item &item) {
         Clipboard::getInstance().copy(record.body);
         app->returnToPreviousWindow();
         return true;
     });
 
-    options.emplace_back(UTF8(utils::localize.get("sms_delete_message")),
+    options.emplace_back(UTF8(utils::translate("sms_delete_message")),
                          [=](gui::Item &item) { return app->removeSms(record); });
 
     return options;
@@ -58,14 +58,14 @@ std::list<gui::Option> newMessageWindowOptions(app::ApplicationMessages *app,
 {
     std::list<gui::Option> options;
 
-    options.emplace_back(UTF8(utils::localize.get("sms_use_template")), [=](gui::Item &item) {
+    options.emplace_back(UTF8(utils::translate("sms_use_template")), [=](gui::Item &item) {
         std::unique_ptr<gui::SwitchData> data = std::make_unique<SMSTemplateRequest>(requestingWindow);
         app->switchWindow(gui::name::window::sms_templates, std::move(data));
         return true;
     });
 
     if (Clipboard::getInstance().gotData()) {
-        options.emplace_back(utils::localize.get("sms_paste"), [=](gui::Item &item) {
+        options.emplace_back(utils::translate("sms_paste"), [=](gui::Item &item) {
             text->addText(Clipboard::getInstance().paste());
             app->returnToPreviousWindow();
             return true;

--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -38,10 +38,10 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_messages_templates"));
+        setTitle(utils::translate("app_messages_templates"));
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::use));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::use));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         namespace style = style::messages::templates::list;
 

--- a/module-apps/application-messages/windows/SMSThreadViewWindow.cpp
+++ b/module-apps/application-messages/windows/SMSThreadViewWindow.cpp
@@ -28,9 +28,9 @@ namespace gui
           smsModel{std::make_shared<SMSThreadModel>(app)}
     {
         AppWindow::buildInterface();
-        setTitle(utils::localize.get("app_messages_title_main"));
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        setTitle(utils::translate("app_messages_title_main"));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::options));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         smsList = new gui::ListView(this,
                                     style::messages::smsList::x,

--- a/module-apps/application-messages/windows/SearchResults.cpp
+++ b/module-apps/application-messages/windows/SearchResults.cpp
@@ -19,11 +19,11 @@ namespace gui
         namespace msgThreadStyle = style::messages::threads;
 
         AppWindow::buildInterface();
-        setTitle(utils::localize.get("app_messages_title_main"));
+        setTitle(utils::translate("app_messages_title_main"));
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::search));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::search));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
         body = new gui::Item();
         body->setBoundingBox(bodySize());
         addWidget(body);

--- a/module-apps/application-messages/windows/SearchStart.cpp
+++ b/module-apps/application-messages/windows/SearchStart.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SearchStart.hpp"
@@ -13,15 +13,15 @@ namespace gui
     SMSSearch::SMSSearch(app::Application *app) : AppWindow(app, name::window::thread_sms_search)
     {
         buildInterface();
-        setTitle(utils::localize.get("app_messages_title_main"));
+        setTitle(utils::translate("app_messages_title_main"));
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::search));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::search));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
         body = new gui::Item();
         body->setBoundingBox(bodySize());
         addWidget(body);
-        auto text = inputBox(this, utils::localize.get("common_search_uc"), "search");
+        auto text = inputBox(this, utils::translate("common_search_uc"), "search");
         text->setInputMode(new InputMode(
             {InputMode::ABC, InputMode::abc, InputMode::digit},
             [=](const UTF8 &Text) { application->getCurrentWindow()->bottomBarTemporaryMode(Text); },
@@ -36,7 +36,7 @@ namespace gui
             }
             if (inputEvent.keyCode == KeyCode::KEY_ENTER) {
                 auto search_text = text->getText();
-                app->showSearchResults(utils::localize.get("common_search_results") + ": " + std::string(search_text),
+                app->showSearchResults(utils::translate("common_search_results") + ": " + std::string(search_text),
                                        search_text);
                 return true;
             }

--- a/module-apps/application-messages/windows/ThreadWindowOptions.cpp
+++ b/module-apps/application-messages/windows/ThreadWindowOptions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ThreadWindowOptions.hpp"
@@ -25,28 +25,28 @@ std::list<gui::Option> threadWindowOptions(app::ApplicationMessages *app, const 
     options.emplace_back(gui::Option{std::make_unique<gui::option::Contact>(app, contactOperation, contact)});
 
     if (record->isUnread()) {
-        options.emplace_back(gui::Option{utils::localize.get("sms_mark_read"), [=](gui::Item &item) {
+        options.emplace_back(gui::Option{utils::translate("sms_mark_read"), [=](gui::Item &item) {
                                              app->markSmsThreadAsRead(record->ID);
                                              app->returnToPreviousWindow();
                                              return true;
                                          }});
     }
     else {
-        options.emplace_back(gui::Option{utils::localize.get("sms_mark_unread"), [=](gui::Item &item) {
+        options.emplace_back(gui::Option{utils::translate("sms_mark_unread"), [=](gui::Item &item) {
                                              app->markSmsThreadAsUnread(record->ID);
                                              app->returnToPreviousWindow();
                                              return true;
                                          }});
     }
 
-    options.emplace_back(gui::Option{utils::localize.get("sms_delete_conversation"), [=](gui::Item &item) {
+    options.emplace_back(gui::Option{utils::translate("sms_delete_conversation"), [=](gui::Item &item) {
                                          LOG_INFO("Removing sms thread!");
                                          return app->removeSmsThread(record);
                                      }});
 
     // TODO
     // shouldn't this be in show contact details actually? it would be much easier too
-    // {utils::localize.get("sms_add_to_contacts"), [=](gui::Item &item) { return true; }},
+    // {utils::translate("sms_add_to_contacts"), [=](gui::Item &item) { return true; }},
 
     return options;
 };

--- a/module-apps/application-music-player/windows/MusicPlayerAllSongsWindow.cpp
+++ b/module-apps/application-music-player/windows/MusicPlayerAllSongsWindow.cpp
@@ -30,10 +30,10 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_music_player_all_songs"));
+        setTitle(utils::translate("app_music_player_all_songs"));
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("app_music_player_play"));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate("app_music_player_play"));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         songsList = new gui::ListView(this,
                                       musicPlayerStyle::allSongsWindow::x,

--- a/module-apps/application-music-player/windows/MusicPlayerEmptyWindow.cpp
+++ b/module-apps/application-music-player/windows/MusicPlayerEmptyWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MusicPlayerEmptyWindow.hpp"
@@ -30,13 +30,13 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get("app_music_player_music_library"));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get("app_music_player_quit"));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate("app_music_player_music_library"));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate("app_music_player_quit"));
 
         img = new gui::Image(this, noteImg::x, noteImg::y, "note");
 
         text = new Text(this, infoText::x, infoText::y, infoText::w, infoText::h);
-        text->setText(utils::localize.get("app_music_player_music_empty_window_notification"));
+        text->setText(utils::translate("app_music_player_music_empty_window_notification"));
         text->setTextType(TextType::MultiLine);
         text->setEditMode(EditMode::Browse);
         text->setEdges(RectangleEdge::None);

--- a/module-apps/application-notes/ApplicationNotes.cpp
+++ b/module-apps/application-notes/ApplicationNotes.cpp
@@ -121,7 +121,7 @@ namespace app
             return std::make_unique<gui::DialogYesNo>(app, name);
         });
         windowsFactory.attach(
-            utils::localize.get("app_phonebook_options_title"),
+            utils::translate("app_phonebook_options_title"),
             [](Application *app, const std::string &name) { return std::make_unique<gui::OptionWindow>(app, name); });
 
         attachPopups({gui::popup::ID::Volume,

--- a/module-apps/application-notes/model/NotesListModel.cpp
+++ b/module-apps/application-notes/model/NotesListModel.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "NotesListModel.hpp"
@@ -53,7 +53,7 @@ namespace app::notes
         item->inputCallback = [this, note = note.get()](gui::Item &, const gui::InputEvent &event) {
             if (event.isShortPress() && event.is(gui::KeyCode::KEY_LF)) {
                 application->switchWindow(
-                    utils::localize.get("app_phonebook_options_title"),
+                    utils::translate("app_phonebook_options_title"),
                     std::make_unique<gui::OptionsWindowOptions>(noteListOptions(application, *note, *notesRepository)));
             }
             return false;

--- a/module-apps/application-notes/widgets/NotesItem.cpp
+++ b/module-apps/application-notes/widgets/NotesItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "NotesItem.hpp"
@@ -57,7 +57,7 @@ namespace gui
     void NotesItem::setDateText(std::uint32_t timestamp)
     {
         if (auto dt = utils::time::DateTime(timestamp); dt.isYesterday()) {
-            date->setText(utils::localize.get("common_yesterday"));
+            date->setText(utils::translate("common_yesterday"));
         }
         else {
             date->setText(dt);

--- a/module-apps/application-notes/windows/NoteEditWindow.cpp
+++ b/module-apps/application-notes/windows/NoteEditWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "NoteEditWindow.hpp"
@@ -49,7 +49,7 @@ namespace app::notes
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_notes_edit_new_note"));
+        setTitle(utils::translate("app_notes_edit_new_note"));
 
         namespace editStyle = app::notes::style::edit;
         charactersCounter   = new gui::Label(
@@ -77,13 +77,13 @@ namespace app::notes
         edit->setTextLimitType(gui::TextLimitType::MaxSignsCount, MaxCharactersCount);
 
         bottomBar->setActive(gui::BottomBar::Side::LEFT, true);
-        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::localize.get(::style::strings::common::options));
+        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate(::style::strings::common::options));
 
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(::style::strings::common::save));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(::style::strings::common::save));
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(::style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(::style::strings::common::back));
 
         setFocusItem(edit);
     }
@@ -129,7 +129,7 @@ namespace app::notes
             }
             if (inputEvent.is(gui::KeyCode::KEY_LF)) {
                 application->switchWindow(
-                    utils::localize.get("app_phonebook_options_title"),
+                    utils::translate("app_phonebook_options_title"),
                     std::make_unique<gui::OptionsWindowOptions>(noteEditOptions(application, *notesRecord, edit)));
             }
         }

--- a/module-apps/application-notes/windows/NoteMainWindow.cpp
+++ b/module-apps/application-notes/windows/NoteMainWindow.cpp
@@ -45,14 +45,14 @@ namespace app::notes
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_notes_title_main"));
+        setTitle(utils::translate("app_notes_title_main"));
 
         bottomBar->setActive(gui::BottomBar::Side::LEFT, true);
-        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::localize.get(::style::strings::common::options));
+        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate(::style::strings::common::options));
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(::style::strings::common::open));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(::style::strings::common::open));
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(::style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(::style::strings::common::back));
 
         namespace windowStyle = app::notes::style::main_window;
         leftArrowImage        = new gui::Image(this,
@@ -103,7 +103,7 @@ namespace app::notes
                                       ::style::window_width,
                                       ::style::window_height - ::style::header::height - ::style::footer::height,
                                       "phonebook_empty_grey_circle_W_G",
-                                      utils::localize.get("app_notes_no_notes"));
+                                      utils::translate("app_notes_no_notes"));
         emptyListIcon->focusChangedCallback = [this]([[maybe_unused]] gui::Item &item) {
             onEmptyList();
             return true;

--- a/module-apps/application-notes/windows/NotePreviewWindow.cpp
+++ b/module-apps/application-notes/windows/NotePreviewWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "NotePreviewWindow.hpp"
@@ -49,7 +49,7 @@ namespace app::notes
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_notes_title_main"));
+        setTitle(utils::translate("app_notes_title_main"));
 
         namespace previewStyle = app::notes::style::preview;
         date                   = new gui::Label(
@@ -71,13 +71,13 @@ namespace app::notes
         note->setCursorStartPosition(gui::CursorStartPosition::DocumentBegin);
 
         bottomBar->setActive(gui::BottomBar::Side::LEFT, true);
-        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::localize.get(::style::strings::common::options));
+        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate(::style::strings::common::options));
 
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get("app_notes_edit"));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate("app_notes_edit"));
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(::style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(::style::strings::common::back));
 
         setFocusItem(note);
     }
@@ -98,12 +98,12 @@ namespace app::notes
     {
         utils::time::DateTime dt{timestamp};
         std::ostringstream dateText;
-        dateText << utils::localize.get("app_notes_edited") << ": ";
+        dateText << utils::translate("app_notes_edited") << ": ";
         if (dt.isToday()) {
-            dateText << utils::localize.get("common_today") << ", ";
+            dateText << utils::translate("common_today") << ", ";
         }
         else if (dt.isYesterday()) {
-            dateText << utils::localize.get("common_yesterday") << ", ";
+            dateText << utils::translate("common_yesterday") << ", ";
         }
         dateText << dt;
         date->setText(dateText.str());
@@ -116,7 +116,7 @@ namespace app::notes
                 application->switchWindow(gui::name::window::note_edit, std::make_unique<NoteSwitchData>(*notesRecord));
             }
             else if (inputEvent.is(gui::KeyCode::KEY_LF)) {
-                application->switchWindow(utils::localize.get("app_phonebook_options_title"),
+                application->switchWindow(utils::translate("app_phonebook_options_title"),
                                           std::make_unique<gui::OptionsWindowOptions>(notePreviewOptions(
                                               application, *notesRecord, presenter->getRepository(), note)));
             }

--- a/module-apps/application-notes/windows/NotesOptions.cpp
+++ b/module-apps/application-notes/windows/NotesOptions.cpp
@@ -21,15 +21,15 @@ namespace app::notes
                        std::function<bool(gui::Item &)> onClickCallback,
                        std::list<gui::Option> &options)
         {
-            options.emplace_back(utils::localize.get(translationId), onClickCallback);
+            options.emplace_back(utils::translate(translationId), onClickCallback);
         }
 
         void removeNote(const NotesRecord &record, Application *application, AbstractNotesRepository &notesRepository)
         {
             auto metaData = std::make_unique<gui::DialogMetadataMessage>(
-                gui::DialogMetadata{utils::localize.get("app_alarm_clock_title_main"),
+                gui::DialogMetadata{utils::translate("app_alarm_clock_title_main"),
                                     "phonebook_contact_delete_trashcan",
-                                    utils::localize.get("app_notes_note_delete_confirmation"),
+                                    utils::translate("app_notes_note_delete_confirmation"),
                                     "",
                                     [record, application, &notesRepository] {
                                         notesRepository.remove(record, [application](bool) {

--- a/module-apps/application-notes/windows/SearchEngineWindow.cpp
+++ b/module-apps/application-notes/windows/SearchEngineWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SearchEngineWindow.hpp"
@@ -27,14 +27,14 @@ namespace app::notes
     void SearchEngineWindow::buildInterface()
     {
         AppWindow::buildInterface();
-        setTitle(utils::localize.get("app_notes_title_main"));
+        setTitle(utils::translate("app_notes_title_main"));
 
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::search));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::search));
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        input = gui::inputBox(this, utils::localize.get("common_search_uc"), "search");
+        input = gui::inputBox(this, utils::translate("common_search_uc"), "search");
         setFocusItem(input);
     }
 

--- a/module-apps/application-notes/windows/SearchResultsWindow.cpp
+++ b/module-apps/application-notes/windows/SearchResultsWindow.cpp
@@ -27,12 +27,12 @@ namespace app::notes
     void SearchResultsWindow::buildInterface()
     {
         AppWindow::buildInterface();
-        setTitle(utils::localize.get("app_notes_title_main"));
+        setTitle(utils::translate("app_notes_title_main"));
 
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(::style::strings::common::open));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(::style::strings::common::open));
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(::style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(::style::strings::common::back));
 
         list = new gui::ListView(this,
                                  style::list::X,
@@ -71,9 +71,9 @@ namespace app::notes
 
     void SearchResultsWindow::onNothingFound(const std::string &searchText)
     {
-        gui::DialogMetadata meta{utils::localize.get("common_results_prefix") + searchText,
+        gui::DialogMetadata meta{utils::translate("common_results_prefix") + searchText,
                                  "search_big",
-                                 utils::localize.get("app_notes_search_no_results")};
+                                 utils::translate("app_notes_search_no_results")};
         auto data                        = std::make_unique<gui::DialogMetadataMessage>(meta);
         data->ignoreCurrentWindowOnStack = true;
         application->switchWindow(gui::name::window::note_dialog, std::move(data));

--- a/module-apps/application-onboarding/model/EULARepository.cpp
+++ b/module-apps/application-onboarding/model/EULARepository.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <module-utils/gsl/gsl_util>
@@ -16,12 +16,12 @@ namespace app::onBoarding
 
     std::string EULARepository::getEulaText()
     {
-        auto displayLanguageName = utils::localize.getDisplayLanguage();
+        const auto &displayLanguageName = utils::getDisplayLanguage();
         auto eulaFile            = std::ifstream(licensesPath / displayLanguageName / fileName);
         auto fileHandlerCleanup  = gsl::finally([&eulaFile]() { eulaFile.close(); });
 
         if (!eulaFile.is_open()) {
-            eulaFile.open(licensesPath / utils::i18n::DefaultLanguage / fileName);
+            eulaFile.open(licensesPath / utils::getDefaultLanguage() / fileName);
 
             if (!eulaFile.is_open()) {
                 throw std::runtime_error("EULA assets missing in system!");

--- a/module-apps/application-onboarding/windows/ConfigurationSuccessfulDialogWindow.cpp
+++ b/module-apps/application-onboarding/windows/ConfigurationSuccessfulDialogWindow.cpp
@@ -15,7 +15,7 @@ namespace app::onBoarding
     ConfigurationSuccessfulDialogWindow::ConfigurationSuccessfulDialogWindow(app::Application *app)
         : gui::Dialog(app, gui::window::name::onBoarding_configuration_successful)
     {
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::start));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::start));
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, false);
     }
 
@@ -24,9 +24,9 @@ namespace app::onBoarding
         if (inputEvent.isShortPress()) {
             if (inputEvent.is(gui::KeyCode::KEY_ENTER)) {
                 auto metaData = std::make_unique<gui::DialogMetadataMessage>(
-                    gui::DialogMetadata{utils::localize.get("app_onboarding_title_update_info"),
+                    gui::DialogMetadata{utils::translate("app_onboarding_title_update_info"),
                                         "update_icon_W_G",
-                                        utils::localize.get("app_onboarding_update_info"),
+                                        utils::translate("app_onboarding_update_info"),
                                         "",
                                         [=]() -> bool { return true; }});
                 application->switchWindow(

--- a/module-apps/application-onboarding/windows/ConfigurePasscodeWindow.cpp
+++ b/module-apps/application-onboarding/windows/ConfigurePasscodeWindow.cpp
@@ -41,14 +41,14 @@ namespace gui
 
     void ConfigurePasscodeWindow::buildBottomBar()
     {
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::confirm));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::skip));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::confirm));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::skip));
     }
 
     void ConfigurePasscodeWindow::buildTitleBar()
     {
-        setTitle(utils::localize.get("app_onboarding_passcode_configuration"));
+        setTitle(utils::translate("app_onboarding_passcode_configuration"));
     }
 
     void ConfigurePasscodeWindow::processPasscode()
@@ -74,9 +74,9 @@ namespace gui
         case PinLock::LockState::NewPasscodeInvalid: {
 
             auto metaData = std::make_unique<gui::DialogMetadataMessage>(
-                gui::DialogMetadata{utils::localize.get("app_onboarding_passcode_configuration"),
+                gui::DialogMetadata{utils::translate("app_onboarding_passcode_configuration"),
                                     "info_big_circle_W_G",
-                                    utils::localize.get("app_onboarding_wrong_password"),
+                                    utils::translate("app_onboarding_wrong_password"),
                                     "",
                                     [this]() {
                                         application->switchWindow(gui::window::name::onBoarding_configure_passcode,

--- a/module-apps/application-onboarding/windows/EULALicenseWindow.cpp
+++ b/module-apps/application-onboarding/windows/EULALicenseWindow.cpp
@@ -40,7 +40,7 @@ namespace app::onBoarding
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_onboarding_eula_license"));
+        setTitle(utils::translate("app_onboarding_eula_license"));
 
         namespace previewStyle = app::notes::style::preview;
         eulaText               = new gui::Text(
@@ -56,10 +56,10 @@ namespace app::onBoarding
         bottomBar->setActive(gui::BottomBar::Side::LEFT, true);
 
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(::style::strings::common::accept));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(::style::strings::common::accept));
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(::style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(::style::strings::common::back));
 
         setFocusItem(eulaText);
     }

--- a/module-apps/application-onboarding/windows/NoConfigurationDialogWindow.cpp
+++ b/module-apps/application-onboarding/windows/NoConfigurationDialogWindow.cpp
@@ -15,7 +15,7 @@ namespace app::onBoarding
     NoConfigurationDialogWindow::NoConfigurationDialogWindow(app::Application *app)
         : gui::Dialog(app, gui::window::name::onBoarding_no_configuration)
     {
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::start));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::start));
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, false);
     }
 
@@ -24,9 +24,9 @@ namespace app::onBoarding
         if (inputEvent.isShortPress()) {
             if (inputEvent.is(gui::KeyCode::KEY_ENTER)) {
                 auto metaData = std::make_unique<gui::DialogMetadataMessage>(
-                    gui::DialogMetadata{utils::localize.get("app_onboarding_title_update_info"),
+                    gui::DialogMetadata{utils::translate("app_onboarding_title_update_info"),
                                         "update_icon_W_G",
-                                        utils::localize.get("app_onboarding_update_info"),
+                                        utils::translate("app_onboarding_update_info"),
                                         "",
                                         [=]() -> bool { return true; }});
                 application->switchWindow(

--- a/module-apps/application-onboarding/windows/OnBoardingDateAndTimeWindow.cpp
+++ b/module-apps/application-onboarding/windows/OnBoardingDateAndTimeWindow.cpp
@@ -24,9 +24,9 @@ namespace app::onBoarding
     {
         DateAndTimeMainWindow::onBeforeShow(mode, data);
 
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::save));
-        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::localize.get(style::strings::common::Switch));
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::save));
+        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate(style::strings::common::Switch));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
     }
 
     bool OnBoardingDateAndTimeWindow::onInput(const gui::InputEvent &inputEvent)
@@ -43,9 +43,9 @@ namespace app::onBoarding
         }
         else if (inputEvent.isShortPress() && inputEvent.is(gui::KeyCode::KEY_ENTER)) {
             auto metaData = std::make_unique<gui::DialogMetadataMessage>(
-                gui::DialogMetadata{utils::localize.get("app_onboarding_title_configuration"),
+                gui::DialogMetadata{utils::translate("app_onboarding_title_configuration"),
                                     "success_icon_W_G",
-                                    utils::localize.get("app_onboarding_configuration_successful"),
+                                    utils::translate("app_onboarding_configuration_successful"),
                                     "",
                                     [=]() -> bool { return true; }});
             application->switchWindow(gui::window::name::onBoarding_configuration_successful,
@@ -60,13 +60,13 @@ namespace app::onBoarding
 
     bool OnBoardingDateAndTimeWindow::bottomBarCallback(gui::Item &item)
     {
-        setBottomBarText(utils::localize.get(style::strings::common::save), gui::BottomBar::Side::CENTER);
+        setBottomBarText(utils::translate(style::strings::common::save), gui::BottomBar::Side::CENTER);
 
         if (item.focus) {
-            setBottomBarText(utils::localize.get(style::strings::common::Switch), gui::BottomBar::Side::LEFT);
+            setBottomBarText(utils::translate(style::strings::common::Switch), gui::BottomBar::Side::LEFT);
         }
         else {
-            setBottomBarText(utils::localize.get(style::strings::common::select), gui::BottomBar::Side::LEFT);
+            setBottomBarText(utils::translate(style::strings::common::select), gui::BottomBar::Side::LEFT);
         }
         return true;
     }

--- a/module-apps/application-onboarding/windows/OnBoardingMainWindow.cpp
+++ b/module-apps/application-onboarding/windows/OnBoardingMainWindow.cpp
@@ -23,7 +23,7 @@ namespace app::onBoarding
         AppWindow::buildInterface();
 
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(::style::strings::common::start));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(::style::strings::common::start));
 
         new gui::Image(this, 0, 0, 0, 0, "logo");
     }

--- a/module-apps/application-onboarding/windows/StartConfigurationWindow.cpp
+++ b/module-apps/application-onboarding/windows/StartConfigurationWindow.cpp
@@ -27,11 +27,11 @@ namespace app::onBoarding
         AppWindow::buildInterface();
 
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(::style::strings::common::start));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(::style::strings::common::start));
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(::style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(::style::strings::common::back));
         bottomBar->setActive(gui::BottomBar::Side::LEFT, true);
-        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::localize.get(::style::strings::common::skip));
+        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate(::style::strings::common::skip));
 
         new gui::Icon(this,
                       0,
@@ -39,7 +39,7 @@ namespace app::onBoarding
                       style::window_width,
                       style::window::default_body_height,
                       "logo_no_text",
-                      utils::localize.get("app_onboarding_start_configuration"));
+                      utils::translate("app_onboarding_start_configuration"));
     }
 
     bool StartConfigurationWindow::onInput(const gui::InputEvent &inputEvent)
@@ -58,15 +58,15 @@ namespace app::onBoarding
             if (inputEvent.is(gui::KeyCode::KEY_LF)) {
 
                 auto metaData = std::make_unique<gui::DialogMetadataMessage>(gui::DialogMetadata{
-                    utils::localize.get("app_onboarding_title"),
+                    utils::translate("app_onboarding_title"),
                     "info_icon_W_G",
-                    utils::localize.get("app_onboarding_skip_confirm"),
+                    utils::translate("app_onboarding_skip_confirm"),
                     "",
                     [=]() -> bool {
                         auto metaData = std::make_unique<gui::DialogMetadataMessage>(
-                            gui::DialogMetadata{utils::localize.get("app_onboarding_title_configuration"),
+                            gui::DialogMetadata{utils::translate("app_onboarding_title_configuration"),
                                                 "info_icon_W_G",
-                                                utils::localize.get("app_onboarding_no_configuration"),
+                                                utils::translate("app_onboarding_no_configuration"),
                                                 "",
                                                 [=]() -> bool { return true; }});
 

--- a/module-apps/application-onboarding/windows/UpdateDialogWindow.cpp
+++ b/module-apps/application-onboarding/windows/UpdateDialogWindow.cpp
@@ -15,7 +15,7 @@ namespace app::onBoarding
     UpdateDialogWindow::UpdateDialogWindow(app::Application *app)
         : gui::Dialog(app, gui::window::name::onBoarding_update)
     {
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::ok));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::ok));
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, false);
     }
 

--- a/module-apps/application-phonebook/ApplicationPhonebook.cpp
+++ b/module-apps/application-phonebook/ApplicationPhonebook.cpp
@@ -193,8 +193,8 @@ namespace app
     {
         gui::DialogMetadata meta;
         meta.icon                        = "search_big";
-        meta.text                        = utils::localize.get("app_phonebook_search_no_results");
-        meta.title                       = utils::localize.get("common_results_prefix") + "\"" + query + "\"";
+        meta.text                        = utils::translate("app_phonebook_search_no_results");
+        meta.title                       = utils::translate("common_results_prefix") + "\"" + query + "\"";
         auto data                        = std::make_unique<gui::DialogMetadataMessage>(meta);
         data->ignoreCurrentWindowOnStack = true;
         LOG_DEBUG("Switching to app_phonebook_search_no_results window.");

--- a/module-apps/application-phonebook/widgets/ContactFlagsWidget.cpp
+++ b/module-apps/application-phonebook/widgets/ContactFlagsWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ContactFlagsWidget.hpp"
@@ -65,10 +65,10 @@ namespace gui
 
     void ContactFlagsWidget::initGUIIcons()
     {
-        favouritesIcon = new ContactFlagIconWidget("small_heart_W_M", utils::localize.get("FAVOURITES"), this);
-        speedDialIcon  = new ContactFlagIconWidget(speedDialPos, utils::localize.get("SPEED DIAL"), this);
-        iceIcon        = new ContactFlagIconWidget("ice", utils::localize.get("ICE"), this);
-        blockedIcon    = new ContactFlagIconWidget("block", utils::localize.get("BLOCKED"), this);
+        favouritesIcon = new ContactFlagIconWidget("small_heart_W_M", utils::translate("FAVOURITES"), this);
+        speedDialIcon  = new ContactFlagIconWidget(speedDialPos, utils::translate("SPEED DIAL"), this);
+        iceIcon        = new ContactFlagIconWidget("ice", utils::translate("ICE"), this);
+        blockedIcon    = new ContactFlagIconWidget("block", utils::translate("BLOCKED"), this);
     }
 
     void ContactFlagsWidget::buildWidget()

--- a/module-apps/application-phonebook/widgets/InformationWidget.cpp
+++ b/module-apps/application-phonebook/widgets/InformationWidget.cpp
@@ -23,7 +23,7 @@ namespace gui
         vBox = new VBox(this, 0, 0, 0, 0);
         vBox->setEdges(RectangleEdge::None);
 
-        titleLabel = new Label(vBox, 0, 0, 0, 0, utils::localize.get("app_phonebook_contact_information"));
+        titleLabel = new Label(vBox, 0, 0, 0, 0, utils::translate("app_phonebook_contact_information"));
         titleLabel->setMinimumSize(phonebookStyle::informationWidget::w,
                                    phonebookStyle::informationWidget::title_label_h);
         titleLabel->setEdges(RectangleEdge::None);

--- a/module-apps/application-phonebook/widgets/InputBoxWithLabelAndIconWidget.cpp
+++ b/module-apps/application-phonebook/widgets/InputBoxWithLabelAndIconWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "InputBoxWithLabelAndIconWidget.hpp"
@@ -96,7 +96,7 @@ namespace gui
 
     void InputBoxWithLabelAndIconWidget::speedDialKeyHandler()
     {
-        descriptionLabel->setText(utils::localize.get("app_phonebook_new_speed_dial_key"));
+        descriptionLabel->setText(utils::translate("app_phonebook_new_speed_dial_key"));
         iconImage->set("speed_dial_empty_W_M");
 
         focusChangedCallback = [&](gui::Item &item) {
@@ -130,7 +130,7 @@ namespace gui
 
     void InputBoxWithLabelAndIconWidget::addToFavouritesHandler()
     {
-        descriptionLabel->setText(utils::localize.get("app_phonebook_new_add_to_fav"));
+        descriptionLabel->setText(utils::translate("app_phonebook_new_add_to_fav"));
         iconImage->set("small_heart_W_M");
         tickImage->set("small_tick_W_M");
 
@@ -138,10 +138,10 @@ namespace gui
             if (focus) {
                 setFocusItem(inputBoxLabel);
                 if (tickImage->visible) {
-                    bottomBarTemporaryMode(utils::localize.get("app_phonebook_uncheck"));
+                    bottomBarTemporaryMode(utils::translate("app_phonebook_uncheck"));
                 }
                 else {
-                    bottomBarTemporaryMode(utils::localize.get("app_phonebook_check"));
+                    bottomBarTemporaryMode(utils::translate("app_phonebook_check"));
                 }
             }
             else {
@@ -158,10 +158,10 @@ namespace gui
             if (event.keyCode == gui::KeyCode::KEY_LF) {
                 tickImage->setVisible(!tickImage->visible);
                 if (tickImage->visible) {
-                    bottomBarTemporaryMode(utils::localize.get("app_phonebook_uncheck"));
+                    bottomBarTemporaryMode(utils::translate("app_phonebook_uncheck"));
                 }
                 else {
-                    bottomBarTemporaryMode(utils::localize.get("app_phonebook_check"));
+                    bottomBarTemporaryMode(utils::translate("app_phonebook_check"));
                 }
                 hBox->resizeItems();
                 return true;
@@ -176,7 +176,7 @@ namespace gui
     }
     void InputBoxWithLabelAndIconWidget::addToICEHandler()
     {
-        descriptionLabel->setText(utils::localize.get("app_phonebook_new_add_to_ice"));
+        descriptionLabel->setText(utils::translate("app_phonebook_new_add_to_ice"));
         iconImage->set("ice");
         tickImage->set("small_tick_W_M");
 
@@ -184,10 +184,10 @@ namespace gui
             if (focus) {
                 setFocusItem(inputBoxLabel);
                 if (tickImage->visible) {
-                    bottomBarTemporaryMode(utils::localize.get("app_phonebook_uncheck"));
+                    bottomBarTemporaryMode(utils::translate("app_phonebook_uncheck"));
                 }
                 else {
-                    bottomBarTemporaryMode(utils::localize.get("app_phonebook_check"));
+                    bottomBarTemporaryMode(utils::translate("app_phonebook_check"));
                 }
             }
             else {
@@ -205,10 +205,10 @@ namespace gui
             if (event.keyCode == gui::KeyCode::KEY_LF) {
                 tickImage->setVisible(!tickImage->visible);
                 if (tickImage->visible) {
-                    bottomBarTemporaryMode(utils::localize.get("app_phonebook_uncheck"));
+                    bottomBarTemporaryMode(utils::translate("app_phonebook_uncheck"));
                 }
                 else {
-                    bottomBarTemporaryMode(utils::localize.get("app_phonebook_check"));
+                    bottomBarTemporaryMode(utils::translate("app_phonebook_check"));
                 }
                 hBox->resizeItems();
                 return true;

--- a/module-apps/application-phonebook/widgets/InputLinesWithLabelIWidget.cpp
+++ b/module-apps/application-phonebook/widgets/InputLinesWithLabelIWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "InputLinesWithLabelIWidget.hpp"
@@ -127,7 +127,7 @@ namespace gui
     }
     void InputLinesWithLabelIWidget::firstNameHandler()
     {
-        titleLabel->setText(utils::localize.get("app_phonebook_new_contact_first_name"));
+        titleLabel->setText(utils::translate("app_phonebook_new_contact_first_name"));
         inputText->setTextType(TextType::SingleLine);
 
         onSaveCallback = [&](std::shared_ptr<ContactRecord> contact) { contact->primaryName = inputText->getText(); };
@@ -136,7 +136,7 @@ namespace gui
     }
     void InputLinesWithLabelIWidget::secondNameHandler()
     {
-        titleLabel->setText(utils::localize.get("app_phonebook_new_contact_second_name"));
+        titleLabel->setText(utils::translate("app_phonebook_new_contact_second_name"));
         inputText->setTextType(TextType::SingleLine);
 
         onSaveCallback = [&](std::shared_ptr<ContactRecord> contact) {
@@ -147,7 +147,7 @@ namespace gui
     }
     void InputLinesWithLabelIWidget::numberHandler()
     {
-        titleLabel->setText(utils::localize.get("app_phonebook_new_contact_number"));
+        titleLabel->setText(utils::translate("app_phonebook_new_contact_number"));
         inputText->setTextType(TextType::SingleLine);
         inputText->setInputMode(new InputMode({InputMode::phone}));
 
@@ -166,7 +166,7 @@ namespace gui
     }
     void InputLinesWithLabelIWidget::secondNumberHandler()
     {
-        titleLabel->setText(utils::localize.get("app_phonebook_new_contact_second_number"));
+        titleLabel->setText(utils::translate("app_phonebook_new_contact_second_number"));
         inputText->setTextType(TextType::SingleLine);
         inputText->setInputMode(new InputMode({InputMode::phone}));
 
@@ -185,7 +185,7 @@ namespace gui
     }
     void InputLinesWithLabelIWidget::emailHandler()
     {
-        titleLabel->setText(utils::localize.get("app_phonebook_new_contact_email"));
+        titleLabel->setText(utils::translate("app_phonebook_new_contact_email"));
         inputText->setTextType(TextType::SingleLine);
 
         onSaveCallback = [&](std::shared_ptr<ContactRecord> contact) { contact->mail = inputText->getText(); };
@@ -194,7 +194,7 @@ namespace gui
     }
     void InputLinesWithLabelIWidget::addressHandler()
     {
-        titleLabel->setText(utils::localize.get("app_phonebook_new_contact_address"));
+        titleLabel->setText(utils::translate("app_phonebook_new_contact_address"));
         inputText->setTextType(TextType::SingleLine);
 
         onSaveCallback = [&](std::shared_ptr<ContactRecord> contact) { contact->address = inputText->getText(); };
@@ -202,7 +202,7 @@ namespace gui
     }
     void InputLinesWithLabelIWidget::noteHandler()
     {
-        titleLabel->setText(utils::localize.get("app_phonebook_new_contact_note"));
+        titleLabel->setText(utils::translate("app_phonebook_new_contact_note"));
         inputText->setTextType(TextType::SingleLine);
 
         onSaveCallback = [&](std::shared_ptr<ContactRecord> contact) { contact->note = inputText->getText(); };

--- a/module-apps/application-phonebook/widgets/OutputLinesTextWithLabelWidget.cpp
+++ b/module-apps/application-phonebook/widgets/OutputLinesTextWithLabelWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "OutputLinesTextWithLabelWidget.hpp"
@@ -74,14 +74,14 @@ namespace gui
 
     void OutputLinesTextWithLabelWidget::addressHandler()
     {
-        titleLabel->setText(utils::localize.get("app_phonebook_new_contact_address"));
+        titleLabel->setText(utils::translate("app_phonebook_new_contact_address"));
 
         onLoadCallback = [&](std::shared_ptr<ContactRecord> contact) { multilineText->setText(contact->address); };
     }
 
     void OutputLinesTextWithLabelWidget::noteHandler()
     {
-        titleLabel->setText(utils::localize.get("app_phonebook_new_contact_note"));
+        titleLabel->setText(utils::translate("app_phonebook_new_contact_note"));
 
         onLoadCallback = [&](std::shared_ptr<ContactRecord> contact) { multilineText->setText(contact->note); };
     }

--- a/module-apps/application-phonebook/windows/PhonebookContactDetails.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookContactDetails.cpp
@@ -26,8 +26,8 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::options));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         contactFlagsWidget = new ContactFlagsWidget(this);
 

--- a/module-apps/application-phonebook/windows/PhonebookContactOptions.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookContactOptions.cpp
@@ -37,7 +37,7 @@ namespace gui
     auto PhonebookContactOptions::contactOptionsList() -> std::list<gui::Option>
     {
         std::list<gui::Option> options;
-        options.emplace_back(gui::Option{utils::localize.get("app_phonebook_options_edit"), [=](gui::Item &item) {
+        options.emplace_back(gui::Option{utils::translate("app_phonebook_options_edit"), [=](gui::Item &item) {
                                              LOG_INFO("Editing contact!");
                                              std::unique_ptr<gui::SwitchData> data =
                                                  std::make_unique<PhonebookItemData>(contact);
@@ -46,7 +46,7 @@ namespace gui
                                                                              std::move(data));
                                              return true;
                                          }});
-        options.emplace_back(gui::Option{utils::localize.get("app_phonebook_options_forward_namecard"),
+        options.emplace_back(gui::Option{utils::translate("app_phonebook_options_forward_namecard"),
                                          [=](gui::Item &item) {
                                              LOG_INFO("Forwarding namecard!");
                                              std::unique_ptr<gui::SwitchData> data =
@@ -58,19 +58,18 @@ namespace gui
                                          },
                                          gui::option::Arrow::Enabled});
         if (contact->isOnBlocked()) {
-            options.emplace_back(
-                gui::Option{utils::localize.get("app_phonebook_options_unblock"), [=](gui::Item &item) {
-                                LOG_INFO("Unblocking contact!");
-                                return contactBlock(false);
-                            }});
+            options.emplace_back(gui::Option{utils::translate("app_phonebook_options_unblock"), [=](gui::Item &item) {
+                                                 LOG_INFO("Unblocking contact!");
+                                                 return contactBlock(false);
+                                             }});
         }
         else {
-            options.emplace_back(gui::Option{utils::localize.get("app_phonebook_options_block"), [=](gui::Item &item) {
+            options.emplace_back(gui::Option{utils::translate("app_phonebook_options_block"), [=](gui::Item &item) {
                                                  LOG_INFO("Blocking contact!");
                                                  return contactBlock(true);
                                              }});
         }
-        options.emplace_back(gui::Option{utils::localize.get("app_phonebook_options_delete"), [=](gui::Item &item) {
+        options.emplace_back(gui::Option{utils::translate("app_phonebook_options_delete"), [=](gui::Item &item) {
                                              LOG_INFO("Deleting contact!");
                                              return contactRemove();
                                          }});
@@ -83,10 +82,10 @@ namespace gui
         std::string dialogText;
 
         if (shouldBeBlocked) {
-            dialogText = utils::localize.get("app_phonebook_options_block_confirm");
+            dialogText = utils::translate("app_phonebook_options_block_confirm");
         }
         else {
-            dialogText = utils::localize.get("app_phonebook_options_unblock_confirm");
+            dialogText = utils::translate("app_phonebook_options_unblock_confirm");
         }
 
         auto contactRec = DBServiceAPI::ContactGetByID(this->application, contact->ID);
@@ -120,7 +119,7 @@ namespace gui
         auto metaData = std::make_unique<gui::DialogMetadataMessage>(
             gui::DialogMetadata{cont.getFormattedName(),
                                 "phonebook_contact_delete_trashcan",
-                                utils::localize.get("app_phonebook_options_delete_confirm"),
+                                utils::translate("app_phonebook_options_delete_confirm"),
                                 "",
                                 [=]() -> bool {
                                     if (!DBServiceAPI::ContactRemove(this->application, contact->ID)) {
@@ -141,13 +140,13 @@ namespace gui
 
         switch (notificationType) {
         case NotificationType::Block:
-            dialogText = utils::localize.get("app_phonebook_options_block_notification");
+            dialogText = utils::translate("app_phonebook_options_block_notification");
             break;
         case NotificationType::Delete:
-            dialogText = utils::localize.get("app_phonebook_options_delete_notification");
+            dialogText = utils::translate("app_phonebook_options_delete_notification");
             break;
         case NotificationType::Unblock:
-            dialogText = utils::localize.get("app_phonebook_options_unblock_notification");
+            dialogText = utils::translate("app_phonebook_options_unblock_notification");
             break;
         }
 

--- a/module-apps/application-phonebook/windows/PhonebookIceContacts.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookIceContacts.cpp
@@ -25,7 +25,7 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_phonebook_ice_contacts_title"));
+        setTitle(utils::translate("app_phonebook_ice_contacts_title"));
 
         contactsListIce = new gui::ListView(this,
                                             phonebookStyle::iceContactsWindow::contactsListIce::x,
@@ -39,8 +39,8 @@ namespace gui
 
         bottomBar->setActive(BottomBar::Side::LEFT, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::call));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::call));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
     }
 
     void PhonebookIceContacts::destroyInterface()

--- a/module-apps/application-phonebook/windows/PhonebookMainWindow.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookMainWindow.cpp
@@ -30,7 +30,7 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_phonebook_title_main"));
+        setTitle(utils::translate("app_phonebook_title_main"));
         leftArrowImage  = new gui::Image(this,
                                         phonebookStyle::mainWindow::leftArrowImage::x,
                                         phonebookStyle::mainWindow::leftArrowImage::y,
@@ -71,9 +71,9 @@ namespace gui
         bottomBar->setActive(BottomBar::Side::LEFT, true);
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::call));
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::call));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::open));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         auto app  = application;
         inputMode = std::make_unique<InputMode>(

--- a/module-apps/application-phonebook/windows/PhonebookNamecardOptions.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookNamecardOptions.cpp
@@ -61,12 +61,12 @@ namespace gui
     {
         std::list<gui::Option> l;
 
-        l.emplace_back(gui::Option{utils::localize.get("app_phonebook_options_send_bt"), [=](gui::Item &item) {
+        l.emplace_back(gui::Option{utils::translate("app_phonebook_options_send_bt"), [=](gui::Item &item) {
                                        LOG_INFO("Sending namecard via bluetooth!");
                                        sendViaBluetooth();
                                        return true;
                                    }});
-        l.emplace_back(gui::Option{utils::localize.get("app_phonebook_options_send_sms"), [=](gui::Item &item) {
+        l.emplace_back(gui::Option{utils::translate("app_phonebook_options_send_sms"), [=](gui::Item &item) {
                                        LOG_INFO("Sending namecard via SMS!");
                                        sendViaSms();
                                        return true;

--- a/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
@@ -30,10 +30,10 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::save));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::save));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("app_phonebook_contact_title"));
+        setTitle(utils::translate("app_phonebook_contact_title"));
 
         list = new gui::ListView(this,
                                  phonebookStyle::newContactWindow::newContactsList::x,
@@ -65,10 +65,10 @@ namespace gui
             break;
         case ContactAction::Add:
         case ContactAction::EditTemporary:
-            setTitle(utils::localize.get("app_phonebook_contact_title"));
+            setTitle(utils::translate("app_phonebook_contact_title"));
             break;
         case ContactAction::Edit:
-            setTitle(utils::localize.get("app_phonebook_options_edit"));
+            setTitle(utils::translate("app_phonebook_options_edit"));
             break;
         }
 
@@ -211,7 +211,7 @@ namespace gui
             contact->ID = oldContactRecord.ID;
         }
 
-        std::string duplicatedNumberPhrase = utils::localize.get("app_phonebook_duplicate_numbers");
+        std::string duplicatedNumberPhrase = utils::translate("app_phonebook_duplicate_numbers");
         phonebookUtils::fillContactData(duplicatedNumberPhrase, oldContactRecord);
 
         auto metaData = std::make_unique<gui::DialogMetadataMessage>(gui::DialogMetadata{
@@ -235,9 +235,9 @@ namespace gui
             contact->ID = oldContactRecord.ID;
         }
 
-        std::string duplicatedSpeedDialPhrase = utils::localize.get("app_phonebook_duplicate_numbers");
+        std::string duplicatedSpeedDialPhrase = utils::translate("app_phonebook_duplicate_numbers");
         phonebookUtils::fillContactData(duplicatedSpeedDialPhrase, oldContactRecord);
-        std::string duplicatedSpeedDialTitle = utils::localize.get("app_phonebook_duplicate_speed_dial_title");
+        std::string duplicatedSpeedDialTitle = utils::translate("app_phonebook_duplicate_speed_dial_title");
         phonebookUtils::fillContactData(duplicatedSpeedDialTitle, oldContactRecord);
 
         auto metaData = std::make_unique<gui::DialogMetadataMessage>(

--- a/module-apps/application-phonebook/windows/PhonebookSearch.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookSearch.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhonebookSearch.hpp"
@@ -17,9 +17,9 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_phonebook_title_main"));
+        setTitle(utils::translate("app_phonebook_title_main"));
 
-        inputField = inputBox(this, utils::localize.get("common_search_uc"), "search");
+        inputField = inputBox(this, utils::translate("common_search_uc"), "search");
         inputField->setInputMode(new InputMode(
             {InputMode::ABC, InputMode::abc, InputMode::digit},
             [=](const UTF8 &Text) { application->getCurrentWindow()->bottomBarTemporaryMode(Text); },
@@ -30,8 +30,8 @@ namespace gui
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::search));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::search));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         setFocusItem(inputField);
     }

--- a/module-apps/application-phonebook/windows/PhonebookSearchResults.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookSearchResults.cpp
@@ -38,9 +38,9 @@ namespace gui
 
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("common_results_prefix"));
+        setTitle(utils::translate("common_results_prefix"));
     }
 
     void PhonebookSearchResults::destroyInterface()
@@ -70,18 +70,18 @@ namespace gui
         assert(searchResultsData != nullptr);
 
         searchResultsModel = searchResultsData->consumeSearchResultsModel();
-        setTitle(utils::localize.get("common_results_prefix") + "\"" + searchResultsModel->getFilter() + "\"");
+        setTitle(utils::translate("common_results_prefix") + "\"" + searchResultsModel->getFilter() + "\"");
         searchResultList->setProvider(searchResultsModel);
 
         if (searchResultsModel->messagesSelectCallback) {
             bottomBar->setActive(BottomBar::Side::LEFT, false);
             bottomBar->setText(BottomBar::Side::LEFT, "");
-            bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
+            bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
         }
         else {
             bottomBar->setActive(BottomBar::Side::LEFT, true);
-            bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::call));
-            bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::open));
+            bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::call));
+            bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::open));
         }
 
         return true;

--- a/module-apps/application-settings-new/ApplicationSettings.cpp
+++ b/module-apps/application-settings-new/ApplicationSettings.cpp
@@ -207,9 +207,9 @@ namespace app
             switchWindow(gui::window::name::dialog_retry,
                          gui::ShowMode::GUI_SHOW_INIT,
                          std::make_unique<gui::DialogMetadataMessage>(
-                             gui::DialogMetadata{utils::localize.get("app_settings_bt"),
+                             gui::DialogMetadata{utils::translate("app_settings_bt"),
                                                  "info_big_circle_W_G",
-                                                 utils::localize.get("app_settings_bluetooth_pairing_error_message"),
+                                                 utils::translate("app_settings_bluetooth_pairing_error_message"),
                                                  "",
                                                  [=]() -> bool {
                                                      bus.sendUnicast(std::make_shared<BluetoothPairMessage>(addr),
@@ -237,9 +237,9 @@ namespace app
             switchWindow(gui::window::name::dialog_retry,
                          gui::ShowMode::GUI_SHOW_INIT,
                          std::make_unique<gui::DialogMetadataMessage>(
-                             gui::DialogMetadata{utils::localize.get("app_settings_bt"),
+                             gui::DialogMetadata{utils::translate("app_settings_bt"),
                                                  "info_big_circle_W_G",
-                                                 utils::localize.get("app_settings_bluetooth_unpairing_error_message"),
+                                                 utils::translate("app_settings_bluetooth_unpairing_error_message"),
                                                  "",
                                                  [=]() -> bool {
                                                      bus.sendUnicast(std::make_shared<message::bluetooth::Unpair>(addr),
@@ -261,9 +261,9 @@ namespace app
             switchWindow(gui::window::name::dialog_retry,
                          gui::ShowMode::GUI_SHOW_INIT,
                          std::make_unique<gui::DialogMetadataMessage>(gui::DialogMetadata{
-                             utils::localize.get("app_settings_bt"),
+                             utils::translate("app_settings_bt"),
                              "info_big_circle_W_G",
-                             utils::localize.get("app_settings_bluetooth_connecting_error_message"),
+                             utils::translate("app_settings_bluetooth_connecting_error_message"),
                              "",
                              [=]() -> bool {
                                  bus.sendUnicast(std::make_shared<message::bluetooth::Connect>(addr),
@@ -283,9 +283,9 @@ namespace app
             switchWindow(gui::window::name::dialog_confirm,
                          gui::ShowMode::GUI_SHOW_INIT,
                          std::make_unique<gui::DialogMetadataMessage>(
-                             gui::DialogMetadata{utils::localize.get("app_settings_bt"),
+                             gui::DialogMetadata{utils::translate("app_settings_bt"),
                                                  "info_big_circle_W_G",
-                                                 utils::localize.get("app_settings_bluetooth_init_error_message"),
+                                                 utils::translate("app_settings_bluetooth_init_error_message"),
                                                  "",
                                                  [=]() -> bool {
                                                      switchWindow(gui::window::name::bluetooth);
@@ -371,7 +371,7 @@ namespace app
     {
         windowsFactory.attach(gui::name::window::main_window, [](Application *app, const std::string &name) {
             return std::make_unique<gui::OptionWindow>(
-                app, utils::localize.get("app_settings_title_main_new"), mainWindowOptionsNew(app));
+                app, utils::translate("app_settings_title_main_new"), mainWindowOptionsNew(app));
         });
         windowsFactory.attach(gui::window::name::bluetooth, [](Application *app, const std::string &name) {
             return std::make_unique<gui::BluetoothWindow>(app);

--- a/module-apps/application-settings-new/models/DateAndTimeModel.cpp
+++ b/module-apps/application-settings-new/models/DateAndTimeModel.cpp
@@ -62,7 +62,7 @@ void DateAndTimeModel::createData()
     dateItem = new gui::SettingsDateItem();
 
     timeItem = new gui::SettingsTimeItem(
-        utils::localize.get("app_settings_title_time"),
+        utils::translate("app_settings_title_time"),
         gui::TimeWidget::Type::Start,
         [&](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text, false); },
         [&]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); });

--- a/module-apps/application-settings-new/models/FromTimeToTimeModel.cpp
+++ b/module-apps/application-settings-new/models/FromTimeToTimeModel.cpp
@@ -60,13 +60,13 @@ unsigned int FromTimeToTimeModel::requestRecordsCount()
 void FromTimeToTimeModel::createData()
 {
     fromTimeItem = new gui::SettingsTimeItem(
-        utils::localize.get("app_settings_nightshift_from"),
+        utils::translate("app_settings_nightshift_from"),
         gui::TimeWidget::Type::Start,
         [&](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text, false); },
         [&]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); });
 
     toTimeItem = new gui::SettingsTimeItem(
-        utils::localize.get("app_settings_nightshift_to"),
+        utils::translate("app_settings_nightshift_to"),
         gui::TimeWidget::Type::End,
         [&](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text, false); },
         [&]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); });

--- a/module-apps/application-settings-new/models/SARInfoRepository.cpp
+++ b/module-apps/application-settings-new/models/SARInfoRepository.cpp
@@ -14,11 +14,11 @@ SARInfoRepository::SARInfoRepository(std::filesystem::path certificationInfoPath
 
 std::string SARInfoRepository::getSarInfoText()
 {
-    auto displayLanguageName = utils::localize.getDisplayLanguage();
+    const auto &displayLanguageName = utils::getDisplayLanguage();
     auto sarInfoFile         = std::ifstream(certificationInfoPath / displayLanguageName / fileName);
 
     if (!sarInfoFile.is_open()) {
-        sarInfoFile.open(certificationInfoPath / utils::i18n::DefaultLanguage / fileName);
+        sarInfoFile.open(certificationInfoPath / utils::getDefaultLanguage() / fileName);
 
         if (!sarInfoFile.is_open()) {
             throw std::runtime_error("SAR info assets are missing in the system!");

--- a/module-apps/application-settings-new/widgets/ApnInputWidget.cpp
+++ b/module-apps/application-settings-new/widgets/ApnInputWidget.cpp
@@ -128,7 +128,7 @@ namespace gui
 
     void ApnInputWidget::nameHandler()
     {
-        titleLabel->setText(utils::localize.get("app_settings_apn_name"));
+        titleLabel->setText(utils::translate("app_settings_apn_name"));
         inputText->setTextType(TextType::SingleLine);
         onSaveCallback = [&](std::shared_ptr<packet_data::APN::Config> apnRecord) {
             apnRecord->apn = inputText->getText();
@@ -141,7 +141,7 @@ namespace gui
 
     void ApnInputWidget::apnHandler()
     {
-        titleLabel->setText(utils::localize.get("app_settings_apn_APN"));
+        titleLabel->setText(utils::translate("app_settings_apn_APN"));
         inputText->setTextType(TextType::SingleLine);
         onSaveCallback = [&](std::shared_ptr<packet_data::APN::Config> apnRecord) {
             apnRecord->ip = inputText->getText();
@@ -154,7 +154,7 @@ namespace gui
 
     void ApnInputWidget::usernameHandler()
     {
-        titleLabel->setText(utils::localize.get("app_settings_apn_username"));
+        titleLabel->setText(utils::translate("app_settings_apn_username"));
         inputText->setTextType(TextType::SingleLine);
         onSaveCallback = [&](std::shared_ptr<packet_data::APN::Config> apnRecord) {
             apnRecord->username = inputText->getText();
@@ -167,7 +167,7 @@ namespace gui
 
     void ApnInputWidget::passwordNumberHandler()
     {
-        titleLabel->setText(utils::localize.get("app_settings_apn_password"));
+        titleLabel->setText(utils::translate("app_settings_apn_password"));
         inputText->setTextType(TextType::SingleLine);
         onSaveCallback = [&](std::shared_ptr<packet_data::APN::Config> apnRecord) {
             apnRecord->password = inputText->getText();
@@ -180,7 +180,7 @@ namespace gui
 
     void ApnInputWidget::authtypeHandler()
     {
-        titleLabel->setText(utils::localize.get("app_settings_apn_authtype"));
+        titleLabel->setText(utils::translate("app_settings_apn_authtype"));
         inputText->setTextType(TextType::SingleLine);
         onSaveCallback = [&](std::shared_ptr<packet_data::APN::Config> apnRecord) {
             apnRecord->setAuthMethod(inputText->getText());
@@ -193,7 +193,7 @@ namespace gui
 
     void ApnInputWidget::apntypeHandler()
     {
-        titleLabel->setText(utils::localize.get("app_settings_apn_apntype"));
+        titleLabel->setText(utils::translate("app_settings_apn_apntype"));
         inputText->setTextType(TextType::SingleLine);
         onSaveCallback = [&](std::shared_ptr<packet_data::APN::Config> apnRecord) {
             apnRecord->setApnType(inputText->getText());
@@ -205,7 +205,7 @@ namespace gui
     }
     void ApnInputWidget::protocolHandler()
     {
-        titleLabel->setText(utils::localize.get("app_settings_apn_apnprotocol"));
+        titleLabel->setText(utils::translate("app_settings_apn_apnprotocol"));
         inputText->setTextType(TextType::SingleLine);
         onSaveCallback = [&](std::shared_ptr<packet_data::APN::Config> apnRecord) {
             apnRecord->setApnProtocol(inputText->getText());

--- a/module-apps/application-settings-new/widgets/CategoryWidget.cpp
+++ b/module-apps/application-settings-new/widgets/CategoryWidget.cpp
@@ -84,7 +84,7 @@ namespace gui
                 descriptionLabel->setFont(style::window::font::mediumbold);
                 setFocusItem(inputBoxLabel);
                 auto bottorBarText =
-                    category.enabled ? utils::localize.get("common_uncheck") : utils::localize.get("common_check");
+                    category.enabled ? utils::translate("common_uncheck") : utils::translate("common_check");
                 this->bottomBarTemporaryMode(bottorBarText);
             }
             else {
@@ -100,7 +100,7 @@ namespace gui
             enableCategory(category.enabled);
             tickImage->setVisible(category.enabled);
             auto bottorBarText =
-                category.enabled ? utils::localize.get("common_uncheck") : utils::localize.get("common_check");
+                category.enabled ? utils::translate("common_uncheck") : utils::translate("common_check");
             this->bottomBarTemporaryMode(bottorBarText);
             hBox->resizeItems();
             return true;

--- a/module-apps/application-settings-new/widgets/QuoteWidget.cpp
+++ b/module-apps/application-settings-new/widgets/QuoteWidget.cpp
@@ -71,7 +71,7 @@ namespace gui
             if (item.focus) {
                 descriptionLabel->setFont(style::window::font::mediumbold);
                 auto bottorBarText =
-                    quote.enabled ? utils::localize.get("common_uncheck") : utils::localize.get("common_check");
+                    quote.enabled ? utils::translate("common_uncheck") : utils::translate("common_check");
                 this->bottomBarTemporaryMode(bottorBarText);
             }
             else {
@@ -86,8 +86,7 @@ namespace gui
             quote.enabled = !quote.enabled;
             enableQuote(quote.enabled);
             tickImage->showImage(quote.enabled);
-            auto bottorBarText =
-                quote.enabled ? utils::localize.get("common_uncheck") : utils::localize.get("common_check");
+            auto bottorBarText = quote.enabled ? utils::translate("common_uncheck") : utils::translate("common_check");
             this->bottomBarTemporaryMode(bottorBarText);
             hBox->resizeItems();
             return true;

--- a/module-apps/application-settings-new/windows/AboutYourPureWindow.cpp
+++ b/module-apps/application-settings-new/windows/AboutYourPureWindow.cpp
@@ -10,7 +10,7 @@ namespace gui
     AboutYourPureWindow::AboutYourPureWindow(app::Application *app)
         : BaseSettingsWindow(app, window::name::about_your_pure)
     {
-        setTitle(utils::localize.get("app_settings_about_your_pure"));
+        setTitle(utils::translate("app_settings_about_your_pure"));
     }
 
     auto AboutYourPureWindow::buildOptionsList() -> std::list<Option>
@@ -18,7 +18,7 @@ namespace gui
         std::list<Option> optionList;
         auto addOption = [&](UTF8 name, const std::string &window) {
             optionList.emplace_back(std::make_unique<option::OptionSettings>(
-                utils::translateI18(name),
+                utils::translate(name),
                 [=](Item &item) {
                     LOG_INFO("switching to %s page", window.c_str());
                     application->switchWindow(window, nullptr);

--- a/module-apps/application-settings-new/windows/AddDeviceWindow.cpp
+++ b/module-apps/application-settings-new/windows/AddDeviceWindow.cpp
@@ -52,7 +52,7 @@ namespace gui
                 gui::option::SettingRightItem::Bt));
         }
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::add));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::add));
 
         return optionsList;
     }

--- a/module-apps/application-settings-new/windows/AlarmClockWindow.cpp
+++ b/module-apps/application-settings-new/windows/AlarmClockWindow.cpp
@@ -15,17 +15,16 @@ namespace gui
         : BaseSettingsWindow(app, gui::window::name::alarm_clock), mWidgetMaker(this),
           mAudioModel(std::move(audioModel))
     {
-        setTitle(utils::localize.get("app_settings_apps_alarm_clock"));
+        setTitle(utils::translate("app_settings_apps_alarm_clock"));
     }
 
     std::list<Option> AlarmClockWindow::buildOptionsList()
     {
         std::list<gui::Option> optionList;
         mVibrationsEnabled = mAudioModel->isVibrationEnabled();
-        mWidgetMaker.addSwitchOption(optionList,
-                                     utils::translateI18("app_settings_vibration"),
-                                     mVibrationsEnabled,
-                                     [&]() { switchVibrationState(); });
+        mWidgetMaker.addSwitchOption(optionList, utils::translate("app_settings_vibration"), mVibrationsEnabled, [&]() {
+            switchVibrationState();
+        });
 
         auto focusCallback = [&](gui::Item &item) {
             if (item.focus) {
@@ -35,7 +34,7 @@ namespace gui
         };
 
         optionList.emplace_back(std::make_unique<gui::SpinBoxOptionSettings>(
-            utils::translateI18("app_settings_volume"),
+            utils::translate("app_settings_volume"),
             mAudioModel->getVolume(),
             std::ceil(10.0),
             [&](uint8_t value) {

--- a/module-apps/application-settings-new/windows/AllDevicesWindow.cpp
+++ b/module-apps/application-settings-new/windows/AllDevicesWindow.cpp
@@ -24,7 +24,7 @@ namespace gui
 
     void AllDevicesWindow::buildInterface()
     {
-        setTitle(utils::localize.get("app_settings_bluetooth_all_devices"));
+        setTitle(utils::translate("app_settings_bluetooth_all_devices"));
         leftArrowImage = new gui::Image(this,
                                         style::settings::window::leftArrowImage::x,
                                         style::settings::window::leftArrowImage::y,
@@ -62,9 +62,9 @@ namespace gui
             application->switchWindow(gui::window::name::dialog_settings,
                                       gui::ShowMode::GUI_SHOW_INIT,
                                       std::make_unique<gui::DialogMetadataMessage>(gui::DialogMetadata{
-                                          utils::localize.get("app_settings_bluetooth_add_device"),
+                                          utils::translate("app_settings_bluetooth_add_device"),
                                           "search_big",
-                                          utils::localize.get("app_settings_bluetooth_searching_devices")}));
+                                          utils::translate("app_settings_bluetooth_searching_devices")}));
             return true;
         }
         if (inputEvent.is(KeyCode::KEY_LF)) {
@@ -106,10 +106,10 @@ namespace gui
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(isConnected ? utils::translateI18("common_disconnect")
-                                                           : utils::translateI18("common_connect"),
+                        this->setBottomBarText(isConnected ? utils::translate("common_disconnect")
+                                                           : utils::translate("common_connect"),
                                                BottomBar::Side::CENTER);
-                        this->setBottomBarText(utils::translateI18("common_forget"), BottomBar::Side::LEFT);
+                        this->setBottomBarText(utils::translate("common_forget"), BottomBar::Side::LEFT);
                         this->bottomBar->setActive(BottomBar::Side::LEFT, true);
                         addressOfSelectedDevice = addr;
                     }
@@ -118,7 +118,7 @@ namespace gui
                 nullptr,
                 isConnected ? gui::option::SettingRightItem::Text : gui::option::SettingRightItem::Bt,
                 false,
-                utils::localize.get("app_settings_option_connected")));
+                utils::translate("app_settings_option_connected")));
         }
         return optionsList;
     }

--- a/module-apps/application-settings-new/windows/ApnOptionsWindow.cpp
+++ b/module-apps/application-settings-new/windows/ApnOptionsWindow.cpp
@@ -12,7 +12,7 @@ namespace gui
 {
     ApnOptionsWindow::ApnOptionsWindow(app::Application *app) : BaseSettingsWindow(app, window::name::apn_options)
     {
-        setTitle(utils::localize.get("app_settings_apn_options"));
+        setTitle(utils::translate("app_settings_apn_options"));
         apnSettingsModel = new ApnSettingsModel(application);
     }
 
@@ -21,7 +21,7 @@ namespace gui
         std::list<gui::Option> optionsList;
 
         optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::localize.get("app_settings_apn_options_edit"),
+            utils::translate("app_settings_apn_options_edit"),
             [=](gui::Item &item) {
                 std::unique_ptr<gui::SwitchData> data = std::make_unique<ApnItemData>(apn);
                 application->switchWindow(gui::window::name::new_apn, gui::ShowMode::GUI_SHOW_INIT, std::move(data));
@@ -31,7 +31,7 @@ namespace gui
             this));
 
         optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::localize.get("app_settings_apn_options_delete"),
+            utils::translate("app_settings_apn_options_delete"),
             [=](gui::Item &item) {
                 apnSettingsModel->removeAPN(apn);
                 return true;
@@ -40,7 +40,7 @@ namespace gui
             this));
 
         optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::localize.get("app_settings_apn_options_set_as_default"),
+            utils::translate("app_settings_apn_options_set_as_default"),
             [=](gui::Item &item) {
                 apnSettingsModel->setAsDefaultAPN(apn);
                 return true;

--- a/module-apps/application-settings-new/windows/ApnSettingsWindow.cpp
+++ b/module-apps/application-settings-new/windows/ApnSettingsWindow.cpp
@@ -20,7 +20,7 @@ namespace gui
 
     void ApnSettingsWindow::buildInterface()
     {
-        setTitle(utils::localize.get("app_settings_network_apn_settings"));
+        setTitle(utils::translate("app_settings_network_apn_settings"));
 
         leftArrowImage = new gui::Image(this,
                                         style::settings::window::leftArrowImage::x,
@@ -40,9 +40,9 @@ namespace gui
                                  style::window_width,
                                  style::window_height - style::header::height - style::footer::height,
                                  "phonebook_empty_grey_circle_W_G",
-                                 utils::localize.get("app_settings_apn_settings_no_apns"));
+                                 utils::translate("app_settings_apn_settings_no_apns"));
 
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::options));
 
         activeApn        = std::make_shared<packet_data::APN::Config>();
         apnSettingsModel = std::make_shared<ApnSettingsModel>(application);

--- a/module-apps/application-settings-new/windows/AppsAndToolsWindow.cpp
+++ b/module-apps/application-settings-new/windows/AppsAndToolsWindow.cpp
@@ -12,14 +12,14 @@ namespace gui
     AppsAndToolsWindow::AppsAndToolsWindow(app::Application *app) : OptionWindow(app, gui::window::name::apps_and_tools)
     {
         addOptions(appsAndToolsOptionsList());
-        setTitle(utils::localize.get("app_settings_apps"));
+        setTitle(utils::translate("app_settings_apps"));
     }
 
     std::list<Option> AppsAndToolsWindow::appsAndToolsOptionsList()
     {
         std::list<gui::Option> optionList;
 
-        auto i18     = [](std::string text) { return utils::localize.get(text); };
+        auto i18     = [](std::string text) { return utils::translate(text); };
         auto addMenu = [&](UTF8 name, std::string window) {
             optionList.emplace_back(gui::Option{name,
                                                 [=](gui::Item &item) {

--- a/module-apps/application-settings-new/windows/AutolockWindow.cpp
+++ b/module-apps/application-settings-new/windows/AutolockWindow.cpp
@@ -12,7 +12,7 @@ namespace gui
 
     AutolockWindow::AutolockWindow(app::Application *app) : BaseSettingsWindow(app, window::name::autolock)
     {
-        setTitle(utils::localize.get("app_settings_display_locked_screen_autolock"));
+        setTitle(utils::translate("app_settings_display_locked_screen_autolock"));
     }
 
     auto AutolockWindow::buildOptionsList() -> std::list<gui::Option>
@@ -30,7 +30,7 @@ namespace gui
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::select),
+                        this->setBottomBarText(utils::translate(style::strings::common::select),
                                                BottomBar::Side::CENTER);
                     }
                     return true;

--- a/module-apps/application-settings-new/windows/BluetoothCheckPasskeyWindow.cpp
+++ b/module-apps/application-settings-new/windows/BluetoothCheckPasskeyWindow.cpp
@@ -26,12 +26,12 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_settings_bt"));
+        setTitle(utils::translate("app_settings_bt"));
 
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::confirm));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::confirm));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         image = new Image(this, passkey_style::image::x, passkey_style::image::y, 0, 0, "bluetooth_W_G");
 
@@ -42,7 +42,7 @@ namespace gui
                           style::window::label::default_h);
         label->setFont(style::window::font::big);
         label->setEdges(RectangleEdge::None);
-        label->setText(utils::localize.get("app_settings_bluetooth_enter_passkey"));
+        label->setText(utils::translate("app_settings_bluetooth_enter_passkey"));
 
         text = new Text(
             this, passkey_style::text::x, passkey_style::text::y, passkey_style::text::w, passkey_style::text::h);

--- a/module-apps/application-settings-new/windows/BluetoothWindow.cpp
+++ b/module-apps/application-settings-new/windows/BluetoothWindow.cpp
@@ -35,15 +35,14 @@ namespace gui
         std::list<gui::Option> optionsList;
 
         optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_bluetooth_main"),
+            utils::translate("app_settings_bluetooth_main"),
             [=](gui::Item & /*unused*/) {
                 changeBluetoothState(isBluetoothSwitchOn);
                 return true;
             },
             [=](gui::Item &item) {
                 if (item.focus) {
-                    this->setBottomBarText(utils::translateI18(style::strings::common::Switch),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::Switch), BottomBar::Side::CENTER);
                 }
                 return true;
             },
@@ -52,14 +51,14 @@ namespace gui
 
         if (isBluetoothSwitchOn) {
             optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-                utils::translateI18("app_settings_bluetooth_all_devices"),
+                utils::translate("app_settings_bluetooth_all_devices"),
                 [=](gui::Item & /*unused*/) {
                     this->application->switchWindow(gui::window::name::all_devices, gui::ShowMode::GUI_SHOW_INIT);
                     return true;
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::select),
+                        this->setBottomBarText(utils::translate(style::strings::common::select),
                                                BottomBar::Side::CENTER);
                     }
                     return true;
@@ -68,14 +67,14 @@ namespace gui
                 gui::option::SettingRightItem::ArrowWhite,
                 true));
             optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-                utils::translateI18("app_settings_bluetooth_phone_visibility"),
+                utils::translate("app_settings_bluetooth_phone_visibility"),
                 [=](gui::Item & /*unused*/) {
                     changeVisibility(isPhoneVisibilitySwitchOn);
                     return true;
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::Switch),
+                        this->setBottomBarText(utils::translate(style::strings::common::Switch),
                                                BottomBar::Side::CENTER);
                     }
                     return true;
@@ -84,14 +83,14 @@ namespace gui
                 isPhoneVisibilitySwitchOn ? gui::option::SettingRightItem::On : gui::option::SettingRightItem::Off));
             if (isPhoneVisibilitySwitchOn) {
                 optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-                    utils::translateI18("app_settings_bluetooth_phone_name"),
+                    utils::translate("app_settings_bluetooth_phone_name"),
                     [=](gui::Item & /*unused*/) {
                         this->application->switchWindow(gui::window::name::phone_name, gui::ShowMode::GUI_SHOW_INIT);
                         return true;
                     },
                     [=](gui::Item &item) {
                         if (item.focus) {
-                            this->setBottomBarText(utils::translateI18(style::strings::common::select),
+                            this->setBottomBarText(utils::translate(style::strings::common::select),
                                                    BottomBar::Side::CENTER);
                         }
                         return true;

--- a/module-apps/application-settings-new/windows/CalendarWindow.cpp
+++ b/module-apps/application-settings-new/windows/CalendarWindow.cpp
@@ -14,7 +14,7 @@ namespace gui
                                    std::unique_ptr<audio_settings::AbstractAudioSettingsModel> &&audioModel)
         : BaseSettingsWindow(app, gui::window::name::calendar), mWidgetMaker(this), mAudioModel(std::move(audioModel))
     {
-        setTitle(utils::localize.get("app_settings_apps_calendar"));
+        setTitle(utils::translate("app_settings_apps_calendar"));
     }
 
     std::list<Option> CalendarWindow::buildOptionsList()
@@ -23,18 +23,17 @@ namespace gui
         mVibrationsEnabled = mAudioModel->isVibrationEnabled();
         mSoundEnabled      = mAudioModel->isSoundEnabled();
 
-        mWidgetMaker.addSwitchOption(optionList,
-                                     utils::translateI18("app_settings_vibration"),
-                                     mVibrationsEnabled,
-                                     [&]() { switchVibrationState(); });
+        mWidgetMaker.addSwitchOption(optionList, utils::translate("app_settings_vibration"), mVibrationsEnabled, [&]() {
+            switchVibrationState();
+        });
 
         mWidgetMaker.addSwitchOption(
-            optionList, utils::translateI18("app_settings_sound"), mSoundEnabled, [&]() { switchSoundState(); });
+            optionList, utils::translate("app_settings_sound"), mSoundEnabled, [&]() { switchSoundState(); });
 
         if (mSoundEnabled) {
             mWidgetMaker.addSelectOption(
                 optionList,
-                utils::translateI18("app_settings_notification_sound"),
+                utils::translate("app_settings_notification_sound"),
                 [&]() { openNoticicationSoundWindow(); },
                 true);
         }

--- a/module-apps/application-settings-new/windows/CallRingtoneWindow.cpp
+++ b/module-apps/application-settings-new/windows/CallRingtoneWindow.cpp
@@ -9,6 +9,6 @@ namespace gui
 {
     CallRingtoneWindow::CallRingtoneWindow(app::Application *app) : BaseSettingsWindow(app, window::name::call_ringtone)
     {
-        setTitle(utils::localize.get("app_settings_call_ringtome"));
+        setTitle(utils::translate("app_settings_call_ringtome"));
     }
 } // namespace gui

--- a/module-apps/application-settings-new/windows/CertificationWindow.cpp
+++ b/module-apps/application-settings-new/windows/CertificationWindow.cpp
@@ -20,7 +20,7 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_settings_certification"));
+        setTitle(utils::translate("app_settings_certification"));
 
         usFccIdText = new gui::Text(this,
                                     style::certification::textfc::x,
@@ -76,17 +76,17 @@ namespace gui
                                        style::certification::imagece::height,
                                        "settings_certification_ce");
 
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
     }
 
     void CertificationWindow::onBeforeShow(ShowMode mode, SwitchData *data)
     {
         // dummy data for now (to be changed later)
-        usFccIdText->setText(utils::localize.get("app_settings_us_fcc_id"));
+        usFccIdText->setText(utils::translate("app_settings_us_fcc_id"));
         usFccIdValue->setText(certno);
-        canadaIcText->setText(utils::localize.get("app_settings_canada_ic"));
+        canadaIcText->setText(utils::translate("app_settings_canada_ic"));
         canadaIcValue->setText(certno);
-        europeCeText->setText(utils::localize.get("app_settings_europe"));
+        europeCeText->setText(utils::translate("app_settings_europe"));
         europeCeValue->setText(certno);
     }
 

--- a/module-apps/application-settings-new/windows/ChangeDateAndTimeWindow.cpp
+++ b/module-apps/application-settings-new/windows/ChangeDateAndTimeWindow.cpp
@@ -20,12 +20,12 @@ namespace gui
     void ChangeDateAndTimeWindow::buildInterface()
     {
         AppWindow::buildInterface();
-        setTitle(utils::localize.get("app_settings_date_and_time"));
+        setTitle(utils::translate("app_settings_date_and_time"));
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
         bottomBar->setActive(gui::BottomBar::Side::CENTER, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::localize.get(style::strings::common::save));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::CENTER, utils::translate(style::strings::common::save));
 
         list = new gui::ListView(this,
                                  style::window::date_and_time::listView_x,

--- a/module-apps/application-settings-new/windows/ChangePasscodeWindow.cpp
+++ b/module-apps/application-settings-new/windows/ChangePasscodeWindow.cpp
@@ -76,7 +76,7 @@ namespace gui
 
     void ChangePasscodeWindow::buildTitleBar()
     {
-        setTitle(utils::localize.get("app_settings_security_change_passcode"));
+        setTitle(utils::translate("app_settings_security_change_passcode"));
     }
 
     void ChangePasscodeWindow::destroyInterface()
@@ -108,9 +108,9 @@ namespace gui
                 application->setLockScreenPasscodeOn(false);
 
                 auto metaData = std::make_unique<gui::DialogMetadataMessage>(
-                    gui::DialogMetadata{utils::localize.get("app_settings_security_change_passcode"),
+                    gui::DialogMetadata{utils::translate("app_settings_security_change_passcode"),
                                         "success_icon_W_G",
-                                        utils::localize.get("app_settings_security_passcode_disabled"),
+                                        utils::translate("app_settings_security_passcode_disabled"),
                                         "",
                                         [this]() {
                                             application->switchWindow(gui::window::name::security);
@@ -170,9 +170,9 @@ namespace gui
             application->setLockScreenPasscodeOn(true);
 
             auto metaData = std::make_unique<gui::DialogMetadataMessage>(
-                gui::DialogMetadata{utils::localize.get("app_settings_security_change_passcode"),
+                gui::DialogMetadata{utils::translate("app_settings_security_change_passcode"),
                                     "success_icon_W_G",
-                                    utils::localize.get("app_settings_security_passcode_changed_successfully"),
+                                    utils::translate("app_settings_security_passcode_changed_successfully"),
                                     "",
                                     [this]() {
                                         application->switchWindow(gui::window::name::security);

--- a/module-apps/application-settings-new/windows/ChangeTimeZone.cpp
+++ b/module-apps/application-settings-new/windows/ChangeTimeZone.cpp
@@ -1,4 +1,7 @@
-﻿#include "ChangeTimeZone.hpp"
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "ChangeTimeZone.hpp"
 
 #include <application-settings-new/ApplicationSettings.hpp>
 
@@ -7,7 +10,7 @@ namespace gui
 
     ChangeTimeZone::ChangeTimeZone(app::Application *app) : BaseSettingsWindow(app, window::name::change_date_and_time)
     {
-        setTitle(utils::localize.get("app_settings_date_and_time_time_zone"));
+        setTitle(utils::translate("app_settings_date_and_time_time_zone"));
     }
 
     std::list<Option> ChangeTimeZone::buildOptionsList()

--- a/module-apps/application-settings-new/windows/ConnectionFrequencyWindow.cpp
+++ b/module-apps/application-settings-new/windows/ConnectionFrequencyWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ConnectionFrequencyWindow.hpp"
@@ -23,10 +23,10 @@ namespace gui
 
         auto intervalText = [](uint8_t value) {
             if (value == 0) {
-                return utils::localize.get("app_alarm_clock_repeat_never");
+                return utils::translate("app_alarm_clock_repeat_never");
             }
             const std::string toReplace = "%0";
-            std::string temp            = utils::translateI18("app_meditation_interval_every_x_minutes");
+            std::string temp            = utils::translate("app_meditation_interval_every_x_minutes");
             temp.replace(temp.find(toReplace), toReplace.size(), std::to_string(value));
             return temp;
         };
@@ -44,8 +44,8 @@ namespace gui
                                                                        : option::SettingRightItem::Disabled));
         }
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         return optList;
     }

--- a/module-apps/application-settings-new/windows/DateAndTimeMainWindow.cpp
+++ b/module-apps/application-settings-new/windows/DateAndTimeMainWindow.cpp
@@ -13,7 +13,7 @@ namespace gui
     DateAndTimeMainWindow::DateAndTimeMainWindow(app::Application *app)
         : BaseSettingsWindow(app, window::name::date_and_time)
     {
-        setTitle(utils::localize.get("app_settings_date_and_time"));
+        setTitle(utils::translate("app_settings_date_and_time"));
         automaticDateAndTimeIsOn = utils::dateAndTimeSettings.isAutomaticDateAndTimeOn();
         automaticTimeZoneIsOn    = utils::dateAndTimeSettings.isAutomaticTimeZoneOn();
         timeFormat               = utils::dateAndTimeSettings.getTimeFormat();
@@ -43,7 +43,7 @@ namespace gui
         };
 
         addSwitchOption(
-            utils::translateI18("app_settings_date_and_time_automatic_date_and_time"),
+            utils::translate("app_settings_date_and_time_automatic_date_and_time"),
             [=](Item &item) {
                 automaticDateAndTimeIsOn = !automaticDateAndTimeIsOn;
                 app::manager::Controller::changeAutomaticDateAndTimeIsOn(application, automaticDateAndTimeIsOn);
@@ -53,7 +53,7 @@ namespace gui
             automaticDateAndTimeIsOn ? option::SettingRightItem::On : option::SettingRightItem::Off);
 
         if (!automaticDateAndTimeIsOn) {
-            addOption(utils::translateI18("app_settings_date_and_time_change_date_and_time"), [=](Item &item) {
+            addOption(utils::translate("app_settings_date_and_time_change_date_and_time"), [=](Item &item) {
                 LOG_INFO("switching to %s page", window::name::change_date_and_time);
                 application->switchWindow(window::name::change_date_and_time, nullptr);
                 return true;
@@ -61,7 +61,7 @@ namespace gui
         }
 
         addSwitchOption(
-            utils::translateI18("app_settings_date_and_time_automatic_time_zone"),
+            utils::translate("app_settings_date_and_time_automatic_time_zone"),
             [=](Item &item) {
                 automaticTimeZoneIsOn = !automaticTimeZoneIsOn;
                 app::manager::Controller::changeAutomaticTimeZoneIsOn(application, automaticTimeZoneIsOn);
@@ -71,7 +71,7 @@ namespace gui
             automaticTimeZoneIsOn ? option::SettingRightItem::On : option::SettingRightItem::Off);
 
         if (!automaticTimeZoneIsOn) {
-            addOption(utils::translateI18("app_settings_date_and_time_change_time_zone"), [=](Item &item) {
+            addOption(utils::translate("app_settings_date_and_time_change_time_zone"), [=](Item &item) {
                 LOG_INFO("switching to %s page", window::name::change_time_zone);
                 application->switchWindow(window::name::change_time_zone, nullptr);
                 return true;
@@ -79,7 +79,7 @@ namespace gui
         }
 
         addSwitchOption(
-            utils::translateI18("app_settings_date_and_time_time_format"),
+            utils::translate("app_settings_date_and_time_time_format"),
             [=](Item &item) {
                 timeFormat = (timeFormat == utils::time::Locale::TimeFormat::FormatTime12H)
                                  ? utils::time::Locale::TimeFormat::FormatTime24H
@@ -92,7 +92,7 @@ namespace gui
             utils::time::Locale::get_time_format(timeFormat).data());
 
         addSwitchOption(
-            utils::translateI18("app_settings_date_and_time_date_format"),
+            utils::translate("app_settings_date_and_time_date_format"),
             [=](Item &item) {
                 dateFormat = (dateFormat == utils::time::Locale::DateFormat::DD_MM_YYYY)
                                  ? utils::time::Locale::DateFormat::MM_DD_YYYY
@@ -110,10 +110,10 @@ namespace gui
     bool DateAndTimeMainWindow::bottomBarCallback(Item &item)
     {
         if (item.focus) {
-            setBottomBarText(utils::localize.get(style::strings::common::Switch), BottomBar::Side::CENTER);
+            setBottomBarText(utils::translate(style::strings::common::Switch), BottomBar::Side::CENTER);
         }
         else {
-            setBottomBarText(utils::localize.get(style::strings::common::select), BottomBar::Side::CENTER);
+            setBottomBarText(utils::translate(style::strings::common::select), BottomBar::Side::CENTER);
         }
         return true;
     }

--- a/module-apps/application-settings-new/windows/DisplayAndKeypadWindow.cpp
+++ b/module-apps/application-settings-new/windows/DisplayAndKeypadWindow.cpp
@@ -15,7 +15,7 @@ namespace gui
         : OptionWindow(app, gui::window::name::display_and_keypad)
     {
         addOptions(displayAndKeypadOptionsList());
-        setTitle(utils::localize.get("app_settings_disp_key"));
+        setTitle(utils::translate("app_settings_disp_key"));
     }
 
     std::list<Option> DisplayAndKeypadWindow::displayAndKeypadOptionsList()
@@ -35,7 +35,7 @@ namespace gui
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::select),
+                        this->setBottomBarText(utils::translate(style::strings::common::select),
                                                BottomBar::Side::CENTER);
                     }
                     return true;
@@ -44,11 +44,11 @@ namespace gui
                 gui::option::SettingRightItem::ArrowWhite));
         };
 
-        addMenu(utils::translateI18("app_settings_display_display_light"), gui::window::name::display_light);
-        addMenu(utils::translateI18("app_settings_display_font_size"), gui::window::name::font_size);
-        addMenu(utils::translateI18("app_settings_display_locked_screen"), gui::window::name::locked_screen);
-        addMenu(utils::translateI18("app_settings_display_keypad_light"), gui::window::name::keypad_light);
-        addMenu(utils::translateI18("app_settings_display_input_language"), gui::window::name::input_language);
+        addMenu(utils::translate("app_settings_display_display_light"), gui::window::name::display_light);
+        addMenu(utils::translate("app_settings_display_font_size"), gui::window::name::font_size);
+        addMenu(utils::translate("app_settings_display_locked_screen"), gui::window::name::locked_screen);
+        addMenu(utils::translate("app_settings_display_keypad_light"), gui::window::name::keypad_light);
+        addMenu(utils::translate("app_settings_display_input_language"), gui::window::name::input_language);
 
         return optionList;
     }

--- a/module-apps/application-settings-new/windows/DisplayLightWindow.cpp
+++ b/module-apps/application-settings-new/windows/DisplayLightWindow.cpp
@@ -21,7 +21,7 @@ namespace gui
         isAutoLightSwitchOn    = values.mode == screen_light_control::ScreenLightMode::Automatic;
         brightnessValue        = values.parameters.manualModeBrightness;
 
-        setTitle(utils::localize.get("app_settings_display_display_light"));
+        setTitle(utils::translate("app_settings_display_display_light"));
 
         screenLightSettings->setBrightnessFunction();
 
@@ -72,7 +72,7 @@ namespace gui
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::Switch),
+                        this->setBottomBarText(utils::translate(style::strings::common::Switch),
                                                BottomBar::Side::CENTER);
                     }
                     return true;
@@ -91,9 +91,9 @@ namespace gui
                 text, nullptr, nullptr, this, gui::option::SettingRightItem::Disabled));
         };
 
-        addOnOffOoption(utils::translateI18("app_settings_display_light_main"), isDisplayLightSwitchOn);
+        addOnOffOoption(utils::translate("app_settings_display_light_main"), isDisplayLightSwitchOn);
         if (isDisplayLightSwitchOn) {
-            addOnOffOoption(utils::translateI18("app_settings_display_light_auto"), isAutoLightSwitchOn);
+            addOnOffOoption(utils::translate("app_settings_display_light_auto"), isAutoLightSwitchOn);
         }
 
         if (isDisplayLightSwitchOn && !isAutoLightSwitchOn) {
@@ -115,13 +115,13 @@ namespace gui
 
         auto setBottomBarOnSpinnerFocus = [&](gui::Item &item) {
             if (item.focus) {
-                setBottomBarText(utils::translateI18(style::strings::common::set), BottomBar::Side::CENTER);
+                setBottomBarText(utils::translate(style::strings::common::set), BottomBar::Side::CENTER);
             }
             return true;
         };
 
         auto spinner = std::make_unique<gui::SpinBoxOptionSettings>(
-            utils::translateI18("app_settings_display_light_brightness"),
+            utils::translate("app_settings_display_light_brightness"),
             std::ceil(brightnessValue / brightnessStep),
             std::ceil(screen_light_control::Parameters::MAX_BRIGHTNESS / brightnessStep),
             setBrightness,

--- a/module-apps/application-settings-new/windows/DoNotDisturbWindow.cpp
+++ b/module-apps/application-settings-new/windows/DoNotDisturbWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DoNotDisturbWindow.hpp"
@@ -19,7 +19,7 @@ namespace gui
 
     void DoNotDisturbWindow::buildInterface()
     {
-        setTitle(utils::translateI18("app_settings_title_do_not_disturb"));
+        setTitle(utils::translate("app_settings_title_do_not_disturb"));
         optionsList->setSize(optionsList->getWidth(),
                              optionsList->getHeight() - style::settings::window::offline::body_offset);
         bar = new Rect(this,
@@ -34,7 +34,7 @@ namespace gui
                                    style::window::default_body_width,
                                    style::settings::window::offline::description_h);
         descriptionText->setFont(style::window::font::medium);
-        descriptionText->setText(utils::translateI18("app_settings_info_dnd"));
+        descriptionText->setText(utils::translate("app_settings_info_dnd"));
         descriptionText->setVisible(true);
     }
 
@@ -42,7 +42,7 @@ namespace gui
     {
         std::list<gui::Option> optList;
         optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_notifications_when_locked"),
+            utils::translate("app_settings_notifications_when_locked"),
             [=](gui::Item &item) {
                 dndSettings->setNotificationsWhenLocked(!dndSettings->getNotificationsWhenLocked());
                 refreshOptionsList();
@@ -54,7 +54,7 @@ namespace gui
                                                         : gui::option::SettingRightItem::Off));
 
         optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_calls_from_favorites"),
+            utils::translate("app_settings_calls_from_favorites"),
             [=](gui::Item &item) {
                 dndSettings->setCallsFromFavourite(!dndSettings->getCallsFromFavourite());
                 refreshOptionsList();
@@ -65,8 +65,8 @@ namespace gui
             (dndSettings->getCallsFromFavourite()) ? gui::option::SettingRightItem::On
                                                    : gui::option::SettingRightItem::Off));
 
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::Switch));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::Switch));
         return optList;
     }
 } // namespace gui

--- a/module-apps/application-settings-new/windows/EditQuotesWindow.cpp
+++ b/module-apps/application-settings-new/windows/EditQuotesWindow.cpp
@@ -12,7 +12,7 @@ namespace gui
 {
     EditQuotesWindow::EditQuotesWindow(app::Application *app) : BaseSettingsWindow(app, window::name::edit_quotes)
     {
-        setTitle(utils::localize.get("app_settings_display_wallpaper_edit_quotes"));
+        setTitle(utils::translate("app_settings_display_wallpaper_edit_quotes"));
     }
 
     auto EditQuotesWindow::buildOptionsList() -> std::list<gui::Option>
@@ -28,7 +28,7 @@ namespace gui
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::Switch),
+                        this->setBottomBarText(utils::translate(style::strings::common::Switch),
                                                BottomBar::Side::CENTER);
                     }
                     return true;
@@ -37,19 +37,19 @@ namespace gui
                 switcher ? gui::option::SettingRightItem::Checked : gui::option::SettingRightItem::Disabled));
         };
 
-        addCheckOption(utils::translateI18("app_settings_display_wallpaper_quotes_our_favourites"),
+        addCheckOption(utils::translate("app_settings_display_wallpaper_quotes_our_favourites"),
                        isOurFavouritesSwitchOn);
 
         if (isOurFavouritesSwitchOn) {
             optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-                utils::translateI18("app_settings_display_wallpaper_quotes_categories"),
+                utils::translate("app_settings_display_wallpaper_quotes_categories"),
                 [=](gui::Item &item) {
                     application->switchWindow(gui::window::name::quote_categories, nullptr);
                     return true;
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::select),
+                        this->setBottomBarText(utils::translate(style::strings::common::select),
                                                BottomBar::Side::CENTER);
                     }
                     return true;
@@ -58,18 +58,18 @@ namespace gui
                 gui::option::SettingRightItem::ArrowWhite));
         }
 
-        addCheckOption(utils::translateI18("app_settings_display_wallpaper_quotes_custom"), isCustomSwitchOn);
+        addCheckOption(utils::translate("app_settings_display_wallpaper_quotes_custom"), isCustomSwitchOn);
 
         if (isCustomSwitchOn) {
             optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-                utils::translateI18("app_settings_display_wallpaper_edit_quotes"),
+                utils::translate("app_settings_display_wallpaper_edit_quotes"),
                 [=](gui::Item &item) {
                     application->switchWindow(gui::window::name::quotes, nullptr);
                     return true;
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::select),
+                        this->setBottomBarText(utils::translate(style::strings::common::select),
                                                BottomBar::Side::CENTER);
                     }
                     return true;

--- a/module-apps/application-settings-new/windows/FontSizeWindow.cpp
+++ b/module-apps/application-settings-new/windows/FontSizeWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "FontSizeWindow.hpp"
@@ -12,7 +12,7 @@ namespace gui
 
     FontSizeWindow::FontSizeWindow(app::Application *app) : BaseSettingsWindow(app, gui::window::name::font_size)
     {
-        setTitle(utils::localize.get("app_settings_display_font_size"));
+        setTitle(utils::translate("app_settings_display_font_size"));
     }
 
     auto FontSizeWindow::buildOptionsList() -> std::list<gui::Option>

--- a/module-apps/application-settings-new/windows/InputLanguageWindow.cpp
+++ b/module-apps/application-settings-new/windows/InputLanguageWindow.cpp
@@ -14,7 +14,7 @@ namespace gui
     InputLanguageWindow::InputLanguageWindow(app::Application *app)
         : BaseSettingsWindow(app, window::name::input_language)
     {
-        setTitle(utils::localize.get("app_settings_display_input_language"));
+        setTitle(utils::translate("app_settings_display_input_language"));
     }
 
     auto InputLanguageWindow::buildOptionsList() -> std::list<gui::Option>
@@ -32,7 +32,7 @@ namespace gui
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::select),
+                        this->setBottomBarText(utils::translate(style::strings::common::select),
                                                BottomBar::Side::CENTER);
                     }
                     return true;

--- a/module-apps/application-settings-new/windows/KeypadLightWindow.cpp
+++ b/module-apps/application-settings-new/windows/KeypadLightWindow.cpp
@@ -29,7 +29,7 @@ namespace gui
             break;
         }
 
-        setTitle(utils::localize.get("app_settings_display_keypad_light"));
+        setTitle(utils::translate("app_settings_display_keypad_light"));
     }
 
     void KeypadLightWindow::switchHandler(bool &toggleSwitch)
@@ -63,7 +63,7 @@ namespace gui
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::Switch),
+                        this->setBottomBarText(utils::translate(style::strings::common::Switch),
                                                BottomBar::Side::CENTER);
                     }
                     return true;
@@ -72,9 +72,9 @@ namespace gui
                 Switch ? gui::option::SettingRightItem::Checked : gui::option::SettingRightItem::Disabled));
         };
 
-        addCheckOption(utils::translateI18("app_settings_display_keypad_light_on"), isAlwaysOnSwitchOn);
-        addCheckOption(utils::translateI18("app_settings_display_keypad_light_off"), isOffSwitchOn);
-        addCheckOption(utils::translateI18("app_settings_display_keypad_light_active"), isActiveSwitchOn);
+        addCheckOption(utils::translate("app_settings_display_keypad_light_on"), isAlwaysOnSwitchOn);
+        addCheckOption(utils::translate("app_settings_display_keypad_light_off"), isOffSwitchOn);
+        addCheckOption(utils::translate("app_settings_display_keypad_light_active"), isActiveSwitchOn);
 
         return optionsList;
     } // namespace gui

--- a/module-apps/application-settings-new/windows/LanguagesWindow.cpp
+++ b/module-apps/application-settings-new/windows/LanguagesWindow.cpp
@@ -14,12 +14,12 @@ namespace gui
     LanguagesWindow::LanguagesWindow(app::Application *app, std::string name)
         : BaseSettingsWindow(app, std::move(name)), langList(loader.getAvailableDisplayLanguages())
     {
-        setTitle(utils::localize.get("app_settings_title_languages"));
+        setTitle(utils::translate("app_settings_title_languages"));
     }
 
     void LanguagesWindow::onBeforeShow(ShowMode mode, SwitchData *data)
     {
-        selectedLanguage = utils::localize.getDisplayLanguage();
+        selectedLanguage = utils::getDisplayLanguage();
         setLanguageIndex();
 
         refreshOptionsList(selectedLanguageIndex);

--- a/module-apps/application-settings-new/windows/LockedScreenWindow.cpp
+++ b/module-apps/application-settings-new/windows/LockedScreenWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "LockedScreenWindow.hpp"
@@ -12,7 +12,7 @@ namespace gui
 
     LockedScreenWindow::LockedScreenWindow(app::Application *app) : BaseSettingsWindow(app, window::name::locked_screen)
     {
-        setTitle(utils::localize.get("app_settings_display_locked_screen"));
+        setTitle(utils::translate("app_settings_display_locked_screen"));
     }
 
     auto LockedScreenWindow::buildOptionsList() -> std::list<Option>
@@ -32,7 +32,7 @@ namespace gui
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::select),
+                        this->setBottomBarText(utils::translate(style::strings::common::select),
                                                BottomBar::Side::CENTER);
                     }
                     return true;
@@ -41,8 +41,8 @@ namespace gui
                 gui::option::SettingRightItem::ArrowWhite));
         };
 
-        addMenu(utils::translateI18("app_settings_display_locked_screen_autolock"), gui::window::name::autolock);
-        addMenu(utils::translateI18("app_settings_display_locked_screen_wallpaper"), gui::window::name::wallpaper);
+        addMenu(utils::translate("app_settings_display_locked_screen_autolock"), gui::window::name::autolock);
+        addMenu(utils::translate("app_settings_display_locked_screen_wallpaper"), gui::window::name::wallpaper);
 
         return optionList;
     }

--- a/module-apps/application-settings-new/windows/MessageSoundWindow.cpp
+++ b/module-apps/application-settings-new/windows/MessageSoundWindow.cpp
@@ -9,6 +9,6 @@ namespace gui
 {
     MessageSoundWindow::MessageSoundWindow(app::Application *app) : BaseSettingsWindow(app, window::name::message_sound)
     {
-        setTitle(utils::localize.get("app_settings_message_sound"));
+        setTitle(utils::translate("app_settings_message_sound"));
     }
 } // namespace gui

--- a/module-apps/application-settings-new/windows/MessagesWindow.cpp
+++ b/module-apps/application-settings-new/windows/MessagesWindow.cpp
@@ -15,7 +15,7 @@ namespace gui
         : BaseSettingsWindow(app, gui::window::name::messages), mWidgetMaker(this), mAudioModel(std::move(audioModel))
     {
         mShowUnreadMessagesFirst = false;
-        setTitle(utils::localize.get("app_settings_apps_messages"));
+        setTitle(utils::translate("app_settings_apps_messages"));
     }
 
     std::list<Option> MessagesWindow::buildOptionsList()
@@ -24,29 +24,25 @@ namespace gui
         mVibrationsEnabled = mAudioModel->isVibrationEnabled();
         mSoundEnabled      = mAudioModel->isSoundEnabled();
 
-        mWidgetMaker.addSwitchOption(optionList,
-                                     utils::translateI18("app_settings_vibration"),
-                                     mVibrationsEnabled,
-                                     [&]() { switchVibrationState(); });
+        mWidgetMaker.addSwitchOption(optionList, utils::translate("app_settings_vibration"), mVibrationsEnabled, [&]() {
+            switchVibrationState();
+        });
 
         mWidgetMaker.addSwitchOption(
-            optionList, utils::translateI18("app_settings_sound"), mSoundEnabled, [&]() { switchSoundState(); });
+            optionList, utils::translate("app_settings_sound"), mSoundEnabled, [&]() { switchSoundState(); });
 
         if (mSoundEnabled) {
             mWidgetMaker.addSelectOption(
-                optionList,
-                utils::translateI18("app_settings_message_sound"),
-                [&]() { openMessageSoundWindow(); },
-                true);
+                optionList, utils::translate("app_settings_message_sound"), [&]() { openMessageSoundWindow(); }, true);
         }
 
         mWidgetMaker.addSwitchOption(optionList,
-                                     utils::translateI18("app_settings_show_unread_first"),
+                                     utils::translate("app_settings_show_unread_first"),
                                      mShowUnreadMessagesFirst,
                                      [&]() { switchShowUnreadFirst(); });
 
         mWidgetMaker.addSelectOption(
-            optionList, utils::translateI18("app_settings_Templates"), [&]() { openMessageTemplates(); });
+            optionList, utils::translate("app_settings_Templates"), [&]() { openMessageTemplates(); });
         return optionList;
     }
 

--- a/module-apps/application-settings-new/windows/NetworkWindow.cpp
+++ b/module-apps/application-settings-new/windows/NetworkWindow.cpp
@@ -27,15 +27,15 @@ namespace gui
         auto sim         = simParams->getSim();
         switch (sim) {
         case Store::GSM::SIM::SIM1:
-            simStr = utils::translateI18("app_settings_network_sim1");
+            simStr = utils::translate("app_settings_network_sim1");
             break;
         case Store::GSM::SIM::SIM2:
-            simStr = utils::translateI18("app_settings_network_sim2");
+            simStr = utils::translate("app_settings_network_sim2");
             break;
         case Store::GSM::SIM::NONE:
         case Store::GSM::SIM::SIM_FAIL:
         case Store::GSM::SIM::SIM_UNKNOWN:
-            simStr      = utils::translateI18("app_settings_network_sim_none");
+            simStr      = utils::translate("app_settings_network_sim_none");
             phoneNumber = {};
             break;
         }
@@ -43,7 +43,7 @@ namespace gui
         auto voLteOn     = operatorsSettings->getVoLTEOn();
 
         optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_network_active_card") + ":" + simStr + " / " + phoneNumber,
+            utils::translate("app_settings_network_active_card") + ":" + simStr + " / " + phoneNumber,
             [=](gui::Item &item) {
                 if (Store::GSM::SIM::SIM1 == sim) {
                     simParams->setSim(Store::GSM::SIM::SIM2);
@@ -56,19 +56,17 @@ namespace gui
             },
             [=](gui::Item &item) {
                 if (item.focus) {
-                    this->setBottomBarText(utils::localize.get(style::strings::common::Switch),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::Switch), BottomBar::Side::CENTER);
                 }
                 else {
-                    this->setBottomBarText(utils::localize.get(style::strings::common::select),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::select), BottomBar::Side::CENTER);
                 }
                 return true;
             },
             this));
 
         optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_network_operator_auto_select"),
+            utils::translate("app_settings_network_operator_auto_select"),
             [=](gui::Item &item) {
                 operatorsSettings->setOperatorsOn(!operatorsOn);
                 refreshOptions(netOptList());
@@ -79,7 +77,7 @@ namespace gui
             operatorsOn ? gui::option::SettingRightItem::On : gui::option::SettingRightItem::Off));
         if (!operatorsOn) {
             optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-                utils::translateI18("app_settings_network_all_operators"),
+                utils::translate("app_settings_network_all_operators"),
                 [=](gui::Item &item) {
                     this->application->switchWindow(gui::window::name::all_operators, nullptr);
                     return true;
@@ -91,7 +89,7 @@ namespace gui
         }
 
         optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_network_pin_settings") + " (" + simStr + ")",
+            utils::translate("app_settings_network_pin_settings") + " (" + simStr + ")",
             [=](gui::Item &item) {
                 auto pinSettingsData = std::make_unique<gui::PINSettingsSimData>(simStr);
                 this->application->switchWindow(gui::window::name::pin_settings, std::move(pinSettingsData));
@@ -103,7 +101,7 @@ namespace gui
             false));
 
         optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_network_import_contacts_from_sim_card"),
+            utils::translate("app_settings_network_import_contacts_from_sim_card"),
             [=](gui::Item &item) {
                 this->application->switchWindow(gui::window::name::import_contacts, nullptr);
                 return true;
@@ -112,7 +110,7 @@ namespace gui
             nullptr));
 
         optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_network_voice_over_lte"),
+            utils::translate("app_settings_network_voice_over_lte"),
             [=](gui::Item &item) {
                 operatorsSettings->setVoLTEOn(!voLteOn);
                 refreshOptions(netOptList());
@@ -123,7 +121,7 @@ namespace gui
             voLteOn ? gui::option::SettingRightItem::On : gui::option::SettingRightItem::Off));
 
         optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_network_apn_settings"),
+            utils::translate("app_settings_network_apn_settings"),
             [=](gui::Item &item) {
                 this->application->switchWindow(gui::window::name::apn_settings, nullptr);
                 return true;
@@ -133,7 +131,7 @@ namespace gui
             gui::option::SettingRightItem::ArrowWhite,
             true));
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
 
         return optList;
     }

--- a/module-apps/application-settings-new/windows/NewApnWindow.cpp
+++ b/module-apps/application-settings-new/windows/NewApnWindow.cpp
@@ -26,10 +26,10 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::save));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::save));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("app_settings_new_edit_apn"));
+        setTitle(utils::translate("app_settings_new_edit_apn"));
 
         list = new gui::ListView(this,
                                  style::settings::window::newApn::x,

--- a/module-apps/application-settings-new/windows/NightshiftWindow.cpp
+++ b/module-apps/application-settings-new/windows/NightshiftWindow.cpp
@@ -20,13 +20,13 @@ namespace gui
     void NightshiftWindow::buildInterface()
     {
         AppWindow::buildInterface();
-        setTitle(utils::localize.get("app_settings_title_nightshift"));
+        setTitle(utils::translate("app_settings_title_nightshift"));
 
         bottomBar->setActive(BottomBar::Side::LEFT, false);
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::save));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::save));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         list = new gui::ListView(this,
                                  style::window::date_and_time::listView_x,

--- a/module-apps/application-settings-new/windows/NotificationSoundWindow.cpp
+++ b/module-apps/application-settings-new/windows/NotificationSoundWindow.cpp
@@ -10,6 +10,6 @@ namespace gui
     NotificationSoundWindow::NotificationSoundWindow(app::Application *app)
         : BaseSettingsWindow(app, window::name::notification_sound)
     {
-        setTitle(utils::localize.get("app_settings_notification_sound"));
+        setTitle(utils::translate("app_settings_notification_sound"));
     }
 } // namespace gui

--- a/module-apps/application-settings-new/windows/OfflineWindow.cpp
+++ b/module-apps/application-settings-new/windows/OfflineWindow.cpp
@@ -21,7 +21,7 @@ namespace gui
 
     void OfflineWindow::buildInterface()
     {
-        setTitle(utils::translateI18("app_settings_title_offline"));
+        setTitle(utils::translate("app_settings_title_offline"));
         optionsList->setSize(optionsList->getWidth(),
                              optionsList->getHeight() - style::settings::window::offline::body_offset);
 
@@ -37,8 +37,8 @@ namespace gui
                                    style::window::default_body_width,
                                    style::settings::window::offline::description_h);
         descriptionText->setFont(style::window::font::medium);
-        descriptionText->setText(utils::translateI18(isFlightMode ? "app_settings_info_offline_flight_mode"
-                                                                  : "app_settings_info_offline_messages_only"));
+        descriptionText->setText(utils::translate(isFlightMode ? "app_settings_info_offline_flight_mode"
+                                                               : "app_settings_info_offline_messages_only"));
         descriptionText->setVisible(true);
     }
 
@@ -46,19 +46,19 @@ namespace gui
     {
         std::list<gui::Option> optList;
         optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_allow"),
+            utils::translate("app_settings_allow"),
             [=](gui::Item &item) { return changeFlightMode(!isFlightMode); },
             nullptr,
             nullptr,
             gui::option::SettingRightItem::Text,
             false,
-            utils::translateI18(isFlightMode ? "app_settings_no_network_connection_flight_mode"
-                                             : "app_settings_messages_only"),
+            utils::translate(isFlightMode ? "app_settings_no_network_connection_flight_mode"
+                                          : "app_settings_messages_only"),
             false));
 
         if (!isFlightMode) {
             optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-                utils::translateI18("app_settings_title_connection_frequency"),
+                utils::translate("app_settings_title_connection_frequency"),
                 [=](gui::Item &item) {
                     this->application->switchWindow(gui::window::name::connection_frequency, nullptr);
                     return true;
@@ -68,8 +68,8 @@ namespace gui
                 gui::option::SettingRightItem::ArrowWhite));
         }
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::Switch));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::Switch));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         return optList;
     }
@@ -78,8 +78,8 @@ namespace gui
     {
         this->isFlightMode = isFlightMode;
         offlineSettings->setFlightMode(isFlightMode);
-        descriptionText->setText(utils::translateI18(isFlightMode ? "app_settings_info_offline_flight_mode"
-                                                                  : "app_settings_info_offline_messages_only"));
+        descriptionText->setText(utils::translate(isFlightMode ? "app_settings_info_offline_flight_mode"
+                                                               : "app_settings_info_offline_messages_only"));
         rebuildOptionList();
         return true;
     }

--- a/module-apps/application-settings-new/windows/OptionsWidgetMaker.cpp
+++ b/module-apps/application-settings-new/windows/OptionsWidgetMaker.cpp
@@ -20,11 +20,11 @@ namespace gui
             },
             [=](Item &item) {
                 if (item.focus) {
-                    mWindow->setBottomBarText(utils::localize.get(style::strings::common::Switch),
+                    mWindow->setBottomBarText(utils::translate(style::strings::common::Switch),
                                               BottomBar::Side::CENTER);
                 }
                 else {
-                    mWindow->setBottomBarText(utils::localize.get(style::strings::common::select),
+                    mWindow->setBottomBarText(utils::translate(style::strings::common::select),
                                               BottomBar::Side::CENTER);
                 }
                 return true;

--- a/module-apps/application-settings-new/windows/PINSettingsWindow.cpp
+++ b/module-apps/application-settings-new/windows/PINSettingsWindow.cpp
@@ -20,8 +20,7 @@ namespace gui
     void PINSettingsWindow::onBeforeShow(ShowMode /*mode*/, SwitchData *data)
     {
         if (const auto pinSettingsSimData = dynamic_cast<PINSettingsSimData *>(data); pinSettingsSimData != nullptr) {
-            setTitle(utils::translateI18("app_settings_network_pin_settings") + " (" + pinSettingsSimData->getSim() +
-                     ")");
+            setTitle(utils::translate("app_settings_network_pin_settings") + " (" + pinSettingsSimData->getSim() + ")");
         }
         if (const auto pinSettingsLockStateData = dynamic_cast<PINSettingsLockStateData *>(data);
             pinSettingsLockStateData != nullptr) {
@@ -35,19 +34,17 @@ namespace gui
         std::list<Option> optionList;
 
         optionList.emplace_back(std::make_unique<option::OptionSettings>(
-            utils::translateI18("app_settings_network_pin"),
+            utils::translate("app_settings_network_pin"),
             [=](Item & /*item*/) {
                 changePinState(pinIsOn);
                 return true;
             },
             [=](Item &item) {
                 if (item.focus) {
-                    this->setBottomBarText(utils::localize.get(style::strings::common::Switch),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::Switch), BottomBar::Side::CENTER);
                 }
                 else {
-                    this->setBottomBarText(utils::localize.get(style::strings::common::select),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::select), BottomBar::Side::CENTER);
                 }
                 return true;
             },
@@ -56,7 +53,7 @@ namespace gui
 
         if (pinIsOn) {
             optionList.emplace_back(std::make_unique<option::OptionSettings>(
-                utils::translateI18("app_settings_network_pin_change_code"),
+                utils::translate("app_settings_network_pin_change_code"),
                 [=](Item & /*item*/) {
                     using namespace app::manager::actions;
                     auto params = std::make_unique<PasscodeParams>(Store::GSM::get()->selected,

--- a/module-apps/application-settings-new/windows/PhoneModesWindow.cpp
+++ b/module-apps/application-settings-new/windows/PhoneModesWindow.cpp
@@ -23,7 +23,7 @@ namespace gui
         std::list<gui::Option> optList;
 
         optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_connected"),
+            utils::translate("app_settings_connected"),
             [=](gui::Item &item) { return true; },
             [=](gui::Item &item) {
                 if (item.focus) {
@@ -34,15 +34,14 @@ namespace gui
             this));
 
         optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_title_do_not_disturb"),
+            utils::translate("app_settings_title_do_not_disturb"),
             [=](gui::Item &item) {
                 this->application->switchWindow(gui::window::name::do_not_disturb, nullptr);
                 return true;
             },
             [=](gui::Item &item) {
                 if (item.focus) {
-                    this->setBottomBarText(utils::localize.get(style::strings::common::adjust),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::adjust), BottomBar::Side::CENTER);
                 }
                 return true;
             },
@@ -50,22 +49,21 @@ namespace gui
             gui::option::SettingRightItem::ArrowWhite));
 
         optList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_title_offline"),
+            utils::translate("app_settings_title_offline"),
             [=](gui::Item &item) {
                 this->application->switchWindow(gui::window::name::offline, nullptr);
                 return true;
             },
             [=](gui::Item &item) {
                 if (item.focus) {
-                    this->setBottomBarText(utils::localize.get(style::strings::common::adjust),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::adjust), BottomBar::Side::CENTER);
                 }
                 return true;
             },
             this,
             gui::option::SettingRightItem::ArrowWhite));
 
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         return optList;
     }

--- a/module-apps/application-settings-new/windows/PhoneNameWindow.cpp
+++ b/module-apps/application-settings-new/windows/PhoneNameWindow.cpp
@@ -21,15 +21,15 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_settings_bluetooth_phone_name"));
+        setTitle(utils::translate("app_settings_bluetooth_phone_name"));
 
-        inputField = inputBox(this, utils::localize.get("app_settings_bluetooth_phone_name"));
+        inputField = inputBox(this, utils::translate("app_settings_bluetooth_phone_name"));
         bottomBar->setActive(BottomBar::Side::LEFT, false);
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::save));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::save));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         setFocusItem(inputField);
     }

--- a/module-apps/application-settings-new/windows/PhoneWindow.cpp
+++ b/module-apps/application-settings-new/windows/PhoneWindow.cpp
@@ -14,7 +14,7 @@ namespace gui
                              std::unique_ptr<audio_settings::AbstractAudioSettingsModel> &&audioModel)
         : BaseSettingsWindow(app, gui::window::name::phone), mWidgetMaker(this), mAudioModel(std::move(audioModel))
     {
-        setTitle(utils::localize.get("app_settings_apps_phone"));
+        setTitle(utils::translate("app_settings_apps_phone"));
     }
 
     std::list<Option> PhoneWindow::buildOptionsList()
@@ -23,17 +23,16 @@ namespace gui
         mVibrationsEnabled = mAudioModel->isVibrationEnabled();
         mSoundEnabled      = mAudioModel->isSoundEnabled();
 
-        mWidgetMaker.addSwitchOption(optionList,
-                                     utils::translateI18("app_settings_vibration"),
-                                     mVibrationsEnabled,
-                                     [&]() { switchVibrationState(); });
+        mWidgetMaker.addSwitchOption(optionList, utils::translate("app_settings_vibration"), mVibrationsEnabled, [&]() {
+            switchVibrationState();
+        });
 
         mWidgetMaker.addSwitchOption(
-            optionList, utils::translateI18("app_settings_sound"), mSoundEnabled, [&]() { switchSoundState(); });
+            optionList, utils::translate("app_settings_sound"), mSoundEnabled, [&]() { switchSoundState(); });
 
         if (mSoundEnabled) {
             mWidgetMaker.addSelectOption(
-                optionList, utils::translateI18("app_settings_call_ringtome"), [&]() { openRingtoneWindow(); }, true);
+                optionList, utils::translate("app_settings_call_ringtome"), [&]() { openRingtoneWindow(); }, true);
         }
 
         return optionList;

--- a/module-apps/application-settings-new/windows/QuoteCategoriesWindow.cpp
+++ b/module-apps/application-settings-new/windows/QuoteCategoriesWindow.cpp
@@ -19,10 +19,10 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_settings_display_wallpaper_quotes_categories"));
+        setTitle(utils::translate("app_settings_display_wallpaper_quotes_categories"));
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::check));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::check));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         list = new gui::ListView(this,
                                  style::quotes::categories::list::X,

--- a/module-apps/application-settings-new/windows/QuotesAddWindow.cpp
+++ b/module-apps/application-settings-new/windows/QuotesAddWindow.cpp
@@ -42,8 +42,8 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::save));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::save));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         auto vBox = new VBox(this,
                              style::window::default_left_margin,
@@ -64,7 +64,7 @@ namespace gui
         authorLabel->setMinimumSize(style::headerWidth, style::window::label::default_h);
         authorLabel->setEdges(RectangleEdge::None);
         authorLabel->setAlignment(gui::Alignment{gui::Alignment::Horizontal::Left});
-        authorLabel->setText(utils::localize.get("app_settings_display_wallpaper_quotes_author"));
+        authorLabel->setText(utils::translate("app_settings_display_wallpaper_quotes_author"));
         authorLabel->setPenFocusWidth(::style::window::default_border_focus_w);
         authorLabel->setFont(::style::window::font::verysmall);
         authorLabel->setPadding(gui::Padding(0, 0, 0, 0));
@@ -93,7 +93,7 @@ namespace gui
         quoteLabel->setMinimumSize(style::headerWidth, style::window::label::default_h);
         quoteLabel->setEdges(RectangleEdge::None);
         quoteLabel->setPenFocusWidth(::style::window::default_border_focus_w);
-        quoteLabel->setText(utils::localize.get("app_settings_display_wallpaper_quotes_note"));
+        quoteLabel->setText(utils::translate("app_settings_display_wallpaper_quotes_note"));
         quoteLabel->setFont(::style::window::font::verysmall);
         quoteLabel->setAlignment(gui::Alignment{gui::Alignment::Horizontal::Left});
         quoteLabel->activeItem = false;
@@ -120,7 +120,7 @@ namespace gui
         quoteCharCounter->setFont(::style::window::font::verysmall);
         quoteCharCounter->setAlignment(gui::Alignment{gui::Alignment::Horizontal::Right});
 
-        setTitle(utils::localize.get("app_settings_display_wallpaper_quotes_new"));
+        setTitle(utils::translate("app_settings_display_wallpaper_quotes_new"));
         vBox->resizeItems();
         setFocusItem(quoteText);
     }
@@ -136,12 +136,12 @@ namespace gui
         quoteData   = quotedata->getQuote();
 
         if (quoteAction == QuoteAction::Edit) {
-            setTitle(utils::localize.get("app_settings_display_wallpaper_quotes_edit"));
+            setTitle(utils::translate("app_settings_display_wallpaper_quotes_edit"));
             quoteText->setText(quoteData.quote);
             authorText->setText(quoteData.author);
         }
         else {
-            setTitle(utils::localize.get("app_settings_display_wallpaper_quotes_new"));
+            setTitle(utils::translate("app_settings_display_wallpaper_quotes_new"));
         }
 
         setQuoteCharactersCount(quoteText->getText().length());

--- a/module-apps/application-settings-new/windows/QuotesMainWindow.cpp
+++ b/module-apps/application-settings-new/windows/QuotesMainWindow.cpp
@@ -41,11 +41,11 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_settings_display_wallpaper_quotes"));
+        setTitle(utils::translate("app_settings_display_wallpaper_quotes"));
 
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::check));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::options));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::check));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::options));
 
         new gui::Image(this, style::quotes::arrow_x, style::quotes::arrow_y, 0, 0, "arrow_left");
         new gui::Image(this, style::quotes::cross_x, style::quotes::cross_y, 0, 0, "cross");

--- a/module-apps/application-settings-new/windows/QuotesOptionsWindow.cpp
+++ b/module-apps/application-settings-new/windows/QuotesOptionsWindow.cpp
@@ -18,7 +18,7 @@ namespace gui
     QuotesOptionsWindow::QuotesOptionsWindow(app::Application *app)
         : BaseSettingsWindow(app, gui::window::name::quotes), quotesModel(std::make_shared<Quotes::QuotesModel>(app))
     {
-        setTitle(utils::localize.get("app_settings_display_wallpaper_quotes_options"));
+        setTitle(utils::translate("app_settings_display_wallpaper_quotes_options"));
     }
 
     auto QuotesOptionsWindow::buildOptionsList() -> std::list<gui::Option>
@@ -26,7 +26,7 @@ namespace gui
         std::list<gui::Option> optionsList;
 
         optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_display_wallpaper_quotes_edit"),
+            utils::translate("app_settings_display_wallpaper_quotes_edit"),
             [=](gui::Item &item) {
                 application->switchWindow(gui::window::name::new_quote,
                                           std::make_unique<QuoteSwitchData>(QuoteAction::Edit, quote));
@@ -34,35 +34,33 @@ namespace gui
             },
             [=](gui::Item &item) {
                 if (item.focus) {
-                    this->setBottomBarText(utils::translateI18(style::strings::common::select),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::select), BottomBar::Side::CENTER);
                 }
                 return true;
             },
             this));
 
         optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_display_wallpaper_quotes_delete"),
+            utils::translate("app_settings_display_wallpaper_quotes_delete"),
             [=](gui::Item &item) {
-                auto metaData = std::make_unique<gui::DialogMetadataMessage>(gui::DialogMetadata{
-                    quote.quote,
-                    "phonebook_contact_delete_trashcan",
-                    utils::localize.get("app_settings_display_wallpaper_quotes_delete_confirmation"),
-                    "",
-                    [this]() {
-                        auto backToQuotesMainWindow = 2;
-                        quotesModel->remove(quote);
-                        application->returnToPreviousWindow(backToQuotesMainWindow);
-                        return true;
-                    }});
+                auto metaData = std::make_unique<gui::DialogMetadataMessage>(
+                    gui::DialogMetadata{quote.quote,
+                                        "phonebook_contact_delete_trashcan",
+                                        utils::translate("app_settings_display_wallpaper_quotes_delete_confirmation"),
+                                        "",
+                                        [this]() {
+                                            auto backToQuotesMainWindow = 2;
+                                            quotesModel->remove(quote);
+                                            application->returnToPreviousWindow(backToQuotesMainWindow);
+                                            return true;
+                                        }});
                 application->switchWindow(
                     gui::window::name::quotes_dialog_yes_no, gui::ShowMode::GUI_SHOW_INIT, std::move(metaData));
                 return true;
             },
             [=](gui::Item &item) {
                 if (item.focus) {
-                    this->setBottomBarText(utils::translateI18(style::strings::common::select),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::select), BottomBar::Side::CENTER);
                 }
                 return true;
             },

--- a/module-apps/application-settings-new/windows/SARInfoWindow.cpp
+++ b/module-apps/application-settings-new/windows/SARInfoWindow.cpp
@@ -35,7 +35,7 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_settings_sar"));
+        setTitle(utils::translate("app_settings_sar"));
 
         namespace sarStyle = style::settings::window::sar;
         sarInfoText =
@@ -49,7 +49,7 @@ namespace gui
         sarInfoText->setCursorStartPosition(gui::CursorStartPosition::DocumentBegin);
 
         bottomBar->setActive(gui::BottomBar::Side::RIGHT, true);
-        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::localize.get(::style::strings::common::back));
+        bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(::style::strings::common::back));
 
         setFocusItem(sarInfoText);
     }

--- a/module-apps/application-settings-new/windows/SecurityMainWindow.cpp
+++ b/module-apps/application-settings-new/windows/SecurityMainWindow.cpp
@@ -20,7 +20,7 @@ namespace gui
         std::list<Option> optionList;
 
         optionList.emplace_back(std::make_unique<option::OptionSettings>(
-            utils::translateI18("app_settings_security_lock_screen_passcode"),
+            utils::translate("app_settings_security_lock_screen_passcode"),
             [=](Item &item) {
                 lockScreenPasscodeIsOn = !lockScreenPasscodeIsOn;
                 LOG_INFO("switching to %s page", window::name::change_passcode);
@@ -32,12 +32,10 @@ namespace gui
             },
             [=](Item &item) {
                 if (item.focus) {
-                    this->setBottomBarText(utils::localize.get(style::strings::common::Switch),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::Switch), BottomBar::Side::CENTER);
                 }
                 else {
-                    this->setBottomBarText(utils::localize.get(style::strings::common::select),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::select), BottomBar::Side::CENTER);
                 }
                 return true;
             },
@@ -45,7 +43,7 @@ namespace gui
             lockScreenPasscodeIsOn ? option::SettingRightItem::On : option::SettingRightItem::Off));
 
         optionList.emplace_back(std::make_unique<option::OptionSettings>(
-            utils::translateI18("app_settings_security_usb_passcode"),
+            utils::translate("app_settings_security_usb_passcode"),
             [=](Item &item) {
                 auto lock = std::make_unique<gui::PinLock>(
                     Store::GSM::SIM::NONE, PinLock::LockState::PasscodeRequired, PinLock::LockType::Screen);
@@ -60,12 +58,10 @@ namespace gui
             },
             [=](Item &item) {
                 if (item.focus) {
-                    this->setBottomBarText(utils::localize.get(style::strings::common::Switch),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::Switch), BottomBar::Side::CENTER);
                 }
                 else {
-                    this->setBottomBarText(utils::localize.get(style::strings::common::select),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::select), BottomBar::Side::CENTER);
                 }
                 return true;
             },
@@ -74,7 +70,7 @@ namespace gui
 
         if (lockScreenPasscodeIsOn) {
             optionList.emplace_back(std::make_unique<option::OptionSettings>(
-                utils::translateI18("app_settings_security_change_passcode"),
+                utils::translate("app_settings_security_change_passcode"),
                 [=](Item &item) {
                     LOG_INFO("switching to %s page", window::name::change_passcode);
                     application->switchWindow(

--- a/module-apps/application-settings-new/windows/SettingsMainWindow.cpp
+++ b/module-apps/application-settings-new/windows/SettingsMainWindow.cpp
@@ -12,7 +12,7 @@ std::list<gui::Option> mainWindowOptionsNew(app::Application *app)
 {
     std::list<gui::Option> l;
 
-    auto i18     = [](const std::string &text) { return utils::localize.get(text); };
+    auto i18     = [](const std::string &text) { return utils::translate(text); };
     auto addMenu = [&l, &app](UTF8 name, const std::string &window = "") {
         l.emplace_back(gui::Option{name,
                                    [=](gui::Item &item) {

--- a/module-apps/application-settings-new/windows/SystemMainWindow.cpp
+++ b/module-apps/application-settings-new/windows/SystemMainWindow.cpp
@@ -18,7 +18,7 @@ namespace gui
         std::list<Option> optionList;
         auto addOption = [&](UTF8 name, const std::string &window) {
             optionList.emplace_back(std::make_unique<option::OptionSettings>(
-                utils::translateI18(name),
+                utils::translate(name),
                 [=](Item &item) {
                     LOG_INFO("switching to %s page", window.c_str());
                     application->switchWindow(window, nullptr);
@@ -31,12 +31,12 @@ namespace gui
 
         auto addFactoryResetOption = [&](UTF8 name, const std::string &window) {
             optionList.emplace_back(std::make_unique<option::OptionSettings>(
-                utils::translateI18(name),
+                utils::translate(name),
                 [=](Item &item) {
                     auto metaData = std::make_unique<gui::DialogMetadataMessage>(
-                        gui::DialogMetadata{utils::localize.get("app_settings_factory_reset"),
+                        gui::DialogMetadata{utils::translate("app_settings_factory_reset"),
                                             "info_big_circle_W_G",
-                                            utils::localize.get("app_settings_display_factory_reset_confirmation"),
+                                            utils::translate("app_settings_display_factory_reset_confirmation"),
                                             "",
                                             [this]() {
                                                 auto msg = std::make_shared<sdesktop::FactoryMessage>();

--- a/module-apps/application-settings-new/windows/TechnicalInformationWindow.cpp
+++ b/module-apps/application-settings-new/windows/TechnicalInformationWindow.cpp
@@ -23,7 +23,7 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_settings_technical_information"));
+        setTitle(utils::translate("app_settings_technical_information"));
 
         modelText  = new gui::Text(this,
                                   style::techinfo::textmodel::x,
@@ -69,19 +69,19 @@ namespace gui
                                   style::techinfo::valueimea::width,
                                   style::techinfo::valueimea::height);
 
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
     }
 
     void TechnicalInformationWindow::onBeforeShow(ShowMode mode, SwitchData *data)
     {
         // dummy data for now
-        modelText->setText(utils::localize.get("app_settings_tech_info_model"));
+        modelText->setText(utils::translate("app_settings_tech_info_model"));
         modelValue->setText(model);
-        serialNumberText->setText(utils::localize.get("app_settings_tech_info_serial_number"));
+        serialNumberText->setText(utils::translate("app_settings_tech_info_serial_number"));
         serialNumberValue->setText(serialNumber);
-        osVersionText->setText(utils::localize.get("app_settings_tech_info_os_version"));
+        osVersionText->setText(utils::translate("app_settings_tech_info_os_version"));
         osVersionValue->setText(std::string(VERSION));
-        imeiText->setText(utils::localize.get("app_settings_tech_info_imei"));
+        imeiText->setText(utils::translate("app_settings_tech_info_imei"));
         imeiValue->setText(imei);
     }
 

--- a/module-apps/application-settings-new/windows/TorchWindow.cpp
+++ b/module-apps/application-settings-new/windows/TorchWindow.cpp
@@ -19,7 +19,7 @@ namespace gui
 
     void TorchWindow::buildInterface()
     {
-        setTitle(utils::translateI18("app_settings_title_torch"));
+        setTitle(utils::translate("app_settings_title_torch"));
         optionsList->setSize(optionsList->getWidth(),
                              optionsList->getHeight() - style::settings::window::torch::body_offset);
         bar = new Rect(this,
@@ -34,7 +34,7 @@ namespace gui
                                    style::window::default_body_width,
                                    style::settings::window::torch::description_h);
         descriptionText->setFont(style::window::font::medium);
-        descriptionText->setText(utils::translateI18("app_settings_torch_description"));
+        descriptionText->setText(utils::translate("app_settings_torch_description"));
         descriptionText->setVisible(false);
     }
 
@@ -43,15 +43,14 @@ namespace gui
         std::list<gui::Option> optionsList;
 
         optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            utils::translateI18("app_settings_torch_sunset_red_light_option"),
+            utils::translate("app_settings_torch_sunset_red_light_option"),
             [=](gui::Item &item) {
                 toggleSwitchState();
                 return true;
             },
             [=](gui::Item &item) {
                 if (item.focus) {
-                    this->setBottomBarText(utils::translateI18(style::strings::common::Switch),
-                                           BottomBar::Side::CENTER);
+                    this->setBottomBarText(utils::translate(style::strings::common::Switch), BottomBar::Side::CENTER);
                 }
                 return true;
             },
@@ -60,14 +59,14 @@ namespace gui
 
         if (switchState) {
             optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-                utils::translateI18("app_settings_torch_nightshift_time_option"),
+                utils::translate("app_settings_torch_nightshift_time_option"),
                 [=](gui::Item &item) {
                     application->switchWindow(gui::window::name::nightshift, gui::ShowMode::GUI_SHOW_INIT);
                     return true;
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::select),
+                        this->setBottomBarText(utils::translate(style::strings::common::select),
                                                BottomBar::Side::CENTER);
                     }
                     return true;

--- a/module-apps/application-settings-new/windows/WallpaperWindow.cpp
+++ b/module-apps/application-settings-new/windows/WallpaperWindow.cpp
@@ -12,7 +12,7 @@ namespace gui
 {
     WallpaperWindow::WallpaperWindow(app::Application *app) : BaseSettingsWindow(app, window::name::wallpaper)
     {
-        setTitle(utils::localize.get("app_settings_display_locked_screen_wallpaper"));
+        setTitle(utils::translate("app_settings_display_locked_screen_wallpaper"));
     }
 
     auto WallpaperWindow::buildOptionsList() -> std::list<gui::Option>
@@ -28,7 +28,7 @@ namespace gui
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::Switch),
+                        this->setBottomBarText(utils::translate(style::strings::common::Switch),
                                                BottomBar::Side::CENTER);
                     }
                     return true;
@@ -37,20 +37,20 @@ namespace gui
                 Switch ? gui::option::SettingRightItem::Checked : gui::option::SettingRightItem::Disabled));
         };
 
-        addCheckOption(utils::translateI18("app_settings_display_wallpaper_logo"), isWallpaperLogoSwitchOn);
-        addCheckOption(utils::translateI18("app_settings_display_wallpaper_clock"), isWallpaperClockSwitchOn);
-        addCheckOption(utils::translateI18("app_settings_display_wallpaper_quotes"), isWallpaperQuotesSwitchOn);
+        addCheckOption(utils::translate("app_settings_display_wallpaper_logo"), isWallpaperLogoSwitchOn);
+        addCheckOption(utils::translate("app_settings_display_wallpaper_clock"), isWallpaperClockSwitchOn);
+        addCheckOption(utils::translate("app_settings_display_wallpaper_quotes"), isWallpaperQuotesSwitchOn);
 
         if (isWallpaperQuotesSwitchOn) {
             optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-                utils::translateI18("app_settings_display_wallpaper_edit_quotes"),
+                utils::translate("app_settings_display_wallpaper_edit_quotes"),
                 [=](gui::Item &item) {
                     application->switchWindow(gui::window::name::edit_quotes, nullptr);
                     return true;
                 },
                 [=](gui::Item &item) {
                     if (item.focus) {
-                        this->setBottomBarText(utils::translateI18(style::strings::common::select),
+                        this->setBottomBarText(utils::translate(style::strings::common::select),
                                                BottomBar::Side::CENTER);
                     }
                     return true;

--- a/module-apps/application-settings/ApplicationSettings.cpp
+++ b/module-apps/application-settings/ApplicationSettings.cpp
@@ -120,7 +120,7 @@ namespace app
     {
         windowsFactory.attach(gui::name::window::main_window, [](Application *app, const std::string &name) {
             return std::make_unique<gui::OptionWindow>(
-                app, utils::localize.get("app_settings_title_main"), mainWindowOptions(app));
+                app, utils::translate("app_settings_title_main"), mainWindowOptions(app));
         });
 
         windowsFactory.attach(app::sim_select, [this](Application *app, const std::string &name) {

--- a/module-apps/application-settings/windows/BtScanWindow.cpp
+++ b/module-apps/application-settings/windows/BtScanWindow.cpp
@@ -60,10 +60,10 @@ namespace gui
         AppWindow::buildInterface();
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("BT_scan_results"));
+        setTitle(utils::translate("BT_scan_results"));
 
         box = new gui::VBox(this, 0, title->offset_h(), style::window_width, 7 * style::window::label::default_h);
 

--- a/module-apps/application-settings/windows/BtWindow.cpp
+++ b/module-apps/application-settings/windows/BtWindow.cpp
@@ -57,10 +57,10 @@ namespace gui
         AppWindow::buildInterface();
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("app_settings_bt"));
+        setTitle(utils::translate("app_settings_bt"));
 
         LOG_INFO("Create box layout");
         box = new gui::VBox(this, 0, title->offset_h(), style::window_width, 8 * style::window::label::default_h);

--- a/module-apps/application-settings/windows/CellularPassthroughWindow.cpp
+++ b/module-apps/application-settings/windows/CellularPassthroughWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CellularPassthroughWindow.hpp"
@@ -29,10 +29,10 @@ namespace gui
         AppWindow::buildInterface();
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("app_settings_cellular_passthrough"));
+        setTitle(utils::translate("app_settings_cellular_passthrough"));
 
         layout = new VBox(this, 0, title->offset_h(), style::window_width, 8 * style::window::label::big_h);
         layout->setPenFocusWidth(style::window::default_border_no_focus_w);

--- a/module-apps/application-settings/windows/ColorTestWindow.cpp
+++ b/module-apps/application-settings/windows/ColorTestWindow.cpp
@@ -26,7 +26,7 @@ namespace gui
     {
         AppWindow::buildInterface();
 
-        setTitle(utils::localize.get("app_settings_title_color_test"));
+        setTitle(utils::translate("app_settings_title_color_test"));
 
         colorListView = new ColorTestListView(application,
                                               this,
@@ -39,11 +39,11 @@ namespace gui
         colorListView->rebuildList();
 
         bottomBar->setActive(BottomBar::Side::LEFT, true);
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get("app_settings_toolbar_reset"));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate("app_settings_toolbar_reset"));
         bottomBar->setActive(BottomBar::Side::CENTER, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::save));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::save));
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         applyInputCallback();
 

--- a/module-apps/application-settings/windows/DateTimeWindow.cpp
+++ b/module-apps/application-settings/windows/DateTimeWindow.cpp
@@ -50,10 +50,10 @@ namespace gui
         AppWindow::buildInterface();
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("app_settings_date_and_time"));
+        setTitle(utils::translate("app_settings_date_and_time"));
 
         // create date widgets
         uint32_t w = this->getWidth();
@@ -68,17 +68,17 @@ namespace gui
                                  style::settings::date::date_time_box_h);
 
         auto item = addDateTimeItem(nullptr,
-                                    utils::localize.get("app_settings_title_day"),
+                                    utils::translate("app_settings_title_day"),
                                     time.get_date_time_substr(utils::time::GetParameters::Day));
         dateItems.insert(std::pair<DateTimeItems, Item *>(DateTimeItems::Day, item));
 
         item = addDateTimeItem(nullptr,
-                               utils::localize.get("app_settings_title_month"),
+                               utils::translate("app_settings_title_month"),
                                time.get_date_time_substr(utils::time::GetParameters::Month));
         dateItems.insert(std::pair<DateTimeItems, Item *>(DateTimeItems::Month, item));
 
         item = addDateTimeItem(nullptr,
-                               utils::localize.get("app_settings_title_year"),
+                               utils::translate("app_settings_title_year"),
                                time.get_date_time_substr(utils::time::GetParameters::Year));
         dateItems.insert(std::pair<DateTimeItems, Item *>(DateTimeItems::Year, item));
 
@@ -129,7 +129,7 @@ namespace gui
                                  style::settings::date::time_box_y_pos,
                                  w,
                                  style::settings::date::date_time_box_h);
-        item     = addDateTimeItem(nullptr, utils::localize.get("app_settings_title_time"), std::to_string(hourValue));
+        item     = addDateTimeItem(nullptr, utils::translate("app_settings_title_time"), std::to_string(hourValue));
         timeItems.insert(std::pair<DateTimeItems, Item *>(DateTimeItems::Hour, item));
         timeBody->addWidget(item);
         timeBody->addWidget(addSpacer(":"));

--- a/module-apps/application-settings/windows/EinkModeWindow.cpp
+++ b/module-apps/application-settings/windows/EinkModeWindow.cpp
@@ -25,8 +25,8 @@ namespace gui
         AppWindow::buildInterface();
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         setTitle("Change eink mode");
         auto label               = new Label(this, 100, 200, 300, 50, "Change mode on click");

--- a/module-apps/application-settings/windows/FotaWindow.cpp
+++ b/module-apps/application-settings/windows/FotaWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "FotaWindow.hpp"
@@ -39,8 +39,8 @@ namespace gui
 
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("Go"));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get("common_back"));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate("Go"));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate("common_back"));
 
         mainBox = new gui::VBox(this, 0, title->offset_h(), style::window_width, style::window_height);
         mainBox->setPenWidth(style::window::default_border_no_focus_w);

--- a/module-apps/application-settings/windows/Info.cpp
+++ b/module-apps/application-settings/windows/Info.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Info.hpp"
@@ -35,7 +35,7 @@ namespace gui
     {
         AppWindow::buildInterface();
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         setTitle("Info");
 
@@ -47,12 +47,12 @@ namespace gui
         addAlignedLabelWithValue(box, "GIT branch:", std::string(GIT_BRANCH));
         addAlignedLabelWithValue(box, "Version:", std::string(VERSION));
         {
-            addAlignedLabelWithValue(box, "Bootloader:", utils::localize.get("not available"));
+            addAlignedLabelWithValue(box, "Bootloader:", utils::translate("not available"));
         }
         std::string firmwareVersion;
         CellularServiceAPI::GetFirmwareVersion(getApplication(), firmwareVersion);
         addAlignedLabelWithValue(
-            box, "Modem Frimware:", (firmwareVersion.empty() ? utils::localize.get("not available") : firmwareVersion));
+            box, "Modem Frimware:", (firmwareVersion.empty() ? utils::translate("not available") : firmwareVersion));
     }
 
     void Info::destroyInterface()

--- a/module-apps/application-settings/windows/LanguageWindow.cpp
+++ b/module-apps/application-settings/windows/LanguageWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <functional>
@@ -46,10 +46,10 @@ namespace gui
         AppWindow::buildInterface();
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
-        setTitle(utils::localize.get("app_settings_title_languages"));
+        setTitle(utils::translate("app_settings_title_languages"));
         const auto &langList = loader.getAvailableDisplayLanguages();
         for (const auto &lang : langList) {
             options.push_back(addOptionLabel(lang, [=](gui::Item &item) {

--- a/module-apps/application-settings/windows/SettingsMainWindow.cpp
+++ b/module-apps/application-settings/windows/SettingsMainWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SettingsMainWindow.hpp"
@@ -15,7 +15,7 @@ std::list<gui::Option> mainWindowOptions(app::Application *app)
 {
     std::list<gui::Option> l;
 
-    auto i18     = [](std::string text) { return utils::localize.get(text); };
+    auto i18     = [](std::string text) { return utils::translate(text); };
     auto addMenu = [&](UTF8 name, std::string window = "") {
         l.emplace_back(gui::Option{name,
                                    [=](gui::Item &item) {

--- a/module-apps/application-settings/windows/TestMessageWindow.cpp
+++ b/module-apps/application-settings/windows/TestMessageWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 /*
@@ -58,8 +58,8 @@ namespace gui
         AppWindow::buildInterface();
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         receivedLabel = new gui::Label(this, 10, 50, 480 - 20, 50, "Received SMS");
         receivedLabel->setAlignment(

--- a/module-apps/application-settings/windows/UITestWindow.cpp
+++ b/module-apps/application-settings/windows/UITestWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "UITestWindow.hpp"
@@ -25,8 +25,8 @@ namespace gui
         // prebuild
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
         setTitle("UI TEST");
         text = new gui::Text(
             this, style::window::default_left_margin, title->offset_h(), style::window::default_body_width, 300);

--- a/module-apps/application-special-input/windows/SpecialInputMainWindow.cpp
+++ b/module-apps/application-special-input/windows/SpecialInputMainWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SpecialInputMainWindow.hpp"
@@ -32,9 +32,9 @@ void SpecialInputMainWindow::buildInterface()
 {
     AppWindow::buildInterface();
 
-    bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-    bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
-    bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::emoji));
+    bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
+    bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
+    bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::emoji));
 
     charList = new gui::ListView(this,
                                  specialInputStyle::specialInputListView::x,
@@ -74,13 +74,13 @@ void SpecialInputMainWindow::switchPage()
     if (actualWindow == specialInputStyle::CharactersType::Emoji) {
         model->createData(specialInputStyle::CharactersType::SpecialCharacters);
         actualWindow = specialInputStyle::CharactersType::SpecialCharacters;
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::emoji));
-        setTitle(utils::localize.get("app_special_input_window"));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::emoji));
+        setTitle(utils::translate("app_special_input_window"));
     }
     else if (actualWindow == specialInputStyle::CharactersType::SpecialCharacters) {
         model->createData(specialInputStyle::CharactersType::Emoji);
         actualWindow = specialInputStyle::CharactersType::Emoji;
-        bottomBar->setText(BottomBar::Side::LEFT, utils::localize.get(style::strings::common::special_chars));
-        setTitle(utils::localize.get("app_emoji_input_window"));
+        bottomBar->setText(BottomBar::Side::LEFT, utils::translate(style::strings::common::special_chars));
+        setTitle(utils::translate("app_emoji_input_window"));
     }
 }

--- a/module-apps/options/type/OptionCall.cpp
+++ b/module-apps/options/type/OptionCall.cpp
@@ -16,8 +16,8 @@ namespace gui::option
     {
         assert(app != nullptr);
 
-        text = "<text>" + utils::localize.get("sms_call_text") + "<b>" + contact.getFormattedName().c_str() +
-               "</b></text>";
+        text =
+            "<text>" + utils::translate("sms_call_text") + "<b>" + contact.getFormattedName().c_str() + "</b></text>";
 
         activatedCallback = [app, contact](gui::Item &item) {
             if (!contact.numbers.empty()) {

--- a/module-apps/options/type/OptionContact.cpp
+++ b/module-apps/options/type/OptionContact.cpp
@@ -20,16 +20,16 @@ namespace gui::option
 
         switch (contactOperation) {
         case ContactOperation::Details:
-            text = utils::localize.get("app_options_contact_details");
+            text = utils::translate("app_options_contact_details");
             break;
         case ContactOperation::Add:
-            text = utils::localize.get("app_options_contact_add");
+            text = utils::translate("app_options_contact_add");
             break;
         case ContactOperation::Edit:
-            text = utils::localize.get("app_options_contact_edit");
+            text = utils::translate("app_options_contact_edit");
             break;
         default:
-            text = utils::localize.get("app_options_invalid_option");
+            text = utils::translate("app_options_invalid_option");
             LOG_WARN("ContactOperation %d not supported", static_cast<int>(contactOperation));
             break;
         }

--- a/module-apps/popups/TetheringConfirmationPopup.cpp
+++ b/module-apps/popups/TetheringConfirmationPopup.cpp
@@ -17,8 +17,8 @@ namespace gui
     void TetheringConfirmationPopup::onBeforeShow(ShowMode mode, [[maybe_unused]] SwitchData *data)
     {
         DialogMetadata metadata;
-        metadata.title  = utils::translateI18("tethering");
-        metadata.text   = utils::translateI18("tethering_enable_question");
+        metadata.title  = utils::translate("tethering");
+        metadata.text   = utils::translate("tethering_enable_question");
         metadata.icon   = "tethering_icon";
         metadata.action = [this]() {
             application->bus.sendUnicast(std::make_shared<sys::TetheringEnabledResponse>(),

--- a/module-apps/popups/TetheringPhoneModePopup.cpp
+++ b/module-apps/popups/TetheringPhoneModePopup.cpp
@@ -17,7 +17,7 @@ namespace gui
     {
         DialogMetadata metadata;
         metadata.title  = "";
-        metadata.text   = utils::translateI18("tethering_phone_mode_change_prohibited");
+        metadata.text   = utils::translate("tethering_phone_mode_change_prohibited");
         metadata.icon   = "info_big_circle_W_G";
         metadata.action = [this]() {
             auto params = std::make_unique<gui::PopupRequestParams>(gui::popup::ID::TetheringPhoneModeChangeProhibited);

--- a/module-apps/popups/VolumeWindow.cpp
+++ b/module-apps/popups/VolumeWindow.cpp
@@ -21,7 +21,7 @@ namespace gui
                                title->offset_h(),
                                style::window::default_body_width,
                                style::window::volume::title_height,
-                               utils::localize.get(style::window::volume::base_title_key));
+                               utils::translate(style::window::volume::base_title_key));
 
         volumeText->setPenWidth(style::window::default_border_no_focus_w);
         volumeText->setFont(style::window::font::mediumbold);
@@ -69,7 +69,7 @@ namespace gui
 
     void VolumeWindow::showProperText(const AudioContext &audioContext, const audio::Volume volume) noexcept
     {
-        volumeText->setText(utils::localize.get(style::window::volume::base_title_key));
+        volumeText->setText(utils::translate(style::window::volume::base_title_key));
         const auto [profileType, playbackType] = audioContext;
         if (playbackType == audio::PlaybackType::Multimedia) {
             showMultimediaPlayback();
@@ -88,17 +88,17 @@ namespace gui
 
     void VolumeWindow::showMultimediaPlayback() noexcept
     {
-        volumeText->setText(utils::localize.get(style::window::volume::music_title_key));
+        volumeText->setText(utils::translate(style::window::volume::music_title_key));
     }
 
     void VolumeWindow::showCalling() noexcept
     {
-        volumeText->setText(utils::localize.get(style::window::volume::call_title_key));
+        volumeText->setText(utils::translate(style::window::volume::call_title_key));
     }
 
     void VolumeWindow::showMuted() noexcept
     {
-        volumeText->setText(utils::localize.get(style::window::volume::mute_title_key));
+        volumeText->setText(utils::translate(style::window::volume::mute_title_key));
     }
 
     bool VolumeWindow::onInput(const gui::InputEvent &inputEvent)

--- a/module-apps/widgets/ActiveIconFactory.cpp
+++ b/module-apps/widgets/ActiveIconFactory.cpp
@@ -28,7 +28,7 @@ auto ActiveIconFactory::makeCustomIcon(const UTF8 &image,
         if (icon->focus) {
             icon->setEdges(RectangleEdge::Bottom | RectangleEdge::Top);
             application->getCurrentWindow()->bottomBarTemporaryMode(
-                utils::localize.get(name), BottomBar::Side::CENTER, false);
+                utils::translate(name), BottomBar::Side::CENTER, false);
         }
         else {
             icon->setEdges(RectangleEdge::None);

--- a/module-apps/widgets/BrightnessBox.cpp
+++ b/module-apps/widgets/BrightnessBox.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <i18n/i18n.hpp>
@@ -11,7 +11,7 @@ namespace gui
     {
         setEdges(RectangleEdge::None);
         addArrow("arrow_left", Alignment::Horizontal::Left);
-        addBrightnessTitle(this, utils::localize.get(style::window::brightness::title_key));
+        addBrightnessTitle(this, utils::translate(style::window::brightness::title_key));
         addArrow("arrow_right", Alignment::Horizontal::Right);
 
         resizeItems();

--- a/module-apps/widgets/ButtonOnOff.cpp
+++ b/module-apps/widgets/ButtonOnOff.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ButtonOnOff.hpp"
@@ -27,12 +27,12 @@ namespace gui
         currentState = newButtonState;
         if (currentState == ButtonState::On) {
             setFillColor(ColorFullBlack);
-            setText(utils::translateI18("app_settings_toggle_on"));
+            setText(utils::translate("app_settings_toggle_on"));
             setTextColor(ColorFullWhite);
         }
         else if (currentState == ButtonState::Off) {
             setFillColor(ColorFullWhite);
-            setText(utils::translateI18("app_settings_toggle_off"));
+            setText(utils::translate("app_settings_toggle_off"));
             setTextColor(ColorFullBlack);
         }
     }

--- a/module-apps/widgets/DateWidget.cpp
+++ b/module-apps/widgets/DateWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DateWidget.hpp"
@@ -33,17 +33,17 @@ namespace gui
 
         dayLabel = new Label(labelsHBox, 0, 0, 0, 0);
         applyLabelSpecificProperties(dayLabel);
-        dayLabel->setText(utils::localize.get("app_settings_title_day"));
+        dayLabel->setText(utils::translate("app_settings_title_day"));
 
         monthLabel = new Label(labelsHBox, 0, 0, 0, 0);
         applyLabelSpecificProperties(monthLabel);
         monthLabel->setMargins(Margins(date_and_time::separator, 0, 0, 0));
-        monthLabel->setText(utils::localize.get("app_settings_title_month"));
+        monthLabel->setText(utils::translate("app_settings_title_month"));
 
         yearLabel = new Label(labelsHBox, 0, 0, 0, 0);
         applyLabelSpecificProperties(yearLabel);
         yearLabel->setMargins(Margins(date_and_time::separator, 0, 0, 0));
-        yearLabel->setText(utils::localize.get("app_settings_title_year"));
+        yearLabel->setText(utils::translate("app_settings_title_year"));
 
         dateHBox = new HBox(this, 0, 0, 0, 0);
         dateHBox->setMinimumSize(style::window::default_body_width, date_and_time::hBox_h);

--- a/module-apps/widgets/ModesBox.cpp
+++ b/module-apps/widgets/ModesBox.cpp
@@ -49,7 +49,7 @@ namespace gui
                                 0,
                                 style::window::modes::width,
                                 style::window::modes::height / style::window::modes::number_of_entries);
-        connected->addText(utils::localize.get(style::window::modes::connected::title_key),
+        connected->addText(utils::translate(style::window::modes::connected::title_key),
                            style::window::font::medium,
                            style::window::modes::text::width,
                            style::window::modes::height / style::window::modes::number_of_entries);
@@ -65,7 +65,7 @@ namespace gui
                                  style::window::modes::width,
                                  style::window::modes::height / style::window::modes::number_of_entries);
 
-        notDisturb->addText(utils::localize.get(style::window::modes::notdisturb::title_key),
+        notDisturb->addText(utils::translate(style::window::modes::notdisturb::title_key),
                             style::window::font::medium,
                             style::window::modes::text::width,
                             style::window::modes::height / style::window::modes::number_of_entries);
@@ -79,7 +79,7 @@ namespace gui
                               0,
                               style::window::modes::width,
                               style::window::modes::height / style::window::modes::number_of_entries);
-        offline->addText(utils::localize.get(style::window::modes::offline::title_key),
+        offline->addText(utils::translate(style::window::modes::offline::title_key),
                          style::window::font::medium,
                          style::window::modes::text::width,
                          style::window::modes::height / style::window::modes::number_of_entries);
@@ -91,7 +91,7 @@ namespace gui
                                   style::window::modes::width,
                                   style::window::modes::height / style::window::modes::number_of_entries);
 
-        messageOnly->addText(utils::localize.get(style::window::modes::offline::description_key),
+        messageOnly->addText(utils::translate(style::window::modes::offline::description_key),
                              style::window::font::verysmall,
                              style::window::modes::text::width,
                              style::window::modes::height / style::window::modes::number_of_entries);

--- a/module-apps/widgets/TimeWidget.cpp
+++ b/module-apps/widgets/TimeWidget.cpp
@@ -187,7 +187,7 @@ namespace gui
         };
         mode12hInput->focusChangedCallback = [&](Item &item) {
             if (item.focus) {
-                bottomBarTemporaryMode(utils::localize.get("common_switch"));
+                bottomBarTemporaryMode(utils::translate("common_switch"));
             }
             else {
                 bottomBarRestoreFromTemporaryMode();

--- a/module-apps/windows/Dialog.cpp
+++ b/module-apps/windows/Dialog.cpp
@@ -12,7 +12,7 @@ using namespace gui;
 Dialog::Dialog(app::Application *app, const std::string &name) : gui::AppWindow(app, name)
 {
     AppWindow::buildInterface();
-    bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+    bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
     setTitle("");
 
     icon = new Icon(this,
@@ -40,7 +40,7 @@ void Dialog::onBeforeShow(ShowMode mode, SwitchData *data)
 DialogConfirm::DialogConfirm(app::Application *app, const std::string &name) : Dialog(app, name)
 {
     bottomBar->setActive(BottomBar::Side::RIGHT, false);
-    bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::ok));
+    bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::ok));
     setFocusItem(icon);
     icon->inputCallback = [=](Item &, const InputEvent &inputEvent) -> bool {
         if (inputEvent.state == InputEvent::State::keyReleasedShort && inputEvent.keyCode == gui::KeyCode::KEY_RF) {
@@ -75,18 +75,18 @@ DialogYesNo::DialogYesNo(app::Application *app, const std::string &name) : Dialo
     no  = createYesNoOption(hBox, gui::dialog::Option::NO);
     yes = createYesNoOption(hBox, gui::dialog::Option::YES);
 
-    bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get("common_confirm"));
+    bottomBar->setText(BottomBar::Side::CENTER, utils::translate("common_confirm"));
 }
 
 Label *DialogYesNo::createYesNoOption(Item *parent, const gui::dialog::Option &optionName)
 {
     Label *option = new Label(parent, 0, 0, 0, 0, "");
     if (optionName == gui::dialog::Option::YES) {
-        option->setText(utils::localize.get(style::strings::common::yes));
+        option->setText(utils::translate(style::strings::common::yes));
         option->activatedCallback = [=](Item &) -> bool { return false; };
     }
     else if (optionName == gui::dialog::Option::NO) {
-        option->setText(utils::localize.get(style::strings::common::no));
+        option->setText(utils::translate(style::strings::common::no));
         option->setMargins(Margins(0, 0, dialog::style::option::margin, 0));
         option->activatedCallback = [=](Item &) -> bool {
             application->returnToPreviousWindow();
@@ -145,7 +145,7 @@ void DialogYesNoIconTxt::onBeforeShow(ShowMode mode, SwitchData *data)
 
 DialogRetry::DialogRetry(app::Application *app, const std::string &name) : Dialog(app, name)
 {
-    bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::retry));
+    bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::retry));
     setFocusItem(bottomBar);
 }
 

--- a/module-apps/windows/NoEvents.cpp
+++ b/module-apps/windows/NoEvents.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "NoEvents.hpp"
@@ -58,16 +58,16 @@ void NoEvents::onBeforeShow(ShowMode mode, SwitchData *data)
         };
     }
 
-    if (title->getText() == utils::localize.get("app_calendar_title_main")) {
+    if (title->getText() == utils::translate("app_calendar_title_main")) {
         bottomBar->setActive(gui::BottomBar::Side::LEFT, true);
-        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::localize.get("app_calendar_bar_month"));
+        bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate("app_calendar_bar_month"));
     }
 }
 
 bool NoEvents::onInput(const gui::InputEvent &inputEvent)
 {
     if (inputEvent.isShortPress() && inputEvent.is(gui::KeyCode::KEY_RF) &&
-        title->getText() == utils::localize.get("app_calendar_title_main")) {
+        title->getText() == utils::translate("app_calendar_title_main")) {
         app::manager::Controller::switchBack(application);
         return true;
     }
@@ -77,7 +77,7 @@ bool NoEvents::onInput(const gui::InputEvent &inputEvent)
     }
 
     if (inputEvent.isShortPress() && inputEvent.is(gui::KeyCode::KEY_LF) &&
-        title->getText() == utils::localize.get("app_calendar_title_main")) {
+        title->getText() == utils::translate("app_calendar_title_main")) {
         application->switchWindow(gui::name::window::main_window);
         return true;
     }

--- a/module-apps/windows/OptionWindow.cpp
+++ b/module-apps/windows/OptionWindow.cpp
@@ -78,8 +78,8 @@ namespace gui
         AppWindow::buildInterface();
         bottomBar->setActive(BottomBar::Side::CENTER, true);
         bottomBar->setActive(BottomBar::Side::RIGHT, true);
-        bottomBar->setText(BottomBar::Side::CENTER, utils::localize.get(style::strings::common::select));
-        bottomBar->setText(BottomBar::Side::RIGHT, utils::localize.get(style::strings::common::back));
+        bottomBar->setText(BottomBar::Side::CENTER, utils::translate(style::strings::common::select));
+        bottomBar->setText(BottomBar::Side::RIGHT, utils::translate(style::strings::common::back));
 
         setTitle(name);
 

--- a/module-cellular/Modem/ATStream.cpp
+++ b/module-cellular/Modem/ATStream.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include "ATStream.hpp"
 #include "ATCommon.hpp"
+#include <map>
 
 namespace at
 {

--- a/module-cellular/at/src/UrcCpin.cpp
+++ b/module-cellular/at/src/UrcCpin.cpp
@@ -1,7 +1,8 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "UrcCpin.hpp"
+#include <map>
 
 using namespace at::urc;
 

--- a/module-db/Interface/ContactRecord.hpp
+++ b/module-db/Interface/ContactRecord.hpp
@@ -88,7 +88,7 @@ struct ContactRecord : public Record
             return getNumberAsName();
         }
         if (type == NameFormatType::List || type == NameFormatType::Title) {
-            return utils::localize.get("app_phonebook_contact_no_name");
+            return utils::translate("app_phonebook_contact_no_name");
         }
         return "";
     }

--- a/module-db/tests/ContactsRecord_tests.cpp
+++ b/module-db/tests/ContactsRecord_tests.cpp
@@ -192,7 +192,7 @@ TEST_CASE("Test contact name formatting")
     REQUIRE(testRecord.getFormattedName(ContactRecord::NameFormatType::List) == numberFormattedTest);
     REQUIRE(testRecord.getFormattedName(ContactRecord::NameFormatType::NotUseNumber) == "");
     REQUIRE(testRecord.getFormattedName(ContactRecord::NameFormatType::Title) ==
-            utils::localize.get("app_phonebook_contact_no_name"));
+            utils::translate("app_phonebook_contact_no_name"));
 
     testRecord.numbers.clear();
     testRecord.numbers = std::vector<ContactRecord::Number>({
@@ -204,16 +204,16 @@ TEST_CASE("Test contact name formatting")
     REQUIRE(testRecord.getFormattedName(ContactRecord::NameFormatType::List) == numberFormattedTest);
     REQUIRE(testRecord.getFormattedName(ContactRecord::NameFormatType::NotUseNumber) == "");
     REQUIRE(testRecord.getFormattedName(ContactRecord::NameFormatType::Title) ==
-            utils::localize.get("app_phonebook_contact_no_name"));
+            utils::translate("app_phonebook_contact_no_name"));
 
     testRecord.numbers.clear();
 
     REQUIRE(testRecord.getFormattedName(ContactRecord::NameFormatType::Default) == "");
     REQUIRE(testRecord.getFormattedName(ContactRecord::NameFormatType::List) ==
-            utils::localize.get("app_phonebook_contact_no_name"));
+            utils::translate("app_phonebook_contact_no_name"));
     REQUIRE(testRecord.getFormattedName(ContactRecord::NameFormatType::NotUseNumber) == "");
     REQUIRE(testRecord.getFormattedName(ContactRecord::NameFormatType::Title) ==
-            utils::localize.get("app_phonebook_contact_no_name"));
+            utils::translate("app_phonebook_contact_no_name"));
 }
 
 TEST_CASE("Test converting contact data to string")

--- a/module-gui/gui/input/Translator.cpp
+++ b/module-gui/gui/input/Translator.cpp
@@ -215,11 +215,9 @@ namespace gui
     std::vector<std::string> Profiles::getProfilesNames()
     {
         std::vector<std::string> profilesNames;
-        LOG_INFO("Scanning %s profiles folder: %s",
-                 utils::files::jsonExtension,
-                 utils::localize.InputLanguageDirPath.c_str());
+        LOG_INFO("Scanning %s profiles folder: %s", utils::files::jsonExtension, utils::getInputLanguagePath().c_str());
 
-        for (const auto &entry : std::filesystem::directory_iterator(utils::localize.InputLanguageDirPath)) {
+        for (const auto &entry : std::filesystem::directory_iterator(utils::getInputLanguagePath())) {
             profilesNames.push_back(std::filesystem::path(entry.path().stem()));
         }
 
@@ -251,7 +249,7 @@ namespace gui
         std::vector<std::string> profilesNames = getProfilesNames();
         for (const auto &profileName : profilesNames) {
             if (!profileName.empty()) {
-                auto filePath = utils::localize.InputLanguageDirPath / (profileName + utils::files::jsonExtension);
+                auto filePath = utils::getInputLanguagePath() / (profileName + utils::files::jsonExtension);
                 loadProfile(filePath);
             }
         }
@@ -272,7 +270,7 @@ namespace gui
 
     Profile &Profiles::get(const std::string &name)
     {
-        std::filesystem::path filepath = utils::localize.InputLanguageDirPath / (name + utils::files::jsonExtension);
+        std::filesystem::path filepath = utils::getInputLanguagePath() / (name + utils::files::jsonExtension);
         // if profile not in profile map -> load
         if (filepath.empty()) {
             LOG_ERROR("Request for nonexistent profile: %s", filepath.c_str());

--- a/module-gui/gui/widgets/CheckBox.cpp
+++ b/module-gui/gui/widgets/CheckBox.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CheckBox.hpp"
@@ -37,10 +37,10 @@ namespace gui
             if (focus) {
                 setFocusItem(image);
                 if (image->visible) {
-                    bottomBarTemporaryMode(utils::localize.get("common_uncheck"));
+                    bottomBarTemporaryMode(utils::translate("common_uncheck"));
                 }
                 else {
-                    bottomBarTemporaryMode(utils::localize.get("common_check"));
+                    bottomBarTemporaryMode(utils::translate("common_check"));
                 }
             }
             else {
@@ -58,10 +58,10 @@ namespace gui
                 if (event.keyCode == gui::KeyCode::KEY_LF) {
                     image->setVisible(!image->visible);
                     if (image->visible) {
-                        bottomBarTemporaryMode(utils::localize.get("common_uncheck"));
+                        bottomBarTemporaryMode(utils::translate("common_uncheck"));
                     }
                     else {
-                        bottomBarTemporaryMode(utils::localize.get("common_check"));
+                        bottomBarTemporaryMode(utils::translate("common_check"));
                     }
                     return true;
                 }
@@ -70,10 +70,10 @@ namespace gui
                 if (event.keyCode == gui::KeyCode::KEY_ENTER) {
                     image->setVisible(!image->visible);
                     if (image->visible) {
-                        bottomBarTemporaryMode(utils::localize.get("common_uncheck"));
+                        bottomBarTemporaryMode(utils::translate("common_uncheck"));
                     }
                     else {
-                        bottomBarTemporaryMode(utils::localize.get("common_check"));
+                        bottomBarTemporaryMode(utils::translate("common_check"));
                     }
                     return true;
                 }

--- a/module-gui/gui/widgets/InputMode.cpp
+++ b/module-gui/gui/widgets/InputMode.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <InputMode.hpp>
@@ -66,7 +66,7 @@ const std::string &InputMode::get()
         actualInputMode == input_mode.find(InputMode::phone)->second) {
         return input_mode.at(modeNow());
     }
-    return utils::localize.getInputLanguageFilename(actualInputMode);
+    return utils::getInputLanguageFilename(actualInputMode);
 }
 
 void InputMode::show_input_type()

--- a/module-gui/gui/widgets/TopBar/BatteryText.cpp
+++ b/module-gui/gui/widgets/TopBar/BatteryText.cpp
@@ -28,12 +28,12 @@ namespace gui::top_bar
 
     void BatteryText::showBatteryCharging()
     {
-        label->setText(utils::localize.get("topbar_battery_charging"));
+        label->setText(utils::translate("topbar_battery_charging"));
     }
 
     void BatteryText::showBatteryChargingDone()
     {
-        label->setText(utils::localize.get("topbar_battery_plugged"));
+        label->setText(utils::translate("topbar_battery_plugged"));
     }
 
 } // namespace gui::top_bar

--- a/module-gui/gui/widgets/TopBar/PhoneMode.cpp
+++ b/module-gui/gui/widgets/TopBar/PhoneMode.cpp
@@ -23,11 +23,11 @@ namespace gui::top_bar
     {
         switch (mode) {
         case sys::phone_modes::PhoneMode::DoNotDisturb:
-            setText(utils::localize.get("home_modes_notdisturb"));
+            setText(utils::translate("home_modes_notdisturb"));
             break;
 
         case sys::phone_modes::PhoneMode::Offline:
-            setText(utils::localize.get("home_modes_offline"));
+            setText(utils::translate("home_modes_offline"));
             break;
 
         case sys::phone_modes::PhoneMode::Connected:

--- a/module-gui/test/test-catch-text/test-gui-Text.cpp
+++ b/module-gui/test/test-catch-text/test-gui-Text.cpp
@@ -168,7 +168,7 @@ TEST_CASE("Text buildDrawList")
 
 TEST_CASE("handle input mode ABC/abc/1234")
 {
-    utils::localize.setInputLanguage("English"); /// needed to load input mode
+    utils::setInputLanguage("English"); /// needed to load input mode
     auto &fontmanager = mockup::fontManager();
     auto font         = fontmanager.getFont(0);
     auto text         = gui::TestText();

--- a/module-services/service-appmgr/model/ApplicationManager.cpp
+++ b/module-services/service-appmgr/model/ApplicationManager.cpp
@@ -142,7 +142,7 @@ namespace app::manager
 
     sys::ReturnCodes ApplicationManager::InitHandler()
     {
-        utils::localize.setDisplayLanguage(
+        utils::setDisplayLanguage(
             settings->getValue(settings::SystemProperties::displayLanguage, settings::SettingsScope::Global));
 
         settings->registerValueChange(
@@ -328,7 +328,7 @@ namespace app::manager
         connect(typeid(DisplayLanguageChangeRequest), [this](sys::Message *request) {
             auto msg = static_cast<DisplayLanguageChangeRequest *>(request);
             handleDisplayLanguageChange(msg);
-            return std::make_shared<GetCurrentDisplayLanguageResponse>(utils::localize.getDisplayLanguage());
+            return std::make_shared<GetCurrentDisplayLanguageResponse>(utils::getDisplayLanguage());
         });
         connect(typeid(InputLanguageChangeRequest), [this](sys::Message *request) {
             auto msg = static_cast<InputLanguageChangeRequest *>(request);
@@ -369,7 +369,7 @@ namespace app::manager
             return sys::MessageNone{};
         });
         connect(typeid(GetCurrentDisplayLanguageRequest), [&](sys::Message *request) {
-            return std::make_shared<GetCurrentDisplayLanguageResponse>(utils::localize.getDisplayLanguage());
+            return std::make_shared<GetCurrentDisplayLanguageResponse>(utils::getDisplayLanguage());
         });
         connect(typeid(UpdateInProgress), [this](sys::Message *) {
             closeApplicationsOnUpdate();
@@ -757,13 +757,12 @@ namespace app::manager
     {
         const auto &requestedLanguage = msg->getLanguage();
 
-        if (requestedLanguage == utils::localize.getDisplayLanguage()) {
+        if (not utils::setDisplayLanguage(requestedLanguage)) {
             LOG_WARN("The selected language is already set. Ignore.");
             return false;
         }
         settings->setValue(
             settings::SystemProperties::displayLanguage, requestedLanguage, settings::SettingsScope::Global);
-        utils::localize.setDisplayLanguage(requestedLanguage);
         rebuildActiveApplications();
         return true;
     }
@@ -772,13 +771,12 @@ namespace app::manager
     {
         const auto &requestedLanguage = msg->getLanguage();
 
-        if (requestedLanguage == utils::localize.getInputLanguage()) {
+        if (not utils::setInputLanguage(requestedLanguage)) {
             LOG_WARN("The selected language is already set. Ignore.");
             return false;
         }
         settings->setValue(
             settings::SystemProperties::inputLanguage, requestedLanguage, settings::SettingsScope::Global);
-        utils::localize.setInputLanguage(requestedLanguage);
         return true;
     }
 
@@ -985,7 +983,7 @@ namespace app::manager
 
     void ApplicationManager::displayLanguageChanged(std::string value)
     {
-        if (utils::localize.setDisplayLanguage(value)) {
+        if (utils::setDisplayLanguage(value)) {
             rebuildActiveApplications();
         }
     }
@@ -1012,7 +1010,7 @@ namespace app::manager
 
     void ApplicationManager::inputLanguageChanged(std::string value)
     {
-        utils::localize.setInputLanguage(value);
+        utils::setInputLanguage(value);
     }
 
     auto ApplicationManager::handleDOMRequest(sys::Message *request) -> std::shared_ptr<sys::ResponseMessage>

--- a/module-services/service-cellular/requests/CallForwardingRequest.cpp
+++ b/module-services/service-cellular/requests/CallForwardingRequest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <string>
@@ -8,6 +8,7 @@
 #include <at/ATFactory.hpp>
 
 #include "service-cellular/requests/CallForwardingRequest.hpp"
+#include <map>
 
 namespace
 {

--- a/module-services/service-cellular/requests/PinChangeRequest.cpp
+++ b/module-services/service-cellular/requests/PinChangeRequest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <string>
@@ -9,6 +9,7 @@
 
 #include "service-cellular/requests/PinChangeRequest.hpp"
 #include <at/ATFactory.hpp>
+#include <map>
 
 namespace
 {

--- a/module-services/service-cellular/requests/SupplementaryServicesRequest.cpp
+++ b/module-services/service-cellular/requests/SupplementaryServicesRequest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <string>
@@ -15,6 +15,7 @@
 #include "service-cellular/requests/ColpRequest.hpp"
 #include "service-cellular/requests/CallWaitingRequest.hpp"
 #include "service-cellular/requests/CallBarringRequest.hpp"
+#include <map>
 
 namespace
 {

--- a/module-services/service-db/service-db/SettingsCache.hpp
+++ b/module-services/service-db/service-db/SettingsCache.hpp
@@ -1,5 +1,9 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
 #include <mutex.hpp>
 #include "SettingsMessages.hpp"
+#include <map>
 
 namespace settings
 {

--- a/module-services/service-db/test/test-entry-path.cpp
+++ b/module-services/service-db/test/test-entry-path.cpp
@@ -2,6 +2,7 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
+#include <map>
 
 #include "service-db/SettingsMessages.hpp"
 

--- a/module-utils/i18n/i18n.hpp
+++ b/module-utils/i18n/i18n.hpp
@@ -3,10 +3,9 @@
 
 #pragma once
 
-#include "json/json11.hpp"
 #include <string>
 #include <filesystem>
-#include <mutex.hpp>
+#include <vector>
 
 using Language = std::string;
 
@@ -24,45 +23,22 @@ namespace utils
         virtual ~LangLoader() = default;
         std::vector<Language> getAvailableDisplayLanguages() const;
         std::vector<Language> getAvailableInputLanguages() const;
-        json11::Json createJson(const std::string &filename);
     };
 
-    class i18n
+    const std::string &translate(const std::string &text);
+    const std::string &getDisplayLanguage();
+    const std::string &getInputLanguageFilename(const std::string &inputMode);
+
+    bool setInputLanguage(const Language &lang);
+    bool setDisplayLanguage(const Language &lang);
+    void resetDisplayLanguages();
+
+    const std::filesystem::path getInputLanguagePath();
+    const std::filesystem::path getDisplayLanguagePath();
+
+    constexpr auto getDefaultLanguage()
     {
-      private:
-        json11::Json displayLanguage;
-        json11::Json fallbackLanguage; // backup language if item not found
-        LangLoader loader;
-        Language fallbackLanguageName = DefaultLanguage;
-        Language inputLanguage = fallbackLanguageName;
-        Language inputLanguageFilename;
-        Language currentDisplayLanguage;
-        mutable cpp_freertos::MutexStandard mutex;
-
-        void changeDisplayLanguage(const json11::Json &lang);
-        void loadFallbackLanguage();
-
-      public:
-        static constexpr auto DefaultLanguage              = "English";
-        std::filesystem::path DisplayLanguageDirPath       = "assets/lang";
-        std::filesystem::path InputLanguageDirPath         = "assets/profiles";
-        void resetAssetsPath(const std::filesystem::path &);
-
-        virtual ~i18n() = default;
-        void setInputLanguage(const Language &lang);
-        const std::string &getInputLanguage(const std::string &inputMode);
-        const std::string &getInputLanguageFilename(const std::string &inputMode);
-        const std::string &getInputLanguage();
-        const std::string &getDisplayLanguage();
-        const std::string &get(const std::string &str);
-        bool setDisplayLanguage(const Language &lang);
-        void resetDisplayLanguages();
-    };
-
-    // Global instance of i18 class
-    extern i18n localize;
-    inline auto translateI18(const std::string &text)
-    {
-        return utils::localize.get(text);
-    };
+        return "English";
+    }
+    void resetAssetsPath(const std::filesystem::path &);
 } // namespace utils

--- a/module-utils/i18n/i18nImpl.hpp
+++ b/module-utils/i18n/i18nImpl.hpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <mutex.hpp>
+#include <json/json11.hpp>
+#include "i18n.hpp"
+
+namespace utils
+{
+
+    class LangLoaderImpl : public LangLoader
+    {
+      public:
+        json11::Json createJson(const std::string &filename);
+    };
+
+    class i18n
+    {
+      private:
+        json11::Json displayLanguage;
+        json11::Json fallbackLanguage; // backup language if item not found
+        LangLoaderImpl loader;
+        Language fallbackLanguageName = getDefaultLanguage();
+        Language inputLanguage        = fallbackLanguageName;
+        Language inputLanguageFilename;
+        Language currentDisplayLanguage;
+        std::filesystem::path InputLanguageDirPath   = "assets/profiles";
+        std::filesystem::path DisplayLanguageDirPath = "assets/lang";
+        mutable cpp_freertos::MutexStandard mutex;
+
+        void changeDisplayLanguage(const json11::Json &lang);
+        void loadFallbackLanguage();
+
+      protected:
+        const std::string &get(const std::string &str);
+        json11::Json &getDisplayLanguageJSON()
+        {
+            return displayLanguage;
+        }
+        json11::Json &getFallbackLanguageJSON()
+        {
+            return fallbackLanguage;
+        }
+        const std::string &getDisplayLanguage()
+        {
+            return currentDisplayLanguage;
+        }
+        const std::string &getInputLanguageFilename(const std::string &inputMode);
+        bool setInputLanguage(const Language &lang);
+        bool setDisplayLanguage(const Language &lang);
+        const std::filesystem::path getInputLanguagePath()
+        {
+            return InputLanguageDirPath;
+        }
+        const std::filesystem::path getDisplayLanguagePath()
+        {
+            return DisplayLanguageDirPath;
+        }
+
+        void resetDisplayLanguages();
+        void resetAssetsPath(const std::filesystem::path &);
+    };
+
+} // namespace utils

--- a/module-utils/test/test_i18n.cpp
+++ b/module-utils/test/test_i18n.cpp
@@ -11,107 +11,107 @@ using namespace std;
 
 TEST_CASE("Test set display language - empty display language string")
 {
-    utils::localize.resetAssetsPath("sys/current/assets");
-    utils::localize.resetDisplayLanguages();
-    REQUIRE(utils::localize.getDisplayLanguage() == "");
+    utils::resetAssetsPath("sys/current/assets");
+    utils::resetDisplayLanguages();
+    REQUIRE(utils::getDisplayLanguage().empty());
 
     // Invalid string provided - language should be set to default one.
-    CHECK(utils::localize.setDisplayLanguage(""));
-    REQUIRE(utils::localize.getDisplayLanguage() == utils::localize.DefaultLanguage);
+    CHECK(utils::setDisplayLanguage(""));
+    REQUIRE(utils::getDisplayLanguage() == utils::getDefaultLanguage());
 }
 
 TEST_CASE("Test set display language - invalid display language string")
 {
-    utils::localize.resetAssetsPath("sys/current/assets");
-    utils::localize.resetDisplayLanguages();
-    REQUIRE(utils::localize.getDisplayLanguage() == "");
+    utils::resetAssetsPath("sys/current/assets");
+    utils::resetDisplayLanguages();
+    REQUIRE(utils::getDisplayLanguage().empty());
 
     // Invalid string provided - language should be set to default one.
-    CHECK(utils::localize.setDisplayLanguage("NonExistingLanguage"));
-    REQUIRE(utils::localize.getDisplayLanguage() == utils::localize.DefaultLanguage);
+    CHECK(utils::setDisplayLanguage("NonExistingLanguage"));
+    REQUIRE(utils::getDisplayLanguage() == utils::getDefaultLanguage());
 }
 
 TEST_CASE("Test set display language - double invalid display language string")
 {
-    utils::localize.resetAssetsPath("sys/current/assets");
-    utils::localize.resetDisplayLanguages();
-    REQUIRE(utils::localize.getDisplayLanguage() == "");
+    utils::resetAssetsPath("sys/current/assets");
+    utils::resetDisplayLanguages();
+    REQUIRE(utils::getDisplayLanguage().empty());
 
     // Invalid string provided - language should be set to default one.
-    CHECK(utils::localize.setDisplayLanguage(""));
-    REQUIRE(utils::localize.getDisplayLanguage() == utils::localize.DefaultLanguage);
+    CHECK(utils::setDisplayLanguage(""));
+    REQUIRE(utils::getDisplayLanguage() == utils::getDefaultLanguage());
 
     // Invalid string provided - language already set to default one so method returns false.
-    CHECK_FALSE(utils::localize.setDisplayLanguage("NonExistingLanguage"));
-    REQUIRE(utils::localize.getDisplayLanguage() == utils::localize.DefaultLanguage);
+    CHECK_FALSE(utils::setDisplayLanguage("NonExistingLanguage"));
+    REQUIRE(utils::getDisplayLanguage() == utils::getDefaultLanguage());
 }
 
 TEST_CASE("Test set display language - set display language with valid string")
 {
     static constexpr auto languageToChange = "Polski";
 
-    utils::localize.resetAssetsPath("sys/current/assets");
-    utils::localize.resetDisplayLanguages();
-    REQUIRE(utils::localize.getDisplayLanguage() == "");
+    utils::resetAssetsPath("sys/current/assets");
+    utils::resetDisplayLanguages();
+    REQUIRE(utils::getDisplayLanguage().empty());
 
     // Valid string provided - language should change.
-    CHECK(utils::localize.setDisplayLanguage(languageToChange));
-    REQUIRE(utils::localize.getDisplayLanguage() == languageToChange);
+    CHECK(utils::setDisplayLanguage(languageToChange));
+    REQUIRE(utils::getDisplayLanguage() == languageToChange);
 }
 
 TEST_CASE("Test set display language - set display language with valid string and try to invalidate")
 {
     static constexpr auto languageToChange = "Polski";
 
-    utils::localize.resetAssetsPath("sys/current/assets");
-    utils::localize.resetDisplayLanguages();
-    REQUIRE(utils::localize.getDisplayLanguage() == "");
+    utils::resetAssetsPath("sys/current/assets");
+    utils::resetDisplayLanguages();
+    REQUIRE(utils::getDisplayLanguage().empty());
 
     // Valid string provided - language should change.
-    CHECK(utils::localize.setDisplayLanguage(languageToChange));
-    REQUIRE(utils::localize.getDisplayLanguage() == languageToChange);
+    CHECK(utils::setDisplayLanguage(languageToChange));
+    REQUIRE(utils::getDisplayLanguage() == languageToChange);
 
     // Invalid string provided - language should not be changed as valid one is set.
-    CHECK_FALSE(utils::localize.setDisplayLanguage(""));
-    REQUIRE(utils::localize.getDisplayLanguage() == languageToChange);
+    CHECK_FALSE(utils::setDisplayLanguage(""));
+    REQUIRE(utils::getDisplayLanguage() == languageToChange);
 }
 
 TEST_CASE("Test get string method - no display language set")
 {
-    utils::localize.resetAssetsPath("sys/current/assets");
-    utils::localize.resetDisplayLanguages();
-    REQUIRE(utils::localize.getDisplayLanguage() == "");
+    utils::resetAssetsPath("sys/current/assets");
+    utils::resetDisplayLanguages();
+    REQUIRE(utils::getDisplayLanguage().empty());
 
     // No languages provided
-    REQUIRE(utils::localize.get("common_yes") == "common_yes");
+    REQUIRE(utils::translate("common_yes") == "common_yes");
 }
 
 TEST_CASE("Test get string method - invalid display language set")
 {
-    utils::localize.resetAssetsPath("sys/current/assets");
-    utils::localize.resetDisplayLanguages();
-    REQUIRE(utils::localize.getDisplayLanguage() == "");
+    utils::resetAssetsPath("sys/current/assets");
+    utils::resetDisplayLanguages();
+    REQUIRE(utils::getDisplayLanguage().empty());
 
     // Invalid string provided - language should be set to default one.
-    CHECK(utils::localize.setDisplayLanguage(""));
-    REQUIRE(utils::localize.getDisplayLanguage() == utils::localize.DefaultLanguage);
+    CHECK(utils::setDisplayLanguage(""));
+    REQUIRE(utils::getDisplayLanguage() == utils::getDefaultLanguage());
 
     // Default fallback language set - English
-    REQUIRE(utils::localize.get("common_yes") == "Yes");
+    REQUIRE(utils::translate("common_yes") == "Yes");
 }
 
 TEST_CASE("Test get string method - valid display language set")
 {
     static constexpr auto languageToChange = "Polski";
 
-    utils::localize.resetAssetsPath("sys/current/assets");
-    utils::localize.resetDisplayLanguages();
-    REQUIRE(utils::localize.getDisplayLanguage() == "");
+    utils::resetAssetsPath("sys/current/assets");
+    utils::resetDisplayLanguages();
+    REQUIRE(utils::getDisplayLanguage().empty());
 
     // Valid string provided - language should change.
-    CHECK(utils::localize.setDisplayLanguage(languageToChange));
-    REQUIRE(utils::localize.getDisplayLanguage() == languageToChange);
+    CHECK(utils::setDisplayLanguage(languageToChange));
+    REQUIRE(utils::getDisplayLanguage() == languageToChange);
 
     // Display language set - Polish
-    REQUIRE(utils::localize.get("common_yes") == "Tak");
+    REQUIRE(utils::translate("common_yes") == "Tak");
 }

--- a/module-utils/test/unittest_TimeRangeParser.cpp
+++ b/module-utils/test/unittest_TimeRangeParser.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #define CATCH_CONFIG_MAIN
@@ -28,7 +28,7 @@ TEST_CASE("Time display parser")
         REQUIRE("24" == TimePointToMinutesString(event.date_from));
         REQUIRE("3" == TimePointToHourString12H(event.date_till));
         REQUIRE("36" == TimePointToMinutesString(event.date_till));
-        REQUIRE(returnString == "2:24 - 3:36 " + utils::localize.get(utils::time::Locale::getPM()));
+        REQUIRE(returnString == "2:24 - 3:36 " + utils::translate(utils::time::Locale::getPM()));
     }
 
     SECTION("Before noon time input (mode12h)")
@@ -45,7 +45,7 @@ TEST_CASE("Time display parser")
         REQUIRE("59" == TimePointToMinutesString(event.date_from));
         REQUIRE("7" == TimePointToHourString12H(event.date_till));
         REQUIRE("45" == TimePointToMinutesString(event.date_till));
-        REQUIRE(returnString == "5:59 - 7:45 " + utils::localize.get(utils::time::Locale::getAM()));
+        REQUIRE(returnString == "5:59 - 7:45 " + utils::translate(utils::time::Locale::getAM()));
     }
 
     SECTION("Mixed time input (mode12h)")
@@ -62,8 +62,8 @@ TEST_CASE("Time display parser")
         REQUIRE("05" == TimePointToMinutesString(event.date_from));
         REQUIRE("7" == TimePointToHourString12H(event.date_till));
         REQUIRE("55" == TimePointToMinutesString(event.date_till));
-        REQUIRE(returnString == "1:05 " + utils::localize.get(utils::time::Locale::getAM()) + " - 7:55 " +
-                                    utils::localize.get(utils::time::Locale::getPM()));
+        REQUIRE(returnString == "1:05 " + utils::translate(utils::time::Locale::getAM()) + " - 7:55 " +
+                                    utils::translate(utils::time::Locale::getPM()));
     }
 
     SECTION("Before noon time input - short version (mode12h)")
@@ -78,7 +78,7 @@ TEST_CASE("Time display parser")
         REQUIRE("2020-12-31 19:55:00" == TimePointToString(event.date_till));
         REQUIRE("12" == TimePointToHourString12H(event.date_from));
         REQUIRE("05" == TimePointToMinutesString(event.date_from));
-        REQUIRE(returnString == "12:05 " + utils::localize.get(utils::time::Locale::getAM()));
+        REQUIRE(returnString == "12:05 " + utils::translate(utils::time::Locale::getAM()));
     }
 
     SECTION("After noon time input - short version (mode12h)")
@@ -93,7 +93,7 @@ TEST_CASE("Time display parser")
         REQUIRE("2020-12-31 19:55:00" == TimePointToString(event.date_till));
         REQUIRE("12" == TimePointToHourString12H(event.date_from));
         REQUIRE("05" == TimePointToMinutesString(event.date_from));
-        REQUIRE(returnString == "12:05 " + utils::localize.get(utils::time::Locale::getPM()));
+        REQUIRE(returnString == "12:05 " + utils::translate(utils::time::Locale::getPM()));
     }
 
     SECTION("Time input (mode24h)")
@@ -138,6 +138,6 @@ TEST_CASE("Time display parser")
             event.date_from, event.date_till, Version::normal, false);
         REQUIRE("2020-10-20 00:00:00" == TimePointToString(event.date_from));
         REQUIRE("2020-10-20 23:59:00" == TimePointToString(event.date_till));
-        REQUIRE(returnString == utils::localize.get("app_calendar_all_day"));
+        REQUIRE(returnString == utils::translate("app_calendar_all_day"));
     }
 }

--- a/module-utils/test/unittest_duration.cpp
+++ b/module-utils/test/unittest_duration.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <cstring>
@@ -12,11 +12,9 @@
 
 #include <catch2/catch.hpp>
 
-utils::i18n localize;
-
 TEST_CASE("Duration - creation")
 {
-    utils::localize.setDisplayLanguage("English");
+    utils::setDisplayLanguage("English");
 
     SECTION("default constructor")
     {
@@ -59,7 +57,7 @@ TEST_CASE("Duration - creation")
 
 TEST_CASE("Duration - arithemtics")
 {
-    utils::localize.setDisplayLanguage("English");
+    utils::setDisplayLanguage("English");
 
     SECTION("Addition")
     {
@@ -97,7 +95,7 @@ TEST_CASE("Duration - arithemtics")
 
 TEST_CASE("Duration - comparision")
 {
-    utils::localize.setDisplayLanguage("English");
+    utils::setDisplayLanguage("English");
 
     SECTION("Duration")
     {
@@ -141,7 +139,7 @@ TEST_CASE("Duration - comparision")
 
 TEST_CASE("Duration - display")
 {
-    utils::localize.setDisplayLanguage("English");
+    utils::setDisplayLanguage("English");
 
     {
         using namespace utils::time;

--- a/module-utils/time/TimeRangeParser.cpp
+++ b/module-utils/time/TimeRangeParser.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TimeRangeParser.hpp"
@@ -14,9 +14,9 @@ namespace utils::time
     std::string TimeRangeParser::AMPMtoString(bool isAm)
     {
         if (isAm) {
-            return utils::localize.get(utils::time::Locale::getAM());
+            return utils::translate(utils::time::Locale::getAM());
         }
-        return utils::localize.get(utils::time::Locale::getPM());
+        return utils::translate(utils::time::Locale::getPM());
     }
 
     std::string TimeRangeParser::getCalendarTimeString(TimePoint startDate,
@@ -29,7 +29,7 @@ namespace utils::time
 
         if (startTime.hours().count() == 0 && startTime.minutes().count() == 0 && endTime.hours().count() == max_hour &&
             endTime.minutes().count() == max_minutes) {
-            return utils::localize.get("app_calendar_all_day");
+            return utils::translate("app_calendar_all_day");
         }
         else {
             bool startIsAm = true;

--- a/module-utils/time/time_conversion.cpp
+++ b/module-utils/time/time_conversion.cpp
@@ -336,8 +336,8 @@ namespace utils::time
     UTF8 Duration::str(DisplayedFormat displayedFormat) const
     {
         // switch between format low and hig
-        std::string data = utils::localize.get(hours != 0 ? formatMap.at(displayedFormat).highFormat
-                                                          : formatMap.at(displayedFormat).lowFormat);
+        std::string data = utils::translate(hours != 0 ? formatMap.at(displayedFormat).highFormat
+                                                       : formatMap.at(displayedFormat).lowFormat);
         fillStr(data);
 
         return data;

--- a/module-utils/time/time_locale.hpp
+++ b/module-utils/time/time_locale.hpp
@@ -147,7 +147,7 @@ namespace utils
                     return "";
                 }
                 else {
-                    return localize.get(tlocale.days[day]);
+                    return translate(tlocale.days[day]);
                 }
             }
 
@@ -158,7 +158,7 @@ namespace utils
                     return "";
                 }
                 else {
-                    return localize.get(tlocale.daysShort[day]);
+                    return translate(tlocale.daysShort[day]);
                 }
             }
 
@@ -169,33 +169,33 @@ namespace utils
                     return "";
                 }
                 else {
-                    return localize.get(tlocale.months[mon]);
+                    return translate(tlocale.months[mon]);
                 }
             }
 
             static const UTF8 yesterday()
             {
-                return localize.get(tlocale.lyesterday);
+                return translate(tlocale.lyesterday);
             }
 
             static const UTF8 today()
             {
-                return localize.get(tlocale.ltoday);
+                return translate(tlocale.ltoday);
             }
 
             static const std::string format(TimeFormat what)
             {
-                return localize.get(tlocale.time_formats[static_cast<unsigned>(what)]);
+                return translate(tlocale.time_formats[static_cast<unsigned>(what)]);
             }
 
             static const UTF8 getAM()
             {
-                return localize.get("common_AM");
+                return translate("common_AM");
             }
 
             static const UTF8 getPM()
             {
-                return localize.get("common_PM");
+                return translate("common_PM");
             }
         };
 


### PR DESCRIPTION
Proposal to cleanup our i18 access. we should consider utis::translation etc - calls in i18.hpp as separate API ie. i18::translate instead

please check changes commit by commit to not check renames