### PR TITLE
[EGD-6768] Disable logs in interrupts

### DIFF
--- a/module-utils/log/log.cpp
+++ b/module-utils/log/log.cpp
@@ -4,12 +4,19 @@
 #include "log.hpp"
 #include "Logger.hpp"
 #include <ticks.hpp>
+#include <macros.h>
 
 using Log::Logger;
 
 int log_Printf(const char *fmt, ...)
 {
     va_list args;
+
+    // temporarily disable logs in interrupts for heap overwriting reasons
+    if (isIRQ()) {
+        return 0;
+    }
+
     va_start(args, fmt);
     const int result = Logger::get().log(Log::Device::DEFAULT, fmt, args);
     va_end(args);
@@ -19,6 +26,12 @@ int log_Printf(const char *fmt, ...)
 int log_Log(logger_level level, const char *file, int line, const char *function, const char *fmt, ...)
 {
     va_list args;
+
+    // temporarily disable logs in interrupts for heap overwriting reasons
+    if (isIRQ()) {
+        return 0;
+    }
+
     va_start(args, fmt);
     const int result = Logger::get().log(level, file, line, function, fmt, args);
     va_end(args);
@@ -30,6 +43,12 @@ extern "C"
     void bt_log_custom(const char *file, int line, const char *foo, const char *fmt, ...)
     {
         va_list args;
+
+        // temporarily disable logs in interrupts for heap overwriting reasons
+        if (isIRQ()) {
+            return;
+        }
+
         va_start(args, fmt);
         Logger::get().log(LOGTRACE, file, line, foo, fmt, args);
         va_end(args);


### PR DESCRIPTION
Temporarily disable logs in interrupts
for heap overwriting reasons