### PR TITLE
[CP-148] Fix setting of response in the Parser Context

### DIFF
--- a/module-services/service-desktop/endpoints/Context.hpp
+++ b/module-services/service-desktop/endpoints/Context.hpp
@@ -92,7 +92,7 @@ namespace parserFSM
 
         auto setResponse(endpoint::ResponseContext r)
         {
-            r = responseContext;
+            responseContext = r;
         }
 
         auto setResponseStatus(http::Code status)


### PR DESCRIPTION
Incomming ResponseContext was overwritten instead of used.