### PR TITLE
[EGD-6799] Cleanup audio device interface

### DIFF
--- a/module-audio/Audio/AudioDevice.hpp
+++ b/module-audio/Audio/AudioDevice.hpp
@@ -30,80 +30,24 @@ namespace audio
             Bluetooth
         };
 
-        enum class Flags
-        {
-            OutputMono   = 1 << 0,
-            OutputStereo = 1 << 1,
-            InputLeft    = 1 << 2,
-            InputRight   = 1 << 3,
-            InputStereo  = 1 << 4
-        };
-
-        enum class InputPath
-        {
-            Headphones,
-            Microphone,
-            None
-        };
-
-        enum class OutputPath
-        {
-            Headphones,
-            Earspeaker,
-            Loudspeaker,
-            None
-        };
-
-        using Configuration = struct
-        {
-            uint32_t sampleRate_Hz = 0; /*!< Sample rate of audio data */
-            uint32_t bitWidth      = 0; /*!< Data length of audio data, usually 8/16/24/32 bits */
-            uint32_t flags         = 0; /*!< In/Out configuration flags */
-            float outputVolume     = 0.0f;
-            float inputGain        = 0.0f;
-            InputPath inputPath    = InputPath::None;
-            OutputPath outputPath  = OutputPath::None;
-        };
-
         virtual ~AudioDevice() = default;
 
-        virtual RetCode Start(const Configuration &format) = 0;
-        virtual RetCode Stop()                             = 0;
-
-        virtual RetCode OutputVolumeCtrl(float vol)                 = 0;
-        virtual RetCode InputGainCtrl(float gain)                   = 0;
-        virtual RetCode OutputPathCtrl(OutputPath outputPath)       = 0;
-        virtual RetCode InputPathCtrl(InputPath inputPath)          = 0;
-        virtual bool IsFormatSupported(const Configuration &format) = 0;
-
-        float GetOutputVolume() const noexcept
+        virtual RetCode Start()
         {
-            return currentFormat.outputVolume;
+            return RetCode::Success;
         }
 
-        float GetInputGain() const noexcept
+        virtual RetCode Stop()
         {
-            return currentFormat.inputGain;
+            return RetCode::Success;
         }
 
-        OutputPath GetOutputPath() const noexcept
+        virtual RetCode setOutputVolume(float vol) = 0;
+        virtual RetCode setInputGain(float gain)   = 0;
+
+        auto getSinkFormat() -> AudioFormat override
         {
-            return currentFormat.outputPath;
+            return getSourceFormat();
         }
-
-        InputPath GetInputPath() const noexcept
-        {
-            return currentFormat.inputPath;
-        }
-
-        Configuration GetCurrentFormat() const noexcept
-        {
-            return currentFormat;
-        }
-
-      protected:
-        Configuration currentFormat;
-
-        bool isInitialized = false;
     };
 } // namespace audio

--- a/module-audio/Audio/AudioDeviceFactory.cpp
+++ b/module-audio/Audio/AudioDeviceFactory.cpp
@@ -8,12 +8,12 @@ using namespace audio;
 AudioDeviceFactory::AudioDeviceFactory(Observer *observer) : _observer(observer)
 {}
 
-std::shared_ptr<AudioDevice> AudioDeviceFactory::CreateDevice(AudioDevice::Type deviceType)
+std::shared_ptr<AudioDevice> AudioDeviceFactory::CreateDevice(const audio::Profile &profile)
 {
-    std::shared_ptr<AudioDevice> device = getDeviceFromType(deviceType);
+    std::shared_ptr<AudioDevice> device = getDevice(profile);
 
     if (_observer != nullptr && device) {
-        _observer->onDeviceCreated(device, deviceType);
+        _observer->onDeviceCreated(device, profile.GetAudioDeviceType());
     }
 
     return device;

--- a/module-audio/Audio/AudioDeviceFactory.hpp
+++ b/module-audio/Audio/AudioDeviceFactory.hpp
@@ -5,6 +5,8 @@
 
 #include "AudioDevice.hpp"
 
+#include <Audio/Profiles/Profile.hpp>
+
 #include <memory>
 
 namespace audio
@@ -22,10 +24,11 @@ namespace audio
         explicit AudioDeviceFactory(Observer *observer = nullptr);
 
         void setObserver(Observer *observer) noexcept;
-        std::shared_ptr<AudioDevice> CreateDevice(AudioDevice::Type);
+        std::shared_ptr<AudioDevice> CreateDevice(const Profile &profile);
+        virtual std::shared_ptr<AudioDevice> createCellularAudioDevice() = 0;
 
       protected:
-        virtual std::shared_ptr<AudioDevice> getDeviceFromType(AudioDevice::Type) = 0;
+        virtual std::shared_ptr<AudioDevice> getDevice(const Profile &profile) = 0;
 
       private:
         Observer *_observer = nullptr;

--- a/module-audio/Audio/Endpoint.cpp
+++ b/module-audio/Audio/Endpoint.cpp
@@ -10,7 +10,6 @@
 
 using audio::AbstractStream;
 using audio::Endpoint;
-using audio::IOProxy;
 using audio::Sink;
 using audio::Source;
 using audio::StreamConnection;
@@ -105,9 +104,4 @@ Sink *StreamConnection::getSink() const noexcept
 AbstractStream *StreamConnection::getStream() const noexcept
 {
     return _stream;
-}
-
-auto Source::getSourceFormat() -> AudioFormat
-{
-    return audio::nullFormat;
 }

--- a/module-audio/Audio/Endpoint.hpp
+++ b/module-audio/Audio/Endpoint.hpp
@@ -35,7 +35,7 @@ namespace audio
         [[nodiscard]] virtual auto getTraits() const -> Traits = 0;
 
         auto isFormatSupported(const AudioFormat &format) -> bool;
-        virtual auto getSupportedFormats() -> const std::vector<AudioFormat> & = 0;
+        virtual auto getSupportedFormats() -> std::vector<AudioFormat> = 0;
 
       protected:
         AbstractStream *_stream = nullptr;
@@ -44,18 +44,19 @@ namespace audio
     class Sink : public Endpoint
     {
       public:
-        virtual void onDataSend()    = 0;
-        virtual void enableOutput()  = 0;
-        virtual void disableOutput() = 0;
+        virtual auto getSinkFormat() -> AudioFormat = 0;
+        virtual void onDataSend()                   = 0;
+        virtual void enableOutput()                 = 0;
+        virtual void disableOutput()                = 0;
     };
 
     class Source : public Endpoint
     {
       public:
-        virtual auto getSourceFormat() -> AudioFormat;
-        virtual void onDataReceive() = 0;
-        virtual void enableInput()   = 0;
-        virtual void disableInput()  = 0;
+        virtual auto getSourceFormat() -> AudioFormat = 0;
+        virtual void onDataReceive()                  = 0;
+        virtual void enableInput()                    = 0;
+        virtual void disableInput()                   = 0;
     };
 
     class IOProxy : public Source, public Sink

--- a/module-audio/Audio/Operation/Operation.cpp
+++ b/module-audio/Audio/Operation/Operation.cpp
@@ -93,8 +93,13 @@ namespace audio
         supportedProfiles.emplace_back(Profile::Create(profile, volume, gain), isAvailable);
     }
 
-    std::shared_ptr<AudioDevice> Operation::CreateDevice(AudioDevice::Type type)
+    std::shared_ptr<AudioDevice> Operation::CreateDevice(const Profile &profile)
     {
-        return factory->CreateDevice(type);
+        return factory->CreateDevice(profile);
+    }
+
+    std::shared_ptr<AudioDevice> Operation::createCellularAudioDevice()
+    {
+        return factory->createCellularAudioDevice();
     }
 } // namespace audio

--- a/module-audio/Audio/Operation/Operation.hpp
+++ b/module-audio/Audio/Operation/Operation.hpp
@@ -151,7 +151,8 @@ namespace audio
         virtual audio::RetCode SwitchProfile(const Profile::Type type) = 0;
         std::shared_ptr<Profile> GetProfile(const Profile::Type type);
 
-        std::shared_ptr<AudioDevice> CreateDevice(AudioDevice::Type type);
+        std::shared_ptr<AudioDevice> CreateDevice(const Profile &profile);
+        std::shared_ptr<AudioDevice> createCellularAudioDevice();
     };
 
 } // namespace audio

--- a/module-audio/Audio/Operation/RecorderOperation.cpp
+++ b/module-audio/Audio/Operation/RecorderOperation.cpp
@@ -57,11 +57,11 @@ namespace audio
         currentProfile = defaultProfile;
 
         uint32_t channels = 0;
