### PR TITLE
[EGD-6575] Rename Unicast with timeout as UnicastSync

### DIFF
--- a/module-apps/application-settings-new/ApplicationSettings.cpp
+++ b/module-apps/application-settings-new/ApplicationSettings.cpp
@@ -622,7 +622,7 @@ namespace app
     {
         constexpr int timeout = pdMS_TO_TICKS(1500);
 
-        auto response = bus.sendUnicast(
+        auto response = bus.sendUnicastSync(
             std::make_shared<sevm::ScreenLightControlRequestParameters>(), service::name::evt_manager, timeout);
 
         if (response.first == sys::ReturnCodes::Success) {

--- a/module-apps/application-settings/windows/BtScanWindow.cpp
+++ b/module-apps/application-settings/windows/BtScanWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <functional>
@@ -73,7 +73,7 @@ namespace gui
 
                 std::shared_ptr<BluetoothAddrMessage> msg =
                     std::make_shared<BluetoothAddrMessage>(bd_addr_to_str(device.address));
-                application->bus.sendUnicast(msg, "ServiceBluetooth", 5000);
+                application->bus.sendUnicastSync(msg, "ServiceBluetooth", 5000);
 
                 message_bt2(application, BluetoothMessage::Request::StopScan);
                 // message_bt2(application, BluetoothMessage::Request::Start);

--- a/module-apps/application-settings/windows/ColorTestWindow.cpp
+++ b/module-apps/application-settings/windows/ColorTestWindow.cpp
@@ -78,7 +78,7 @@ namespace gui
     {
         if (scheme != currentColorScheme) {
             currentColorScheme = scheme;
-            application->bus.sendUnicast(
+            application->bus.sendUnicastSync(
                 std::make_shared<service::gui::ChangeColorScheme>(std::move(scheme)), service::name::gui, 100);
             LOG_INFO("Updated color scheme");
 

--- a/module-apps/application-settings/windows/EinkModeWindow.cpp
+++ b/module-apps/application-settings/windows/EinkModeWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <memory>
@@ -39,7 +39,7 @@ namespace gui
                 last_mode = service::eink::EinkModeMessage::Mode::Normal;
             }
 
-            application->bus.sendUnicast(
+            application->bus.sendUnicastSync(
                 std::make_shared<service::eink::EinkModeMessage>(last_mode), service::name::eink, 5000);
             return true;
         };

--- a/module-services/service-antenna/api/AntennaServiceAPI.cpp
+++ b/module-services/service-antenna/api/AntennaServiceAPI.cpp
@@ -29,7 +29,7 @@ namespace AntennaServiceAPI
     bool LockRequest(sys::Service *serv, antenna::lockState request)
     {
         auto msg = std::make_shared<AntennaLockRequestMessage>(MessageType::AntennaLockService, request);
-        auto ret = serv->bus.sendUnicast(msg, service::name::antenna, 5000);
+        auto ret = serv->bus.sendUnicastSync(msg, service::name::antenna, 5000);
         if (ret.first == sys::ReturnCodes::Success) {
 
             return true;
@@ -40,7 +40,7 @@ namespace AntennaServiceAPI
     bool GetLockState(sys::Service *serv, antenna::lockState &response)
     {
         auto msg = std::make_shared<AntennaLockRequestMessage>(MessageType::AntennaGetLockState);
-        auto ret = serv->bus.sendUnicast(msg, service::name::antenna, 5000);
+        auto ret = serv->bus.sendUnicastSync(msg, service::name::antenna, 5000);
         if (ret.first == sys::ReturnCodes::Success) {
             auto responseMsg = dynamic_cast<AntennaLockRequestResponse *>(ret.second.get());
             if (responseMsg != nullptr) {

--- a/module-services/service-audio/AudioServiceAPI.cpp
+++ b/module-services/service-audio/AudioServiceAPI.cpp
@@ -25,7 +25,7 @@ namespace AudioServiceAPI
         {
             auto msgType = static_cast<int>(msg->type);
             LOG_DEBUG("Msg type %d", msgType);
-            auto ret = serv->bus.sendUnicast(msg, service::name::audio, sys::BusProxy::defaultTimeout);
+            auto ret = serv->bus.sendUnicastSync(msg, service::name::audio, sys::BusProxy::defaultTimeout);
             if (ret.first == sys::ReturnCodes::Success) {
                 if (auto resp = std::dynamic_pointer_cast<AudioResponseMessage>(ret.second)) {
                     LOG_DEBUG("Msg type %d done", msgType);

--- a/module-services/service-cellular/CellularServiceAPI.cpp
+++ b/module-services/service-cellular/CellularServiceAPI.cpp
@@ -53,7 +53,7 @@ std::string CellularServiceAPI::GetIMSI(sys::Service *serv, bool getFullIMSINumb
 
     auto msg = std::make_shared<CellularGetIMSIMessage>();
 
-    auto ret                          = serv->bus.sendUnicast(msg, ServiceCellular::serviceName, 5000);
+    auto ret                          = serv->bus.sendUnicastSync(msg, ServiceCellular::serviceName, 5000);
     CellularResponseMessage *response = dynamic_cast<CellularResponseMessage *>(ret.second.get());
 
     if (response == nullptr) {
@@ -74,7 +74,7 @@ std::string CellularServiceAPI::GetOwnNumber(sys::Service *serv)
 {
     auto msg = std::make_shared<CellularGetOwnNumberMessage>();
 
-    auto ret                          = serv->bus.sendUnicast(msg, ServiceCellular::serviceName, 5000);
+    auto ret                          = serv->bus.sendUnicastSync(msg, ServiceCellular::serviceName, 5000);
     CellularResponseMessage *response = dynamic_cast<CellularResponseMessage *>(ret.second.get());
 
     if (response == nullptr) {
@@ -129,7 +129,7 @@ bool CellularServiceAPI::SelectAntenna(sys::Service *serv, bsp::cellular::antenn
 {
     auto msg     = std::make_shared<CellularAntennaRequestMessage>();
     msg->antenna = antenna;
-    auto ret     = serv->bus.sendUnicast(msg, ServiceCellular::serviceName, 5000);
+    auto ret     = serv->bus.sendUnicastSync(msg, ServiceCellular::serviceName, 5000);
 
     CellularResponseMessage *response = dynamic_cast<CellularResponseMessage *>(ret.second.get());
 
@@ -145,7 +145,7 @@ bool CellularServiceAPI::SelectAntenna(sys::Service *serv, bsp::cellular::antenn
 bool CellularServiceAPI::SetScanMode(sys::Service *serv, std::string mode)
 {
     auto msg = std::make_shared<CellularSetScanModeMessage>(mode);
-    auto ret = serv->bus.sendUnicast(msg, ServiceCellular::serviceName, 5000);
+    auto ret = serv->bus.sendUnicastSync(msg, ServiceCellular::serviceName, 5000);
 
     CellularResponseMessage *response = dynamic_cast<CellularResponseMessage *>(ret.second.get());
 
@@ -159,7 +159,7 @@ bool CellularServiceAPI::SetScanMode(sys::Service *serv, std::string mode)
 bool CellularServiceAPI::GetScanMode(sys::Service *serv)
 {
     auto msg = std::make_shared<CellularGetScanModeMessage>();
-    auto ret = serv->bus.sendUnicast(msg, ServiceCellular::serviceName, 1000);
+    auto ret = serv->bus.sendUnicastSync(msg, ServiceCellular::serviceName, 1000);
 
     CellularResponseMessage *response = dynamic_cast<CellularResponseMessage *>(ret.second.get());
 
@@ -174,7 +174,7 @@ bool CellularServiceAPI::GetScanMode(sys::Service *serv)
 bool CellularServiceAPI::GetFirmwareVersion(sys::Service *serv, std::string &response)
 {
     auto msg = std::make_shared<CellularGetFirmwareVersionMessage>();
-    auto ret = serv->bus.sendUnicast(msg, ServiceCellular::serviceName, 1000);
+    auto ret = serv->bus.sendUnicastSync(msg, ServiceCellular::serviceName, 1000);
     if (ret.first == sys::ReturnCodes::Success) {
         auto celResponse = std::dynamic_pointer_cast<CellularResponseMessage>(ret.second);
         if ((celResponse != nullptr) && (celResponse->retCode == true)) {
@@ -201,7 +201,7 @@ bool CellularServiceAPI::GetCSQ(sys::Service *serv, std::string &response)
 {
 
     auto msg = std::make_shared<CellularGetCsqMessage>();
-    auto ret = serv->bus.sendUnicast(msg, ServiceCellular::serviceName, 5000);
+    auto ret = serv->bus.sendUnicastSync(msg, ServiceCellular::serviceName, 5000);
     if (ret.first == sys::ReturnCodes::Success) {
         auto responseMsg = std::dynamic_pointer_cast<CellularResponseMessage>(ret.second);
         if ((responseMsg != nullptr) && (responseMsg->retCode == true)) {
@@ -214,7 +214,7 @@ bool CellularServiceAPI::GetCSQ(sys::Service *serv, std::string &response)
 bool CellularServiceAPI::GetCREG(sys::Service *serv, std::string &response)
 {
     auto msg = std::make_shared<CellularGetCregMessage>();
-    auto ret = serv->bus.sendUnicast(msg, ServiceCellular::serviceName, 5000);
+    auto ret = serv->bus.sendUnicastSync(msg, ServiceCellular::serviceName, 5000);
     if (ret.first == sys::ReturnCodes::Success) {
         auto responseMsg = std::dynamic_pointer_cast<CellularResponseMessage>(ret.second);
         if ((responseMsg != nullptr) && (responseMsg->retCode == true)) {
@@ -227,7 +227,7 @@ bool CellularServiceAPI::GetCREG(sys::Service *serv, std::string &response)
 bool CellularServiceAPI::GetQNWINFO(sys::Service *serv, std::string &response)
 {
     auto msg = std::make_shared<CellularGetNwinfoMessage>();
-    auto ret = serv->bus.sendUnicast(msg, ServiceCellular::serviceName, 5000);
+    auto ret = serv->bus.sendUnicastSync(msg, ServiceCellular::serviceName, 5000);
     if (ret.first == sys::ReturnCodes::Success) {
         auto responseMsg = std::dynamic_pointer_cast<CellularResponseMessage>(ret.second);
         if ((responseMsg != nullptr) && (responseMsg->retCode == true)) {
@@ -241,7 +241,7 @@ bool CellularServiceAPI::GetQNWINFO(sys::Service *serv, std::string &response)
 bool CellularServiceAPI::GetAntenna(sys::Service *serv, bsp::cellular::antenna &response)
 {
     auto msg = std::make_shared<CellularGetAntennaMessage>();
-    auto ret = serv->bus.sendUnicast(msg, ServiceCellular::serviceName, 5000);
+    auto ret = serv->bus.sendUnicastSync(msg, ServiceCellular::serviceName, 5000);
     if (ret.first == sys::ReturnCodes::Success) {
         auto responseMsg = std::dynamic_pointer_cast<CellularAntennaResponseMessage>(ret.second);
         if ((responseMsg != nullptr) && (responseMsg->retCode == true)) {

--- a/module-services/service-db/DBServiceAPI.cpp
+++ b/module-services/service-db/DBServiceAPI.cpp
@@ -69,7 +69,7 @@ auto DBServiceAPI::ContactGetByIDWithTemporary(sys::Service *serv, uint32_t cont
 auto DBServiceAPI::ContactGetByIDCommon(sys::Service *serv, std::shared_ptr<DBContactMessage> contactMsg)
     -> std::unique_ptr<std::vector<ContactRecord>>
 {
-    auto ret             = serv->bus.sendUnicast(contactMsg, service::name::db, DefaultTimeoutInMs);
+    auto ret             = serv->bus.sendUnicastSync(contactMsg, service::name::db, DefaultTimeoutInMs);
     auto contactResponse = dynamic_cast<DBContactResponseMessage *>(ret.second.get());
     if (contactResponse == nullptr) {
         LOG_ERROR("DB response error, return code: %s", c_str(ret.first));
@@ -102,7 +102,7 @@ auto DBServiceAPI::MatchContactByPhoneNumber(sys::Service *serv, const utils::Ph
 {
     auto msg = std::make_shared<DBContactNumberMessage>(numberView);
 
-    auto ret             = serv->bus.sendUnicast(std::move(msg), service::name::db, DefaultTimeoutInMs);
+    auto ret             = serv->bus.sendUnicastSync(std::move(msg), service::name::db, DefaultTimeoutInMs);
     auto contactResponse = dynamic_cast<DBContactNumberResponseMessage *>(ret.second.get());
     if (contactResponse == nullptr || contactResponse->retCode != sys::ReturnCodes::Success) {
         LOG_ERROR("DB response error, return code: %s", c_str(ret.first));
@@ -152,7 +152,7 @@ auto DBServiceAPI::ContactAdd(sys::Service *serv, const ContactRecord &rec) -> b
 {
     std::shared_ptr<DBContactMessage> msg = std::make_shared<DBContactMessage>(MessageType::DBContactAdd, rec);
 
-    auto ret             = serv->bus.sendUnicast(msg, service::name::db, DefaultTimeoutInMs);
+    auto ret             = serv->bus.sendUnicastSync(msg, service::name::db, DefaultTimeoutInMs);
     auto contactResponse = dynamic_cast<DBContactResponseMessage *>(ret.second.get());
     if (contactResponse == nullptr) {
         LOG_ERROR("DB response error, return code: %s", c_str(ret.first));
@@ -169,7 +169,7 @@ auto DBServiceAPI::ContactRemove(sys::Service *serv, uint32_t id) -> bool
     std::shared_ptr<DBContactMessage> msg = std::make_shared<DBContactMessage>(MessageType::DBContactRemove);
     msg->id                               = id;
 
-    auto ret             = serv->bus.sendUnicast(msg, service::name::db, DefaultTimeoutInMs);
+    auto ret             = serv->bus.sendUnicastSync(msg, service::name::db, DefaultTimeoutInMs);
     auto contactResponse = dynamic_cast<DBContactResponseMessage *>(ret.second.get());
     if (contactResponse == nullptr) {
         LOG_ERROR("DB response error, return code: %s", c_str(ret.first));
@@ -185,7 +185,7 @@ auto DBServiceAPI::ContactUpdate(sys::Service *serv, const ContactRecord &rec) -
 {
     std::shared_ptr<DBContactMessage> msg = std::make_shared<DBContactMessage>(MessageType::DBContactUpdate, rec);
 
-    auto ret             = serv->bus.sendUnicast(msg, service::name::db, DefaultTimeoutInMs);
+    auto ret             = serv->bus.sendUnicastSync(msg, service::name::db, DefaultTimeoutInMs);
     auto contactResponse = dynamic_cast<DBContactResponseMessage *>(ret.second.get());
     if (contactResponse == nullptr) {
         LOG_ERROR("DB response error, return code: %s", c_str(ret.first));
@@ -203,7 +203,7 @@ auto DBServiceAPI::CalllogAdd(sys::Service *serv, const CalllogRecord &rec) -> C
 
     LOG_DEBUG("CalllogAdd %s", utils::to_string(rec).c_str());
 
-    auto ret             = serv->bus.sendUnicast(msg, service::name::db, DefaultTimeoutInMs);
+    auto ret             = serv->bus.sendUnicastSync(msg, service::name::db, DefaultTimeoutInMs);
     auto calllogResponse = dynamic_cast<DBCalllogResponseMessage *>(ret.second.get());
     if (calllogResponse == nullptr) {
         LOG_ERROR("DB response error, return code: %s", c_str(ret.first));
@@ -224,7 +224,7 @@ auto DBServiceAPI::CalllogRemove(sys::Service *serv, uint32_t id) -> bool
     std::shared_ptr<DBCalllogMessage> msg = std::make_shared<DBCalllogMessage>(MessageType::DBCalllogRemove);
     msg->id                               = id;
 
-    auto ret             = serv->bus.sendUnicast(msg, service::name::db, DefaultTimeoutInMs);
+    auto ret             = serv->bus.sendUnicastSync(msg, service::name::db, DefaultTimeoutInMs);
     auto calllogResponse = dynamic_cast<DBCalllogResponseMessage *>(ret.second.get());
     if (calllogResponse == nullptr) {
         LOG_ERROR("DB response error, return code: %s", c_str(ret.first));
@@ -242,7 +242,7 @@ auto DBServiceAPI::CalllogUpdate(sys::Service *serv, const CalllogRecord &rec) -
 
     LOG_DEBUG("CalllogUpdate %s", utils::to_string(rec).c_str());
 
-    auto ret             = serv->bus.sendUnicast(msg, service::name::db, DefaultTimeoutInMs);
+    auto ret             = serv->bus.sendUnicastSync(msg, service::name::db, DefaultTimeoutInMs);
     auto calllogResponse = dynamic_cast<DBCalllogResponseMessage *>(ret.second.get());
     if (calllogResponse == nullptr) {
         LOG_ERROR("DB response error, return code: %s", c_str(ret.first));
@@ -261,7 +261,7 @@ auto DBServiceAPI::DBBackup(sys::Service *serv, std::string backupPath) -> bool
     std::shared_ptr<DBServiceMessageBackup> msg =
         std::make_shared<DBServiceMessageBackup>(MessageType::DBServiceBackup, backupPath);
 
-    auto ret = serv->bus.sendUnicast(msg, service::name::db, DefaultTimeoutInMs);
+    auto ret = serv->bus.sendUnicastSync(msg, service::name::db, DefaultTimeoutInMs);
     if (ret.first == sys::ReturnCodes::Success) {
         return true;
     }

--- a/module-services/service-db/DBServiceAPI_GetByQuery.cpp
+++ b/module-services/service-db/DBServiceAPI_GetByQuery.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "service-db/DBServiceAPI.hpp"
@@ -33,5 +33,5 @@ sys::SendResult DBServiceAPI::GetQueryWithReply(sys::Service *serv,
                                                 std::uint32_t timeout)
 {
     auto msg = std::make_shared<db::QueryMessage>(database, std::move(query));
-    return serv->bus.sendUnicast(msg, service::name::db, timeout);
+    return serv->bus.sendUnicastSync(msg, service::name::db, timeout);
 }

--- a/module-services/service-evtmgr/api/EventManagerServiceAPI.cpp
+++ b/module-services/service-evtmgr/api/EventManagerServiceAPI.cpp
@@ -23,7 +23,7 @@ bsp::Board EventManagerServiceAPI::GetBoard(sys::Service *serv)
     constexpr uint32_t timeout = 1000;
 
     std::shared_ptr<sys::DataMessage> msg = std::make_shared<sys::DataMessage>(MessageType::EVMGetBoard);
-    auto ret                              = serv->bus.sendUnicast(msg, service::name::evt_manager, timeout);
+    auto ret                              = serv->bus.sendUnicastSync(msg, service::name::evt_manager, timeout);
 
     sevm::EVMBoardResponseMessage *response = dynamic_cast<sevm::EVMBoardResponseMessage *>(ret.second.get());
 

--- a/module-services/service-lwip/ServiceLwIP.cpp
+++ b/module-services/service-lwip/ServiceLwIP.cpp
@@ -44,7 +44,7 @@ extern "C"
 sys::ReturnCodes message_lwip(sys::Service *app, LwIP_message::Request req)
 {
     std::shared_ptr<LwIP_message> msg = std::make_shared<LwIP_message>(req);
-    auto ret                          = app->bus.sendUnicast(msg, "ServiceLwIP", 5000);
+    auto ret                          = app->bus.sendUnicastSync(msg, "ServiceLwIP", 5000);
     if (ret.first != sys::ReturnCodes::Success) {
         LOG_ERROR("err: %s", c_str(ret.first));
     }

--- a/module-sys/Service/BusProxy.cpp
+++ b/module-sys/Service/BusProxy.cpp
@@ -24,9 +24,11 @@ namespace sys
         return ret;
     }
 
-    SendResult BusProxy::sendUnicast(std::shared_ptr<Message> message, const std::string &targetName, uint32_t timeout)
+    SendResult BusProxy::sendUnicastSync(std::shared_ptr<Message> message,
+                                         const std::string &targetName,
+                                         uint32_t timeout)
     {
-        auto ret = busImpl->SendUnicast(std::move(message), targetName, owner, timeout);
+        auto ret = busImpl->SendUnicastSync(std::move(message), targetName, owner, timeout);
         if (ret.first != ReturnCodes::Failure) {
             watchdog.refresh();
         }

--- a/module-sys/Service/BusProxy.hpp
+++ b/module-sys/Service/BusProxy.hpp
@@ -24,7 +24,9 @@ namespace sys
         ~BusProxy() noexcept;
 
         bool sendUnicast(std::shared_ptr<Message> message, const std::string &targetName);
-        SendResult sendUnicast(std::shared_ptr<Message> message, const std::string &targetName, std::uint32_t timeout);
+        SendResult sendUnicastSync(std::shared_ptr<Message> message,
+                                   const std::string &targetName,
+                                   std::uint32_t timeout);
         void sendMulticast(std::shared_ptr<Message> message, BusChannel channel);
         void sendBroadcast(std::shared_ptr<Message> message);
 

--- a/module-sys/Service/details/bus/Bus.cpp
+++ b/module-sys/Service/details/bus/Bus.cpp
@@ -101,10 +101,10 @@ namespace sys
         return false;
     }
 
-    SendResult Bus::SendUnicast(std::shared_ptr<Message> message,
-                                const std::string &targetName,
-                                Service *sender,
-                                std::uint32_t timeout)
+    SendResult Bus::SendUnicastSync(std::shared_ptr<Message> message,
+                                    const std::string &targetName,
+                                    Service *sender,
+                                    std::uint32_t timeout)
     {
         std::vector<std::shared_ptr<Message>> tempMsg;
         tempMsg.reserve(4); // reserve space for 4 elements to avoid costly memory allocations

--- a/module-sys/Service/details/bus/Bus.hpp
+++ b/module-sys/Service/details/bus/Bus.hpp
@@ -38,10 +38,10 @@ namespace sys
          * @param timeout       Timeout
          * @return Return code and a response.
          */
-        SendResult SendUnicast(std::shared_ptr<Message> message,
-                               const std::string &targetName,
-                               Service *sender,
-                               std::uint32_t timeout);
+        SendResult SendUnicastSync(std::shared_ptr<Message> message,
+                                   const std::string &targetName,
+                                   Service *sender,
+                                   std::uint32_t timeout);
 
         /**
          * Sends a message to the specified channel.

--- a/module-sys/SystemManager/SystemManager.cpp
+++ b/module-sys/SystemManager/SystemManager.cpp
@@ -240,16 +240,16 @@ namespace sys
     bool SystemManager::Restore(Service *s)
     {
         LOG_DEBUG("trying to enter restore state");
-        auto ret = s->bus.sendUnicast(std::make_shared<SystemManagerCmd>(Code::Restore),
-                                      service::name::system_manager,
-                                      sys::constants::restoreTimeout);
+        auto ret = s->bus.sendUnicastSync(std::make_shared<SystemManagerCmd>(Code::Restore),
+                                          service::name::system_manager,
+                                          sys::constants::restoreTimeout);
         if (ret.first != ReturnCodes::Success) {
             LOG_WARN("Can't stop all services, %d ms wait time", sys::constants::restoreTimeout);
         }
         auto msgCloseApplications = std::make_shared<app::manager::UpdateInProgress>(service::name::system_manager);
-        ret                       = s->bus.sendUnicast(std::move(msgCloseApplications),
-                                 app::manager::ApplicationManager::ServiceName,
-                                 sys::constants::restoreTimeout);
+        ret                       = s->bus.sendUnicastSync(std::move(msgCloseApplications),
+                                     app::manager::ApplicationManager::ServiceName,
+                                     sys::constants::restoreTimeout);
         if (ret.first != ReturnCodes::Success) {
             LOG_WARN("Can't stop all applications, %d ms wait time", sys::constants::restoreTimeout);
         }
@@ -272,7 +272,7 @@ namespace sys
 
     bool SystemManager::SuspendService(const std::string &name, sys::Service *caller)
     {
-        auto ret = caller->bus.sendUnicast(
+        auto ret = caller->bus.sendUnicastSync(
             std::make_shared<SystemMessage>(SystemMessageType::SwitchPowerMode, ServicePowerMode::SuspendToRAM),
             name,
             1000);
@@ -286,7 +286,7 @@ namespace sys
 
     bool SystemManager::ResumeService(const std::string &name, sys::Service *caller)
     {
-        auto ret = caller->bus.sendUnicast(
+        auto ret = caller->bus.sendUnicastSync(
             std::make_shared<SystemMessage>(SystemMessageType::SwitchPowerMode, ServicePowerMode::Active), name, 1000);
         auto resp = std::static_pointer_cast<ResponseMessage>(ret.second);
 
@@ -301,7 +301,7 @@ namespace sys
         service->StartService();
 
         auto msg  = std::make_shared<SystemMessage>(SystemMessageType::Start);
-        auto ret  = caller->bus.sendUnicast(msg, service->GetName(), timeout);
+        auto ret  = caller->bus.sendUnicastSync(msg, service->GetName(), timeout);
         auto resp = std::static_pointer_cast<ResponseMessage>(ret.second);
 
         if (ret.first == ReturnCodes::Success && (resp->retCode == ReturnCodes::Success)) {
@@ -331,7 +331,7 @@ namespace sys
     bool SystemManager::RequestServiceClose(const std::string &name, Service *caller, TickType_t timeout)
     {
         auto msg  = std::make_shared<SystemMessage>(SystemMessageType::Exit);
-        auto ret  = caller->bus.sendUnicast(msg, name, timeout);
+        auto ret  = caller->bus.sendUnicastSync(msg, name, timeout);
         auto resp = std::static_pointer_cast<ResponseMessage>(ret.second);
 
         if (ret.first != ReturnCodes::Success) {


### PR DESCRIPTION
Using Unicast with timeout is dangerous and strongly discouraged.
This change allows for more precise tracking of such cases.