### PR TITLE
[EGD-6615] Fix tethering repeated notification

### DIFF
--- a/module-services/service-desktop/DesktopMessages.cpp
+++ b/module-services/service-desktop/DesktopMessages.cpp
@@ -40,4 +40,16 @@ namespace sdesktop
         }
     } // namespace developerMode
 
+    namespace usb
+    {
+        USBConfigured::USBConfigured(USBConfigurationType configurationType)
+            : sys::DataMessage(MessageType::USBConfigured), configurationType(configurationType)
+        {}
+
+        USBConfigurationType USBConfigured::getConfigurationType() const noexcept
+        {
+            return configurationType;
+        }
+    } // namespace usb
+
 } // namespace sdesktop

--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -211,8 +211,11 @@ sys::ReturnCodes ServiceDesktop::InitHandler()
     });
 
     connect(sdesktop::usb::USBConfigured(), [&](sys::Message *msg) {
-        bus.sendUnicast(std::make_shared<sys::TetheringStateRequest>(sys::phone_modes::Tethering::On),
-                        service::name::system_manager);
+        auto message = static_cast<sdesktop::usb::USBConfigured *>(msg);
+        if (message->getConfigurationType() == sdesktop::usb::USBConfigurationType::firstConfiguration) {
+            bus.sendUnicast(std::make_shared<sys::TetheringStateRequest>(sys::phone_modes::Tethering::On),
+                            service::name::system_manager);
+        }
 
         if (!usbSecurityModel->isSecurityEnabled()) {
             LOG_INFO("Endpoint security disabled.");

--- a/module-services/service-desktop/WorkerDesktop.cpp
+++ b/module-services/service-desktop/WorkerDesktop.cpp
@@ -134,8 +134,16 @@ bool WorkerDesktop::handleMessage(uint32_t queueID)
         }
         else if (notification == bsp::USBDeviceStatus::Configured) {
             cpuSentinel->HoldMinimumFrequency(bsp::CpuFrequencyHz::Level_4);
-            ownerService->bus.sendUnicast(std::make_shared<sdesktop::usb::USBConfigured>(),
-                                          service::name::service_desktop);
+            if (usbStatus == bsp::USBDeviceStatus::Connected) {
+                ownerService->bus.sendUnicast(std::make_shared<sdesktop::usb::USBConfigured>(
+                                                  sdesktop::usb::USBConfigurationType::firstConfiguration),
+                                              service::name::service_desktop);
+            }
+            else {
+                ownerService->bus.sendUnicast(std::make_shared<sdesktop::usb::USBConfigured>(
+                                                  sdesktop::usb::USBConfigurationType::reconfiguration),
+                                              service::name::service_desktop);
+            }
         }
         else if (notification == bsp::USBDeviceStatus::Disconnected) {
             usbSuspendTimer.start();
@@ -143,6 +151,7 @@ bool WorkerDesktop::handleMessage(uint32_t queueID)
             ownerService->bus.sendUnicast(std::make_shared<sdesktop::usb::USBDisconnected>(),
                                           service::name::service_desktop);
         }
+        usbStatus = notification;
     }
     else {
         LOG_INFO("handeMessage got message on an unhandled queue");

--- a/module-services/service-desktop/service-desktop/DesktopMessages.hpp
+++ b/module-services/service-desktop/service-desktop/DesktopMessages.hpp
@@ -72,6 +72,12 @@ namespace sdesktop
 
     namespace usb
     {
+        enum class USBConfigurationType
+        {
+            firstConfiguration,
+            reconfiguration
+        };
+
         class USBConnected : public sys::DataMessage
         {
           public:
@@ -83,9 +89,13 @@ namespace sdesktop
         class USBConfigured : public sys::DataMessage
         {
           public:
-            USBConfigured() : sys::DataMessage(MessageType::USBConfigured)
-            {}
+            explicit USBConfigured(
+                USBConfigurationType configurationType = sdesktop::usb::USBConfigurationType::firstConfiguration);
             ~USBConfigured() override = default;
+            USBConfigurationType getConfigurationType() const noexcept;
+
+          private:
+            USBConfigurationType configurationType;
         };
 
         class USBDisconnected : public sys::DataMessage

--- a/module-services/service-desktop/service-desktop/WorkerDesktop.hpp
+++ b/module-services/service-desktop/service-desktop/WorkerDesktop.hpp
@@ -76,6 +76,7 @@ class WorkerDesktop : public sys::Worker, public bsp::USBDeviceListener
     sys::Service *ownerService = nullptr;
     parserFSM::StateMachine parser;
     sys::TimerHandle usbSuspendTimer;
+    bsp::USBDeviceStatus usbStatus = bsp::USBDeviceStatus::Disconnected;
 
     std::shared_ptr<sys::CpuSentinel> cpuSentinel;
 };


### PR DESCRIPTION
Repair of repeated tethering notification after disconnection. Phone will now only react to USB plug-in event instead of USB configured event which was issued every time MUX was switched.