### PR TITLE
Receiving notifications on bt

### DIFF
--- a/module-bluetooth/Bluetooth/btstack_config.h
+++ b/module-bluetooth/Bluetooth/btstack_config.h
@@ -35,7 +35,7 @@
 #define ENABLE_LOG_DEBUG
 #define ENABLE_SCO_OVER_HCI
 #define ENABLE_SDP_DES_DUMP
-#define ENABLE_EHCILL
+// #define ENABLE_EHCILL
 
 // BTstack configuration. buffers, sizes, ...
 #define HCI_INCOMING_PRE_BUFFER_SIZE 14 // sizeof benep heade, avoid memcpy

--- a/module-services/service-audio/ServiceAudio.cpp
+++ b/module-services/service-audio/ServiceAudio.cpp
@@ -364,6 +364,12 @@ std::unique_ptr<AudioResponseMessage> ServiceAudio::HandleSendEvent(std::shared_
         if (newState != bluetoothConnected) {
             LOG_DEBUG("Bluetooth connection status changed: %s", newState ? "connected" : "disconnected");
             bluetoothConnected = newState;
+            HandleStop({audio::PlaybackType::Alarm,
+                        audio::PlaybackType::CallRingtone,
+                        audio::PlaybackType::Meditation,
+                        audio::PlaybackType::Notifications,
+                        audio::PlaybackType::TextMessageRingtone},
+                       audio::Token());
         }
     }
 


### PR DESCRIPTION
Any notification could be heard via bt audio device while it's connected to the pure.
If any notification is being played and bt device would disconnect playback will be stopped.
Disabled bluetooth low power as it was causing issues with the playback.
JIRA for the low power bug https://appnroll.atlassian.net/browse/EGD-6681