### PR TITLE
[EGD-6563] Don't allow to edit exponent output in calculator

### DIFF
--- a/module-apps/application-calculator/data/CalculatorInputProcessorText.cpp
+++ b/module-apps/application-calculator/data/CalculatorInputProcessorText.cpp
@@ -13,7 +13,7 @@ calc::InputProcessorText::InputProcessorText(gsl::strict_not_null<gui::Text *> i
 
 bool calc::InputProcessorText::handle(const gui::InputEvent &event)
 {
-    if (clearInput) {
+    if (clearInput || inputContainsExponent()) {
         clear();
     }
 
@@ -157,7 +157,12 @@ bool calc::InputProcessorText::decimalLimitReached() const
     return false;
 }
 
-std::uint32_t calc::InputProcessorText::getPenultimate()
+bool calc::InputProcessorText::inputContainsExponent() const
+{
+    return std::string{inputField->getText()}.find('e') != std::string::npos;
+}
+
+std::uint32_t calc::InputProcessorText::getPenultimate() const
 {
     const auto &text = inputField->getText();
     const auto len   = text.length();

--- a/module-apps/application-calculator/data/CalculatorInputProcessorText.hpp
+++ b/module-apps/application-calculator/data/CalculatorInputProcessorText.hpp
@@ -28,7 +28,9 @@ namespace calc
         bool isPreviousNumberDecimal() const;
         bool decimalLimitReached() const;
 
-        std::uint32_t getPenultimate();
+        bool inputContainsExponent() const;
+
+        std::uint32_t getPenultimate() const;
 
         gui::Text *inputField{nullptr};
         bool clearInput{false};

--- a/module-apps/application-calculator/tests/CalculatorInput_tests.cpp
+++ b/module-apps/application-calculator/tests/CalculatorInput_tests.cpp
@@ -351,5 +351,26 @@ SCENARIO("Input Processor tests")
                 }
             }
         }
+
+        WHEN("We do BIG math")
+        {
+            inputField.setText("99999×99999");
+            passShortKeyPress(KeyCodes::JoystickEnter);
+
+            THEN("Output contains exponent")
+            {
+                REQUIRE(inputField.getText() == "9.9998e9");
+            }
+
+            AND_WHEN("We start typing")
+            {
+                passShortKeyPresses({KeyCodes::NumericKey4, MinusKey, KeyCodes::NumericKey5, KeyCodes::NumericKey6});
+
+                THEN("Input is cleared before typing")
+                {
+                    REQUIRE(inputField.getText() == "4-56");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Clear the calculator input field before typing if it contains exponent
output from previous calculations.