-        if ((currentProfile->GetInOutFlags() & static_cast<uint32_t>(AudioDevice::Flags::InputLeft)) ||
-            (currentProfile->GetInOutFlags() & static_cast<uint32_t>(AudioDevice::Flags::InputRight))) {
+        if ((currentProfile->GetInOutFlags() & static_cast<uint32_t>(audio::codec::Flags::InputLeft)) ||
+            (currentProfile->GetInOutFlags() & static_cast<uint32_t>(audio::codec::Flags::InputRight))) {
             channels = 1;
         }
-        else if (currentProfile->GetInOutFlags() & static_cast<uint32_t>(AudioDevice::Flags::InputStereo)) {
+        else if (currentProfile->GetInOutFlags() & static_cast<uint32_t>(audio::codec::Flags::InputStereo)) {
             channels = 2;
         }
 
@@ -85,8 +85,8 @@ namespace audio
         operationToken = token;
         state          = State::Active;
 
-        if (audioDevice->IsFormatSupported(currentProfile->GetAudioConfiguration())) {
-            auto ret = audioDevice->Start(currentProfile->GetAudioConfiguration());
+        if (audioDevice->isFormatSupportedBySource(currentProfile->getAudioFormat())) {
+            auto ret = audioDevice->Start();
             return GetDeviceError(ret);
         }
         else {
@@ -124,7 +124,7 @@ namespace audio
         }
 
         state    = State::Active;
-        auto ret = audioDevice->Start(currentProfile->GetAudioConfiguration());
+        auto ret = audioDevice->Start();
         return GetDeviceError(ret);
     }
 
@@ -158,7 +158,7 @@ namespace audio
             return RetCode::UnsupportedProfile;
         }
 
-        audioDevice = CreateDevice(currentProfile->GetAudioDeviceType());
+        audioDevice = CreateDevice(*currentProfile);
         if (audioDevice == nullptr) {
             LOG_ERROR("Error creating AudioDevice");
             return RetCode::Failed;
@@ -181,14 +181,14 @@ namespace audio
     audio::RetCode RecorderOperation::SetOutputVolume(float vol)
     {
         currentProfile->SetOutputVolume(vol);
-        auto ret = audioDevice->OutputVolumeCtrl(vol);
+        auto ret = audioDevice->setOutputVolume(vol);
         return GetDeviceError(ret);
     }
 
     audio::RetCode RecorderOperation::SetInputGain(float gain)
     {
         currentProfile->SetInputGain(gain);
-        auto ret = audioDevice->InputGainCtrl(gain);
+        auto ret = audioDevice->setInputGain(gain);
         return GetDeviceError(ret);
     }
 

--- a/module-audio/Audio/Operation/RouterOperation.cpp
+++ b/module-audio/Audio/Operation/RouterOperation.cpp
@@ -31,14 +31,14 @@ namespace audio
     audio::RetCode RouterOperation::SetOutputVolume(float vol)
     {
         currentProfile->SetOutputVolume(vol);
-        auto ret = audioDevice->OutputVolumeCtrl(vol);
+        auto ret = audioDevice->setOutputVolume(vol);
         return GetDeviceError(ret);
     }
 
     audio::RetCode RouterOperation::SetInputGain(float gain)
     {
         currentProfile->SetInputGain(gain);
-        auto ret = audioDevice->InputGainCtrl(gain);
+        auto ret = audioDevice->setInputGain(gain);
         return GetDeviceError(ret);
     }
 
@@ -51,22 +51,20 @@ namespace audio
         state          = State::Active;
 
         // check if audio devices support desired audio format
-        if (!audioDevice->IsFormatSupported(currentProfile->GetAudioConfiguration())) {
+        if (!audioDevice->isFormatSupportedBySource(currentProfile->getAudioFormat())) {
             return RetCode::InvalidFormat;
         }
 
-        if (!audioDeviceCellular->IsFormatSupported(currentProfile->GetAudioConfiguration())) {
+        if (!audioDeviceCellular->isFormatSupportedBySource(currentProfile->getAudioFormat())) {
             return RetCode::InvalidFormat;
         }
 
         // try to run devices with the format
-        if (auto ret = audioDevice->Start(currentProfile->GetAudioConfiguration());
-            ret != AudioDevice::RetCode::Success) {
+        if (auto ret = audioDevice->Start(); ret != AudioDevice::RetCode::Success) {
             return GetDeviceError(ret);
         }
 
-        if (auto ret = audioDeviceCellular->Start(currentProfile->GetAudioConfiguration());
-            ret != AudioDevice::RetCode::Success) {
+        if (auto ret = audioDeviceCellular->Start(); ret != AudioDevice::RetCode::Success) {
             return GetDeviceError(ret);
         }
 
@@ -197,13 +195,13 @@ namespace audio
             Stop();
         }
 
-        audioDevice = CreateDevice(newProfile->GetAudioDeviceType());
+        audioDevice = CreateDevice(*newProfile);
         if (audioDevice == nullptr) {
             LOG_ERROR("Error creating AudioDevice");
             return RetCode::Failed;
         }
 
-        audioDeviceCellular = CreateDevice(AudioDevice::Type::Cellular);
+        audioDeviceCellular = createCellularAudioDevice();
         if (audioDeviceCellular == nullptr) {
             LOG_ERROR("Error creating AudioDeviceCellular");
             return RetCode::Failed;

--- a/module-audio/Audio/Profiles/Profile.cpp
+++ b/module-audio/Audio/Profiles/Profile.cpp
@@ -79,7 +79,7 @@ namespace audio
 
     Profile::Profile(const std::string &name,
                      const Type type,
-                     const AudioDevice::Configuration &fmt,
+                     const audio::codec::Configuration &fmt,
                      AudioDevice::Type devType)
         : audioConfiguration(fmt), audioDeviceType(devType), name(name), type(type)
     {}
@@ -94,12 +94,12 @@ namespace audio
         audioConfiguration.outputVolume = vol;
     }
 
-    void Profile::SetInputPath(AudioDevice::InputPath path)
+    void Profile::SetInputPath(audio::codec::InputPath path)
     {
         audioConfiguration.inputPath = path;
     }
 
-    void Profile::SetOutputPath(AudioDevice::OutputPath path)
+    void Profile::SetOutputPath(audio::codec::OutputPath path)
     {
         audioConfiguration.outputPath = path;
     }

--- a/module-audio/Audio/Profiles/Profile.hpp
+++ b/module-audio/Audio/Profiles/Profile.hpp
@@ -3,7 +3,8 @@
 
 #pragma once
 
-#include "Audio/AudioDevice.hpp"
+#include <Audio/AudioDevice.hpp>
+#include <Audio/codec.hpp>
 
 #include <memory>
 #include <functional>
@@ -54,9 +55,9 @@ namespace audio
 
         void SetSampleRate(uint32_t samplerate);
 
-        void SetOutputPath(AudioDevice::OutputPath path);
+        void SetOutputPath(audio::codec::OutputPath path);
 
-        void SetInputPath(AudioDevice::InputPath path);
+        void SetInputPath(audio::codec::InputPath path);
 
         Volume GetOutputVolume() const
         {
@@ -78,12 +79,12 @@ namespace audio
             return audioConfiguration.flags;
         }
 
-        AudioDevice::OutputPath GetOutputPath() const
+        audio::codec::OutputPath GetOutputPath() const
         {
             return audioConfiguration.outputPath;
         }
 
-        AudioDevice::InputPath GetInputPath() const
+        audio::codec::InputPath GetInputPath() const
         {
             return audioConfiguration.inputPath;
         }
@@ -93,15 +94,16 @@ namespace audio
             return audioDeviceType;
         }
 
-        [[deprecated]] AudioDevice::Configuration GetAudioConfiguration()
+        [[deprecated]] audio::codec::Configuration GetAudioConfiguration() const
         {
             return audioConfiguration;
         }
 
         auto getAudioFormat() const noexcept
         {
-            auto isStereo = (audioConfiguration.flags & static_cast<uint32_t>(AudioDevice::Flags::OutputStereo)) != 0 ||
-                            (audioConfiguration.flags & static_cast<uint32_t>(AudioDevice::Flags::InputStereo)) != 0;
+            auto isStereo =
+                (audioConfiguration.flags & static_cast<std::uint32_t>(audio::codec::Flags::OutputStereo)) != 0 ||
+                (audioConfiguration.flags & static_cast<std::uint32_t>(audio::codec::Flags::InputStereo)) != 0;
             auto channels = isStereo ? 2U : 1U;
             return AudioFormat(audioConfiguration.sampleRate_Hz, audioConfiguration.bitWidth, channels);
         }
@@ -119,10 +121,10 @@ namespace audio
       protected:
         Profile(const std::string &name,
                 const Type type,
-                const AudioDevice::Configuration &fmt,
+                const audio::codec::Configuration &fmt,
                 AudioDevice::Type devType);
 
-        AudioDevice::Configuration audioConfiguration{};
+        audio::codec::Configuration audioConfiguration;
         AudioDevice::Type audioDeviceType = AudioDevice::Type::Audiocodec;
 
         std::string name;

--- a/module-audio/Audio/Profiles/ProfileIdle.hpp
+++ b/module-audio/Audio/Profiles/ProfileIdle.hpp
@@ -11,7 +11,7 @@ namespace audio
     class ProfileIdle : public Profile
     {
       public:
-        ProfileIdle() : Profile("Idle", Type::Idle, AudioDevice::Configuration{}, AudioDevice::Type::None)
+        ProfileIdle() : Profile("Idle", Type::Idle, audio::codec::Configuration{}, AudioDevice::Type::None)
         {}
     };
 

--- a/module-audio/Audio/Profiles/ProfilePlaybackBluetoothA2DP.hpp
+++ b/module-audio/Audio/Profiles/ProfilePlaybackBluetoothA2DP.hpp
@@ -14,13 +14,13 @@ namespace audio
         ProfilePlaybackBluetoothA2DP(Volume volume)
             : Profile("Playback Bluetooth A2DP",
                       Type::PlaybackBluetoothA2DP,
-                      AudioDevice::Configuration{.sampleRate_Hz = 44100,
-                                                 .bitWidth      = 16,
-                                                 .flags         = 0,
-                                                 .outputVolume  = static_cast<float>(volume),
-                                                 .inputGain     = 0,
-                                                 .inputPath     = AudioDevice::InputPath::None,
-                                                 .outputPath    = AudioDevice::OutputPath::None},
+                      audio::codec::Configuration{.sampleRate_Hz = 44100,
+                                                  .bitWidth      = 16,
+                                                  .flags         = 0,
+                                                  .outputVolume  = static_cast<float>(volume),
+                                                  .inputGain     = 0,
+                                                  .inputPath     = audio::codec::InputPath::None,
+                                                  .outputPath    = audio::codec::OutputPath::None},
                       AudioDevice::Type::Bluetooth)
         {}
     };

--- a/module-audio/Audio/Profiles/ProfilePlaybackHeadphones.hpp
+++ b/module-audio/Audio/Profiles/ProfilePlaybackHeadphones.hpp
@@ -13,13 +13,13 @@ namespace audio
         ProfilePlaybackHeadphones(Volume volume)
             : Profile("Playback Headphones",
                       Type::PlaybackHeadphones,
-                      AudioDevice::Configuration{.sampleRate_Hz = 0,
-                                                 .bitWidth      = 16,
-                                                 .flags         = 0,
-                                                 .outputVolume  = static_cast<float>(volume),
-                                                 .inputGain     = 0,
-                                                 .inputPath     = AudioDevice::InputPath::None,
-                                                 .outputPath    = AudioDevice::OutputPath::Headphones},
+                      audio::codec::Configuration{.sampleRate_Hz = 0,
+                                                  .bitWidth      = 16,
+                                                  .flags         = 0,
+                                                  .outputVolume  = static_cast<float>(volume),
+                                                  .inputGain     = 0,
+                                                  .inputPath     = audio::codec::InputPath::None,
+                                                  .outputPath    = audio::codec::OutputPath::Headphones},
                       AudioDevice::Type::Audiocodec)
         {}
     };

--- a/module-audio/Audio/Profiles/ProfilePlaybackLoudspeaker.hpp
+++ b/module-audio/Audio/Profiles/ProfilePlaybackLoudspeaker.hpp
@@ -14,13 +14,13 @@ namespace audio
         ProfilePlaybackLoudspeaker(Volume volume)
             : Profile("Playback Loudspeaker",
                       Type::PlaybackLoudspeaker,
-                      AudioDevice::Configuration{.sampleRate_Hz = 0,
-                                                 .bitWidth      = 16,
-                                                 .flags         = 0,
-                                                 .outputVolume  = static_cast<float>(volume),
-                                                 .inputGain     = 0,
-                                                 .inputPath     = AudioDevice::InputPath::None,
-                                                 .outputPath    = AudioDevice::OutputPath::Loudspeaker},
+                      audio::codec::Configuration{.sampleRate_Hz = 0,
+                                                  .bitWidth      = 16,
+                                                  .flags         = 0,
+                                                  .outputVolume  = static_cast<float>(volume),
+                                                  .inputGain     = 0,
+                                                  .inputPath     = audio::codec::InputPath::None,
+                                                  .outputPath    = audio::codec::OutputPath::Loudspeaker},
                       AudioDevice::Type::Audiocodec)
         {}
     };

--- a/module-audio/Audio/Profiles/ProfileRecordingBluetoothHSP.hpp
+++ b/module-audio/Audio/Profiles/ProfileRecordingBluetoothHSP.hpp
@@ -12,18 +12,18 @@ namespace audio
     {
       public:
         ProfileRecordingBluetoothHSP(Gain gain)
-            : Profile("Recording Bluetooth HSP",
-                      Type::RecordingHeadphones,
-                      AudioDevice::Configuration{
-                          .sampleRate_Hz = 8000,
-                          .bitWidth      = 16,
-                          .flags =
-                              static_cast<uint32_t>(AudioDevice::Flags::InputLeft), // microphone use left audio channel
-                          .outputVolume = 0,
-                          .inputGain    = static_cast<float>(gain),
-                          .inputPath    = AudioDevice::InputPath::None,
-                          .outputPath   = AudioDevice::OutputPath::None},
-                      AudioDevice::Type::Bluetooth)
+            : Profile(
+                  "Recording Bluetooth HSP",
+                  Type::RecordingHeadphones,
+                  audio::codec::Configuration{.sampleRate_Hz = 8000,
+                                              .bitWidth      = 16,
+                                              .flags         = static_cast<uint32_t>(
+                                                  audio::codec::Flags::InputLeft), // microphone use left audio channel
+                                              .outputVolume = 0,
+                                              .inputGain    = static_cast<float>(gain),
+                                              .inputPath    = audio::codec::InputPath::None,
+                                              .outputPath   = audio::codec::OutputPath::None},
+                  AudioDevice::Type::Bluetooth)
         {}
     };
 

--- a/module-audio/Audio/Profiles/ProfileRecordingHeadphones.hpp
+++ b/module-audio/Audio/Profiles/ProfileRecordingHeadphones.hpp
@@ -11,18 +11,18 @@ namespace audio
     {
       public:
         ProfileRecordingHeadphones(Gain gain)
-            : Profile("Recording Headset",
-                      Type::RecordingHeadphones,
-                      AudioDevice::Configuration{
-                          .sampleRate_Hz = 44100,
-                          .bitWidth      = 16,
-                          .flags =
-                              static_cast<uint32_t>(AudioDevice::Flags::InputLeft), // microphone use left audio channel
-                          .outputVolume = 0,
-                          .inputGain    = static_cast<float>(gain),
-                          .inputPath    = AudioDevice::InputPath::Headphones,
-                          .outputPath   = AudioDevice::OutputPath::None},
-                      AudioDevice::Type::Audiocodec)
+            : Profile(
+                  "Recording Headset",
+                  Type::RecordingHeadphones,
+                  audio::codec::Configuration{.sampleRate_Hz = 44100,
+                                              .bitWidth      = 16,
+                                              .flags         = static_cast<uint32_t>(
+                                                  audio::codec::Flags::InputLeft), // microphone use left audio channel
+                                              .outputVolume = 0,
+                                              .inputGain    = static_cast<float>(gain),
+                                              .inputPath    = audio::codec::InputPath::Headphones,
+                                              .outputPath   = audio::codec::OutputPath::None},
+                  AudioDevice::Type::Audiocodec)
         {}
     };
 

--- a/module-audio/Audio/Profiles/ProfileRecordingOnBoardMic.hpp
+++ b/module-audio/Audio/Profiles/ProfileRecordingOnBoardMic.hpp
@@ -11,18 +11,18 @@ namespace audio
     {
       public:
         ProfileRecordingOnBoardMic(Gain gain)
-            : Profile("Recording On Board Microphone",
-                      Type::RecordingBuiltInMic,
-                      AudioDevice::Configuration{
-                          .sampleRate_Hz = 44100,
-                          .bitWidth      = 16,
-                          .flags =
-                              static_cast<uint32_t>(AudioDevice::Flags::InputLeft), // microphone use left audio channel
-                          .outputVolume = 0,
-                          .inputGain    = static_cast<float>(gain),
-                          .inputPath    = AudioDevice::InputPath::Microphone,
-                          .outputPath   = AudioDevice::OutputPath::None},
-                      AudioDevice::Type::Audiocodec)
+            : Profile(
+                  "Recording On Board Microphone",
+                  Type::RecordingBuiltInMic,
+                  audio::codec::Configuration{.sampleRate_Hz = 44100,
+                                              .bitWidth      = 16,
+                                              .flags         = static_cast<uint32_t>(
+                                                  audio::codec::Flags::InputLeft), // microphone use left audio channel
+                                              .outputVolume = 0,
+                                              .inputGain    = static_cast<float>(gain),
+                                              .inputPath    = audio::codec::InputPath::Microphone,
+                                              .outputPath   = audio::codec::OutputPath::None},
+                  AudioDevice::Type::Audiocodec)
         {}
     };
 

--- a/module-audio/Audio/Profiles/ProfileRoutingBluetoothHSP.hpp
+++ b/module-audio/Audio/Profiles/ProfileRoutingBluetoothHSP.hpp
@@ -13,16 +13,16 @@ namespace audio
         ProfileRoutingBluetoothHSP(Volume volume, Gain gain)
             : Profile("Routing Bluetooth HSP",
                       Type::RoutingBluetoothHSP,
-                      AudioDevice::Configuration{
+                      audio::codec::Configuration{
                           .sampleRate_Hz = 8000,
                           .bitWidth      = 16,
                           .flags         = static_cast<uint32_t>(
-                                       AudioDevice::Flags::InputLeft) | // microphone use left audio channel
-                                   static_cast<uint32_t>(AudioDevice::Flags::OutputMono),
+                                       audio::codec::Flags::InputLeft) | // microphone use left audio channel
+                                   static_cast<uint32_t>(audio::codec::Flags::OutputMono),
                           .outputVolume = static_cast<float>(volume),
                           .inputGain    = static_cast<float>(gain),
-                          .inputPath    = AudioDevice::InputPath::None,
-                          .outputPath   = AudioDevice::OutputPath::None},
+                          .inputPath    = audio::codec::InputPath::None,
+                          .outputPath   = audio::codec::OutputPath::None},
                       AudioDevice::Type::Bluetooth)
         {}
     };

