### PR TITLE
[EGD-6695] Fix simulator build for valgrind

### DIFF
--- a/board/linux/libiosyscalls/CMakeLists.txt
+++ b/board/linux/libiosyscalls/CMakeLists.txt
@@ -28,12 +28,16 @@ add_library(${PROJECT_NAME} SHARED ${SOURCES})
 
 target_compile_options( ${PROJECT_NAME} PRIVATE "-Wno-nonnull-compare" )
 get_target_property( target_options ${PROJECT_NAME} COMPILE_OPTIONS)
-list(REMOVE_ITEM target_options "-fsanitize=address")
-set_property(TARGET ${PROJECT_NAME} PROPERTY COMPILE_OPTIONS ${target_options} )
+if("-fsanitize=address" IN_LIST target_options )
+    list(REMOVE_ITEM target_options "-fsanitize=address")
+    set_property(TARGET ${PROJECT_NAME} PROPERTY COMPILE_OPTIONS ${target_options} )
+endif()
 
 get_target_property( target_options ${PROJECT_NAME} LINK_OPTIONS)
-list(REMOVE_ITEM target_options "-fsanitize=address")
-set_property(TARGET ${PROJECT_NAME} PROPERTY LINK_OPTIONS ${target_options} )
+if("-fsanitize=address" IN_LIST target_options )
+    list(REMOVE_ITEM target_options "-fsanitize=address")
+    set_property(TARGET ${PROJECT_NAME} PROPERTY LINK_OPTIONS ${target_options} )
+endif()
 
 target_link_options(${PROJECT_NAME} PRIVATE
 		"-Wl,--version-script"


### PR DESCRIPTION
Valgrind requires sanitizer to be off, fixing cmake errors.