### PR TITLE
[EGD-6561] Limit calculator decimals to 6 digits

### DIFF
--- a/module-apps/application-calculator/data/CalculatorInputProcessor.hpp
+++ b/module-apps/application-calculator/data/CalculatorInputProcessor.hpp
@@ -43,6 +43,8 @@ namespace calc
     class InputProcessor
     {
       public:
+        static inline constexpr auto DecimalDigitsLimit = 6;
+
         virtual ~InputProcessor() = default;
 
         virtual bool handle(const gui::InputEvent &event) = 0;

--- a/module-apps/application-calculator/data/CalculatorInputProcessorText.cpp
+++ b/module-apps/application-calculator/data/CalculatorInputProcessorText.cpp
@@ -83,6 +83,11 @@ bool calc::InputProcessorText::handle(const gui::InputEvent &event)
         return true;
     }
 
+    if (decimalLimitReached()) {
+        // Consume event to don't allow more decimals
+        return true;
+    }
+
     return false;
 }
 
@@ -111,7 +116,7 @@ void calc::InputProcessorText::writeEquation(bool lastCharIsSymbol, const UTF8 &
     }
 }
 
-bool calc::InputProcessorText::isPreviousNumberDecimal()
+bool calc::InputProcessorText::isPreviousNumberDecimal() const
 {
     if (!inputField->getText().empty()) {
         std::vector<int> symbolsIndexes;
@@ -135,6 +140,20 @@ bool calc::InputProcessorText::isPreviousNumberDecimal()
         }
         return lastNumber.find(utils::localize.get("app_calculator_decimal_separator")) != std::string::npos;
     }
+    return false;
+}
+
+bool calc::InputProcessorText::decimalLimitReached() const
+{
+    if (!isPreviousNumberDecimal())
+        return false;
+
+    const auto &txt          = std::string{inputField->getText()};
+    const auto separator_pos = txt.find_last_of(utils::localize.get("app_calculator_decimal_separator"));
+
+    if ((txt.size() - separator_pos) > DecimalDigitsLimit)
+        return true;
+
     return false;
 }
 

--- a/module-apps/application-calculator/data/CalculatorInputProcessorText.hpp
+++ b/module-apps/application-calculator/data/CalculatorInputProcessorText.hpp
@@ -24,7 +24,10 @@ namespace calc
 
       private:
         void writeEquation(bool lastCharIsSymbol, const UTF8 &symbol);
-        bool isPreviousNumberDecimal();
+
+        bool isPreviousNumberDecimal() const;
+        bool decimalLimitReached() const;
+
         std::uint32_t getPenultimate();
 
         gui::Text *inputField{nullptr};

--- a/module-apps/application-calculator/tests/CalculatorInput_tests.cpp
+++ b/module-apps/application-calculator/tests/CalculatorInput_tests.cpp
@@ -159,6 +159,21 @@ SCENARIO("Input Processor tests")
                     REQUIRE(inputField.getText() == "0.12345");
                 }
             }
+
+            AND_WHEN("We try to enter more than 6 decimals")
+            {
+                passShortKeyPresses({KeyCodes::NumericKey4,
+                                     KeyCodes::NumericKey5,
+                                     KeyCodes::NumericKey6,
+                                     KeyCodes::NumericKey7,
+                                     KeyCodes::NumericKey8,
+                                     KeyCodes::NumericKey9});
+
+                THEN("The input is truncated to 6 decimals")
+                {
+                    REQUIRE(inputField.getText() == "0.123456");
+                }
+            }
         }
 
         WHEN("We enter zero")
@@ -286,6 +301,21 @@ SCENARIO("Input Processor tests")
                         THEN("It is ignored")
                         {
                             REQUIRE(inputField.getText() == "123+4.56456");
+                        }
+                    }
+
+                    AND_WHEN("We try to enter more than 6 decimals")
+                    {
+                        passShortKeyPresses({KeyCodes::NumericKey4,
+                                             KeyCodes::NumericKey5,
+                                             KeyCodes::NumericKey6,
+                                             KeyCodes::NumericKey7,
+                                             KeyCodes::NumericKey8,
+                                             KeyCodes::NumericKey9});
+
+                        THEN("The input is truncated to 6 decimals")
+                        {
+                            REQUIRE(inputField.getText() == "123+4.564567");
                         }
                     }
                 }


### PR DESCRIPTION
Limit to 6 since our `utils::to_string(double)' functions also
limits to 6 decimals.