--- a/module-audio/Audio/Profiles/ProfileRoutingEarspeaker.hpp
+++ b/module-audio/Audio/Profiles/ProfileRoutingEarspeaker.hpp
@@ -13,16 +13,16 @@ namespace audio
         ProfileRoutingEarspeaker(Volume volume, Gain gain)
             : Profile("Routing Earspeaker",
                       Type::RoutingEarspeaker,
-                      AudioDevice::Configuration{
+                      audio::codec::Configuration{
                           .sampleRate_Hz = 16000,
                           .bitWidth      = 16,
                           .flags         = static_cast<uint32_t>(
-                                       AudioDevice::Flags::InputLeft) | // microphone use left audio channel
-                                   static_cast<uint32_t>(AudioDevice::Flags::OutputMono),
+                                       audio::codec::Flags::InputLeft) | // microphone use left audio channel
+                                   static_cast<uint32_t>(audio::codec::Flags::OutputMono),
                           .outputVolume = static_cast<float>(volume),
                           .inputGain    = static_cast<float>(gain),
-                          .inputPath    = AudioDevice::InputPath::Microphone,
-                          .outputPath   = AudioDevice::OutputPath::Earspeaker},
+                          .inputPath    = audio::codec::InputPath::Microphone,
+                          .outputPath   = audio::codec::OutputPath::Earspeaker},
                       AudioDevice::Type::Audiocodec)
         {}
     };

