### PR TITLE
[EGD-6682] Fix BT name change bug

### DIFF
--- a/module-services/service-bluetooth/ServiceBluetooth.cpp
+++ b/module-services/service-bluetooth/ServiceBluetooth.cpp
@@ -212,6 +212,8 @@ auto ServiceBluetooth::handle(message::bluetooth::SetDeviceName *msg) -> std::sh
     auto newName = msg->getName();
     bluetooth::set_name(newName);
     settingsHolder->setValue(bluetooth::Settings::DeviceName, newName);
+    sendWorkerCommand(bluetooth::Command(bluetooth::Command::Type::PowerOff));
+    sendWorkerCommand(bluetooth::Command(bluetooth::Command::Type::PowerOn));
     return sys::MessageNone{};
 }
 


### PR DESCRIPTION
To update the BT name there is a need to restart the BT stack.
Sending proper command during working stack wasn't working