### PR TITLE
[EGD-6796] Fix excesive ATA command with HSP

### DIFF
--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -1913,6 +1913,10 @@ void ServiceCellular::apnListChanged(const std::string &value)
 auto ServiceCellular::handleCellularAnswerIncomingCallMessage(CellularMessage *msg)
     -> std::shared_ptr<CellularResponseMessage>
 {
+    if (ongoingCall.getType() != CallType::CT_INCOMING) {
+        return std::make_shared<CellularResponseMessage>(true);
+    }
+
     auto channel = cmux->get(CellularMux::Channel::Commands);
     auto ret     = false;
     if (channel) {

--- a/module-services/service-cellular/service-cellular/CellularCall.hpp
+++ b/module-services/service-cellular/service-cellular/CellularCall.hpp
@@ -92,6 +92,12 @@ namespace CellularCall
         {
             return isActiveCall;
         }
+
+        [[nodiscard]] CallType getType() const noexcept
+        {
+            return call.type;
+        }
+
         void setCpuSentinel(std::shared_ptr<sys::CpuSentinel> sentinel);
     };
 } // namespace CellularCall


### PR DESCRIPTION
This commit fixes excessive ATA command when using HSP.
It adds simple call type check when handling incoming call.