--- a/module-audio/Audio/Profiles/ProfileRoutingHeadphones.hpp
+++ b/module-audio/Audio/Profiles/ProfileRoutingHeadphones.hpp
@@ -13,16 +13,16 @@ namespace audio
         ProfileRoutingHeadphones(Volume volume, Gain gain)
             : Profile("Routing Headset",
                       Type::RoutingHeadphones,
-                      AudioDevice::Configuration{
+                      audio::codec::Configuration{
                           .sampleRate_Hz = 16000,
                           .bitWidth      = 16,
                           .flags         = static_cast<uint32_t>(
-                                       AudioDevice::Flags::InputLeft) | // microphone use left audio channel
-                                   static_cast<uint32_t>(AudioDevice::Flags::OutputMono),
+                                       audio::codec::Flags::InputLeft) | // microphone use left audio channel
+                                   static_cast<uint32_t>(audio::codec::Flags::OutputMono),
                           .outputVolume = static_cast<float>(volume),
                           .inputGain    = static_cast<float>(gain),
-                          .inputPath    = AudioDevice::InputPath::Headphones,
-                          .outputPath   = AudioDevice::OutputPath::Headphones},
+                          .inputPath    = audio::codec::InputPath::Headphones,
+                          .outputPath   = audio::codec::OutputPath::Headphones},
                       AudioDevice::Type::Audiocodec)
         {}
     };

--- a/module-audio/Audio/Profiles/ProfileRoutingLoudspeaker.hpp
+++ b/module-audio/Audio/Profiles/ProfileRoutingLoudspeaker.hpp
@@ -13,16 +13,16 @@ namespace audio
         ProfileRoutingLoudspeaker(Volume volume, Gain gain)
             : Profile("Routing Speakerphone",
                       Type::RoutingLoudspeaker,
-                      AudioDevice::Configuration{
+                      audio::codec::Configuration{
                           .sampleRate_Hz = 16000,
                           .bitWidth      = 16,
                           .flags         = static_cast<uint32_t>(
-                                       AudioDevice::Flags::InputLeft) | // microphone use left audio channel
-                                   static_cast<uint32_t>(AudioDevice::Flags::OutputMono),
+                                       audio::codec::Flags::InputLeft) | // microphone use left audio channel
+                                   static_cast<uint32_t>(audio::codec::Flags::OutputMono),
                           .outputVolume = static_cast<float>(volume),
                           .inputGain    = static_cast<float>(gain),
-                          .inputPath    = AudioDevice::InputPath::Microphone,
-                          .outputPath   = AudioDevice::OutputPath::Loudspeaker},
+                          .inputPath    = audio::codec::InputPath::Microphone,
+                          .outputPath   = audio::codec::OutputPath::Loudspeaker},
                       AudioDevice::Type::Audiocodec)
         {}
     };

--- a/module-audio/Audio/codec.hpp
+++ b/module-audio/Audio/codec.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <cstdint>
+
+namespace audio::codec
+{
+    enum class Flags
+    {
+        OutputMono   = 1 << 0,
+        OutputStereo = 1 << 1,
+        InputLeft    = 1 << 2,
+        InputRight   = 1 << 3,
+        InputStereo  = 1 << 4
+    };
+
+    enum class InputPath
+    {
+        Headphones,
+        Microphone,
+        None
+    };
+
+    enum class OutputPath
+    {
+        Headphones,
+        Earspeaker,
+        Loudspeaker,
+        None
+    };
+
+    struct Configuration
+    {
+        std::uint32_t sampleRate_Hz = 0; /*!< Sample rate of audio data */
+        std::uint32_t bitWidth      = 0; /*!< Data length of audio data, usually 8/16/24/32 bits */
+        std::uint32_t flags         = 0; /*!< In/Out configuration flags */
+        float outputVolume          = 0.0f;
+        float inputGain             = 0.0f;
+        InputPath inputPath         = InputPath::None;
+        OutputPath outputPath       = OutputPath::None;
+    };
+
+} // namespace audio::codec

--- a/module-audio/Audio/decoder/Decoder.cpp
+++ b/module-audio/Audio/decoder/Decoder.cpp
@@ -172,13 +172,9 @@ namespace audio
         return AudioFormat{tags->sample_rate, bitWidth, channels};
     }
 
-    auto Decoder::getSupportedFormats() -> const std::vector<AudioFormat> &
+    auto Decoder::getSupportedFormats() -> std::vector<AudioFormat>
     {
-        if (formats.empty()) {
-            formats.push_back(getSourceFormat());
-        }
-
-        return formats;
+        return std::vector<AudioFormat>{getSourceFormat()};
     }
 
     auto Decoder::getTraits() const -> Endpoint::Traits

--- a/module-audio/Audio/decoder/Decoder.hpp
+++ b/module-audio/Audio/decoder/Decoder.hpp
@@ -108,7 +108,7 @@ namespace audio
         void disableInput() override;
 
         auto getSourceFormat() -> AudioFormat override;
