### PR TITLE
[EGD-6485] Remove Cellular message types from global

### DIFF
--- a/module-apps/Application.cpp
+++ b/module-apps/Application.cpp
@@ -263,10 +263,10 @@ namespace app
     {
         auto msg = dynamic_cast<CellularNotificationMessage *>(msgl);
         if (msg != nullptr) {
-            if (msg->type == CellularNotificationMessage::Type::SignalStrengthUpdate) {
+            if (msg->content == CellularNotificationMessage::Content::SignalStrengthUpdate) {
                 return handleSignalStrengthUpdate(msgl);
             }
-            if (msg->type == CellularNotificationMessage::Type::NetworkStatusUpdate) {
+            if (msg->content == CellularNotificationMessage::Content::NetworkStatusUpdate) {
                 return handleNetworkAccessTechnologyUpdate(msgl);
             }
         }

--- a/module-apps/application-settings-new/ApplicationSettings.cpp
+++ b/module-apps/application-settings-new/ApplicationSettings.cpp
@@ -122,10 +122,10 @@ namespace app
 
         if (auto phoneMsg = dynamic_cast<CellularNotificationMessage *>(msgl); nullptr != phoneMsg) {
             selectedSim = Store::GSM::get()->selected;
-            if (CellularNotificationMessage::Type::SIM_READY == phoneMsg->type) {
+            if (CellularNotificationMessage::Content::SIM_READY == phoneMsg->content) {
                 selectedSimNumber = CellularServiceAPI::GetOwnNumber(this);
             }
-            else if (CellularNotificationMessage::Type::SIM_NOT_READY == phoneMsg->type) {
+            else if (CellularNotificationMessage::Content::SIM_NOT_READY == phoneMsg->content) {
                 selectedSimNumber = {};
             }
             auto currentWindow = getCurrentWindow();

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -2125,7 +2125,7 @@ std::shared_ptr<cellular::RawCommandRespAsync> ServiceCellular::handleCellularSt
     CellularStartOperatorsScanMessage *msg)
 {
     LOG_INFO("CellularStartOperatorsScan handled");
-    auto ret = std::make_shared<cellular::RawCommandRespAsync>(MessageType::CellularOperatorsScanResult);
+    auto ret = std::make_shared<cellular::RawCommandRespAsync>(CellularMessage::Type::OperatorsScanResult);
     NetworkSettings networkSettings(*this);
     ret->data = networkSettings.scanOperators(msg->getFullInfo());
     bus.sendUnicast(ret, msg->sender);
@@ -2303,16 +2303,16 @@ void ServiceCellular::handleCellularHangupCallMessage(CellularHangupCallMessage 
             if (!ongoingCall.endCall(CellularCall::Forced::True)) {
                 LOG_ERROR("Failed to end ongoing call");
             }
-            bus.sendMulticast(std::make_shared<CellularResponseMessage>(true, msg->messageType),
+            bus.sendMulticast(std::make_shared<CellularResponseMessage>(true, msg->type),
                               sys::BusChannel::ServiceCellularNotifications);
         }
         else {
             LOG_ERROR("Call not aborted");
-            bus.sendMulticast(std::make_shared<CellularResponseMessage>(false, msg->messageType),
+            bus.sendMulticast(std::make_shared<CellularResponseMessage>(false, msg->type),
                               sys::BusChannel::ServiceCellularNotifications);
         }
     }
-    bus.sendMulticast(std::make_shared<CellularResponseMessage>(false, msg->messageType),
+    bus.sendMulticast(std::make_shared<CellularResponseMessage>(false, msg->type),
                       sys::BusChannel::ServiceCellularNotifications);
 }
 
@@ -2419,7 +2419,7 @@ auto ServiceCellular::handleCellularGetOwnNumberMessage(sys::Message *msg) -> st
 
 auto ServiceCellular::handleCellularGetNetworkInfoMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
-    auto message  = std::make_shared<cellular::RawCommandRespAsync>(MessageType::CellularNetworkInfoResult);
+    auto message  = std::make_shared<cellular::RawCommandRespAsync>(CellularMessage::Type::NetworkInfoResult);
     message->data = getNetworkInfo();
     bus.sendUnicast(message, msg->sender);
 
@@ -2451,7 +2451,7 @@ auto ServiceCellular::handleCellularGetScanModeMessage(sys::Message *msg) -> std
 {
     auto mode = GetScanMode();
     if (mode != "") {
-        auto response = std::make_shared<cellular::RawCommandRespAsync>(MessageType::CellularGetScanModeResult);
+        auto response = std::make_shared<cellular::RawCommandRespAsync>(CellularMessage::Type::GetScanModeResult);
         response->data.push_back(mode);
         bus.sendUnicast(response, msg->sender);
         return std::make_shared<CellularResponseMessage>(true);
@@ -2536,7 +2536,7 @@ auto ServiceCellular::handleCellularGetNwinfoMessage(sys::Message *msg) -> std::
 auto ServiceCellular::handleCellularGetAntennaMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
     auto antenna = cmux->GetAntenna();
-    return std::make_shared<CellularAntennaResponseMessage>(true, antenna, MessageType::CellularGetAntenna);
+    return std::make_shared<CellularAntennaResponseMessage>(true, antenna, CellularMessage::Type::GetAntenna);
 }
 auto ServiceCellular::handleCellularDtmfRequestMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {

--- a/module-services/service-cellular/service-cellular/CellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/CellularMessage.hpp
@@ -27,20 +27,69 @@
 class CellularMessage : public sys::DataMessage
 {
   public:
-    explicit CellularMessage(MessageType messageType) : sys::DataMessage(messageType){};
+    enum class Type
+    {
+        Uninitialized,
+        StateRequest,       ///< cellular change state request, only for use by cellular
+        Notification,       ///< Async notification message
+        AnswerIncomingCall, ///< Answer incoming call
+        HangupCall,         ///< Hang up call
+        Ringing,
+        IncomingCall,
+        CallerId,
+        CallRequest,      ///< Call request
+        PowerStateChange, ///< Change power state of the module
+
+        ListCurrentCalls,
+        SimProcedure,        // Broadcast on sim state changed
+        SimResponse,         // Send to PIN window (show, error state, hide)
+        SimVerifyPinRequest, // Send from PIN window with PIN, PUK, ... number
+        SetVoLTE,
+        SetFlightMode,
+
+        PacketData, ///< for all PacketData messages
+
+        GetOwnNumber,
+        GetIMSI,
+        GetNetworkInfo,
+        StartOperatorsScan,
+        OperatorsScanResult,
+        NetworkInfoResult,
+        SelectAntenna,
+        SetScanMode,
+        GetScanMode,
+        GetScanModeResult,
+        GetFirmwareVersion,       ///< Asks for current firmware version
+        GetFirmwareVersionResult, ///< Returns current firmware version
+        GetChannel,               ///< Asks for channel, requres chnnel name
+        GetChannelResponse,       ///< Returns channel (and it's name)
+        GetCSQ,
+        GetCREG,
+        GetNWINFO,
+        GetAntenna,
+        TransmitDtmfTones,
+        USSDRequest,
+        TimeUpdated,
+        SimState,
+        MMIData,
+        NewIncomingSMS,
+        RadioOnOff,
+        SendSMS
+    };
+    explicit CellularMessage(Type type) : sys::DataMessage(), type(type)
+    {}
+    const Type type;
 };
 
 class CellularRingingMessage : public CellularMessage
 {
   public:
-    CellularRingingMessage(const utils::PhoneNumber::View &number)
-        : CellularMessage(MessageType::CellularRinging), number(number)
+    CellularRingingMessage(const utils::PhoneNumber::View &number) : CellularMessage(Type::Ringing), number(number)
     {}
-    CellularRingingMessage(const utils::PhoneNumber &number)
-        : CellularMessage(MessageType::CellularRinging), number(number.getView())
+    CellularRingingMessage(const utils::PhoneNumber &number) : CellularMessage(Type::Ringing), number(number.getView())
     {}
     CellularRingingMessage(const std::string &e164number)
-        : CellularMessage(MessageType::CellularRinging), number(utils::PhoneNumber::parse(e164number))
+        : CellularMessage(Type::Ringing), number(utils::PhoneNumber::parse(e164number))
     {}
 
     utils::PhoneNumber::View number;
@@ -50,13 +99,13 @@ class CellularIncominCallMessage : public CellularMessage
 {
   public:
     CellularIncominCallMessage(const utils::PhoneNumber::View &number)
-        : CellularMessage(MessageType::CellularIncomingCall), number(number)
+        : CellularMessage(Type::IncomingCall), number(number)
     {}
     CellularIncominCallMessage(const utils::PhoneNumber &number)
-        : CellularMessage(MessageType::CellularIncomingCall), number(number.getView())
+        : CellularMessage(Type::IncomingCall), number(number.getView())
     {}
     CellularIncominCallMessage(const std::string &e164number)
-        : CellularMessage(MessageType::CellularIncomingCall), number(utils::PhoneNumber::parse(e164number))
+        : CellularMessage(Type::IncomingCall), number(utils::PhoneNumber::parse(e164number))
     {}
 
     utils::PhoneNumber::View number;
@@ -65,14 +114,13 @@ class CellularIncominCallMessage : public CellularMessage
 class CellularCallerIdMessage : public CellularMessage
 {
   public:
-    CellularCallerIdMessage(const utils::PhoneNumber::View &number)
-        : CellularMessage(MessageType::CellularCallerId), number(number)
+    CellularCallerIdMessage(const utils::PhoneNumber::View &number) : CellularMessage(Type::CallerId), number(number)
     {}
     CellularCallerIdMessage(const utils::PhoneNumber &number)
-        : CellularMessage(MessageType::CellularCallerId), number(number.getView())
+        : CellularMessage(Type::CallerId), number(number.getView())
     {}
     CellularCallerIdMessage(const std::string &e164number)
-        : CellularMessage(MessageType::CellularCallerId), number(utils::PhoneNumber::parse(e164number))
+        : CellularMessage(Type::CallerId), number(utils::PhoneNumber::parse(e164number))
     {}
 
     utils::PhoneNumber::View number;
@@ -81,7 +129,7 @@ class CellularCallerIdMessage : public CellularMessage
 class CellularNotificationMessage : public CellularMessage
 {
   public:
-    enum class Type
+    enum class Content
     {
         CallAborted, // user tried to call other device but receiving side dropped call or call unsuccessful
         CallActive,  // call is in progress both if call was initialized by user and when user received incoming call.
@@ -103,20 +151,20 @@ class CellularNotificationMessage : public CellularMessage
     // TODO check and fix all CellularNotificationMessage constructors
 
     CellularNotificationMessage() = delete;
-    CellularNotificationMessage(Type type, const std::string &data = "")
-        : CellularMessage(MessageType::CellularNotification), type(type), data(data)
+    CellularNotificationMessage(Content content, const std::string &data = "")
+        : CellularMessage(Type::Notification), content(content), data(data)
     {}
 
     virtual ~CellularNotificationMessage() = default;
 
-    Type type;
+    Content content;
     std::string data;
 };
 
 class CellularGetCurrentOperatorMessage : public CellularMessage
 {
   public:
-    explicit CellularGetCurrentOperatorMessage() : CellularMessage(MessageType::CellularNotification)
+    explicit CellularGetCurrentOperatorMessage() : CellularMessage(Type::Notification)
     {}
 };
 
@@ -129,7 +177,7 @@ class CellularGetCurrentOperatorResponse : public CellularMessage
 
   public:
     explicit CellularGetCurrentOperatorResponse(std::string currentOperatorName)
-        : CellularMessage(MessageType::CellularNotification), currentOperatorName(currentOperatorName)
+        : CellularMessage(Type::Notification), currentOperatorName(currentOperatorName)
     {}
 
     std::string getCurrentOperatorName() const
@@ -169,7 +217,7 @@ class CellularPowerStateChange : public CellularMessage
 {
   public:
     explicit CellularPowerStateChange(cellular::State::PowerState new_state)
-        : CellularMessage(MessageType::CellularPowerStateChange), newState(new_state)
+        : CellularMessage(Type::PowerStateChange), newState(new_state)
     {}
 
     cellular::State::PowerState getNewState() const noexcept
@@ -187,7 +235,7 @@ class CellularStartOperatorsScanMessage : public CellularMessage
 
   public:
     explicit CellularStartOperatorsScanMessage(bool fullInfoList = false)
-        : CellularMessage(MessageType::CellularStartOperatorsScan), fullInfo(fullInfoList)
+        : CellularMessage(Type::StartOperatorsScan), fullInfo(fullInfoList)
     {}
 
     bool getFullInfo() const noexcept
@@ -204,7 +252,7 @@ class CellularSimStateMessage : public CellularMessage
 
   public:
     explicit CellularSimStateMessage(at::SimState state, std::string message)
-        : CellularMessage(MessageType::CellularSimState), state(state), message(std::move(message))
+        : CellularMessage(Type::SimState), state(state), message(std::move(message))
     {}
 
     at::SimState getState() const noexcept
@@ -228,17 +276,14 @@ class CellularTimeNotificationMessage : public CellularMessage
   public:
     CellularTimeNotificationMessage() = delete;
     explicit CellularTimeNotificationMessage(struct tm time, long int timeZoneGmtOff, std::string timeZoneString)
-        : CellularMessage(MessageType::CellularTimeUpdated), time(time), timeZoneGmtOff(timeZoneGmtOff),
-          timeZoneString(timeZoneString)
+        : CellularMessage(Type::TimeUpdated), time(time), timeZoneGmtOff(timeZoneGmtOff), timeZoneString(timeZoneString)
     {}
 
     explicit CellularTimeNotificationMessage(long int timeZoneGmtOff, std::string timeZoneString)
-        : CellularMessage(MessageType::CellularTimeUpdated), timeZoneGmtOff(timeZoneGmtOff),
-          timeZoneString(timeZoneString)
+        : CellularMessage(Type::TimeUpdated), timeZoneGmtOff(timeZoneGmtOff), timeZoneString(timeZoneString)
     {}
 
-    explicit CellularTimeNotificationMessage(struct tm time)
-        : CellularMessage(MessageType::CellularTimeUpdated), time(time)
+    explicit CellularTimeNotificationMessage(struct tm time) : CellularMessage(Type::TimeUpdated), time(time)
     {}
 
     std::optional<struct tm> getTime(void)
@@ -267,7 +312,7 @@ class CellularUSSDMessage : public CellularMessage
     };
     CellularUSSDMessage() = delete;
     CellularUSSDMessage(RequestType requestType, const std::string &data = "")
-        : CellularMessage(MessageType::CellularUSSDRequest), type(requestType), data(data)
+        : CellularMessage(Type::USSDRequest), type(requestType), data(data)
     {}
 
     RequestType type;
@@ -276,7 +321,7 @@ class CellularUSSDMessage : public CellularMessage
 class CellularRequestMessage : public CellularMessage
 {
   public:
-    CellularRequestMessage(MessageType messageType, std::string data = "") : CellularMessage(messageType), data(data)
+    CellularRequestMessage(Type type, std::string data = "") : CellularMessage(type), data(data)
     {}
 
     std::string data;
@@ -287,7 +332,7 @@ class CellularDtmfRequestMessage : public CellularMessage
     uint32_t digit = 0;
 
   public:
-    CellularDtmfRequestMessage(uint32_t digit) : CellularMessage(MessageType::CellularTransmitDtmfTones), digit(digit)
+    CellularDtmfRequestMessage(uint32_t digit) : CellularMessage(Type::TransmitDtmfTones), digit(digit)
     {}
 
     uint32_t getDigit() const
@@ -299,7 +344,7 @@ class CellularDtmfRequestMessage : public CellularMessage
 class CellularAntennaRequestMessage : public CellularMessage
 {
   public:
-    CellularAntennaRequestMessage() : CellularMessage(MessageType::CellularSelectAntenna)
+    CellularAntennaRequestMessage() : CellularMessage(Type::SelectAntenna)
     {}
 
     bsp::cellular::antenna antenna;
@@ -315,7 +360,7 @@ class CellularCallRequestMessage : public CellularMessage
     };
 
     CellularCallRequestMessage(const utils::PhoneNumber::View &number, RequestMode requestMode = RequestMode::Normal)
-        : CellularMessage(MessageType::CellularCallRequest), number(number), requestMode(requestMode)
+        : CellularMessage(Type::CallRequest), number(number), requestMode(requestMode)
     {}
     utils::PhoneNumber::View number;
     RequestMode requestMode = RequestMode::Normal;
@@ -324,7 +369,7 @@ class CellularCallRequestMessage : public CellularMessage
 class CellularSmsNoSimRequestMessage : public CellularMessage, public app::manager::actions::ConvertibleToAction
 {
   public:
-    CellularSmsNoSimRequestMessage() : CellularMessage{MessageType::MessageTypeUninitialized}
+    CellularSmsNoSimRequestMessage() : CellularMessage{Type::Uninitialized}
     {}
 
     [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
@@ -337,7 +382,7 @@ class CellularSmsNoSimRequestMessage : public CellularMessage, public app::manag
 class CellularSimMessage : public CellularMessage
 {
   public:
-    CellularSimMessage(MessageType messageType, Store::GSM::SIM sim) : CellularMessage(messageType), sim(sim)
+    CellularSimMessage(Type type, Store::GSM::SIM sim) : CellularMessage(type), sim(sim)
     {}
     virtual ~CellularSimMessage() = default;
     Store::GSM::SIM getSimCard() const noexcept
@@ -355,12 +400,12 @@ class CellularSimVerifyPinRequestMessage : public CellularSimMessage
 {
   public:
     CellularSimVerifyPinRequestMessage(Store::GSM::SIM sim, std::vector<unsigned int> pinValue)
-        : CellularSimMessage(MessageType::CellularSimVerifyPinRequest, sim), pinValue(std::move(pinValue))
+        : CellularSimMessage(Type::SimVerifyPinRequest, sim), pinValue(std::move(pinValue))
     {}
     CellularSimVerifyPinRequestMessage(Store::GSM::SIM sim,
                                        std::vector<unsigned int> pinValue,
                                        std::vector<unsigned int> pukValue)
-        : CellularSimMessage(MessageType::CellularSimVerifyPinRequest, sim), pinValue(std::move(pinValue)),
+        : CellularSimMessage(Type::SimVerifyPinRequest, sim), pinValue(std::move(pinValue)),
           pukValue(std::move(pukValue))
     {}
 
@@ -384,7 +429,7 @@ class CellularSimPasscodeRequest : public CellularMessage
     app::manager::actions::PasscodeParams params;
 
     CellularSimPasscodeRequest(Store::GSM::SIM _sim, unsigned int _attempts, std::string _passcodeName)
-        : CellularMessage(MessageType::CellularSimResponse), params(_sim, _attempts, std::move(_passcodeName))
+        : CellularMessage(Type::SimResponse), params(_sim, _attempts, std::move(_passcodeName))
     {}
 };
 
@@ -423,7 +468,7 @@ class CellularUnlockSimMessage : public CellularMessage, public app::manager::ac
     app::manager::actions::SimStateParams params;
 
   public:
-    CellularUnlockSimMessage(Store::GSM::SIM _sim) : CellularMessage(MessageType::CellularSimResponse), params(_sim)
+    CellularUnlockSimMessage(Store::GSM::SIM _sim) : CellularMessage(Type::SimResponse), params(_sim)
     {}
 
     [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
@@ -438,8 +483,7 @@ class CellularBlockSimMessage : public CellularMessage, public app::manager::act
     app::manager::actions::SimStateParams params;
 
   public:
-    explicit CellularBlockSimMessage(Store::GSM::SIM _sim)
-        : CellularMessage(MessageType::CellularSimResponse), params(_sim)
+    explicit CellularBlockSimMessage(Store::GSM::SIM _sim) : CellularMessage(Type::SimResponse), params(_sim)
     {}
 
     [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
@@ -455,7 +499,7 @@ class CellularDisplayCMEMessage : public CellularMessage, public app::manager::a
 
   public:
     CellularDisplayCMEMessage(Store::GSM::SIM _sim, unsigned int _cmeCode)
-        : CellularMessage(MessageType::CellularSimResponse), params(_sim, _cmeCode)
+        : CellularMessage(Type::SimResponse), params(_sim, _cmeCode)
     {}
 
     [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
@@ -472,7 +516,7 @@ class CellularSimDataMessage : public CellularMessage
     Store::GSM::SIM sim = Store::GSM::SIM::NONE;
 
   public:
-    explicit CellularSimDataMessage(Store::GSM::SIM _sim) : CellularMessage{MessageType::CellularSimResponse}, sim{_sim}
+    explicit CellularSimDataMessage(Store::GSM::SIM _sim) : CellularMessage{Type::SimResponse}, sim{_sim}
     {}
     [[nodiscard]] Store::GSM::SIM getSim() const noexcept
     {
@@ -596,20 +640,20 @@ class CellularSimAbortMessage : public CellularSimDataMessage
     {}
 };
 
-class CellularGetChannelMessage : public sys::DataMessage
+class CellularGetChannelMessage : public CellularMessage
 {
   public:
     CellularGetChannelMessage(TS0710::Channel dataChannel = TS0710::Channel::None)
-        : sys::DataMessage(MessageType::CellularGetChannel), dataChannel(dataChannel)
+        : CellularMessage{Type::GetChannel}, dataChannel(dataChannel)
     {}
     TS0710::Channel dataChannel;
 };
 
-class CellularGetChannelResponseMessage : public sys::DataMessage
+class CellularGetChannelResponseMessage : public CellularMessage
 {
   public:
     CellularGetChannelResponseMessage(DLC_channel *dataChannelPtr = nullptr)
-        : sys::DataMessage(MessageType::CellularGetChannelResponse), dataChannelPtr(dataChannelPtr)
+        : CellularMessage{Type::GetChannelResponse}, dataChannelPtr(dataChannelPtr)
     {}
     DLC_channel *dataChannelPtr;
 };
@@ -618,17 +662,18 @@ class CellularResponseMessage : public sys::ResponseMessage
 {
   public:
     CellularResponseMessage(bool retCode,
-                            std::string retdata    = std::string(),
-                            MessageType responseTo = MessageType::MessageTypeUninitialized)
-        : sys::ResponseMessage(sys::ReturnCodes::Success, responseTo), retCode(retCode), data(retdata){};
+                            std::string retdata              = std::string(),
+                            CellularMessage::Type responseTo = CellularMessage::Type::Uninitialized)
+        : sys::ResponseMessage(sys::ReturnCodes::Success), retCode(retCode), data(retdata), cellResponse(responseTo){};
 
-    CellularResponseMessage(bool retCode, MessageType responseTo)
-        : sys::ResponseMessage(sys::ReturnCodes::Success, responseTo), retCode(retCode){};
+    CellularResponseMessage(bool retCode, CellularMessage::Type responseTo)
+        : sys::ResponseMessage(sys::ReturnCodes::Success), retCode(retCode), cellResponse(responseTo){};
 
     virtual ~CellularResponseMessage(){};
 
     bool retCode;
     std::string data;
+    CellularMessage::Type cellResponse;
 };
 
 class CellularSimNewPinResponseMessage : public CellularResponseMessage
@@ -660,16 +705,13 @@ class CellularSimCardLockResponseMessage : public CellularResponseMessage
     }
 };
 
-class CellularAntennaResponseMessage : public sys::ResponseMessage
+class CellularAntennaResponseMessage : public CellularResponseMessage
 {
   public:
-    CellularAntennaResponseMessage(bool retCode, bsp::cellular::antenna retAntenna, MessageType responseTo)
-        : sys::ResponseMessage(sys::ReturnCodes::Success, responseTo), retCode(retCode)
-    {
-        antenna = retAntenna;
-    };
+    CellularAntennaResponseMessage(bool retCode, bsp::cellular::antenna retAntenna, CellularMessage::Type responseTo)
+        : CellularResponseMessage(retCode, responseTo), antenna(retAntenna)
+    {}
 
-    bool retCode;
     bsp::cellular::antenna antenna;
 };
 
@@ -680,7 +722,7 @@ class CellularMMIResult : public CellularMessage
 
     explicit CellularMMIResult(app::manager::actions::MMIResultParams::MMIResult result,
                                std::shared_ptr<app::manager::actions::MMICustomResultParams> customResult = nullptr)
-        : CellularMessage(MessageType::CellularMMIData), params(result, std::move(customResult))
+        : CellularMessage(Type::MMIData), params(result, std::move(customResult))
     {}
 };
 
@@ -707,8 +749,7 @@ class CellularMMIDataMessage : public CellularMessage
     app::manager::actions::MMIParams params;
 
   public:
-    explicit CellularMMIDataMessage(std::string mmiData)
-        : CellularMessage(MessageType::CellularMMIData), params(mmiData)
+    explicit CellularMMIDataMessage(std::string mmiData) : CellularMessage(Type::MMIData), params(mmiData)
     {}
 };
 class CellularMMIResponseMessage : public CellularMMIDataMessage, public app::manager::actions::ConvertibleToAction
@@ -755,7 +796,7 @@ class CellularVoLTEDataMessage : public CellularMessage
     bool VoLTEon = false;
 
   public:
-    explicit CellularVoLTEDataMessage(bool VoLTEon) : CellularMessage{MessageType::CellularSetVoLTE}, VoLTEon{VoLTEon}
+    explicit CellularVoLTEDataMessage(bool VoLTEon) : CellularMessage{Type::SetVoLTE}, VoLTEon{VoLTEon}
     {}
     [[nodiscard]] bool getVoLTEon() const noexcept
     {
@@ -808,7 +849,7 @@ class CellularNewIncomingSMSMessage : public CellularMessage
 {
   public:
     explicit CellularNewIncomingSMSMessage(const std::string &data)
-        : CellularMessage(MessageType::CellularNewIncomingSMS), notificationData(data)
+        : CellularMessage(Type::NewIncomingSMS), notificationData(data)
     {}
     auto getData() const -> std::string
     {
@@ -822,56 +863,56 @@ class CellularNewIncomingSMSMessage : public CellularMessage
 class CellularAnswerIncomingCallMessage : public CellularMessage
 {
   public:
-    CellularAnswerIncomingCallMessage() : CellularMessage(MessageType::CellularAnswerIncomingCall)
+    CellularAnswerIncomingCallMessage() : CellularMessage(Type::AnswerIncomingCall)
     {}
 };
 
 class CellularHangupCallMessage : public CellularMessage
 {
   public:
-    CellularHangupCallMessage() : CellularMessage(MessageType::CellularHangupCall)
+    CellularHangupCallMessage() : CellularMessage(Type::HangupCall)
     {}
 };
 
 class CellularListCallsMessage : public CellularMessage
 {
   public:
-    CellularListCallsMessage() : CellularMessage(MessageType::CellularListCurrentCalls)
+    CellularListCallsMessage() : CellularMessage(Type::ListCurrentCalls)
     {}
 };
 
 class CellularSimProcedureMessage : public CellularMessage
 {
   public:
-    CellularSimProcedureMessage() : CellularMessage(MessageType::CellularSimProcedure)
+    CellularSimProcedureMessage() : CellularMessage(Type::SimProcedure)
     {}
 };
 
 class CellularGetIMSIMessage : public CellularMessage
 {
   public:
-    CellularGetIMSIMessage() : CellularMessage(MessageType::CellularGetIMSI)
+    CellularGetIMSIMessage() : CellularMessage(Type::GetIMSI)
     {}
 };
 
 class CellularGetOwnNumberMessage : public CellularMessage
 {
   public:
-    CellularGetOwnNumberMessage() : CellularMessage(MessageType::CellularGetOwnNumber)
+    CellularGetOwnNumberMessage() : CellularMessage(Type::GetOwnNumber)
     {}
 };
 
 class CellularGetNetworkInfoMessage : public CellularMessage
 {
   public:
-    CellularGetNetworkInfoMessage() : CellularMessage(MessageType::CellularGetNetworkInfo)
+    CellularGetNetworkInfoMessage() : CellularMessage(Type::GetNetworkInfo)
     {}
 };
 
 class CellularSetScanModeMessage : public CellularMessage
 {
   public:
-    CellularSetScanModeMessage(const std::string &mode) : CellularMessage(MessageType::CellularSetScanMode), data(mode)
+    CellularSetScanModeMessage(const std::string &mode) : CellularMessage(Type::SetScanMode), data(mode)
     {}
     std::string data;
 };
@@ -879,42 +920,42 @@ class CellularSetScanModeMessage : public CellularMessage
 class CellularGetScanModeMessage : public CellularMessage
 {
   public:
-    CellularGetScanModeMessage() : CellularMessage(MessageType::CellularGetScanMode)
+    CellularGetScanModeMessage() : CellularMessage(Type::GetScanMode)
     {}
 };
 
 class CellularGetFirmwareVersionMessage : public CellularMessage
 {
   public:
-    CellularGetFirmwareVersionMessage() : CellularMessage(MessageType::CellularGetFirmwareVersion)
+    CellularGetFirmwareVersionMessage() : CellularMessage(Type::GetFirmwareVersion)
     {}
 };
 
 class CellularGetCsqMessage : public CellularMessage
 {
   public:
-    CellularGetCsqMessage() : CellularMessage(MessageType::CellularGetCSQ)
+    CellularGetCsqMessage() : CellularMessage(Type::GetCSQ)
     {}
 };
 
 class CellularGetCregMessage : public CellularMessage
 {
   public:
-    CellularGetCregMessage() : CellularMessage(MessageType::CellularGetCREG)
+    CellularGetCregMessage() : CellularMessage(Type::GetCREG)
     {}
 };
 
 class CellularGetNwinfoMessage : public CellularMessage
 {
   public:
-    CellularGetNwinfoMessage() : CellularMessage(MessageType::CellularGetNWINFO)
+    CellularGetNwinfoMessage() : CellularMessage(Type::GetNWINFO)
     {}
 };
 
 class CellularGetAntennaMessage : public CellularMessage
 {
   public:
-    CellularGetAntennaMessage() : CellularMessage(MessageType::CellularGetAntenna)
+    CellularGetAntennaMessage() : CellularMessage(Type::GetAntenna)
     {}
 };
 
@@ -922,7 +963,7 @@ class CellularSetFlightModeMessage : public CellularMessage
 {
   public:
     explicit CellularSetFlightModeMessage(bool flightModeOn)
-        : CellularMessage(MessageType::CellularSetFlightMode), flightModeOn(flightModeOn)
+        : CellularMessage(Type::SetFlightMode), flightModeOn(flightModeOn)
     {}
     bool flightModeOn;
 };
@@ -931,7 +972,7 @@ class CellularCallActiveNotification : public CellularNotificationMessage
 {
   public:
     explicit CellularCallActiveNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Type::CallActive, data)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::CallActive, data)
     {}
 };
 
@@ -939,7 +980,7 @@ class CellularCallAbortedNotification : public CellularNotificationMessage
 {
   public:
     explicit CellularCallAbortedNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Type::CallAborted, data)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::CallAborted, data)
     {}
 };
 
@@ -947,7 +988,7 @@ class CellularPowerUpProcedureCompleteNotification : public CellularNotification
 {
   public:
     explicit CellularPowerUpProcedureCompleteNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Type::PowerUpProcedureComplete, data)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::PowerUpProcedureComplete, data)
     {}
 };
 
@@ -955,7 +996,7 @@ class CellularPowerDownDeregisteringNotification : public CellularNotificationMe
 {
   public:
     explicit CellularPowerDownDeregisteringNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Type::PowerDownDeregistering, data)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::PowerDownDeregistering, data)
     {}
 };
 
@@ -963,7 +1004,7 @@ class CellularPowerDownDeregisteredNotification : public CellularNotificationMes
 {
   public:
     explicit CellularPowerDownDeregisteredNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Type::PowerDownDeregistered, data)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::PowerDownDeregistered, data)
     {}
 };
 
@@ -971,7 +1012,7 @@ class CellularNewIncomingSMSNotification : public CellularNotificationMessage
 {
   public:
     explicit CellularNewIncomingSMSNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Type::NewIncomingSMS, data)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::NewIncomingSMS, data)
     {}
 };
 
@@ -979,7 +1020,7 @@ class CellularSimReadyNotification : public CellularNotificationMessage
 {
   public:
     explicit CellularSimReadyNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Type::SIM_READY, data)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::SIM_READY, data)
     {}
 };
 
@@ -987,7 +1028,7 @@ class CellularSmsDoneNotification : public CellularNotificationMessage
 {
   public:
     explicit CellularSmsDoneNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Type::SMSDone, data)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::SMSDone, data)
     {}
 };
 
@@ -995,7 +1036,7 @@ class CellularSignalStrengthUpdateNotification : public CellularNotificationMess
 {
   public:
     explicit CellularSignalStrengthUpdateNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Type::SignalStrengthUpdate, data)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::SignalStrengthUpdate, data)
     {}
 };
 
