### PR TITLE
[EGD-6675] Swiping through date/time input causes crash

### DIFF
--- a/module-apps/application-settings/windows/DateTimeWindow.cpp
+++ b/module-apps/application-settings/windows/DateTimeWindow.cpp
@@ -235,12 +235,12 @@ namespace gui
         else {
             if (inputEvent.isShortRelease()) {
                 // handle numeric keys
-                if (const auto value = inputEvent.numericValue(); value >= 0) {
+                if (inputEvent.isDigit()) {
                     if (focusItem == dateBody) {
-                        setDate(value);
+                        setDate(inputEvent.numericValue());
                     }
                     else if (focusItem == timeBody) {
-                        setTime(value);
+                        setTime(inputEvent.numericValue());
                     }
                     ret = true;
                 }

--- a/module-apps/widgets/DateWidget.cpp
+++ b/module-apps/widgets/DateWidget.cpp
@@ -205,8 +205,8 @@ namespace gui
             if (!event.isShortRelease()) {
                 return false;
             }
-            if (auto value = event.numericValue(); value >= 0) {
-                setDate(value, dateInput);
+            if (event.isDigit()) {
+                setDate(event.numericValue(), dateInput);
                 return true;
             }
             else if (event.is(KeyCode::KEY_PND)) {

--- a/module-apps/widgets/TimeWidget.cpp
+++ b/module-apps/widgets/TimeWidget.cpp
@@ -352,8 +352,8 @@ namespace gui
             if (!event.isShortRelease()) {
                 return false;
             }
-            if (auto value = event.numericValue(); value >= 0) {
-                setTime(value, timeInput);
+            if (event.isDigit()) {
+                setTime(event.numericValue(), timeInput);
                 return true;
             }
             else if (event.is(gui::KeyCode::KEY_PND)) {


### PR DESCRIPTION
Phone crashes whenever you try to set new calendar event and change its
date or time.