### PR TITLE
[EGD-6499] Fix audio initialization

### DIFF
--- a/module-audio/board/rt1051/RT1051AudioCodec.cpp
+++ b/module-audio/board/rt1051/RT1051AudioCodec.cpp
@@ -27,6 +27,7 @@ namespace audio
     RT1051AudioCodec::~RT1051AudioCodec()
     {
         Stop();
+        DeinitBsp();
     }
 
     CodecParamsMAX98090::InputPath RT1051AudioCodec::getCodecInputPath(const AudioDevice::Format &format)
@@ -70,6 +71,8 @@ namespace audio
         if (state == State::Running) {
             return AudioDevice::RetCode::Failure;
         }
+
+        InitBsp();
 
         saiInFormat.bitWidth      = format.bitWidth;
         saiInFormat.sampleRate_Hz = format.sampleRate_Hz;
@@ -184,6 +187,16 @@ namespace audio
             return false;
         }
         return true;
+    }
+
+    void RT1051AudioCodec::InitBsp()
+    {
+        bsp::audioInit();
+    }
+
+    void RT1051AudioCodec::DeinitBsp()
+    {
+        bsp::audioDeinit();
     }
 
     void RT1051AudioCodec::InStart()

--- a/module-audio/board/rt1051/RT1051AudioCodec.hpp
+++ b/module-audio/board/rt1051/RT1051AudioCodec.hpp
@@ -78,6 +78,8 @@ namespace audio
         static AT_NONCACHEABLE_SECTION_INIT(sai_edma_handle_t txHandle);
         static AT_NONCACHEABLE_SECTION_INIT(sai_edma_handle_t rxHandle);
 
+        void InitBsp();
+        void DeinitBsp();
         void OutStart();
         void InStart();
         void OutStop();

--- a/module-bsp/board/rt1051/common/board.cpp
+++ b/module-bsp/board/rt1051/common/board.cpp
@@ -194,9 +194,6 @@ namespace bsp
         // Set internal DCDC to DCM mode. Switching between DCM and CCM mode will be done automatically.
         DCDC_BootIntoDCM(DCDC);
 
-        // init audio
-        audioInit();
-
         PrintSystemClocks();
         clearAndPrintBootReason();
     }


### PR DESCRIPTION
Now the peripherals and the audio clocks will be turned on
only when the user is using the audio, which will save energy.