### PR TITLE
[EGD-6599] Add single number call notification

### DIFF
--- a/enabled_unittests
+++ b/enabled_unittests
@@ -130,6 +130,8 @@ TESTS_LIST["catch2-db"]="
     SMS Templates Table tests;
     Thread Record tests;
     Threads Table tests;
+    Notifications Table tests;
+    Notifications Record tests;
 "
 #---------
 TESTS_LIST["catch2-db-initializer"]="

--- a/image/user/db/notifications_001.sql
+++ b/image/user/db/notifications_001.sql
@@ -4,5 +4,6 @@
 CREATE TABLE IF NOT EXISTS notifications(
     _id INTEGER PRIMARY KEY,
     key INTEGER UNIQUE DEFAULT 0,
-    value INTEGER DEFAULT 0
+    value INTEGER DEFAULT 0,
+    contact_id INTEGER DEFAULT 0
 );

--- a/image/user/db/notifications_002.sql
+++ b/image/user/db/notifications_002.sql
@@ -1,7 +1,6 @@
 -- Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 -- For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-INSERT OR IGNORE INTO notifications (key, value) VALUES
-    ('1', '0'),
-    ('2', '0');
- 
+INSERT OR IGNORE INTO notifications (key, value, contact_id) VALUES
+    ('1', '0', '0'),
+    ('2', '0', '0');

