### PR TITLE
[EGD-3119] Do not convert InputEvent to numeric if not digit

### DIFF
--- a/module-gui/gui/widgets/Text.cpp
+++ b/module-gui/gui/widgets/Text.cpp
@@ -580,9 +580,11 @@ namespace gui
             return false;
         }
 
-        if (const auto val = inputEvent.numericValue();
-            inputEvent.isDigit() && checkAdditionBounds(val) == AdditionBound::CanAddAll) {
+        if (!inputEvent.isDigit()) {
+            return false;
+        }
 
+        if (const auto val = inputEvent.numericValue(); checkAdditionBounds(val) == AdditionBound::CanAddAll) {
             setCursorStartPosition(CursorStartPosition::Offset);
             addChar(intToAscii(val));
             onTextChanged();


### PR DESCRIPTION
Make sure InputEvent is a digit key before converting to numeric.