@@ -1003,7 +1044,7 @@ class CellularNetworkStatusUpdateNotification : public CellularNotificationMessa
 {
   public:
     explicit CellularNetworkStatusUpdateNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Type::NetworkStatusUpdate, data)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::NetworkStatusUpdate, data)
     {}
 };
 
@@ -1011,7 +1052,7 @@ class CellularSimNotReadyNotification : public CellularNotificationMessage
 {
   public:
     explicit CellularSimNotReadyNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Type::SIM_NOT_READY, data)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::SIM_NOT_READY, data)
     {}
 };
 
@@ -1019,15 +1060,14 @@ class CellularUrcIncomingNotification : public CellularNotificationMessage
 {
   public:
     explicit CellularUrcIncomingNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Type::NewIncomingUrc, data)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::NewIncomingUrc, data)
     {}
 };
 
 class CellularSetRadioOnOffMessage : public CellularMessage
 {
   public:
-    explicit CellularSetRadioOnOffMessage(bool radioOnOff)
-        : CellularMessage(MessageType::CellularRadioOnOff), radioOnOff(radioOnOff)
+    explicit CellularSetRadioOnOffMessage(bool radioOnOff) : CellularMessage(Type::RadioOnOff), radioOnOff(radioOnOff)
     {}
     auto getRadioOnOf() -> bool
     {
@@ -1071,7 +1111,7 @@ class CellularCallRejectedByOfflineNotification : public CellularResponseMessage
 class CellularSendSMSMessage : public CellularMessage
 {
   public:
-    explicit CellularSendSMSMessage(SMSRecord record) : CellularMessage(MessageType::CellularSendSMS), record(record)
+    explicit CellularSendSMSMessage(SMSRecord record) : CellularMessage(Type::SendSMS), record(record)
     {}
     SMSRecord record;
 };
@@ -1080,13 +1120,13 @@ class CellularRingNotification : public CellularNotificationMessage
 {
   public:
     explicit CellularRingNotification(const utils::PhoneNumber::View &number)
-        : CellularNotificationMessage(CellularNotificationMessage::Type::Ring), number(number)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::Ring), number(number)
     {}
     explicit CellularRingNotification(const utils::PhoneNumber &number)
-        : CellularNotificationMessage(CellularNotificationMessage::Type::Ring), number(number.getView())
+        : CellularNotificationMessage(CellularNotificationMessage::Content::Ring), number(number.getView())
     {}
     explicit CellularRingNotification(const std::string &e164number)
-        : CellularNotificationMessage(CellularNotificationMessage::Type::Ring),
+        : CellularNotificationMessage(CellularNotificationMessage::Content::Ring),
           number(utils::PhoneNumber::parse(e164number))
     {}
     auto getNubmer() const -> utils::PhoneNumber::View
@@ -1102,13 +1142,13 @@ class CellularCallerIdNotification : public CellularNotificationMessage
 {
   public:
     explicit CellularCallerIdNotification(const utils::PhoneNumber::View &number)
-        : CellularNotificationMessage(CellularNotificationMessage::Type::Ring), number(number)
+        : CellularNotificationMessage(CellularNotificationMessage::Content::Ring), number(number)
     {}
     explicit CellularCallerIdNotification(const utils::PhoneNumber &number)
-        : CellularNotificationMessage(CellularNotificationMessage::Type::Ring), number(number.getView())
+        : CellularNotificationMessage(CellularNotificationMessage::Content::Ring), number(number.getView())
     {}
     explicit CellularCallerIdNotification(const std::string &e164number)
-        : CellularNotificationMessage(CellularNotificationMessage::Type::Ring),
+        : CellularNotificationMessage(CellularNotificationMessage::Content::Ring),
           number(utils::PhoneNumber::parse(e164number))
     {}
     auto getNubmer() const -> utils::PhoneNumber::View
@@ -1127,15 +1167,14 @@ namespace cellular
     {
       public:
         const State::ST request;
-        StateChange(const State::ST request = State::ST::Failed)
-            : CellularMessage(MessageType::CellularStateRequest), request(request)
+        StateChange(const State::ST request = State::ST::Failed) : CellularMessage(Type::StateRequest), request(request)
         {}
     };
 
     class RawCommandRespAsync : public CellularMessage
     {
       public:
-        RawCommandRespAsync(MessageType messageType) : CellularMessage(messageType){};
+        RawCommandRespAsync(Type type) : CellularMessage(type){};
         virtual ~RawCommandRespAsync() = default;
         std::vector<std::string> data;
     };

--- a/module-services/service-cellular/service-cellular/PacketDataCellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/PacketDataCellularMessage.hpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <optional>
 #include "CellularMessage.hpp"
-#include "MessageType.hpp"
 
 #include "PacketDataTypes.hpp"
 #include "Result.hpp"
@@ -17,13 +16,11 @@ class CellularGetAPNMessage : public CellularMessage
     std::optional<packet_data::APN::APNType> apnType = std::nullopt;
 
   public:
-    CellularGetAPNMessage() : CellularMessage(MessageType::CellularPacketData)
+    CellularGetAPNMessage() : CellularMessage(Type::PacketData)
     {}
-    CellularGetAPNMessage(std::uint8_t contextId)
-        : CellularMessage(MessageType::CellularPacketData), contextId(contextId)
+    CellularGetAPNMessage(std::uint8_t contextId) : CellularMessage(Type::PacketData), contextId(contextId)
     {}
-    CellularGetAPNMessage(packet_data::APN::APNType apnType)
-        : CellularMessage(MessageType::CellularPacketData), apnType(apnType)
+    CellularGetAPNMessage(packet_data::APN::APNType apnType) : CellularMessage(Type::PacketData), apnType(apnType)
     {}
     [[nodiscard]] const std::optional<packet_data::APN::APNType> getAPNType() const noexcept
     {
@@ -41,7 +38,7 @@ class CellularSetAPNMessage : public CellularMessage // also as DeleteAPN
 
   public:
     CellularSetAPNMessage(std::shared_ptr<packet_data::APN::Config> apnConfig)
-        : CellularMessage(MessageType::CellularPacketData), apnConfig(std::move(apnConfig))
+        : CellularMessage(Type::PacketData), apnConfig(std::move(apnConfig))
     {}
 
     [[nodiscard]] std::shared_ptr<packet_data::APN::Config> getAPNConfig() const noexcept
@@ -56,7 +53,7 @@ class CellularNewAPNMessage : public CellularMessage
 
   public:
     CellularNewAPNMessage(std::shared_ptr<packet_data::APN::Config> apnConfig)
-        : CellularMessage(MessageType::CellularPacketData), apnConfig(std::move(apnConfig))
+        : CellularMessage(Type::PacketData), apnConfig(std::move(apnConfig))
     {}
 
     [[nodiscard]] std::shared_ptr<packet_data::APN::Config> getAPNConfig() const noexcept
@@ -71,7 +68,7 @@ class CellularSetDataTransferMessage : public CellularMessage
 
   public:
     CellularSetDataTransferMessage(packet_data::DataTransfer dataTransfer)
-        : CellularMessage(MessageType::CellularPacketData), dataTransfer(dataTransfer)
+        : CellularMessage(Type::PacketData), dataTransfer(dataTransfer)
     {}
     [[nodiscard]] packet_data::DataTransfer getDataTransfer() const noexcept
     {
@@ -82,14 +79,14 @@ class CellularSetDataTransferMessage : public CellularMessage
 class CellularGetDataTransferMessage : public CellularMessage
 {
   public:
-    CellularGetDataTransferMessage() : CellularMessage(MessageType::CellularPacketData)
+    CellularGetDataTransferMessage() : CellularMessage(Type::PacketData)
     {}
 };
 
 class CellularGetActiveContextsMessage : public CellularMessage
 {
   public:
-    CellularGetActiveContextsMessage() : CellularMessage(MessageType::CellularPacketData)
+    CellularGetActiveContextsMessage() : CellularMessage(Type::PacketData)
     {}
 };
 
@@ -98,8 +95,7 @@ class CellularActivateContextMessage : public CellularMessage
     std::uint8_t contextId;
 
   public:
-    CellularActivateContextMessage(std::uint8_t contextId)
-        : CellularMessage(MessageType::CellularPacketData), contextId(contextId)
+    CellularActivateContextMessage(std::uint8_t contextId) : CellularMessage(Type::PacketData), contextId(contextId)
     {}
     [[nodiscard]] std::uint8_t getContextId() const noexcept
     {
@@ -111,8 +107,7 @@ class CellularDeactivateContextMessage : public CellularMessage
     std::uint8_t contextId;
 
   public:
-    CellularDeactivateContextMessage(std::uint8_t contextId)
-        : CellularMessage(MessageType::CellularPacketData), contextId(contextId)
+    CellularDeactivateContextMessage(std::uint8_t contextId) : CellularMessage(Type::PacketData), contextId(contextId)
     {}
     [[nodiscard]] std::uint8_t getContextId() const noexcept
     {
@@ -127,7 +122,7 @@ class CellularGetAPNResponse : public CellularMessage
 
   public:
     CellularGetAPNResponse(std::vector<std::shared_ptr<packet_data::APN::Config>> apns)
-        : CellularMessage(MessageType::CellularPacketData), apns(std::move(apns))
+        : CellularMessage(Type::PacketData), apns(std::move(apns))
     {}
 
     [[nodiscard]] const std::vector<std::shared_ptr<packet_data::APN::Config>> &getAPNs() const noexcept
@@ -141,7 +136,7 @@ class CellularATResponse : public CellularMessage
     at::Result::Code result;
 
   public:
-    CellularATResponse(at::Result::Code result) : CellularMessage(MessageType::CellularPacketData), result(result)
+    CellularATResponse(at::Result::Code result) : CellularMessage(Type::PacketData), result(result)
     {}
 
     [[nodiscard]] at::Result::Code getResult() const noexcept
@@ -184,7 +179,7 @@ class CellularGetDataTransferResponse : public CellularMessage
 
   public:
     CellularGetDataTransferResponse(packet_data::DataTransfer dataTransfer)
-        : CellularMessage(MessageType::CellularPacketData), dataTransfer(dataTransfer)
+        : CellularMessage(Type::PacketData), dataTransfer(dataTransfer)
     {}
 
     [[nodiscard]] packet_data::DataTransfer getDataTransfer() const noexcept
@@ -199,7 +194,7 @@ class CellularGetActiveContextsResponse : public CellularMessage
 
   public:
     CellularGetActiveContextsResponse(std::optional<std::vector<std::shared_ptr<packet_data::APN::Config>>> result)
-        : CellularMessage(MessageType::CellularPacketData)
+        : CellularMessage(Type::PacketData)
     {
         if (result) {
             result = std::move(*result);

--- a/module-services/service-fota/ServiceFota.cpp
+++ b/module-services/service-fota/ServiceFota.cpp
@@ -50,7 +50,7 @@ namespace FotaService
         connectionTimer = sys::TimerFactory::createPeriodicTimer(
             this, "Fota", std::chrono::milliseconds{defaultTimer}, [this](sys::Timer &) {
                 std::shared_ptr<InternetRequestMessage> msg =
-                    std::make_shared<InternetRequestMessage>(MessageType::CellularListCurrentCalls);
+                    std::make_shared<InternetRequestMessage>(MessageType::MessageTypeUninitialized);
                 bus.sendUnicast(msg, service::name::fota);
             });
         registerMessageHandlers();

--- a/source/MessageType.hpp
+++ b/source/MessageType.hpp
@@ -32,53 +32,6 @@ enum class MessageType
 
     DBQuery,
 
-    // Cellular messages
-    CellularStateRequest,       ///< cellular change state request, only for use by cellular
-    CellularNotification,       ///< Async notification message
-    CellularAnswerIncomingCall, ///< Answer incoming call
-    CellularHangupCall,         ///< Hang up call
-    CellularRinging,
-    CellularIncomingCall,
-    CellularCallerId,
-    CellularCallRequest,      ///< Call request
-    CellularPowerStateChange, ///< Change power state of the module
-
-    CellularListCurrentCalls,
-    CellularSimProcedure,        // Broadcast on sim state changed
-    CellularSimResponse,         // Send to PIN window (show, error state, hide)
-    CellularSimVerifyPinRequest, // Send from PIN window with PIN, PUK, ... number
-    CellularSetVoLTE,
-    CellularSetFlightMode,
-
-    CellularPacketData, ///< for all PacketData messages
-
-    CellularGetOwnNumber,
-    CellularGetIMSI,
-    CellularGetNetworkInfo,
-    CellularStartOperatorsScan,
-    CellularOperatorsScanResult,
-    CellularNetworkInfoResult,
-    CellularSelectAntenna,
-    CellularSetScanMode,
-    CellularGetScanMode,
-    CellularGetScanModeResult,
-    CellularGetFirmwareVersion,       ///< Asks for current firmware version
-    CellularGetFirmwareVersionResult, ///< Returns current firmware version
-    CellularGetChannel,               ///< Asks for channel, requres chnnel name
-    CellularGetChannelResponse,       ///< Returns channel (and it's name)
-    CellularGetCSQ,
-    CellularGetCREG,
-    CellularGetNWINFO,
-    CellularGetAntenna,
-    CellularTransmitDtmfTones,
-    CellularUSSDRequest,
-    CellularTimeUpdated,
-    CellularSimState,
-    CellularMMIData,
-    CellularNewIncomingSMS,
-    CellularRadioOnOff,
-    CellularSendSMS,
-
     DBCalllogAdd [[deprecated]],    ///< Add new note's record
     DBCalllogRemove [[deprecated]], ///< Remove selected note's record
     DBCalllogUpdate [[deprecated]], ///< Update selected note's record


### PR DESCRIPTION
Domain-specific message types should not pollute global space.