### PR TITLE
[EGD-6654] Add self-tuning for RC oscillator

### DIFF
--- a/module-bsp/board/rt1051/bsp/lpm/Oscillator.cpp
+++ b/module-bsp/board/rt1051/bsp/lpm/Oscillator.cpp
@@ -4,10 +4,16 @@
 #include "Oscillator.hpp"
 #include "ClockState.hpp"
 #include <fsl_dcdc.h>
+#include <cstdint>
 
 namespace bsp
 {
-    inline constexpr uint8_t OscillatorReadyCounterValue{127};
+    inline constexpr std::uint8_t OscillatorReadyCounterValue{127};
+    inline constexpr std::uint32_t CurrentTuningValueInUseForConfig0{0x4};
+    inline constexpr std::uint32_t NegativeHysteresisValue{0x2};
+    inline constexpr std::uint32_t TuningValue{0xA7};
+    inline constexpr std::uint32_t CurrentTuningValueInUseForConfig1{0x40};
+    inline constexpr std::uint32_t TargetCountUsedToTune{0x2DC};
 
     void EnableExternalOscillator()
     {
@@ -32,6 +38,16 @@ namespace bsp
                 IsClockEnabled(kCLOCK_Lpuart7) || IsClockEnabled(kCLOCK_Lpuart8)) {
                 return;
             }
+
+            // Enable RC OSC. It needs at least 4ms to be stable, so self tuning need to be enabled.
+            XTALOSC24M->LOWPWR_CTRL |= XTALOSC24M_LOWPWR_CTRL_RC_OSC_EN_MASK;
+            // Configure self-tuning for RC OSC
+            XTALOSC24M->OSC_CONFIG0 = XTALOSC24M_OSC_CONFIG0_RC_OSC_PROG_CUR(bsp::CurrentTuningValueInUseForConfig0) |
+                                      XTALOSC24M_OSC_CONFIG0_SET_HYST_MINUS(bsp::NegativeHysteresisValue) |
+                                      XTALOSC24M_OSC_CONFIG0_RC_OSC_PROG(bsp::TuningValue) |
+                                      XTALOSC24M_OSC_CONFIG0_START_MASK | XTALOSC24M_OSC_CONFIG0_ENABLE_MASK;
+            XTALOSC24M->OSC_CONFIG1 = XTALOSC24M_OSC_CONFIG1_COUNT_RC_CUR(bsp::CurrentTuningValueInUseForConfig1) |
+                                      XTALOSC24M_OSC_CONFIG1_COUNT_RC_TRG(bsp::TargetCountUsedToTune);
 
             /// Switch DCDC to use DCDC internal OSC
             DCDC_SetClockSource(DCDC, kDCDC_ClockInternalOsc);

--- a/module-bsp/board/rt1051/common/clock_config.cpp
+++ b/module-bsp/board/rt1051/common/clock_config.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 /*
@@ -124,7 +124,8 @@ void BOARD_BootClockRUN(void)
 {
     /* Init RTC OSC clock frequency. */
     CLOCK_SetRtcXtalFreq(32768U);
-
+    /* Disable 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
     /* Set XTAL 24MHz clock frequency. */
     CLOCK_SetXtalFreq(24000000U);
     /* Enable XTAL 24MHz clock source. */


### PR DESCRIPTION
Calibrate the RC before switching to the internal oscillator.
This improves the precision of the system clock.