### PR TITLE
[BH-349] Support for BH tag in commit message

### DIFF
--- a/tools/check_commit_messages.py
+++ b/tools/check_commit_messages.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 '''
-Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 '''
 
@@ -33,7 +33,7 @@ def validate_commit(commit):
   empty_line = lines[1]
   body = ''.join(lines[2:]).strip()
 
-  subject_format = r'^\[EGD-\d+\] [A-Z].+[^.]$'
+  subject_format = r'^\[(EGD|BH)-\d+\] [A-Z].+[^.]$'
   if not re.match(subject_format, subject):
     errors.append(f'[{commit.hexsha}] invalid subject "{subject}", should match format "{subject_format}"')
 


### PR DESCRIPTION
Bell Hybrid has it's own jira -> own tickets, we need to update commit
message checker.