### PR TITLE
[EGD-5661] Add power management for filesystem

### DIFF
--- a/module-sys/SystemManager/SystemManager.hpp
+++ b/module-sys/SystemManager/SystemManager.hpp
@@ -189,6 +189,9 @@ namespace sys
         /// periodic update of cpu statistics
         void CpuStatisticsTimerHandler();
 
+        /// used for power management control for the filesystem
+        void UpdateResourcesAfterCpuFrequencyChange(bsp::CpuFrequencyHz newFrequency);
+
         MessagePointer handlePhoneModeRequest(PhoneModeRequest *request);
         MessagePointer handleTetheringStateRequest(TetheringStateRequest *request);
         MessagePointer enableTethering(TetheringEnabledResponse *response);
@@ -207,6 +210,8 @@ namespace sys
         InitFunction userInit;
         InitFunction systemInit;
         std::vector<std::string> readyForCloseRegister;
+
+        std::shared_ptr<sys::CpuSentinel> cpuSentinel;
 
         static std::vector<std::shared_ptr<Service>> servicesList;
         static std::vector<std::shared_ptr<app::Application>> applicationsList;

--- a/module-vfs/board/linux/purefs/include/purefs/blkdev/disk_image.hpp
+++ b/module-vfs/board/linux/purefs/include/purefs/blkdev/disk_image.hpp
@@ -28,10 +28,13 @@ namespace purefs::blkdev
         auto status() const -> media_status override;
         auto get_info(info_type what, hwpart_t hwpart) const -> scount_t override;
         auto erase(sector_t lba, std::size_t count, hwpart_t hwpart) -> int override;
+        auto pm_control(pm_state target_state) -> int override;
+        auto pm_read(pm_state &current_state) -> int override;
         auto range_valid(sector_t lba, std::size_t count, hwpart_t hwpart) const -> bool;
         auto open_and_truncate(hwpart_t hwpart) -> int;
 
       private:
+        pm_state pmState{pm_state::active};
         std::vector<int> m_filedes;
         std::vector<std::size_t> m_sectors;
         const std::string m_image_name;

--- a/module-vfs/board/linux/purefs/src/blkdev/disk_image.cpp
+++ b/module-vfs/board/linux/purefs/src/blkdev/disk_image.cpp
@@ -186,4 +186,16 @@ namespace purefs::blkdev
         }
         return 0;
     }
+
+    auto disk_image::pm_control(pm_state target_state) -> int
+    {
+        pmState = target_state;
+        return 0;
+    }
+    auto disk_image::pm_read(pm_state &current_state) -> int
+    {
+        current_state = pmState;
+        return 0;
+    }
+
 } // namespace purefs::blkdev

--- a/module-vfs/board/rt1051/purefs/include/purefs/blkdev/disk_emmc.hpp
+++ b/module-vfs/board/rt1051/purefs/include/purefs/blkdev/disk_emmc.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "drivers/usdhc/DriverUSDHC.hpp"
 #include <purefs/blkdev/disk.hpp>
 #include <mutex.hpp>
 #include <memory>
@@ -33,14 +34,19 @@ namespace purefs::blkdev
         auto status() const -> media_status override;
         auto get_info(info_type what, hwpart_t hwpart) const -> scount_t override;
         auto erase(sector_t lba, std::size_t count, hwpart_t hwpart) -> int override;
+        auto pm_control(pm_state target_state) -> int override;
+        auto pm_read(pm_state &current_state) -> int override;
 
       private:
         auto switch_partition(hwpart_t newpart) -> int;
 
       private:
         int initStatus;
-        std::unique_ptr<_mmc_card> mmcCard;
+        pm_state pmState{pm_state::active};
         mutable cpp_freertos::MutexRecursive mutex;
         std::atomic<hwpart_t> currHwPart{0};
+
+        std::unique_ptr<_mmc_card> mmcCard;
+        std::shared_ptr<drivers::DriverUSDHC> driverUSDHC;
     };
 } // namespace purefs::blkdev

--- a/module-vfs/include/user/purefs/vfs_subsystem.hpp
+++ b/module-vfs/include/user/purefs/vfs_subsystem.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once


### PR DESCRIPTION
Add peripheral control (USDHC and PLL2 clocks)
for file system support.
This will save energy and extend battery life.