--- a/module-apps/application-desktop/models/ActiveNotificationsModel.cpp
+++ b/module-apps/application-desktop/models/ActiveNotificationsModel.cpp
@@ -63,8 +63,8 @@ auto ActiveNotificationsModel::create(const notifications::NotSeenCallNotificati
     std::function<void()> onKeyLeftFunctionalCallback = nullptr;
 
     if (notification->hasRecord()) {
-        if (const auto &record = notification->getRecord(); !record->numbers.empty()) {
-            onKeyLeftFunctionalCallback = [this, number = record->numbers[0].number]() {
+        if (const auto &record = notification->getRecord(); !record.numbers.empty()) {
+            onKeyLeftFunctionalCallback = [this, number = record.numbers[0].number]() {
                 app::manager::Controller::sendAction(parent->getApplication(),
                                                      app::manager::actions::Dial,
                                                      std::make_unique<app::ExecuteCallData>(number));

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -12,6 +12,7 @@
 #include <service-appmgr/Controller.hpp>
 #include <service-time/ServiceTime.hpp>
 #include <service-time/TimeMessage.hpp>
+#include <notifications/NotificationsModel.hpp>
 
 #include <log/log.hpp>
 
@@ -136,7 +137,6 @@ namespace gui
             return app::manager::Controller::sendAction(
                 application, app::manager::actions::Dial, std::make_unique<app::EnterNumberData>("+"));
         }
-
         if (inputEvent.is(KeyCode::KEY_RF)) {
             application->switchWindow(popup::window::power_off_window);
             return true;

--- a/module-apps/application-desktop/windows/DesktopMainWindow.hpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.hpp
@@ -17,6 +17,8 @@ namespace app
 
 namespace gui
 {
+    class NotificationsModel;
+
     class DesktopMainWindow : public AppWindow
     {
       protected:

--- a/module-apps/notifications/NotificationData.cpp
+++ b/module-apps/notifications/NotificationData.cpp
@@ -2,7 +2,7 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "NotificationData.hpp"
-
+#include <gsl_assert>
 uint32_t notifications::Notification::priorityPool = 0;
 
 using namespace notifications;
@@ -35,33 +35,35 @@ auto Notification::getPriority() const noexcept -> uint32_t
     return priority;
 }
 
-NotSeenSMSNotification::NotSeenSMSNotification(unsigned value)
-    : Notification(NotificationType::NotSeenSms), value{value}
+NotificationWithContact::NotificationWithContact(NotificationType type,
+                                                 unsigned value,
+                                                 std::optional<ContactRecord> record)
+    : Notification(type), value{value}, record{std::move(record)}
 {}
 
-auto NotSeenSMSNotification::getValue() const noexcept -> unsigned
+auto NotificationWithContact::hasRecord() const noexcept -> bool
+{
+    return record.has_value();
+}
+
+auto NotificationWithContact::getRecord() const noexcept -> const ContactRecord &
+{
+    Expects(hasRecord());
+    return record.value();
+}
+
+auto NotificationWithContact::getValue() const noexcept -> unsigned
 {
     return value;
 }
 
-NotSeenCallNotification::NotSeenCallNotification(unsigned value, std::unique_ptr<ContactRecord> record)
-    : Notification(NotificationType::NotSeenCall), value{value}, record{std::move(record)}
+NotSeenSMSNotification::NotSeenSMSNotification(unsigned value, std::optional<ContactRecord> record)
+    : NotificationWithContact(NotificationType::NotSeenSms, value, std::move(record))
 {}
 
-bool NotSeenCallNotification::hasRecord() const noexcept
-{
-    return record != nullptr;
-}
-
-auto NotSeenCallNotification::getRecord() const noexcept -> const std::unique_ptr<ContactRecord> &
-{
-    return record;
-}
-
-auto NotSeenCallNotification::getValue() const noexcept -> unsigned
-{
-    return value;
-}
+NotSeenCallNotification::NotSeenCallNotification(unsigned value, std::optional<ContactRecord> record)
+    : NotificationWithContact(NotificationType::NotSeenCall, value, std::move(record))
+{}
 
 TetheringNotification::TetheringNotification() : Notification(NotificationType::Tethering)
 {}

--- a/module-apps/notifications/NotificationData.hpp
+++ b/module-apps/notifications/NotificationData.hpp
@@ -44,26 +44,30 @@ namespace notifications
         virtual ~Notification() = default;
     };
 
-    class NotSeenSMSNotification : public Notification
+    class NotificationWithContact : public Notification
     {
         unsigned value = 0;
+        std::optional<ContactRecord> record;
+
+      protected:
+        NotificationWithContact(NotificationType type, unsigned value, std::optional<ContactRecord> record);
 
       public:
-        explicit NotSeenSMSNotification(unsigned value);
+        [[nodiscard]] auto hasRecord() const noexcept -> bool;
+        [[nodiscard]] auto getRecord() const noexcept -> const ContactRecord &;
         [[nodiscard]] auto getValue() const noexcept -> unsigned;
     };
 
-    class NotSeenCallNotification : public Notification
+    class NotSeenSMSNotification : public NotificationWithContact
     {
-        unsigned value = 0;
-        std::unique_ptr<ContactRecord> record;
-
       public:
-        explicit NotSeenCallNotification(unsigned value, std::unique_ptr<ContactRecord> record = nullptr);
+        NotSeenSMSNotification(unsigned value, std::optional<ContactRecord> record);
+    };
 
-        [[nodiscard]] bool hasRecord() const noexcept;
-        [[nodiscard]] auto getRecord() const noexcept -> const std::unique_ptr<ContactRecord> &;
-        [[nodiscard]] auto getValue() const noexcept -> unsigned;
+    class NotSeenCallNotification : public NotificationWithContact
+    {
+      public:
+        NotSeenCallNotification(unsigned value, std::optional<ContactRecord> record);
     };
 
     class TetheringNotification : public Notification

--- a/module-apps/notifications/NotificationListItem.cpp
+++ b/module-apps/notifications/NotificationListItem.cpp
@@ -12,7 +12,6 @@
 #include <map>
 
 using namespace gui;
-// using namespace style::desktop;
 
 namespace
 {
@@ -36,14 +35,15 @@ namespace
     auto buildNotificationNameLabel(uint32_t width) -> gui::TextFixedSize *
     {
         auto text =
-            new gui::TextFixedSize(nullptr, 0, 0, style::notifications::textMaxWidth, style::notifications::itemHeight);
-        text->setMaximumSize(width, Axis::X);
+            new gui::TextFixedSize(nullptr, 0, 0, style::notifications::textMinWidth, style::notifications::itemHeight);
 
+        text->setMaximumSize(style::notifications::textMaxWidth, Axis::X);
         text->setAlignment(Alignment(gui::Alignment::Horizontal::Left, gui::Alignment::Vertical::Center));
         text->setPenWidth(style::window::default_border_no_focus_w);
         text->setUnderline(false);
         text->setFont(style::window::font::medium);
         text->activeItem = false;
+        text->setTextLimitType(TextLimitType::MaxLines, 1);
         return text;
     }
 
@@ -135,6 +135,7 @@ NotificationWithEventCounter::NotificationWithEventCounter(notifications::Notifi
 {
     box->addWidget(buildImageInactive("dot_12px_hard_alpha_W_G"));
     box->addWidget(buildNotificationCountText(indicator));
+    text->setMaximumSize(text->getSize(Axis::X), Axis::X);
 }
 
 NotificationWithOnOffButton::NotificationWithOnOffButton(notifications::NotificationType type, gui::ButtonState state)

--- a/module-apps/notifications/NotificationProvider.hpp
+++ b/module-apps/notifications/NotificationProvider.hpp
@@ -11,6 +11,8 @@ namespace sys
     class Service;
 }
 
+class NotificationsRecord;
+
 namespace db
 {
     class NotificationMessage;
@@ -25,7 +27,7 @@ namespace notifications
 
     class NotificationProvider
     {
-        template <NotificationType type, typename T> bool handleNotSeenWithCounter(unsigned int value);
+        template <NotificationType type, typename T> bool handleNotSeenWithCounter(NotificationsRecord &&record);
 
       public:
         explicit NotificationProvider(sys::Service *ownerService);

--- a/module-apps/notifications/NotificationsModel.cpp
+++ b/module-apps/notifications/NotificationsModel.cpp
@@ -65,7 +65,7 @@ auto NotificationsModel::create(const notifications::NotSeenCallNotification *no
                                                  utils::to_string(notification->getValue()));
     if (notification->hasRecord()) {
         const auto &record = notification->getRecord();
-        item->setName(record->getFormattedName());
+        item->setName(record.getFormattedName());
     }
     else {
         item->setName(utils::translate("app_desktop_missed_calls"), true);

--- a/module-db/Databases/NotificationsDB.hpp
+++ b/module-db/Databases/NotificationsDB.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -9,7 +9,7 @@
 class NotificationsDB : public Database
 {
   public:
-    NotificationsDB(const char *name);
+    explicit NotificationsDB(const char *name);
     virtual ~NotificationsDB() = default;
 
     NotificationsTable notifications;

--- a/module-db/Tables/NotificationsTable.cpp
+++ b/module-db/Tables/NotificationsTable.cpp
@@ -1,12 +1,11 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "NotificationsTable.hpp"
-#include "module-db/Interface/NotificationsRecord.hpp"
+#include "Database/Database.hpp"
 
 #include <log/log.hpp>
 #include <Utils.hpp>
-
 #include <cassert>
 
 NotificationsTable::NotificationsTable(Database *db) : Table(db)
@@ -19,7 +18,10 @@ bool NotificationsTable::create()
 
 bool NotificationsTable::add(NotificationsTableRow entry)
 {
-    return db->execute("INSERT or IGNORE INTO notifications (key, value) VALUES (%lu, %lu);", entry.key, entry.value);
+    return db->execute("INSERT or IGNORE INTO notifications (key, value, contact_id) VALUES (%lu, %lu, %lu);",
+                       entry.key,
+                       entry.value,
+                       entry.contactID);
 }
 
 bool NotificationsTable::removeById(uint32_t id)
@@ -42,8 +44,11 @@ bool NotificationsTable::removeByField(NotificationsTableFields field, const cha
 
 bool NotificationsTable::update(NotificationsTableRow entry)
 {
-    return db->execute(
-        "UPDATE notifications SET key = %lu, value = %lu WHERE _id = %lu;", entry.key, entry.value, entry.ID);
+    return db->execute("UPDATE notifications SET key = %lu, value = %lu, contact_id = %lu WHERE _id = %lu;",
+                       entry.key,
+                       entry.value,
+                       entry.contactID,
+                       entry.ID);
 }
 
 NotificationsTableRow NotificationsTable::getById(uint32_t id)
@@ -59,12 +64,12 @@ NotificationsTableRow NotificationsTable::getById(uint32_t id)
     return NotificationsTableRow{
         (*retQuery)[0].getUInt32(), // ID
         (*retQuery)[1].getUInt32(), // key
-        (*retQuery)[2].getUInt32()  // value
-
+        (*retQuery)[2].getUInt32(), // value
+        (*retQuery)[3].getUInt32()  // contactID
     };
 }
 
-NotificationsTableRow NotificationsTable::GetByKey(uint32_t key)
+NotificationsTableRow NotificationsTable::getByKey(uint32_t key)
 {
     auto retQuery = db->query("SELECT * FROM notifications WHERE key= %u;", key);
 
@@ -77,7 +82,8 @@ NotificationsTableRow NotificationsTable::GetByKey(uint32_t key)
     return NotificationsTableRow{
         (*retQuery)[0].getUInt32(), // ID
         (*retQuery)[1].getUInt32(), // key
-        (*retQuery)[2].getUInt32()  // value
+        (*retQuery)[2].getUInt32(), // value
+        (*retQuery)[3].getUInt32()  // contactID
     };
 }
 
@@ -96,6 +102,7 @@ std::vector<NotificationsTableRow> NotificationsTable::getLimitOffset(uint32_t o
             (*retQuery)[0].getUInt32(), // ID
             (*retQuery)[1].getUInt32(), // key
             (*retQuery)[2].getUInt32(), // value
+            (*retQuery)[3].getUInt32()  // contactID
         });
     } while (retQuery->nextRow());
 

--- a/module-db/Tables/NotificationsTable.hpp
+++ b/module-db/Tables/NotificationsTable.hpp
@@ -1,18 +1,20 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include "Table.hpp"
 #include "Record.hpp"
-#include "Database/Database.hpp"
 #include "utf8/UTF8.hpp"
 #include "Common/Common.hpp"
+
+class Database;
 
 struct NotificationsTableRow : public Record
 {
     uint32_t key   = 0;
     uint32_t value = 0;
+    uint32_t contactID = DB_ID_NONE;
 };
 
 enum class NotificationsTableFields
@@ -32,7 +34,7 @@ class NotificationsTable : public Table<NotificationsTableRow, NotificationsTabl
     bool removeByField(NotificationsTableFields field, const char *str) override final;
     bool update(NotificationsTableRow entry) override final;
     NotificationsTableRow getById(uint32_t id) override final;
-    NotificationsTableRow GetByKey(uint32_t key);
+    NotificationsTableRow getByKey(uint32_t key);
     uint32_t count() override final;
     uint32_t countByFieldId(const char *field, uint32_t id) override final;
     std::vector<NotificationsTableRow> getLimitOffset(uint32_t offset, uint32_t limit) override final;

--- a/module-db/queries/calllog/QueryCalllogSetAllRead.hpp
+++ b/module-db/queries/calllog/QueryCalllogSetAllRead.hpp
@@ -1,9 +1,8 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
-#include "Interface/NotificationsRecord.hpp"
 #include <Common/Query.hpp>
 #include <string>
 
@@ -20,7 +19,7 @@ namespace db::query::calllog
     class SetAllReadResult : public QueryResult
     {
       public:
-        SetAllReadResult(bool ret);
+        explicit SetAllReadResult(bool ret);
         [[nodiscard]] auto debugInfo() const -> std::string override;
 
         const bool ret = true;

--- a/module-db/queries/notifications/QueryNotificationsClear.cpp
+++ b/module-db/queries/notifications/QueryNotificationsClear.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "QueryNotificationsClear.hpp"
@@ -11,6 +11,11 @@ namespace db::query::notifications
     auto Clear::debugInfo() const -> std::string
     {
         return "Clear";
+    }
+
+    auto Clear::getKey() const noexcept -> NotificationsRecord::Key
+    {
+        return key;
     }
 
     ClearResult::ClearResult(bool ret) : ret(ret)

--- a/module-db/queries/notifications/QueryNotificationsClear.hpp
+++ b/module-db/queries/notifications/QueryNotificationsClear.hpp
@@ -1,9 +1,9 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
-#include "module-db/Interface/NotificationsRecord.hpp"
+#include <Interface/NotificationsRecord.hpp>
 #include <Common/Query.hpp>
 #include <string>
 
@@ -11,10 +11,12 @@ namespace db::query::notifications
 {
     class Clear : public Query
     {
-      public:
         const NotificationsRecord::Key key;
-        Clear(NotificationsRecord::Key key);
 
+      public:
+        explicit Clear(NotificationsRecord::Key key);
+
+        [[nodiscard]] auto getKey() const noexcept -> NotificationsRecord::Key;
         [[nodiscard]] auto debugInfo() const -> std::string override;
     };
 
@@ -23,7 +25,7 @@ namespace db::query::notifications
         bool ret;
 
       public:
-        ClearResult(bool ret);
+        explicit ClearResult(bool ret);
         [[nodiscard]] auto getResult() const -> bool;
 
         [[nodiscard]] auto debugInfo() const -> std::string override;

--- a/module-db/queries/notifications/QueryNotificationsGet.cpp
+++ b/module-db/queries/notifications/QueryNotificationsGet.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "QueryNotificationsGet.hpp"
@@ -13,7 +13,12 @@ namespace db::query::notifications
         return "Get";
     }
 
-    GetResult::GetResult(NotificationsRecord record) : record(record)
+    auto Get::getKey() const noexcept -> NotificationsRecord::Key
+    {
+        return key;
+    }
+
+    GetResult::GetResult(NotificationsRecord record) : record(std::move(record))
     {}
 
     auto GetResult::getResult() const -> NotificationsRecord

--- a/module-db/queries/notifications/QueryNotificationsGet.hpp
+++ b/module-db/queries/notifications/QueryNotificationsGet.hpp
@@ -1,9 +1,9 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
-#include "module-db/Interface/NotificationsRecord.hpp"
+#include <Interface/NotificationsRecord.hpp>
 #include <Common/Query.hpp>
 #include <string>
 
@@ -11,10 +11,12 @@ namespace db::query::notifications
 {
     class Get : public Query
     {
-      public:
         const NotificationsRecord::Key key;
-        Get(NotificationsRecord::Key key);
 
+      public:
+        explicit Get(NotificationsRecord::Key key);
+
+        [[nodiscard]] auto getKey() const noexcept -> NotificationsRecord::Key;
         [[nodiscard]] auto debugInfo() const -> std::string override;
     };
 
@@ -23,7 +25,7 @@ namespace db::query::notifications
         NotificationsRecord record;
 
       public:
-        GetResult(NotificationsRecord record);
+        explicit GetResult(NotificationsRecord record);
         [[nodiscard]] auto getResult() const -> NotificationsRecord;
 
         [[nodiscard]] auto debugInfo() const -> std::string override;

--- a/module-db/queries/notifications/QueryNotificationsGetAll.hpp
+++ b/module-db/queries/notifications/QueryNotificationsGetAll.hpp
@@ -1,9 +1,9 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
-#include "module-db/Interface/NotificationsRecord.hpp"
+#include <Interface/NotificationsRecord.hpp>
 #include <Common/Query.hpp>
 #include <string>
 
@@ -22,7 +22,7 @@ namespace db::query::notifications
         std::unique_ptr<std::vector<NotificationsRecord>> records;
 
       public:
-        GetAllResult(std::unique_ptr<std::vector<NotificationsRecord>> records);
+        explicit GetAllResult(std::unique_ptr<std::vector<NotificationsRecord>> records);
         [[nodiscard]] auto getResult() -> std::unique_ptr<std::vector<NotificationsRecord>>;
 
         [[nodiscard]] auto debugInfo() const -> std::string override;

--- a/module-db/queries/notifications/QueryNotificationsIncrement.cpp
+++ b/module-db/queries/notifications/QueryNotificationsIncrement.cpp
@@ -1,12 +1,22 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "QueryNotificationsIncrement.hpp"
 
 namespace db::query::notifications
 {
-    Increment::Increment(NotificationsRecord::Key key) : Query(Query::Type::Update), key(key)
+    Increment::Increment(NotificationsRecord::Key key, const utils::PhoneNumber::View &number)
+        : Query(Query::Type::Update), key(key), number(number)
     {}
+
+    auto Increment::getKey() const noexcept -> NotificationsRecord::Key
+    {
+        return key;
+    }
+    auto Increment::getNumber() const noexcept -> const utils::PhoneNumber::View &
+    {
+        return number;
+    }
 
     auto Increment::debugInfo() const -> std::string
     {
@@ -16,7 +26,7 @@ namespace db::query::notifications
     IncrementResult::IncrementResult(bool ret) : ret(ret)
     {}
 
-    auto IncrementResult::getResult() const -> bool
+    auto IncrementResult::getResult() const noexcept -> bool
     {
         return ret;
     }

--- a/module-db/queries/notifications/QueryNotificationsIncrement.hpp
+++ b/module-db/queries/notifications/QueryNotificationsIncrement.hpp
@@ -1,19 +1,25 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
-#include "module-db/Interface/NotificationsRecord.hpp"
+#include <Interface/NotificationsRecord.hpp>
 #include <Common/Query.hpp>
 #include <string>
+#include <PhoneNumber.hpp>
 
 namespace db::query::notifications
 {
     class Increment : public Query
     {
-      public:
         const NotificationsRecord::Key key;
-        Increment(NotificationsRecord::Key key);
+        const utils::PhoneNumber::View number;
+
+      public:
+        Increment(NotificationsRecord::Key key, const utils::PhoneNumber::View &number);
+
+        [[nodiscard]] auto getKey() const noexcept -> NotificationsRecord::Key;
+        [[nodiscard]] auto getNumber() const noexcept -> const utils::PhoneNumber::View &;
 
         [[nodiscard]] auto debugInfo() const -> std::string override;
     };
@@ -23,8 +29,8 @@ namespace db::query::notifications
         bool ret;
 
       public:
-        IncrementResult(bool ret);
-        [[nodiscard]] auto getResult() const -> bool;
+        explicit IncrementResult(bool ret);
+        [[nodiscard]] auto getResult() const noexcept -> bool;
 
         [[nodiscard]] auto debugInfo() const -> std::string override;
     };

--- a/module-db/tests/CMakeLists.txt
+++ b/module-db/tests/CMakeLists.txt
@@ -22,8 +22,8 @@ add_catch2_executable(
         #EventsTable_tests.cpp
         NotesRecord_tests.cpp
         NotesTable_tests.cpp
-        #NotificationsRecord_tests.cpp
-        #NotificationsTable_tests.cpp
+        NotificationsRecord_tests.cpp
+        NotificationsTable_tests.cpp
         QueryInterface.cpp
         SMSRecord_tests.cpp
         SMSTable_tests.cpp

--- a/module-db/tests/NotificationsRecord_tests.cpp
+++ b/module-db/tests/NotificationsRecord_tests.cpp
@@ -1,15 +1,18 @@
 // Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
+#include "common.hpp"
 #include <catch2/catch.hpp>
 
-#include "Interface/NotificationsRecord.hpp"
-#include "Database/Database.hpp"
-#include "Databases/NotificationsDB.hpp"
-#include "module-db/queries/notifications/QueryNotificationsGet.hpp"
-#include "module-db/queries/notifications/QueryNotificationsIncrement.hpp"
-#include "module-db/queries/notifications/QueryNotificationsClear.hpp"
-#include "module-db/queries/notifications/QueryNotificationsGetAll.hpp"
+#include <Interface/NotificationsRecord.hpp>
+#include <Interface/ContactRecord.hpp>
+#include <Database/Database.hpp>
+#include <Databases/NotificationsDB.hpp>
+#include <Databases/ContactsDB.hpp>
+#include <queries/notifications/QueryNotificationsGet.hpp>
+#include <queries/notifications/QueryNotificationsIncrement.hpp>
+#include <queries/notifications/QueryNotificationsClear.hpp>
+#include <queries/notifications/QueryNotificationsGetAll.hpp>
 
 #include <filesystem>
 
@@ -21,16 +24,6 @@
 
 TEST_CASE("Notifications Record tests")
 {
-    Database::initialize();
-
-    const auto notificationsPath = (std::filesystem::path{"sys/user"} / "notifications.db");
-    if (std::filesystem::exists(notificationsPath)) {
-        REQUIRE(std::filesystem::remove(notificationsPath));
-    }
-
-    NotificationsDB notificationsDb{notificationsPath.c_str()};
-
-    REQUIRE(notificationsDb.isInitialized());
 
     SECTION("Default Constructor")
     {
@@ -39,27 +32,43 @@ TEST_CASE("Notifications Record tests")
         REQUIRE(testRec.ID == DB_ID_NONE);
         REQUIRE(testRec.key == NotificationsRecord::Key::NotValidKey);
         REQUIRE(testRec.value == 0);
+        REQUIRE_FALSE(testRec.contactRecord.has_value());
     }
 
     SECTION("Constructor from NotificationsTableRow")
     {
         NotificationsTableRow tableRow{
             {.ID = 10}, .key = static_cast<uint32_t>(NotificationsRecord::Key::Calls), .value = 2};
-
         NotificationsRecord testRec(tableRow);
         REQUIRE(testRec.isValid());
         REQUIRE(testRec.ID == 10);
         REQUIRE(testRec.key == NotificationsRecord::Key::Calls);
         REQUIRE(testRec.value == 2);
+        REQUIRE_FALSE(testRec.contactRecord.has_value());
     }
+
+    Database::initialize();
+    const auto notificationsPath = (std::filesystem::path{"sys/user"} / "notifications.db");
+    const auto contactsPath      = (std::filesystem::path{"sys/user"} / "contacts.db");
+    RemoveDbFiles(notificationsPath.stem());
+    RemoveDbFiles(contactsPath.stem());
+
+    NotificationsDB notificationsDb{notificationsPath.c_str()};
+    ContactsDB contactsDb{contactsPath.c_str()};
+    REQUIRE(notificationsDb.isInitialized());
+    REQUIRE(contactsDb.isInitialized());
 
     const auto notificationsCount = notificationsDb.notifications.count() + 1;
     // clear notifications table
     for (std::size_t id = 1; id <= notificationsCount; id++) {
         REQUIRE(notificationsDb.notifications.removeById(id));
     }
-    NotificationsRecordInterface notificationsRecordInterface(&notificationsDb);
+
+    ContactRecordInterface contactRecordInterface(&contactsDb);
+    NotificationsRecordInterface notificationsRecordInterface(&notificationsDb, &contactRecordInterface);
+    REQUIRE(contactRecordInterface.GetCount() == 0);
     REQUIRE(notificationsRecordInterface.GetCount() == 0);
+
     NotificationsTableRow callsRow{
         {.ID = DB_ID_NONE}, .key = static_cast<uint32_t>(NotificationsRecord::Key::Calls), .value = 0};
 
@@ -80,12 +89,14 @@ TEST_CASE("Notifications Record tests")
         REQUIRE(callsNotifications.ID == 1);
         REQUIRE(callsNotifications.key == NotificationsRecord::Key::Calls);
         REQUIRE(callsNotifications.value == 0);
+        REQUIRE_FALSE(callsNotifications.contactRecord.has_value());
 
         auto smsNotifications = notificationsRecordInterface.GetByID(2);
         REQUIRE(smsNotifications.isValid());
         REQUIRE(smsNotifications.ID == 2);
         REQUIRE(smsNotifications.key == NotificationsRecord::Key::Sms);
         REQUIRE(smsNotifications.value == 0);
+        REQUIRE_FALSE(smsNotifications.contactRecord.has_value());
     }
 
     SECTION("Get entry by key")
@@ -180,7 +191,9 @@ TEST_CASE("Notifications Record tests")
         REQUIRE(entryPost.value == entryPre.value);
     }
 
-    auto getByKey = [&](NotificationsRecord::Key key, uint32_t val) {
+    auto getByKey = [&](NotificationsRecord::Key key,
+                        uint32_t expectedValue,
+                        const std::optional<ContactRecord> &expectedContactRecord = std::nullopt) {
         auto query  = std::make_shared<db::query::notifications::Get>(key);
         auto ret    = notificationsRecordInterface.runQuery(query);
         auto result = dynamic_cast<db::query::notifications::GetResult *>(ret.get());
@@ -188,11 +201,16 @@ TEST_CASE("Notifications Record tests")
         auto record = result->getResult();
         REQUIRE(record.isValid());
         REQUIRE(record.key == key);
-        REQUIRE(record.value == val);
+        REQUIRE(record.value == expectedValue);
+        REQUIRE(record.contactRecord.has_value() == expectedContactRecord.has_value());
+        if (expectedContactRecord.has_value()) {
+            REQUIRE(record.contactRecord.value().ID == expectedContactRecord.value().ID);
+        }
     };
 
-    auto incrementByKey = [&](NotificationsRecord::Key key) {
-        auto query  = std::make_shared<db::query::notifications::Increment>(key);
+    auto incrementByKey = [&](NotificationsRecord::Key key, const std::string &phoneNumber = "+48500500500") {
+        utils::PhoneNumber number(phoneNumber);
+        auto query  = std::make_shared<db::query::notifications::Increment>(key, number.getView());
         auto ret    = notificationsRecordInterface.runQuery(query);
         auto result = dynamic_cast<db::query::notifications::IncrementResult *>(ret.get());
         REQUIRE(result != nullptr);
@@ -251,6 +269,97 @@ TEST_CASE("Notifications Record tests")
         REQUIRE(result != nullptr);
         auto records = result->getResult();
         REQUIRE(records->size() == numberOfNotifcations);
+    }
+
+    SECTION("Notification DB and Contact DB connection tests")
+    {
+        const std::string primaryNameTest_1 = "PrimaryTestNameOne";
+        const std::string numberUserTest_1  = "600123456";
+        ContactRecord testContactRecord_1;
+        testContactRecord_1.primaryName = primaryNameTest_1;
+        testContactRecord_1.numbers =
+            std::vector<ContactRecord::Number>({ContactRecord::Number(utils::PhoneNumber(numberUserTest_1).getView())});
+
+        const std::string primaryNameTest_2 = "PrimaryTestNameTwo";
+        const std::string numberUserTest_2  = "600600600";
+        ContactRecord testContactRecord_2;
+        testContactRecord_2.primaryName = primaryNameTest_2;
+        testContactRecord_2.numbers =
+            std::vector<ContactRecord::Number>({ContactRecord::Number(utils::PhoneNumber(numberUserTest_2).getView())});
+
+        REQUIRE(contactRecordInterface.Add(testContactRecord_1));
+        REQUIRE(contactRecordInterface.Add(testContactRecord_2));
+
+        const auto someUnknownNumber      = "500200300";
+        const auto noNotificationExpected = 0;
+        const auto contactNotExpected     = std::nullopt;
+
+        SECTION("Tests preconditions")
+        {
+            getByKey(NotificationsRecord::Key::Calls, noNotificationExpected);
+        }
+
+        SECTION("Single call notification from unknown number")
+        {
+            const auto expectedNotificationValue = 1;
+            incrementByKey(NotificationsRecord::Key::Calls, someUnknownNumber);
+            getByKey(NotificationsRecord::Key::Calls, expectedNotificationValue, contactNotExpected);
+        }
+
+        SECTION("Single call notification from known number")
+        {
+            const auto expectedNotificationValue = 1;
+            incrementByKey(NotificationsRecord::Key::Calls, numberUserTest_1);
+            getByKey(NotificationsRecord::Key::Calls, expectedNotificationValue, testContactRecord_1);
+            clearByKey(NotificationsRecord::Key::Calls);
+            getByKey(NotificationsRecord::Key::Calls, noNotificationExpected, contactNotExpected);
+        }
+
+        SECTION("Multiple call notifications from single known number")
+        {
+            const auto expectedNotificationValue = 3;
+            for (int i = 0; i < expectedNotificationValue; i++)
+                incrementByKey(NotificationsRecord::Key::Calls, numberUserTest_1);
+            getByKey(NotificationsRecord::Key::Calls, expectedNotificationValue, testContactRecord_1);
+            clearByKey(NotificationsRecord::Key::Calls);
+            getByKey(NotificationsRecord::Key::Calls, noNotificationExpected, contactNotExpected);
+        }
+
+        SECTION("Multiple call notifications from multiple known numbers")
+        {
+            const auto expectedNotificationValue = 2 * 3;
+            for (int i = 0; i < expectedNotificationValue / 2; i++) {
+                incrementByKey(NotificationsRecord::Key::Calls, numberUserTest_1);
+                incrementByKey(NotificationsRecord::Key::Calls, numberUserTest_2);
+            }
+            getByKey(NotificationsRecord::Key::Calls, expectedNotificationValue, contactNotExpected);
+            clearByKey(NotificationsRecord::Key::Calls);
+            getByKey(NotificationsRecord::Key::Calls, noNotificationExpected, contactNotExpected);
+        }
+
+        SECTION("Multiple call notifications in sequence of known-unknown-known numbers")
+        {
+            incrementByKey(NotificationsRecord::Key::Calls, numberUserTest_1);
+            getByKey(NotificationsRecord::Key::Calls, 1, testContactRecord_1);
+
+            incrementByKey(NotificationsRecord::Key::Calls, someUnknownNumber);
+            getByKey(NotificationsRecord::Key::Calls, 2, contactNotExpected);
+
+            incrementByKey(NotificationsRecord::Key::Calls, numberUserTest_1);
+            getByKey(NotificationsRecord::Key::Calls, 3, contactNotExpected);
+        }
+
+        SECTION("Multiple call notifications in sequence of unknown-known-unknown numbers")
+        {
+            incrementByKey(NotificationsRecord::Key::Calls, someUnknownNumber);
+            getByKey(NotificationsRecord::Key::Calls, 1, contactNotExpected);
+
+            incrementByKey(NotificationsRecord::Key::Calls, numberUserTest_1);
+            getByKey(NotificationsRecord::Key::Calls, 2, contactNotExpected);
+
+            incrementByKey(NotificationsRecord::Key::Calls, someUnknownNumber);
+            getByKey(NotificationsRecord::Key::Calls, 3, contactNotExpected);
+        }
     }
 
     Database::deinitialize();

--- a/module-db/tests/NotificationsTable_tests.cpp
+++ b/module-db/tests/NotificationsTable_tests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
+#include "common.hpp"
 #include <catch2/catch.hpp>
 
 #include "Database/Database.hpp"
@@ -17,12 +18,8 @@
 TEST_CASE("Notifications Table tests")
 {
     Database::initialize();
-
     const auto notificationsPath = (std::filesystem::path{"sys/user"} / "notifications.db");
-    if (std::filesystem::exists(notificationsPath)) {
-        REQUIRE(std::filesystem::remove(notificationsPath));
-    }
-
+    RemoveDbFiles(notificationsPath.stem());
     NotificationsDB notificationsDb{notificationsPath.c_str()};
     REQUIRE(notificationsDb.isInitialized());
 
@@ -50,11 +47,12 @@ TEST_CASE("Notifications Table tests")
         REQUIRE(testRow.ID == DB_ID_NONE);
         REQUIRE(testRow.key == 0);
         REQUIRE(testRow.value == 0);
+        REQUIRE(testRow.contactID == DB_ID_NONE);
         REQUIRE_FALSE(testRow.isValid());
     }
 
     REQUIRE(notificationsTbl.add({{.ID = 0}, .key = 3, .value = 8}));
-    REQUIRE(notificationsTbl.add({{.ID = 0}, .key = 4, .value = 16}));
+    REQUIRE(notificationsTbl.add({{.ID = 0}, .key = 4, .value = 16, .contactID = 100}));
 
     REQUIRE(notificationsTbl.count() == 4);
 
@@ -64,6 +62,7 @@ TEST_CASE("Notifications Table tests")
         REQUIRE(entry.ID == 4);
         REQUIRE(entry.key == 4);
         REQUIRE(entry.value == 16);
+        REQUIRE(entry.contactID == 100);
         REQUIRE(entry.isValid());
     }
 
@@ -73,6 +72,7 @@ TEST_CASE("Notifications Table tests")
         REQUIRE(entry.ID == 3);
         REQUIRE(entry.key == 3);
         REQUIRE(entry.value == 8);
+        REQUIRE(entry.contactID == DB_ID_NONE);
         REQUIRE(entry.isValid());
     }
 
@@ -93,11 +93,12 @@ TEST_CASE("Notifications Table tests")
 
     SECTION("Entry update")
     {
-        REQUIRE(notificationsTbl.update({{.ID = 3}, .key = 100, .value = 200}));
+        REQUIRE(notificationsTbl.update({{.ID = 3}, .key = 100, .value = 200, .contactID = 300}));
         auto entry = notificationsTbl.getById(3);
         REQUIRE(entry.ID == 3);
         REQUIRE(entry.key == 100);
         REQUIRE(entry.value == 200);
+        REQUIRE(entry.contactID == 300);
     }
 
     SECTION("Get entry - invalid ID")
@@ -107,14 +108,16 @@ TEST_CASE("Notifications Table tests")
         REQUIRE(entry.ID == DB_ID_NONE);
         REQUIRE(entry.key == 0);
         REQUIRE(entry.value == 0);
+        REQUIRE(entry.ID == DB_ID_NONE);
     }
 
     SECTION("Get by invalid key")
     {
-        auto entry = notificationsTbl.getById(100);
+        auto entry = notificationsTbl.getByKey(100);
         REQUIRE(entry.ID == DB_ID_NONE);
         REQUIRE(entry.key == 0);
         REQUIRE(entry.value == 0);
+        REQUIRE(entry.ID == DB_ID_NONE);
         REQUIRE_FALSE(entry.isValid());
     }
 
@@ -158,13 +161,14 @@ TEST_CASE("Notifications Table tests")
 
     SECTION("Check uniqueness")
     {
-        REQUIRE(notificationsTbl.add({{.ID = 0}, .key = 3, .value = 100}));
+        REQUIRE(notificationsTbl.add({{.ID = 0}, .key = 3, .value = 100, .contactID = 200}));
         REQUIRE(notificationsTbl.count() == 4);
-        auto entry = notificationsTbl.getById(3);
+        auto entry = notificationsTbl.getByKey(3);
+        REQUIRE(entry.isValid());
         REQUIRE(entry.ID == 3);
         REQUIRE(entry.key == 3);
         REQUIRE(entry.value == 8);
-        REQUIRE(entry.isValid());
+        REQUIRE(entry.contactID == DB_ID_NONE);
     }
 
     Database::deinitialize();

--- a/module-gui/gui/widgets/Style.hpp
+++ b/module-gui/gui/widgets/Style.hpp
@@ -249,7 +249,8 @@ namespace style
         inline constexpr auto spanSize     = 8;
         inline constexpr auto digitSize    = 16;
         inline constexpr auto iconWidth    = 35;
-        inline constexpr auto textMaxWidth = 250;
+        inline constexpr auto textMinWidth = 250;
+        inline constexpr auto textMaxWidth = 350;
         inline constexpr auto itemHeight   = 55;
 
         namespace model

--- a/module-services/service-cellular/service-cellular/ServiceCellular.hpp
+++ b/module-services/service-cellular/service-cellular/ServiceCellular.hpp
@@ -279,7 +279,7 @@ class ServiceCellular : public sys::Service
                                             const time_t messageDate,
                                             const SMSType &smsType = SMSType::INBOX) const noexcept;
     bool dbAddSMSRecord(const SMSRecord &record);
-    void onSMSReceived();
+    void onSMSReceived(const utils::PhoneNumber::View &number);
     [[nodiscard]] bool receiveAllMessages();
     /// @}
 

--- a/module-services/service-db/ServiceDB.cpp
+++ b/module-services/service-db/ServiceDB.cpp
@@ -263,7 +263,8 @@ sys::ReturnCodes ServiceDB::InitHandler()
     notesRecordInterface         = std::make_unique<NotesRecordInterface>(notesDB.get());
     calllogRecordInterface       = std::make_unique<CalllogRecordInterface>(calllogDB.get(), contactsDB.get());
     countryCodeRecordInterface   = std::make_unique<CountryCodeRecordInterface>(countryCodesDB.get());
-    notificationsRecordInterface = std::make_unique<NotificationsRecordInterface>(notificationsDB.get());
+    notificationsRecordInterface =
+        std::make_unique<NotificationsRecordInterface>(notificationsDB.get(), contactRecordInterface.get());
     eventsRecordInterface        = std::make_unique<EventsRecordInterface>(eventsDB.get());
     quotesRecordInterface        = std::make_unique<Quotes::QuotesAgent>(quotesDB.get());
 

--- a/module-services/service-db/ServiceDB.hpp
+++ b/module-services/service-db/ServiceDB.hpp
@@ -19,7 +19,6 @@
 #include <Interface/CountryCodeRecord.hpp>
 #include <Interface/EventsRecord.hpp>
 #include <Interface/NotesRecord.hpp>
-#include <Interface/NotificationsRecord.hpp>
 #include <Interface/SMSRecord.hpp>
 #include <Interface/SMSTemplateRecord.hpp>
 #include <Interface/ThreadRecord.hpp>


### PR DESCRIPTION
This PR adds proper notification on call notifications coming from
single number. To that end following changes have been introduced:
 * extension of Notification DB record with contact_id filed
 * use of `ContactRecordInterface` in `NotificationsRecordInterface`
 * extension of `Increment` query to require `PhoneNumber::View`
 * multiple minor changes on path from creating/handling
 `NotificationsRecord` to displaying respective notification.
 
 The result of these changes is to enable https://miro.com/app/board/o9J_kvRRDVg=/?moveToWidget=3074457347306289247&cot=14  on the front end side.