### PR TITLE
[EGD-6315] Fix issues during saving new APN

### DIFF
--- a/module-apps/application-settings-new/models/NewApnModel.cpp
+++ b/module-apps/application-settings-new/models/NewApnModel.cpp
@@ -42,49 +42,43 @@ void NewApnModel::createData()
         [app](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text); },
         [app]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); },
         [app]() { app->getCurrentWindow()->selectSpecialCharacter(); },
-        [this]() { this->apnDataChanged(); }));
+        [this](const std::string &text) { this->apnNameChanged(text); }));
 
     internalData.emplace_back(new gui::ApnInputWidget(
         settingsInternals::ListItemName::APN,
         [app](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text); },
         [app]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); },
-        [app]() { app->getCurrentWindow()->selectSpecialCharacter(); },
-        [this]() { this->apnDataChanged(); }));
+        [app]() { app->getCurrentWindow()->selectSpecialCharacter(); }));
 
     internalData.emplace_back(new gui::ApnInputWidget(
         settingsInternals::ListItemName::Username,
         [app](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text); },
         [app]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); },
-        [app]() { app->getCurrentWindow()->selectSpecialCharacter(); },
-        [this]() { this->apnDataChanged(); }));
+        [app]() { app->getCurrentWindow()->selectSpecialCharacter(); }));
 
     internalData.emplace_back(new gui::ApnInputWidget(
         settingsInternals::ListItemName::Password,
         [app](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text); },
         [app]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); },
-        [app]() { app->getCurrentWindow()->selectSpecialCharacter(); },
-        [this]() { this->apnDataChanged(); }));
+        [app]() { app->getCurrentWindow()->selectSpecialCharacter(); }));
 
     internalData.emplace_back(new gui::ApnInputWidget(
         settingsInternals::ListItemName::AuthType,
         [app](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text); },
         [app]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); },
-        [app]() { app->getCurrentWindow()->selectSpecialCharacter(); },
-        [this]() { this->apnDataChanged(); }));
+        [app]() { app->getCurrentWindow()->selectSpecialCharacter(); }));
 
     internalData.emplace_back(new gui::ApnInputWidget(
         settingsInternals::ListItemName::ApnType,
         [app](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text); },
         [app]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); },
-        [app]() { app->getCurrentWindow()->selectSpecialCharacter(); },
-        [this]() { this->apnDataChanged(); }));
+        [app]() { app->getCurrentWindow()->selectSpecialCharacter(); }));
 
     internalData.emplace_back(new gui::ApnInputWidget(
         settingsInternals::ListItemName::ApnProtocol,
         [app](const UTF8 &text) { app->getCurrentWindow()->bottomBarTemporaryMode(text); },
         [app]() { app->getCurrentWindow()->bottomBarRestoreFromTemporaryMode(); },
-        [app]() { app->getCurrentWindow()->selectSpecialCharacter(); },
-        [this]() { this->apnDataChanged(); }));
+        [app]() { app->getCurrentWindow()->selectSpecialCharacter(); }));
 
     for (auto item : internalData) {
         item->deleteByList = false;
@@ -120,13 +114,9 @@ void NewApnModel::loadData(const std::shared_ptr<packet_data::APN::Config> &apnR
     }
 }
 
-void NewApnModel::apnDataChanged()
+void NewApnModel::apnNameChanged(const std::string &newName)
 {
-    for (auto item : internalData) {
-        if (item->onEmptyCallback && !item->onEmptyCallback()) {
-            application->getCurrentWindow()->setBottomBarActive(gui::BottomBar::Side::CENTER, true); // SAVE button
-            return;
-        }
-    }
-    application->getCurrentWindow()->setBottomBarActive(gui::BottomBar::Side::CENTER, false);
+    LOG_DEBUG("New APN name: %s", newName.c_str());
+    const bool showSaveButton = !newName.empty();
+    application->getCurrentWindow()->setBottomBarActive(gui::BottomBar::Side::CENTER, showSaveButton);
 }

--- a/module-apps/application-settings-new/models/NewApnModel.hpp
+++ b/module-apps/application-settings-new/models/NewApnModel.hpp
@@ -31,5 +31,5 @@ class NewApnModel : public app::InternalModel<gui::ApnListItem *>, public gui::L
     auto getItem(gui::Order order) -> gui::ListItem * override;
 
     void requestRecords(uint32_t offset, uint32_t limit) override;
-    void apnDataChanged();
+    void apnNameChanged(const std::string &newName);
 };

--- a/module-apps/application-settings-new/widgets/ApnInputWidget.cpp
+++ b/module-apps/application-settings-new/widgets/ApnInputWidget.cpp
@@ -13,7 +13,7 @@ namespace gui
                                    std::function<void(const UTF8 &)> bottomBarTemporaryMode,
                                    std::function<void()> bottomBarRestoreFromTemporaryMode,
                                    std::function<void()> selectSpecialCharacter,
