### PR TITLE
[EGD-6843] Fix invalid assert in FSL SNVS driver

### DIFF
--- a/module-bsp/board/rt1051/common/fsl_drivers/fsl_snvs_hp.c
+++ b/module-bsp/board/rt1051/common/fsl_drivers/fsl_snvs_hp.c
@@ -417,8 +417,6 @@ void SNVS_HP_RTC_GetDatetime(SNVS_Type *base, snvs_hp_rtc_datetime_t *datetime)
  */
 status_t SNVS_HP_RTC_SetAlarmSeconds(SNVS_Type *base, uint32_t alarmSeconds)
 {
-    assert(alarmTime != NULL);
-
     uint32_t currSeconds  = 0U;
     uint32_t tmp          = base->HPCR;
 


### PR DESCRIPTION
Fix an invalid assert after the driver was modified in EGD-6605.