### PR TITLE
[EGD-6715] Add third party CMakeLists.txt ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@
 
 # build system
 /CMakeLists.txt                             @mudita/chapter-bsp
+/third-party/CMakeLists.txt                 @mudita/chapter-bsp
 /cmake                                      @mudita/chapter-bsp
 /test/CMakeLists.txt                        @mudita/chapter-bsp
 


### PR DESCRIPTION
This file is owned by BSP.