-                                   std::function<void()> contentChanged,
+                                   std::function<void(const std::string &text)> contentChanged,
                                    unsigned int lines)
         : listItemName(listItemName), checkTextContent(std::move(contentChanged))
     {
@@ -75,7 +75,7 @@ namespace gui
         inputCallback = [&](Item &item, const InputEvent &event) {
             auto result = inputText->onInput(event);
             if (checkTextContent != nullptr) {
-                checkTextContent();
+                checkTextContent(inputText->getText());
             }
             return result;
         };

--- a/module-apps/application-settings-new/widgets/ApnInputWidget.hpp
+++ b/module-apps/application-settings-new/widgets/ApnInputWidget.hpp
@@ -21,14 +21,14 @@ namespace gui
                        std::function<void(const UTF8 &text)> bottomBarTemporaryMode = nullptr,
                        std::function<void()> bottomBarRestoreFromTemporaryMode      = nullptr,
                        std::function<void()> selectSpecialCharacter                 = nullptr,
-                       std::function<void()> contentChanged                         = nullptr,
+                       std::function<void(const std::string &text)> contentChanged  = nullptr,
                        unsigned int lines                                           = 1);
 
       private:
-        VBox *vBox                             = nullptr;
-        Label *titleLabel                      = nullptr;
-        TextFixedSize *inputText               = nullptr;
-        std::function<void()> checkTextContent = nullptr;
+        VBox *vBox                                                    = nullptr;
+        Label *titleLabel                                             = nullptr;
+        TextFixedSize *inputText                                      = nullptr;
+        std::function<void(const std::string &text)> checkTextContent = nullptr;
 
         void applyItemNameSpecificSettings();
         void nameHandler();

--- a/module-apps/application-settings-new/windows/ApnOptionsWindow.cpp
+++ b/module-apps/application-settings-new/windows/ApnOptionsWindow.cpp
@@ -24,6 +24,7 @@ namespace gui
             utils::translate("app_settings_apn_options_edit"),
             [=](gui::Item &item) {
                 std::unique_ptr<gui::SwitchData> data = std::make_unique<ApnItemData>(apn);
+                data->ignoreCurrentWindowOnStack      = true;
                 application->switchWindow(gui::window::name::new_apn, gui::ShowMode::GUI_SHOW_INIT, std::move(data));
                 return true;
             },
@@ -34,6 +35,7 @@ namespace gui
             utils::translate("app_settings_apn_options_delete"),
             [=](gui::Item &item) {
                 apnSettingsModel->removeAPN(apn);
+                application->returnToPreviousWindow();
                 return true;
             },
             nullptr,
@@ -43,6 +45,7 @@ namespace gui
             utils::translate("app_settings_apn_options_set_as_default"),
             [=](gui::Item &item) {
                 apnSettingsModel->setAsDefaultAPN(apn);
+                application->returnToPreviousWindow();
                 return true;
             },
             nullptr,

--- a/module-apps/application-settings-new/windows/NewApnWindow.cpp
+++ b/module-apps/application-settings-new/windows/NewApnWindow.cpp
@@ -11,7 +11,8 @@ namespace gui
 {
 
     NewApnWindow::NewApnWindow(app::Application *app)
-        : AppWindow(app, gui::window::name::new_apn), newApnModel{std::make_shared<NewApnModel>(app)}
+        : AppWindow(app, gui::window::name::new_apn),
+          apn(std::make_shared<packet_data::APN::Config>()), newApnModel{std::make_shared<NewApnModel>(app)}
     {
         buildInterface();
     }
@@ -74,10 +75,13 @@ namespace gui
             return false;
         }
 
-        apn = item->getApn();
-        if (apn == nullptr) {
-            apn = std::make_shared<packet_data::APN::Config>();
-            return true;
+        auto apnItem = item->getApn();
+        if (apnItem != nullptr) {
+            apn = apnItem;
+        }
+
+        if (!apn->apn.empty()) {
+            setSaveButtonVisible(true);
         }
 
         return true;
@@ -94,26 +98,19 @@ namespace gui
             return false;
         }
         if (inputEvent.is(gui::KeyCode::KEY_ENTER)) {
-            if (apn != nullptr) {
-                newApnModel->saveData(apn);
+            newApnModel->saveData(apn);
+            LOG_DEBUG("APN: \"%s\" ", apn->apn.c_str());
+            if (apn != nullptr && !apn->apn.empty()) {
+                apnSettingsModel->saveAPN(apn);
+                LOG_INFO("APN record saved: \"%s\" ", apn->apn.c_str());
+                application->returnToPreviousWindow();
             }
-            verifyAndSave();
+            else {
+                LOG_WARN("APN not saved, name is empty!");
+            }
             return true;
         }
 
         return AppWindow::onInput(inputEvent);
     }
-
-    auto NewApnWindow::verifyAndSave() -> bool
-    {
-        if (apn == nullptr) {
-            LOG_DEBUG("APN record not found");
-            return false;
-        }
-        apnSettingsModel->saveAPN(apn);
-        LOG_DEBUG("APN record  saved : \"%s\" ", apn->apn.c_str());
-
-        return true;
-    }
-
 } // namespace gui

--- a/module-apps/application-settings-new/windows/NewApnWindow.hpp
+++ b/module-apps/application-settings-new/windows/NewApnWindow.hpp
@@ -24,7 +24,6 @@ namespace gui
         void rebuild() override;
         void buildInterface() override;
         void destroyInterface() override;
-        auto verifyAndSave() -> bool;
         void setSaveButtonVisible(bool visible);
         std::shared_ptr<packet_data::APN::Config> apn;
         std::shared_ptr<NewApnModel> newApnModel;


### PR DESCRIPTION
- disallow saving empty APN form - at least `Name` must be provided,
- show `Save` button only if `Name` field is not empty,
- return to APN list window after adding/editing/deleting APN
  or setting APN to default