### PR TITLE
[EGD-6597] Add PM control for all disc in DM

### DIFF
--- a/module-vfs/include/user/purefs/blkdev/disk_manager.hpp
+++ b/module-vfs/include/user/purefs/blkdev/disk_manager.hpp
@@ -79,15 +79,21 @@ namespace purefs::blkdev
          * @param[in] device_name Device or partition name
          * @param[in] target_state Set the target power state
          * @return zero or success otherwise error
-         * @note If the partition is changed whole device state will be suspended
+         * @note If the partition is changed the device state will be suspended
          */
         auto pm_control(disk_fd dfd, pm_state target_state) -> int;
         auto pm_control(std::string_view device_name, pm_state target_state) -> int;
+        /* Set all block devices registered in the disk manager to target pm state
+         * @param[in] target_state Set the target power state
+         * @return Error code from the last failed device
+         * @note If the partition is changed the device state will be suspended
+         */
+        auto pm_control(pm_state target_state) -> int;
         /** Get block device power state
          * @param[in] dfd Disk device handle
          * @param[out] currrent_state Device current state
          * @return zero or success otherwise error
-         * @note If the partition is changed whole device state will be suspended
+         * @note If the partition is changed the device state will be suspended
          */
         auto pm_read(disk_fd dfd, pm_state &current_state) -> int;
         auto pm_read(std::string_view device_name, pm_state &current_state) -> int;

--- a/module-vfs/src/purefs/blkdev/disk_manager.cpp
+++ b/module-vfs/src/purefs/blkdev/disk_manager.cpp
@@ -238,6 +238,19 @@ namespace purefs::blkdev
         }
         return disk->pm_control(target_state);
     }
+    auto disk_manager::pm_control(pm_state target_state) -> int
+    {
+        cpp_freertos::LockGuard _lck(*m_lock);
+        int last_err{};
+        for (const auto &disk : m_dev_map) {
+            auto err = disk.second->pm_control(target_state);
+            if (err) {
+                LOG_ERROR("Unable to change PM state for device %s errno: %i", disk.first.c_str(), err);
+                last_err = err;
+            }
+        }
+        return last_err;
+    }
     auto disk_manager::pm_read(disk_fd dfd, pm_state &current_state) -> int
     {
         if (!dfd) {


### PR DESCRIPTION
This patch add API for send power control message
for all disc registered in the disc manager. It is needed
for power management for suspend resume all discs.