### PR TITLE
[EGD-6752] Fix missing lock guard in the VFS driver

### DIFF
--- a/module-vfs/board/rt1051/purefs/src/blkdev/disk_eeprom.cpp
+++ b/module-vfs/board/rt1051/purefs/src/blkdev/disk_eeprom.cpp
@@ -19,6 +19,7 @@ namespace purefs::blkdev
 
     auto disk_eeprom::status() const -> media_status
     {
+        cpp_freertos::LockGuard lock(mutex);
         return (bsp::eeprom::isPresent(bus_id)) ? (media_status::healthly) : (media_status::error);
     }
 


### PR DESCRIPTION
Fix missing lock guard in the device health status method.

Signed-off-by: Lucjan Bryndza <lucjan.bryndza@mudita.com>