### PR TITLE
[EGD-6767] Disable WALL mechanism in the DB

### DIFF
--- a/module-db/Database/Database.cpp
+++ b/module-db/Database/Database.cpp
@@ -85,7 +85,6 @@ Database::Database(const char *name, bool readOnly)
     initQueryStatementBuffer();
     pragmaQuery("PRAGMA integrity_check;");
     pragmaQuery("PRAGMA locking_mode=EXCLUSIVE");
-    pragmaQuery("PRAGMA journal_mode=WAL");
 
     const auto filePath = (purefs::dir::getUserDiskPath() / "db");
     LOG_INFO("Running scripts: %s", filePath.c_str());


### PR DESCRIPTION
Wall mechanism is not needed due to the littlefs
fail proofs safety. It causes a lot of troubles
in the frame recovery and unnessesry increases
io bandwidth

Signed-off-by: Lucjan Bryndza <lucjan.bryndza@mudita.com>