-        auto getSupportedFormats() -> const std::vector<AudioFormat> & override;
+        auto getSupportedFormats() -> std::vector<AudioFormat> override;
 
         auto getTraits() const -> Endpoint::Traits override;
 
@@ -142,7 +142,6 @@ namespace audio
         // decoding worker
         std::unique_ptr<DecoderWorker> audioWorker;
         DecoderWorker::EndOfFileCallback _endOfFileCallback;
-        std::vector<AudioFormat> formats;
     };
 
 } // namespace audio

--- a/module-audio/Audio/test/MockEndpoint.hpp
+++ b/module-audio/Audio/test/MockEndpoint.hpp
@@ -13,7 +13,8 @@ namespace testing::audio
     {
       public:
         MOCK_METHOD(::audio::Endpoint::Traits, getTraits, (), (const, override));
-        MOCK_METHOD(const std::vector<::audio::AudioFormat> &, getSupportedFormats, (), (override));
+        MOCK_METHOD(std::vector<::audio::AudioFormat>, getSupportedFormats, (), (override));
+        MOCK_METHOD(::audio::AudioFormat, getSinkFormat, (), (override));
         MOCK_METHOD(void, onDataSend, (), (override));
         MOCK_METHOD(void, enableOutput, (), (override));
         MOCK_METHOD(void, disableOutput, (), (override));
@@ -23,7 +24,7 @@ namespace testing::audio
     {
       public:
         MOCK_METHOD(::audio::Endpoint::Traits, getTraits, (), (const, override));
-        MOCK_METHOD(const std::vector<::audio::AudioFormat> &, getSupportedFormats, (), (override));
+        MOCK_METHOD(std::vector<::audio::AudioFormat>, getSupportedFormats, (), (override));
         MOCK_METHOD(::audio::AudioFormat, getSourceFormat, (), (override));
         MOCK_METHOD(void, onDataReceive, (), (override));
         MOCK_METHOD(void, enableInput, (), (override));

--- a/module-audio/Audio/test/TestEndpoint.cpp
+++ b/module-audio/Audio/test/TestEndpoint.cpp
@@ -12,7 +12,7 @@ using audio::test::TestSource;
 TestSink::TestSink(std::vector<AudioFormat> supportedFormats) : formats(std::move(supportedFormats))
 {}
 
-auto TestSink::getSupportedFormats() -> const std::vector<AudioFormat> &
+auto TestSink::getSupportedFormats() -> std::vector<AudioFormat>
 {
     return formats;
 }
@@ -53,7 +53,7 @@ void TestSource::enableInput()
 void TestSource::disableInput()
 {}
 
-auto TestSource::getSupportedFormats() -> const std::vector<AudioFormat> &
+auto TestSource::getSupportedFormats() -> std::vector<AudioFormat>
 {
     return formats;
 }

--- a/module-audio/Audio/test/TestEndpoint.hpp
+++ b/module-audio/Audio/test/TestEndpoint.hpp
@@ -20,7 +20,7 @@ namespace audio::test
         void onDataSend() override;
         void enableOutput() override;
         void disableOutput() override;
-        auto getSupportedFormats() -> const std::vector<AudioFormat> & override;
+        auto getSupportedFormats() -> std::vector<AudioFormat> override;
         auto getTraits() const -> ::audio::Endpoint::Traits override;
 
       private:
@@ -37,7 +37,7 @@ namespace audio::test
         void onDataReceive() override;
         void enableInput() override;
         void disableInput() override;
-        auto getSupportedFormats() -> const std::vector<AudioFormat> & override;
+        auto getSupportedFormats() -> std::vector<AudioFormat> override;
         auto getTraits() const -> ::audio::Endpoint::Traits override;
 
       private:

--- a/module-audio/board/linux/LinuxAudioPlatform.cpp
+++ b/module-audio/board/linux/LinuxAudioPlatform.cpp
@@ -2,6 +2,7 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <Audio/AudioPlatform.hpp>
+#include <Audio/Profiles/Profile.hpp>
 
 #include <memory>
 #include <utility>
@@ -12,8 +13,14 @@ using audio::AudioPlatform;
 
 class DummyAudioFactory : public AudioDeviceFactory
 {
+  public:
+    std::shared_ptr<AudioDevice> createCellularAudioDevice() override
+    {
+        return nullptr;
+    }
+
   protected:
-    std::shared_ptr<AudioDevice> getDeviceFromType([[maybe_unused]] AudioDevice::Type deviceType)
+    std::shared_ptr<AudioDevice> getDevice([[maybe_unused]] const audio::Profile &profile) override
     {
         return nullptr;
     }

--- a/module-audio/board/rt1051/RT1051AudioCodec.cpp
+++ b/module-audio/board/rt1051/RT1051AudioCodec.cpp
@@ -9,20 +9,19 @@
 #include "bsp/BoardDefinitions.hpp"
 #include "board/rt1051/common/audio.hpp"
 
-#include <mutex.hpp>
+using audio::codec::Configuration;
 
 namespace audio
 {
     sai_edma_handle_t RT1051AudioCodec::txHandle = {};
     sai_edma_handle_t RT1051AudioCodec::rxHandle = {};
 
-    RT1051AudioCodec::RT1051AudioCodec()
+    RT1051AudioCodec::RT1051AudioCodec(const Configuration &format)
         : SAIAudioDevice(BOARD_AUDIOCODEC_SAIx, &rxHandle, &txHandle), saiInFormat{}, saiOutFormat{},
           codecParams{}, codec{},
-          formats(audio::AudioFormat::makeMatrix(supportedSampleRates, supportedBitWidths, supportedChannelModes))
-    {
-        isInitialized = true;
-    }
+          formats(audio::AudioFormat::makeMatrix(supportedSampleRates, supportedBitWidths, supportedChannelModes)),
+          currentFormat(format)
+    {}
 
     RT1051AudioCodec::~RT1051AudioCodec()
     {
@@ -30,13 +29,13 @@ namespace audio
         DeinitBsp();
     }
 
-    CodecParamsMAX98090::InputPath RT1051AudioCodec::getCodecInputPath(const AudioDevice::Configuration &format)
+    CodecParamsMAX98090::InputPath RT1051AudioCodec::getCodecInputPath(const Configuration &format)
     {
         switch (format.inputPath) {
-        case AudioDevice::InputPath::Headphones:
+        case audio::codec::InputPath::Headphones:
             return CodecParamsMAX98090::InputPath::Headphones;
 
-        case AudioDevice::InputPath::Microphone:
+        case audio::codec::InputPath::Microphone:
             return CodecParamsMAX98090::InputPath::Microphone;
 
         default:
@@ -44,18 +43,18 @@ namespace audio
         };
     }
 
-    CodecParamsMAX98090::OutputPath RT1051AudioCodec::getCodecOutputPath(const AudioDevice::Configuration &format)
+    CodecParamsMAX98090::OutputPath RT1051AudioCodec::getCodecOutputPath(const Configuration &format)
     {
-        auto mono = (format.flags & static_cast<std::uint32_t>(AudioDevice::Flags::OutputMono)) != 0;
+        auto mono = (format.flags & static_cast<std::uint32_t>(audio::codec::Flags::OutputMono)) != 0;
 
         switch (format.outputPath) {
-        case AudioDevice::OutputPath::Headphones:
+        case audio::codec::OutputPath::Headphones:
             return mono ? CodecParamsMAX98090::OutputPath::HeadphonesMono : CodecParamsMAX98090::OutputPath::Headphones;
 
-        case AudioDevice::OutputPath::Earspeaker:
+        case audio::codec::OutputPath::Earspeaker:
             return CodecParamsMAX98090::OutputPath::Earspeaker;
 
-        case AudioDevice::OutputPath::Loudspeaker:
+        case audio::codec::OutputPath::Loudspeaker:
             return mono ? CodecParamsMAX98090::OutputPath::LoudspeakerMono
                         : CodecParamsMAX98090::OutputPath::Loudspeaker;
 
@@ -64,57 +63,52 @@ namespace audio
         }
     }
 
-    AudioDevice::RetCode RT1051AudioCodec::Start(const AudioDevice::Configuration &format)
+    AudioDevice::RetCode RT1051AudioCodec::Start()
     {
-        cpp_freertos::LockGuard lock(mutex);
-
         if (state == State::Running) {
             return AudioDevice::RetCode::Failure;
         }
 
         InitBsp();
 
-        saiInFormat.bitWidth      = format.bitWidth;
-        saiInFormat.sampleRate_Hz = format.sampleRate_Hz;
+        saiInFormat.bitWidth      = currentFormat.bitWidth;
+        saiInFormat.sampleRate_Hz = currentFormat.sampleRate_Hz;
 
-        saiOutFormat.bitWidth      = format.bitWidth;
-        saiOutFormat.sampleRate_Hz = format.sampleRate_Hz;
+        saiOutFormat.bitWidth      = currentFormat.bitWidth;
+        saiOutFormat.sampleRate_Hz = currentFormat.sampleRate_Hz;
 
-        if (format.flags & static_cast<uint32_t>(AudioDevice::Flags::InputLeft)) {
+        if (currentFormat.flags & static_cast<uint32_t>(audio::codec::Flags::InputLeft)) {
             saiInFormat.stereo = kSAI_MonoLeft;
             InStart();
         }
-        else if (format.flags & static_cast<uint32_t>(AudioDevice::Flags::InputRight)) {
+        else if (currentFormat.flags & static_cast<uint32_t>(audio::codec::Flags::InputRight)) {
             saiInFormat.stereo = kSAI_MonoRight;
             InStart();
         }
-        else if (format.flags & static_cast<uint32_t>(AudioDevice::Flags::InputStereo)) {
+        else if (currentFormat.flags & static_cast<uint32_t>(audio::codec::Flags::InputStereo)) {
             saiInFormat.stereo = kSAI_Stereo;
             InStart();
         }
 
-        if (format.flags & static_cast<uint32_t>(AudioDevice::Flags::OutputMono)) {
+        if (currentFormat.flags & static_cast<uint32_t>(audio::codec::Flags::OutputMono)) {
             saiOutFormat.stereo = kSAI_MonoLeft;
             OutStart();
         }
-        else if (format.flags & static_cast<uint32_t>(AudioDevice::Flags::OutputStereo)) {
+        else if (currentFormat.flags & static_cast<uint32_t>(audio::codec::Flags::OutputStereo)) {
             saiOutFormat.stereo = kSAI_Stereo;
             OutStart();
         }
 
-        codecParams.sampleRate = CodecParamsMAX98090::ValToSampleRate(format.sampleRate_Hz);
+        codecParams.sampleRate = CodecParamsMAX98090::ValToSampleRate(currentFormat.sampleRate_Hz);
         if (codecParams.sampleRate == CodecParamsMAX98090::SampleRate::Invalid) {
             LOG_ERROR("Unsupported sample rate");
         }
 
-        codecParams.inputPath  = getCodecInputPath(format);
-        codecParams.outputPath = getCodecOutputPath(format);
-        codecParams.outVolume  = format.outputVolume;
-        codecParams.inGain     = format.inputGain;
+        codecParams.inputPath  = getCodecInputPath(currentFormat);
+        codecParams.outputPath = getCodecOutputPath(currentFormat);
+        codecParams.outVolume  = currentFormat.outputVolume;
+        codecParams.inGain     = currentFormat.inputGain;
         codec.Start(codecParams);
-
-        // Store format passed
-        currentFormat = format;
 
         state = State::Running;
 
@@ -123,8 +117,6 @@ namespace audio
 
     AudioDevice::RetCode RT1051AudioCodec::Stop()
     {
-        cpp_freertos::LockGuard lock(mutex);
-
         if (state == State::Stopped) {
             return AudioDevice::RetCode::Failure;
         }
@@ -140,7 +132,7 @@ namespace audio
         return AudioDevice::RetCode::Success;
     }
 
-    AudioDevice::RetCode RT1051AudioCodec::OutputVolumeCtrl(float vol)
+    AudioDevice::RetCode RT1051AudioCodec::setOutputVolume(float vol)
     {
         currentFormat.outputVolume = vol;
         CodecParamsMAX98090 params;
@@ -150,7 +142,7 @@ namespace audio
         return AudioDevice::RetCode::Success;
     }
 
-    AudioDevice::RetCode RT1051AudioCodec::InputGainCtrl(float gain)
+    AudioDevice::RetCode RT1051AudioCodec::setInputGain(float gain)
     {
         currentFormat.inputGain = gain;
         CodecParamsMAX98090 params;
@@ -160,7 +152,7 @@ namespace audio
         return AudioDevice::RetCode::Success;
     }
 
-    AudioDevice::RetCode RT1051AudioCodec::InputPathCtrl(InputPath inputPath)
+    AudioDevice::RetCode RT1051AudioCodec::InputPathCtrl(audio::codec::InputPath inputPath)
     {
         currentFormat.inputPath = inputPath;
         CodecParamsMAX98090 params;
@@ -170,7 +162,7 @@ namespace audio
         return AudioDevice::RetCode::Success;
     }
 
-    AudioDevice::RetCode RT1051AudioCodec::OutputPathCtrl(OutputPath outputPath)
+    AudioDevice::RetCode RT1051AudioCodec::OutputPathCtrl(audio::codec::OutputPath outputPath)
     {
         currentFormat.outputPath = outputPath;
         CodecParamsMAX98090 params;
@@ -178,15 +170,6 @@ namespace audio
         params.opCmd      = CodecParamsMAX98090::Cmd::SetOutput;
         codec.Ioctrl(params);
         return AudioDevice::RetCode::Success;
-    }
-
-    bool RT1051AudioCodec::IsFormatSupported(const AudioDevice::Configuration &format)
-    {
-
-        if (CodecParamsMAX98090::ValToSampleRate(format.sampleRate_Hz) == CodecParamsMAX98090::SampleRate::Invalid) {
-            return false;
-        }
-        return true;
     }
 
     void RT1051AudioCodec::InitBsp()
@@ -280,7 +263,7 @@ namespace audio
         memset(&rxHandle, 0, sizeof(rxHandle));
     }
 
-    auto RT1051AudioCodec::getSupportedFormats() -> const std::vector<AudioFormat> &
+    auto RT1051AudioCodec::getSupportedFormats() -> std::vector<AudioFormat>
     {
         return formats;
     }
@@ -288,6 +271,16 @@ namespace audio
     auto RT1051AudioCodec::getTraits() const -> Traits
     {
         return Traits{.usesDMA = true};
+    }
+
+    auto RT1051AudioCodec::getSourceFormat() -> audio::AudioFormat
+    {
+        if (currentFormat.flags == 0) {
+            return audio::nullFormat;
+        }
+
+        auto isMono = (currentFormat.flags & static_cast<unsigned int>(audio::codec::Flags::InputStereo)) == 0;
+        return audio::AudioFormat{currentFormat.sampleRate_Hz, currentFormat.bitWidth, isMono ? 1U : 2U};
     }
 
     void rxAudioCodecCallback(I2S_Type *base, sai_edma_handle_t *handle, status_t status, void *userData)

--- a/module-audio/board/rt1051/RT1051AudioCodec.hpp
+++ b/module-audio/board/rt1051/RT1051AudioCodec.hpp
@@ -16,7 +16,7 @@
 #include "drivers/dmamux/DriverDMAMux.hpp"
 #include "drivers/dma/DriverDMA.hpp"
 
-#include <mutex.hpp>
+#include <Audio/codec.hpp>
 
 #include <initializer_list>
 #include <vector>
@@ -34,20 +34,19 @@ namespace audio
         friend void txAudioCodecCallback(I2S_Type *base, sai_edma_handle_t *handle, status_t status, void *userData);
         friend void rxAudioCodecCallback(I2S_Type *base, sai_edma_handle_t *handle, status_t status, void *userData);
 
-        RT1051AudioCodec();
+        RT1051AudioCodec(const audio::codec::Configuration &format);
         virtual ~RT1051AudioCodec();
 
-        AudioDevice::RetCode Start(const Configuration &format) override final;
+        AudioDevice::RetCode Start() override final;
         AudioDevice::RetCode Stop() override final;
-        AudioDevice::RetCode OutputVolumeCtrl(float vol) override final;
-        AudioDevice::RetCode InputGainCtrl(float gain) override final;
-        AudioDevice::RetCode OutputPathCtrl(OutputPath outputPath) override final;
-        AudioDevice::RetCode InputPathCtrl(InputPath inputPath) override final;
-        bool IsFormatSupported(const Configuration &format) override final;
-        auto getSupportedFormats() -> const std::vector<AudioFormat> & override final;
+        AudioDevice::RetCode setOutputVolume(float vol) override final;
+        AudioDevice::RetCode setInputGain(float gain) override final;
+        auto getSupportedFormats() -> std::vector<AudioFormat> override final;
         auto getTraits() const -> Traits override final;
+        auto getSourceFormat() -> AudioFormat override final;
 
-        cpp_freertos::MutexStandard mutex;
+        AudioDevice::RetCode OutputPathCtrl(audio::codec::OutputPath outputPath);
+        AudioDevice::RetCode InputPathCtrl(audio::codec::InputPath inputPath);
 
       private:
         constexpr static TickType_t codecSettleTime                               = 20 * portTICK_PERIOD_MS;
@@ -75,6 +74,7 @@ namespace audio
         CodecParamsMAX98090 codecParams;
         CodecMAX98090 codec;
         std::vector<audio::AudioFormat> formats;
+        audio::codec::Configuration currentFormat;
 
         static AT_NONCACHEABLE_SECTION_INIT(sai_edma_handle_t txHandle);
         static AT_NONCACHEABLE_SECTION_INIT(sai_edma_handle_t rxHandle);
@@ -86,7 +86,7 @@ namespace audio
         void OutStop();
         void InStop();
 
-        CodecParamsMAX98090::InputPath getCodecInputPath(const AudioDevice::Configuration &format);
-        CodecParamsMAX98090::OutputPath getCodecOutputPath(const AudioDevice::Configuration &format);
+        CodecParamsMAX98090::InputPath getCodecInputPath(const audio::codec::Configuration &format);
+        CodecParamsMAX98090::OutputPath getCodecOutputPath(const audio::codec::Configuration &format);
     };
 } // namespace audio

--- a/module-audio/board/rt1051/RT1051CellularAudio.cpp
+++ b/module-audio/board/rt1051/RT1051CellularAudio.cpp
@@ -8,8 +8,6 @@
 
 #include "bsp/BoardDefinitions.hpp"
 
-#include <mutex.hpp>
-
 namespace audio
 {
 
@@ -18,11 +16,8 @@ namespace audio
     sai_edma_handle_t RT1051CellularAudio::txHandle = {};
     sai_edma_handle_t RT1051CellularAudio::rxHandle = {};
 
-    RT1051CellularAudio::RT1051CellularAudio()
-        : SAIAudioDevice(BOARD_CELLULAR_AUDIO_SAIx, &rxHandle, &txHandle), saiInFormat{}, saiOutFormat{}, config{}
-    {
-        isInitialized = true;
-    }
+    RT1051CellularAudio::RT1051CellularAudio() : SAIAudioDevice(BOARD_CELLULAR_AUDIO_SAIx, &rxHandle, &txHandle)
+    {}
 
     RT1051CellularAudio::~RT1051CellularAudio()
     {
@@ -30,47 +25,16 @@ namespace audio
         Deinit();
     }
 
-    AudioDevice::RetCode RT1051CellularAudio::Start(const AudioDevice::Configuration &format)
+    AudioDevice::RetCode RT1051CellularAudio::Start()
     {
-        cpp_freertos::LockGuard lock(mutex);
-
         if (state == State::Running) {
             LOG_ERROR("Audio device already running");
             return AudioDevice::RetCode::Failure;
         }
 
         Init();
-
-        saiInFormat.bitWidth      = format.bitWidth;
-        saiInFormat.sampleRate_Hz = format.sampleRate_Hz;
-
-        saiOutFormat.bitWidth      = format.bitWidth;
-        saiOutFormat.sampleRate_Hz = format.sampleRate_Hz;
-
-        if (format.flags & static_cast<uint32_t>(AudioDevice::Flags::InputLeft)) {
-            saiInFormat.stereo = kSAI_MonoLeft;
-            InStart();
-        }
-        else if (format.flags & static_cast<uint32_t>(AudioDevice::Flags::InputRight)) {
-            saiInFormat.stereo = kSAI_MonoRight;
-            InStart();
-        }
-        else if (format.flags & static_cast<uint32_t>(AudioDevice::Flags::InputStereo)) {
-            saiInFormat.stereo = kSAI_Stereo;
-            InStart();
-        }
-
-        if (format.flags & static_cast<uint32_t>(AudioDevice::Flags::OutputMono)) {
-            saiOutFormat.stereo = kSAI_MonoLeft;
-            OutStart();
-        }
-        else if (format.flags & static_cast<uint32_t>(AudioDevice::Flags::OutputStereo)) {
-            saiOutFormat.stereo = kSAI_Stereo;
-            OutStart();
-        }
-
-        // Store format passed
-        currentFormat = format;
+        InStart();
+        OutStart();
 
         state = State::Running;
 
@@ -79,8 +43,6 @@ namespace audio
 
     AudioDevice::RetCode RT1051CellularAudio::Stop()
     {
-        cpp_freertos::LockGuard lock(mutex);
-
         if (state == State::Stopped) {
             return AudioDevice::RetCode::Failure;
         }
@@ -88,42 +50,20 @@ namespace audio
         InStop();
         OutStop();
 
-        currentFormat = {};
-        state         = State::Stopped;
+        state = State::Stopped;
 
         return AudioDevice::RetCode::Success;
     }
 
-    AudioDevice::RetCode RT1051CellularAudio::OutputVolumeCtrl(float vol)
+    AudioDevice::RetCode RT1051CellularAudio::setOutputVolume(float vol)
     {
-        currentFormat.outputVolume = vol;
         return AudioDevice::RetCode::Success;
     }
 
-    AudioDevice::RetCode RT1051CellularAudio::InputGainCtrl(float gain)
+    AudioDevice::RetCode RT1051CellularAudio::setInputGain(float gain)
     {
-        currentFormat.inputGain = gain;
         return AudioDevice::RetCode::Success;
     }
-
-    AudioDevice::RetCode RT1051CellularAudio::InputPathCtrl(InputPath inputPath)
-    {
-        currentFormat.inputPath = inputPath;
-        return AudioDevice::RetCode::Success;
-    }
-
-    AudioDevice::RetCode RT1051CellularAudio::OutputPathCtrl(OutputPath outputPath)
-    {
-        currentFormat.outputPath = outputPath;
-        return AudioDevice::RetCode::Success;
-    }
-
-    bool RT1051CellularAudio::IsFormatSupported(const AudioDevice::Configuration &format)
-    {
-        return true;
-    }
-
-    // INTERNALS
 
     void RT1051CellularAudio::Init()
     {
@@ -175,13 +115,13 @@ namespace audio
         sai_transfer_format_t sai_format = {};
 
         /* Configure the audio format */
-        sai_format.bitWidth           = saiInFormat.bitWidth;
+        sai_format.bitWidth           = supportedBitWidth;
         sai_format.channel            = 0U;
-        sai_format.sampleRate_Hz      = saiInFormat.sampleRate_Hz;
+        sai_format.sampleRate_Hz      = supportedSampleRate;
         sai_format.masterClockHz      = mclkSourceClockHz;
         sai_format.isFrameSyncCompact = false;
         sai_format.protocol           = config.protocol;
-        sai_format.stereo             = saiInFormat.stereo;
+        sai_format.stereo             = kSAI_MonoLeft;
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
         sai_format.watermark = FSL_FEATURE_SAI_FIFO_COUNT / 2U;
 #endif
@@ -206,13 +146,13 @@ namespace audio
         sai_transfer_format_t sai_format;
 
         /* Configure the audio format */
-        sai_format.bitWidth           = saiOutFormat.bitWidth;
+        sai_format.bitWidth           = supportedBitWidth;
         sai_format.channel            = 0U;
-        sai_format.sampleRate_Hz      = saiOutFormat.sampleRate_Hz;
+        sai_format.sampleRate_Hz      = supportedSampleRate;
         sai_format.masterClockHz      = mclkSourceClockHz;
         sai_format.isFrameSyncCompact = false;
         sai_format.protocol           = config.protocol;
-        sai_format.stereo             = saiOutFormat.stereo;
+        sai_format.stereo             = kSAI_MonoLeft;
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
         sai_format.watermark = FSL_FEATURE_SAI_FIFO_COUNT / 2U;
 #endif
@@ -249,9 +189,14 @@ namespace audio
         memset(&rxHandle, 0, sizeof(rxHandle));
     }
 
-    auto RT1051CellularAudio::getSupportedFormats() -> const std::vector<AudioFormat> &
+    auto RT1051CellularAudio::getSupportedFormats() -> std::vector<AudioFormat>
     {
-        return formats;
+        return std::vector<AudioFormat>{getSourceFormat()};
+    }
+
+    auto RT1051CellularAudio::getSourceFormat() -> AudioFormat
+    {
+        return AudioFormat(supportedSampleRate, supportedBitWidth, supportedChannels);
     }
 
     auto RT1051CellularAudio::getTraits() const -> Traits

--- a/module-audio/board/rt1051/RT1051DeviceFactory.cpp
+++ b/module-audio/board/rt1051/RT1051DeviceFactory.cpp
@@ -6,17 +6,19 @@
 #include "board/rt1051/RT1051CellularAudio.hpp"
 #include "audio/BluetoothAudioDevice.hpp"
 
+#include <Audio/Profiles/Profile.hpp>
+
 using audio::AudioDevice;
 using audio::RT1051AudioCodec;
 using audio::RT1051CellularAudio;
 using audio::RT1051DeviceFactory;
 
-std::shared_ptr<AudioDevice> RT1051DeviceFactory::getDeviceFromType(AudioDevice::Type deviceType)
+std::shared_ptr<AudioDevice> RT1051DeviceFactory::getDevice(const audio::Profile &profile)
 {
     std::shared_ptr<AudioDevice> device;
-    switch (deviceType) {
+    switch (profile.GetAudioDeviceType()) {
     case AudioDevice::Type::Audiocodec: {
-        device = std::make_shared<RT1051AudioCodec>();
+        device = std::make_shared<RT1051AudioCodec>(profile.GetAudioConfiguration());
     } break;
 
     case AudioDevice::Type::Bluetooth: {
@@ -32,4 +34,9 @@ std::shared_ptr<AudioDevice> RT1051DeviceFactory::getDeviceFromType(AudioDevice:
     };
 
     return device;
+}
+
+std::shared_ptr<AudioDevice> RT1051DeviceFactory::createCellularAudioDevice()
+{
+    return std::make_shared<RT1051CellularAudio>();
 }

--- a/module-audio/board/rt1051/RT1051DeviceFactory.hpp
+++ b/module-audio/board/rt1051/RT1051DeviceFactory.hpp
@@ -4,14 +4,18 @@
 #pragma once
 
 #include <Audio/AudioDeviceFactory.hpp>
+#include <Audio/Profiles/Profile.hpp>
 
 namespace audio
 {
 
     class RT1051DeviceFactory : public AudioDeviceFactory
     {
+      public:
+        std::shared_ptr<AudioDevice> createCellularAudioDevice() override final;
+
       protected:
-        std::shared_ptr<AudioDevice> getDeviceFromType(AudioDevice::Type deviceType) override;
+        std::shared_ptr<AudioDevice> getDevice(const Profile &audioProfile) override;
     };
 
 }; // namespace audio

--- a/module-audio/board/rt1051/SAIAudioDevice.cpp
+++ b/module-audio/board/rt1051/SAIAudioDevice.cpp
@@ -16,6 +16,7 @@ void SAIAudioDevice::initiateRxTransfer()
     audio::Stream::Span dataSpan;
 
     Source::_stream->reserve(dataSpan);
+    LOG_DEBUG("Initiate rx transfer with %u bytes", dataSpan.dataSize);
     auto xfer = sai_transfer_t{.data = dataSpan.data, .dataSize = dataSpan.dataSize};
     SAI_TransferReceiveEDMA(_base, rx, &xfer);
 }

--- a/module-bluetooth/Bluetooth/audio/BluetoothAudioDevice.cpp
+++ b/module-bluetooth/Bluetooth/audio/BluetoothAudioDevice.cpp
@@ -28,24 +28,10 @@ BluetoothAudioDevice::~BluetoothAudioDevice()
 
 void BluetoothAudioDevice::setMediaContext(MediaContext *mediaContext)
 {
-    constexpr static auto supportedBitWidth = 16U;
-    ctx                                     = mediaContext;
-    formats = std::vector<AudioFormat>{AudioFormat{static_cast<unsigned>(AVDTP::sbcConfig.samplingFrequency),
-                                                   supportedBitWidth,
-                                                   static_cast<unsigned>(AVDTP::sbcConfig.numChannels)}};
+    ctx = mediaContext;
 }
 
-auto BluetoothAudioDevice::Start(const Configuration &format) -> audio::AudioDevice::RetCode
-{
-    return audio::AudioDevice::RetCode::Success;
-}
-
-auto BluetoothAudioDevice::Stop() -> audio::AudioDevice::RetCode
-{
-    return audio::AudioDevice::RetCode::Success;
-}
-
-auto BluetoothAudioDevice::OutputVolumeCtrl(float vol) -> audio::AudioDevice::RetCode
+auto BluetoothAudioDevice::setOutputVolume(float vol) -> audio::AudioDevice::RetCode
 {
     const auto volumeToSet = audio::volume::scaler::toAvrcpVolume(vol);
     const auto status      = avrcp_controller_set_absolute_volume(ctx->avrcp_cid, volumeToSet);
@@ -53,28 +39,13 @@ auto BluetoothAudioDevice::OutputVolumeCtrl(float vol) -> audio::AudioDevice::Re
         LOG_ERROR("Can't set volume level. Status %x", status);
         return audio::AudioDevice::RetCode::Failure;
     }
-    currentFormat.outputVolume = vol;
+    outputVolume = vol;
     return audio::AudioDevice::RetCode::Success;
 }
 
-auto BluetoothAudioDevice::InputGainCtrl(float gain) -> audio::AudioDevice::RetCode
+auto BluetoothAudioDevice::setInputGain(float gain) -> audio::AudioDevice::RetCode
 {
     return audio::AudioDevice::RetCode::Success;
-}
-
-auto BluetoothAudioDevice::OutputPathCtrl(OutputPath outputPath) -> audio::AudioDevice::RetCode
-{
-    return audio::AudioDevice::RetCode::Success;
-}
-
-auto BluetoothAudioDevice::InputPathCtrl(InputPath inputPath) -> audio::AudioDevice::RetCode
-{
-    return audio::AudioDevice::RetCode::Success;
-}
-
-auto BluetoothAudioDevice::IsFormatSupported(const Configuration &format) -> bool
-{
-    return true;
 }
 
 void BluetoothAudioDevice::onDataSend()
@@ -133,9 +104,17 @@ auto BluetoothAudioDevice::fillSbcAudioBuffer(MediaContext *context) -> int
     return totalNumBytesRead;
 }
 
-auto BluetoothAudioDevice::getSupportedFormats() -> const std::vector<AudioFormat> &
+auto BluetoothAudioDevice::getSupportedFormats() -> std::vector<audio::AudioFormat>
 {
-    return formats;
+    constexpr static auto supportedBitWidth = 16U;
+    return std::vector<AudioFormat>{AudioFormat{static_cast<unsigned>(AVDTP::sbcConfig.samplingFrequency),
+                                                supportedBitWidth,
+                                                static_cast<unsigned>(AVDTP::sbcConfig.numChannels)}};
+}
+
+auto BluetoothAudioDevice::getSourceFormat() -> audio::AudioFormat
+{
+    return audio::nullFormat;
 }
 
 auto BluetoothAudioDevice::getTraits() const -> Traits

--- a/module-bluetooth/Bluetooth/audio/BluetoothAudioDevice.hpp
+++ b/module-bluetooth/Bluetooth/audio/BluetoothAudioDevice.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <Audio/AudioDevice.hpp>
+#include <Audio/AudioFormat.hpp>
 #include <interface/profiles/A2DP/MediaContext.hpp>
 
 namespace bluetooth
@@ -16,18 +17,12 @@ namespace bluetooth
         explicit BluetoothAudioDevice(MediaContext *mediaContext);
         virtual ~BluetoothAudioDevice();
 
+        RetCode setOutputVolume(float vol) override;
+        RetCode setInputGain(float gain) override;
         void setMediaContext(MediaContext *MediaContext);
-
-        auto Start(const Configuration &format) -> audio::AudioDevice::RetCode override;
-        auto Stop() -> audio::AudioDevice::RetCode override;
-
-        auto OutputVolumeCtrl(float vol) -> audio::AudioDevice::RetCode override;
-        auto InputGainCtrl(float gain) -> audio::AudioDevice::RetCode override;
-        auto OutputPathCtrl(OutputPath outputPath) -> audio::AudioDevice::RetCode override;
-        auto InputPathCtrl(InputPath inputPath) -> audio::AudioDevice::RetCode override;
-        auto IsFormatSupported(const Configuration &format) -> bool override;
-        auto getSupportedFormats() -> const std::vector<audio::AudioFormat> & override;
         auto getTraits() const -> Traits override;
+        auto getSupportedFormats() -> std::vector<audio::AudioFormat> override;
+        auto getSourceFormat() -> audio::AudioFormat override;
 
         // Endpoint control methods
         void onDataSend() override;
@@ -42,7 +37,7 @@ namespace bluetooth
 
         MediaContext *ctx  = nullptr;
         bool outputEnabled = false;
-        std::vector<audio::AudioFormat> formats;
+        float outputVolume = 0.0;
     };
 
 } // namespace bluetooth


### PR DESCRIPTION
This refactoring removes invalid interface dependencies of the original
AudioDevice implementation:
 - move things characteristic to RT1051AudioCodec to audio::codec
 - remove dead methods
 - make start/stop optional and codec configuration independent
 - add more convenient way to get supported formats

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>