### PR TITLE
[EGD-2489] Enable full version of libc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ add_subdirectory(image)
 
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES SUFFIX ".elf")
 
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES LINK_FLAGS "-Xlinker -Map=${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.map ")
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES LINK_FLAGS "-Xlinker -Map=${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.map -u_printf_float")
 
 # M.P: Please don't change the order of modules in the first group ("module-bsp" - "module-utils")
 # They have to be arranged in specific order because of circular dependencies that need to be correctly resolved


### PR DESCRIPTION
Change newlib-nano to full version of newlib to allow
to support full version of the printf family funcs.