### PR TITLE
[EGD-6506] Turn on backlight of function keys during call

### DIFF
--- a/module-apps/application-call/ApplicationCall.hpp
+++ b/module-apps/application-call/ApplicationCall.hpp
@@ -10,6 +10,8 @@
 #include <module-sys/Timers/TimerHandle.hpp>
 #include <SystemManager/SystemManager.hpp>
 #include <service-cellular/CellularMessage.hpp>
+#include <service-evtmgr/Constants.hpp>
+#include <service-evtmgr/EVMessages.hpp>
 #include <time/time_conversion.hpp>
 
 namespace app
@@ -106,6 +108,16 @@ namespace app
         }
         void setState(call::State state) noexcept override
         {
+            if (state == call::State::CALL_IN_PROGRESS) {
+                bus.sendUnicast(
+                    std::make_shared<sevm::KeypadBacklightMessage>(bsp::keypad_backlight::Action::turnOnCallMode),
+                    service::name::evt_manager);
+            }
+            else {
+                bus.sendUnicast(
+                    std::make_shared<sevm::KeypadBacklightMessage>(bsp::keypad_backlight::Action::turnOffCallMode),
+                    service::name::evt_manager);
+            }
             this->state = state;
         }
 

--- a/module-bsp/board/linux/keypad_backlight/keypad_backlight.cpp
+++ b/module-bsp/board/linux/keypad_backlight/keypad_backlight.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "bsp/keypad_backlight/keypad_backlight.hpp"
@@ -24,6 +24,16 @@ namespace bsp::keypad_backlight
     bool turnOnAll()
     {
         diodesState = true;
+        return true;
+    }
+
+    bool turnOnFunctionKeysBacklight()
+    {
+        return true;
+    }
+
+    bool turnOnNumericKeysBacklight()
+    {
         return true;
     }
 

--- a/module-bsp/board/rt1051/bsp/keypad_backlight/LP55281.hpp
+++ b/module-bsp/board/rt1051/bsp/keypad_backlight/LP55281.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -47,8 +47,9 @@ namespace bsp::keypad_backlight
 
     constexpr inline auto NSTDBY       = 0b10000000;
     constexpr inline auto BOOST_EN     = 0b01000000;
-    constexpr inline auto LED_PORTS_EN = 0b00001110; // Only ports 2-4 active on board
-    constexpr inline auto WAKEUP       = NSTDBY | BOOST_EN | LED_PORTS_EN;
+    constexpr inline auto FUNCTION_KEYS_PORTS_EN = NSTDBY | BOOST_EN | 0b00000110; // Only ports 2-3 active
+    constexpr inline auto NUMERIC_KEYS_PORT_EN   = NSTDBY | BOOST_EN | 0b00001000; // Only port 4 active
+    constexpr inline auto ALL_PORTS_EN           = FUNCTION_KEYS_PORTS_EN | NUMERIC_KEYS_PORT_EN; // ports 2-4 active
 
     constexpr inline auto LED_TEST_THRESHOLD = 3; // 0.18mA = (15mA/255) * 3
     constexpr inline auto EN_LED_TEST        = 0b00010000;

--- a/module-bsp/board/rt1051/bsp/keypad_backlight/keypad_backlight.cpp
+++ b/module-bsp/board/rt1051/bsp/keypad_backlight/keypad_backlight.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "bsp/keypad_backlight/keypad_backlight.hpp"
@@ -53,7 +53,7 @@ namespace bsp::keypad_backlight
         using SingleDiode = std::pair<LP55281_Registers, DiodeIntensity>;
         using RGBdiode    = std::array<SingleDiode, rgbChannelsNum>;
 
-        // Channels intesivity according to design specification
+        // Channels intensity according to design specification
         constexpr RGBdiode rightRed = {
             std::make_pair(LP55281_Registers::RED2, gammaCorrection(255)), // Red right button
             std::make_pair(LP55281_Registers::GREEN2, gammaCorrection(68)),
@@ -108,18 +108,15 @@ namespace bsp::keypad_backlight
         shutdown();
     }
 
