### PR TITLE
[EGD-5632] Remove "systemStarted" from "DeveloperMode" EndPoint

### DIFF
--- a/module-services/service-desktop/endpoints/developerMode/DeveloperModeHelper.hpp
+++ b/module-services/service-desktop/endpoints/developerMode/DeveloperModeHelper.hpp
@@ -46,7 +46,6 @@ namespace parserFSM
     {
         inline constexpr auto keyPressed             = "keyPressed";
         inline constexpr auto state                  = "state";
-        inline constexpr auto systemStarted          = "systemStarted";
         inline constexpr auto ATResponse             = "ATResponse";
         inline constexpr auto AT                     = "AT";
         inline constexpr auto timeout                = "timeout";


### PR DESCRIPTION
Remove `systemStarted` field as it's no longer used.