### PR TITLE
[EGD-6657] ApplicationDesktop clean-up

### DIFF
--- a/module-apps/application-desktop/ApplicationDesktop.hpp
+++ b/module-apps/application-desktop/ApplicationDesktop.hpp
@@ -5,26 +5,16 @@
 
 #include "windows/Names.hpp"
 #include "locks/handlers/PinLockHandler.hpp"
-
+#include "widgets/DBNotificationsHandler.hpp"
+#include "Constants.hpp"
 #include <Application.hpp>
 #include <Service/Message.hpp>
-#include <service-cellular/CellularMessage.hpp>
-#include <service-db/DBNotificationMessage.hpp>
-#include <module-db/queries/notifications/QueryNotificationsGetAll.hpp>
-#include <endpoints/update/UpdateMuditaOS.hpp>
-#include <service-desktop/ServiceDesktop.hpp>
 #include <service-desktop/DesktopMessages.hpp>
 
 namespace cellular
 {
     class StateChange;
 }
-
-namespace db::query
-{
-    class ThreadGetCountResult;
-    class CalllogGetCountResult;
-} // namespace db::query
 
 namespace gui
 {
@@ -33,28 +23,10 @@ namespace gui
 
 namespace app
 {
-    inline constexpr auto name_desktop = "ApplicationDesktop";
-
     class ApplicationDesktop : public Application
     {
       public:
         bool need_sim_select = false;
-        struct Notifications
-        {
-            struct Counters
-            {
-                unsigned int SMS   = 0;
-                unsigned int Calls = 0;
-
-                auto areEmpty()
-                {
-                    return Calls == 0 && SMS == 0;
-                }
-            };
-
-            Counters notRead;
-
-        } notifications;
 
         gui::PinLockHandler lockHandler;
 
@@ -75,19 +47,11 @@ namespace app
         void destroyUserInterface() override;
         // if there is modem notification and there is no default SIM selected, then we need to select if when unlock is
         // done
-        bool handle(db::NotificationMessage *msg);
         bool handle(cellular::StateChange *msg);
-        auto handle(db::query::ThreadGetCountResult *msg) -> bool;
-        auto handle(db::query::CalllogGetCountResult *msg) -> bool;
         auto handle(sdesktop::UpdateOsMessage *msg) -> bool;
         auto handle(sdesktop::developerMode::ScreenlockCheckEvent *event) -> bool;
         void handleNotificationsChanged(std::unique_ptr<gui::SwitchData> notificationsParams) override;
-        /**
-         * This static method will be used to lock the phone
-         */
-        //	static bool messageLockPhone( sys::Service* sender, std::string application , const gui::InputEvent& event
-        //);
-        bool showCalls();
+
         unsigned int getLockPassHash() const noexcept
         {
             return lockPassHash;
@@ -112,6 +76,7 @@ namespace app
         void osCurrentVersionChanged(const std::string &value);
         std::string osUpdateVersion{updateos::initSysVer};
         std::string osCurrentVersion{updateos::initSysVer};
+        DBNotificationsHandler dbNotificationHandler;
     };
 
     template <> struct ManifestTraits<ApplicationDesktop>

--- a/module-apps/application-desktop/CMakeLists.txt
+++ b/module-apps/application-desktop/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources( ${PROJECT_NAME}
 	PRIVATE
 		"${CMAKE_CURRENT_LIST_DIR}/ApplicationDesktop.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/widgets/DesktopInputWidget.cpp"
+		"${CMAKE_CURRENT_LIST_DIR}/widgets/DBNotificationsHandler.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/windows/DesktopMainWindow.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/windows/MenuWindow.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/windows/DeadBatteryWindow.cpp"
@@ -31,10 +32,12 @@ target_sources( ${PROJECT_NAME}
 		"${CMAKE_CURRENT_LIST_DIR}/models/ActiveNotificationsModel.cpp"
 	PUBLIC
 		"${CMAKE_CURRENT_LIST_DIR}/ApplicationDesktop.hpp"
+		"${CMAKE_CURRENT_LIST_DIR}/Constants.hpp"
 		"${CMAKE_CURRENT_LIST_DIR}/data/DesktopData.hpp"
 		"${CMAKE_CURRENT_LIST_DIR}/data/DesktopStyle.hpp"
 		"${CMAKE_CURRENT_LIST_DIR}/data/Mmi.hpp"
 		"${CMAKE_CURRENT_LIST_DIR}/widgets/DesktopInputWidget.hpp"
+		"${CMAKE_CURRENT_LIST_DIR}/widgets/DBNotificationsHandler.hpp"
 		"${CMAKE_CURRENT_LIST_DIR}/windows/DesktopMainWindow.hpp"
 		"${CMAKE_CURRENT_LIST_DIR}/windows/MenuWindow.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/windows/Reboot.hpp"

--- a/module-apps/application-desktop/Constants.hpp
+++ b/module-apps/application-desktop/Constants.hpp
@@ -1,0 +1,9 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+namespace app
+{
+    inline constexpr auto name_desktop = "ApplicationDesktop";
+}

--- a/module-apps/application-desktop/widgets/DBNotificationsHandler.cpp
+++ b/module-apps/application-desktop/widgets/DBNotificationsHandler.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "DBNotificationsHandler.hpp"
+
+#include <module-db/queries/messages/threads/QueryThreadsGetCount.hpp>
+#include <module-db/queries/calllog/QueryCalllogGetCount.hpp>
+#include <service-appmgr/Controller.hpp>
+#include <service-db/DBNotificationMessage.hpp>
+
+using namespace app;
+
+namespace
+{
+    bool requestUnreadThreadsCount(app::Application *app)
+    {
+        const auto [succeed, _] = DBServiceAPI::GetQuery(
+            app, db::Interface::Name::SMSThread, std::make_unique<db::query::ThreadGetCount>(EntryState::UNREAD));
+        return succeed;
+    }
+
+    bool requestUnreadCallsCount(app::Application *app)
+    {
+        const auto [succeed, _] = DBServiceAPI::GetQuery(
+            app, db::Interface::Name::Calllog, std::make_unique<db::query::CalllogGetCount>(EntryState::UNREAD));
+        return succeed;
+    }
+} // namespace
+
+DBNotificationsHandler::DBNotificationsHandler(Application *ownerApp)
+    : ownerApp(ownerApp), notifications{{Type::notReadSMS, 0}, {Type::notReadCall, 0}}
+{}
+
+void DBNotificationsHandler::setNotification(Type type, int value)
+{
+    notifications[type] = value;
+}
+
+bool DBNotificationsHandler::hasNotification(Type type) const
+{
+    try {
+        return notifications.at(type) > 0;
+    }
+    catch (const std::out_of_range &e) {
+        LOG_ERROR("Uninitialized notification type");
+    }
+    return false;
+}
+
+bool DBNotificationsHandler::handle(db::NotificationMessage *msg)
+{
+    if (msg->type == db::Query::Type::Read) {
+        return false;
+    }
+
+    if (auto msgInterface = msg->interface; msgInterface == db::Interface::Name::Calllog) {
+        return requestUnreadCallsCount(ownerApp);
+    }
+    else if (msgInterface == db::Interface::Name::SMSThread || msgInterface == db::Interface::Name::SMS) {
+        return requestUnreadThreadsCount(ownerApp);
+    }
+    return false;
+}
+
+bool DBNotificationsHandler::handle(db::QueryResult *msg)
+{
+    if (auto response = dynamic_cast<db::query::ThreadGetCountResult *>(msg);
+        response != nullptr && response->getState() == EntryState::UNREAD) {
+        notifications[Type::notReadSMS] = response->getCount();
+        return true;
+    }
+    if (auto response = dynamic_cast<db::query::CalllogGetCountResult *>(msg);
+        response != nullptr && response->getState() == EntryState::UNREAD) {
+        notifications[Type::notReadCall] = response->getCount();
+        return true;
+    }
+    return false;
+}
+
+void DBNotificationsHandler::initHandler()
+{
+    requestUnreadThreadsCount(ownerApp);
+    requestUnreadCallsCount(ownerApp);
+}

--- a/module-apps/application-desktop/widgets/DBNotificationsHandler.hpp
+++ b/module-apps/application-desktop/widgets/DBNotificationsHandler.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <map>
+
+namespace db
+{
+    class NotificationMessage;
+    class QueryResult;
+} // namespace db
+
+namespace app
+{
+    class Application;
+
+    class DBNotificationsBaseHandler
+    {
+      public:
+        enum class Type
+        {
+            notReadSMS,
+            notReadCall
+        };
+
+        [[nodiscard]] virtual bool hasNotification(Type type) const = 0;
+        virtual ~DBNotificationsBaseHandler()                       = default;
+    };
+
+    class DBNotificationsHandler : public DBNotificationsBaseHandler
+    {
+        Application *ownerApp = nullptr;
+        std::map<Type, int> notifications;
+
+        void setNotification(Type type, int value);
+
+      public:
+        explicit DBNotificationsHandler(Application *ownerApp);
+
+        void initHandler();
+        bool handle(db::NotificationMessage *msg);
+        bool handle(db::QueryResult *msg);
+
+        [[nodiscard]] bool hasNotification(Type type) const override;
+    };
+
+} // namespace app

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -211,9 +211,8 @@ namespace gui
         bottomBar->setText(
             BottomBar::Side::RIGHT, utils::translate("app_desktop_clear_all"), hasDismissibleNotification);
 
-        auto app      = getAppDesktop();
-        inputCallback = [this, app, hasDismissibleNotification]([[maybe_unused]] Item &item,
-                                                                const InputEvent &inputEvent) -> bool {
+        inputCallback = [this, hasDismissibleNotification]([[maybe_unused]] Item &item,
+                                                           const InputEvent &inputEvent) -> bool {
             if (!inputEvent.isShortRelease() || notificationsList->focus) {
                 return false;
             }
@@ -224,7 +223,7 @@ namespace gui
             }
             if (inputEvent.is(gui::KeyCode::KEY_LF)) {
                 LOG_DEBUG("KEY_LF pressed to navigate to calls");
-                return app->showCalls();
+                return app::manager::Controller::sendAction(application, app::manager::actions::ShowCallLog);
             }
             return false;
         };

--- a/module-apps/application-desktop/windows/MenuWindow.hpp
+++ b/module-apps/application-desktop/windows/MenuWindow.hpp
@@ -1,17 +1,19 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include <vector>
 
-#include "AppWindow.hpp"
-#include "GridLayout.hpp"
-#include "widgets/BottomBar.hpp"
-#include "widgets/Label.hpp"
-#include "widgets/Rect.hpp"
+#include <AppWindow.hpp>
+#include <GridLayout.hpp>
+#include <widgets/Rect.hpp>
+#include <utf8/UTF8.hpp>
 
-#include "utf8/UTF8.hpp"
+namespace app
+{
+    class DBNotificationsBaseHandler;
+}
 
 namespace gui
 {
@@ -53,7 +55,7 @@ namespace gui
         MenuPage *toolsMenu = nullptr;
 
       public:
-        MenuWindow(app::Application *app);
+        MenuWindow(app::Application *app, const app::DBNotificationsBaseHandler &accessor);
 
         bool onInput(const InputEvent &inputEvent) override;
 
@@ -65,6 +67,7 @@ namespace gui
         void refresh();
 
       private:
+        const app::DBNotificationsBaseHandler &dbNotifications;
         void invalidate() noexcept;
     };
 

--- a/module-apps/locks/handlers/PinLockHandler.cpp
+++ b/module-apps/locks/handlers/PinLockHandler.cpp
@@ -8,6 +8,7 @@
 #include "application-desktop/windows/Names.hpp"
 #include <module-utils/common_data/EventStore.hpp>
 #include <service-appmgr/service-appmgr/data/SimActionsParams.hpp>
+#include <service-desktop/Constants.hpp>
 
 namespace gui
 {

--- a/module-apps/windows/AppWindow.cpp
+++ b/module-apps/windows/AppWindow.cpp
@@ -7,10 +7,10 @@
 #include "TopBar.hpp"
 #include "TopBar/Time.hpp"
 #include <Style.hpp>
-#include <application-desktop/ApplicationDesktop.hpp>
 #include <i18n/i18n.hpp>
 #include <service-appmgr/Controller.hpp>
 #include <service-audio/AudioServiceAPI.hpp>
+#include <time/DateAndTimeSettings.hpp>
 
 using namespace style::header;
 

--- a/module-services/service-appmgr/model/ApplicationManager.cpp
+++ b/module-services/service-appmgr/model/ApplicationManager.cpp
@@ -37,6 +37,8 @@
 #include <module-services/service-db/agents/settings/SystemSettings.hpp>
 #include <service-appmgr/messages/DOMRequest.hpp>
 #include <service-appmgr/messages/GetAllNotificationsRequest.hpp>
+#include <service-db/DBNotificationMessage.hpp>
+#include <module-db/queries/notifications/QueryNotificationsGetAll.hpp>
 
 #include "module-services/service-appmgr/service-appmgr/messages/ApplicationStatus.hpp"
 

--- a/module-services/service-desktop/endpoints/update/UpdateMuditaOS.cpp
+++ b/module-services/service-desktop/endpoints/update/UpdateMuditaOS.cpp
@@ -10,7 +10,7 @@
 #include <json/json11.hpp>
 #include <log/log.hpp>
 #include <microtar/src/microtar.hpp>
-#include <module-apps/application-desktop/ApplicationDesktop.hpp>
+#include <application-desktop/Constants.hpp>
 #include <service-db/service-db/Settings.hpp>
 #include <purefs/filesystem_paths.hpp>
 #include <time/time_conversion.hpp>

--- a/module-services/service-desktop/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/service-desktop/ServiceDesktop.hpp
@@ -12,7 +12,6 @@
 #include "Service/Service.hpp" // for Service
 #include "Timers/TimerHandle.hpp"
 #include "Constants.hpp"
-#include "WorkerDesktop.hpp"
 #include "USBSecurityModel.hpp"
 #include <endpoints/update/UpdateMuditaOS.hpp>
 #include <service-db/DBServiceName.hpp>

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -36,6 +36,7 @@
 #include <module-services/service-eink/ServiceEink.hpp>
 #include <service-fileindexer/Constants.hpp>
 #include <service-fileindexer/ServiceFileIndexer.hpp>
+#include <service-desktop/ServiceDesktop.hpp>
 
 #if ENABLE_GSM == 1
 #include <service-fota/ServiceFota.hpp>


### PR DESCRIPTION
This PR cleans-up `ApplicationDesktop` after recent changes in
home screen `notSeen` notifications handling.

The `notRead` notifications handling was extracted to separate class.
Removing headers from `ApplicationDesktop` caused some 
compile and linking problems in other, unrelated files so PR provides
occasional changes in `include` structure of such files. 