-    bool turnOnAll()
+    bool configureDiodes()
     {
         constexpr DiodeIntensity intensity = 1.0f; // Maximum brightness
-        Diode_Reg diode_reg                = {.max_current = MAX_DIODE_CURRENT_LIMIT,
-                               .current     = encode_diode_brightness_to_6bits(intensity)};
+        Diode_Reg diodeReg                 = {.max_current = MAX_DIODE_CURRENT_LIMIT,
+                              .current     = encode_diode_brightness_to_6bits(intensity)};
 
-        wakeup();
-        configureModule();
-
-        for (auto &diode : usedSingleOutputs) {
-            std::uint32_t address = static_cast<std::uint32_t>(diode);
-            if (!writeSingleRegister(address, reinterpret_cast<std::uint8_t *>(&diode_reg))) {
+        for (const auto &diode : usedSingleOutputs) {
+            const auto address = static_cast<std::uint32_t>(diode);
+            if (!writeSingleRegister(address, reinterpret_cast<std::uint8_t *>(&diodeReg))) {
                 return false;
             }
         }
@@ -127,26 +124,46 @@ namespace bsp::keypad_backlight
         std::vector<const RGBdiode *> rgbDiodes = {&rightRed, &leftGreen};
         for (const auto &diodes : rgbDiodes) {
             for (const auto &diode : *diodes) {
-                std::uint32_t address = static_cast<std::uint32_t>(diode.first);
-                diode_reg.current     = encode_diode_brightness_to_6bits(diode.second);
-                if (!writeSingleRegister(address, reinterpret_cast<std::uint8_t *>(&diode_reg))) {
+                const auto address = static_cast<std::uint32_t>(diode.first);
+                diodeReg.current   = encode_diode_brightness_to_6bits(diode.second);
+                if (!writeSingleRegister(address, reinterpret_cast<std::uint8_t *>(&diodeReg))) {
                     return false;
                 }
             }
         }
-
         return true;
     }
 
-    bool configureModule()
+    bool turnOnAll()
     {
-        std::uint8_t reg_val = BOOST_OUTPUT_4V;
-        if (!writeSingleRegister(static_cast<std::uint32_t>(LP55281_Registers::BOOST_CTRL), &reg_val)) {
+        wakeup();
+        configureModule(ALL_PORTS_EN);
+        return configureDiodes();
+    }
+
+    bool turnOnFunctionKeysBacklight()
+    {
+        wakeup();
+        configureModule(FUNCTION_KEYS_PORTS_EN);
+        return configureDiodes();
+    }
+
+    bool turnOnNumericKeysBacklight()
+    {
+        wakeup();
+        configureModule(NUMERIC_KEYS_PORT_EN);
+        return configureDiodes();
+    }
+
+    bool configureModule(std::uint8_t enablesRegisterValue)
+    {
+        std::uint8_t boostControlRegisterValue = BOOST_OUTPUT_4V;
+        if (!writeSingleRegister(static_cast<std::uint32_t>(LP55281_Registers::BOOST_CTRL),
+                                 &boostControlRegisterValue)) {
             return false;
         }
 
-        reg_val = WAKEUP;
-        if (!writeSingleRegister(static_cast<std::uint32_t>(LP55281_Registers::ENABLES), &reg_val)) {
+        if (!writeSingleRegister(static_cast<std::uint32_t>(LP55281_Registers::ENABLES), &enablesRegisterValue)) {
             return false;
         }
 

--- a/module-bsp/bsp/keypad_backlight/keypad_backlight.hpp
+++ b/module-bsp/bsp/keypad_backlight/keypad_backlight.hpp
@@ -2,7 +2,6 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
-
 #include <cstdint>
 
 namespace bsp::keypad_backlight
@@ -12,6 +11,8 @@ namespace bsp::keypad_backlight
         turnOff,
         turnOnActiveMode,
         turnOn,
+        turnOnCallMode,
+        turnOffCallMode,
         checkState,
     };
 
@@ -30,7 +31,11 @@ namespace bsp::keypad_backlight
 
     bool turnOnAll();
 
-    bool configureModule();
+    bool turnOnFunctionKeysBacklight();
+
+    bool turnOnNumericKeysBacklight();
+
+    bool configureModule(std::uint8_t enablesRegisterValue);
 
     bool shutdown();
 

--- a/module-services/service-evtmgr/service-evtmgr/EventManager.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/EventManager.hpp
@@ -32,6 +32,7 @@ class EventManager : public sys::Service
     void handleMinuteUpdate(time_t timestamp);
     bool processKeypadBacklightRequest(bsp::keypad_backlight::Action action);
     void startKeypadLightTimer();
+    void restoreKeypadLightState();
     bool processVibraRequest(bsp::vibrator::Action act,
                              std::chrono::milliseconds RepetitionTime = std::chrono::milliseconds{1000});
     void toggleTorchOnOff();
@@ -41,6 +42,7 @@ class EventManager : public sys::Service
     sys::TimerHandle loggerTimer;
     sys::TimerHandle keypadLightTimer;
     bsp::keypad_backlight::State keypadLightState{bsp::keypad_backlight::State::off};
+    bool isKeypadLightInCallMode = false;
 
     static constexpr auto keypadLightTimerName    = "KeypadLightTimer";
     static constexpr auto keypadLightTimerTimeout = std::chrono::seconds(5);
@@ -63,7 +65,7 @@ class EventManager : public sys::Service
     std::unique_ptr<vibra_handle::Vibra> Vibra;
 
   public:
-    EventManager(const std::string &name = service::name::evt_manager);
+    explicit EventManager(const std::string &name = service::name::evt_manager);
     ~EventManager();
 
     sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;


### PR DESCRIPTION
Backlight of function keys are on when call is active.
When call ends, previous backlight mode is restored.