### PR TITLE
[EGD-6794] Fix display light settings

### DIFF
--- a/image/user/db/settings_v2_002.sql
+++ b/image/user/db/settings_v2_002.sql
@@ -33,7 +33,7 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('off_connection_frequency', '0'),
     ('off_notifications_when_locked', '0'),
     ('off_calls_from_favorites', '0'),
-    ('br_state', '0'),
-    ('br_auto_mode', '0'),
-    ('br_level', '50.0f'),
+    ('\EventManager\\br_state', '0'),
+    ('\EventManager\\br_auto_mode', '0'),
+    ('\EventManager\\br_level', '50.0f'),
     ('keypad_light_state', '0');

--- a/module-apps/application-settings-new/ApplicationSettings.cpp
+++ b/module-apps/application-settings-new/ApplicationSettings.cpp
@@ -585,7 +585,7 @@ namespace app
                 return {};
             }
 
-            return {msgState->lightOn, msgState->mode, msgState->parameters};
+            return {msgState->isLightOn(), msgState->getMode(), msgState->getParams()};
         }
 
         return {};
@@ -593,10 +593,8 @@ namespace app
 
     void ApplicationSettingsNew::setBrightness(bsp::eink_frontlight::BrightnessPercentage value)
     {
-        screen_light_control::Parameters parameters{value};
-        bus.sendUnicast(std::make_shared<sevm::ScreenLightSetParameters>(
-                            screen_light_control::ParameterizedAction::setManualModeBrightness, parameters),
-                        service::name::evt_manager);
+        screen_light_control::ManualModeParameters parameters{value};
+        bus.sendUnicast(std::make_shared<sevm::ScreenLightSetManualModeParams>(parameters), service::name::evt_manager);
     }
 
     void ApplicationSettingsNew::setMode(bool isAutoLightSwitchOn)
@@ -612,15 +610,6 @@ namespace app
         bus.sendUnicast(std::make_shared<sevm::ScreenLightControlMessage>(isDisplayLightSwitchOn
                                                                               ? screen_light_control::Action::turnOn
                                                                               : screen_light_control::Action::turnOff),
-                        service::name::evt_manager);
-    }
-    void ApplicationSettingsNew::setBrightnessFunction()
-    {
-        screen_light_control::Parameters parameters;
-        parameters.functionPoints = screen_light_control::functions::BrightnessFunction(
-            {{0.0f, 70.0f}, {250.0f, 70.0f}, {450.0f, 40.0f}, {500.0f, 0.0f}});
-        bus.sendUnicast(std::make_shared<sevm::ScreenLightSetParameters>(
-                            screen_light_control::ParameterizedAction::setAutomaticModeParameters, parameters),
                         service::name::evt_manager);
     }
 

--- a/module-apps/application-settings-new/ApplicationSettings.hpp
+++ b/module-apps/application-settings-new/ApplicationSettings.hpp
@@ -109,15 +109,14 @@ namespace app
             {
                 bool lightOn;
                 screen_light_control::ScreenLightMode mode;
-                screen_light_control::Parameters parameters;
+                screen_light_control::ManualModeParameters parameters;
             };
 
             virtual ~ScreenLightSettings()                      = default;
             virtual auto getCurrentValues() -> Values           = 0;
-            virtual void setBrightness(float brigtnessValue)    = 0;
+            virtual void setBrightness(float brightnessValue)   = 0;
             virtual void setMode(bool isAutoLightSwitchOn)      = 0;
             virtual void setStatus(bool isDisplayLightSwitchOn) = 0;
-            virtual void setBrightnessFunction()                = 0;
         };
 
         class KeypdBacklightSettings
@@ -214,10 +213,9 @@ namespace app
         void setOsUpdateVersion(const std::string &value);
 
         ScreenLightSettings::Values getCurrentValues() override;
-        void setBrightness(float brigtnessValue) override;
+        void setBrightness(float brightnessValue) override;
         void setMode(bool isAutoLightSwitchOn) override;
         void setStatus(bool isDisplayLightSwitchOn) override;
-        void setBrightnessFunction() override;
 
         auto getKeypadBacklightState() -> bsp::keypad_backlight::State override;
         void setKeypadBacklightState(bsp::keypad_backlight::State keypadLightState) override;

--- a/module-apps/application-settings-new/windows/DisplayLightWindow.cpp
+++ b/module-apps/application-settings-new/windows/DisplayLightWindow.cpp
@@ -23,8 +23,6 @@ namespace gui
 
         setTitle(utils::translate("app_settings_display_display_light"));
 
-        screenLightSettings->setBrightnessFunction();
-
         timerCallback = [this](Item &it, sys::Timer &task) { return onTimerTimeout(it, task); };
         timerTask     = app::GuiTimerFactory::createPeriodicTimer(
             application, this, "AmbientLightTimer", std::chrono::milliseconds{gui::lighting::AMBIENT_LIGHT_TIMER_MS});
@@ -122,7 +120,7 @@ namespace gui
         auto spinner = std::make_unique<gui::SpinBoxOptionSettings>(
             utils::translate("app_settings_display_light_brightness"),
             std::ceil(brightnessValue / brightnessStep),
-            std::ceil(screen_light_control::Parameters::MAX_BRIGHTNESS / brightnessStep),
+            std::ceil(screen_light_control::ManualModeParameters::MAX_BRIGHTNESS / brightnessStep),
             setBrightness,
             setBottomBarOnSpinnerFocus);
 

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -222,19 +222,25 @@ sys::ReturnCodes EventManager::InitHandler()
 
     connect(typeid(sevm::ScreenLightControlMessage), [&](sys::Message *msgl) {
         auto *m = dynamic_cast<sevm::ScreenLightControlMessage *>(msgl);
-        backlightHandler.processScreenRequest(m->action);
+        backlightHandler.processScreenRequest(m->getAction(), screen_light_control::Parameters());
         return sys::msgHandled();
     });
 
-    connect(typeid(sevm::ScreenLightSetParameters), [&](sys::Message *msgl) {
-        auto *m = dynamic_cast<sevm::ScreenLightSetParameters *>(msgl);
-        backlightHandler.processScreenRequest(m->action, std::move(m->parameters));
+    connect(typeid(sevm::ScreenLightSetAutoModeParams), [&](sys::Message *msgl) {
+        auto *m = static_cast<sevm::ScreenLightSetAutoModeParams *>(msgl);
+        backlightHandler.processScreenRequest(m->getAction(), screen_light_control::Parameters(m->getParams()));
+        return sys::msgHandled();
+    });
+
+    connect(typeid(sevm::ScreenLightSetManualModeParams), [&](sys::Message *msgl) {
+        auto *m = static_cast<sevm::ScreenLightSetManualModeParams *>(msgl);
+        backlightHandler.processScreenRequest(m->getAction(), screen_light_control::Parameters(m->getParams()));
         return sys::msgHandled();
     });
 
     connect(sevm::ScreenLightControlRequestParameters(), [&](sys::Message *msgl) {
-        screen_light_control::Parameters params = {backlightHandler.getScreenBrightnessValue()};
-        auto msg                                = std::make_shared<sevm::ScreenLightControlParametersResponse>(
+        screen_light_control::ManualModeParameters params = {backlightHandler.getScreenBrightnessValue()};
+        auto msg = std::make_shared<sevm::ScreenLightControlParametersResponse>(
             backlightHandler.getScreenLightState(), backlightHandler.getScreenAutoModeState(), params);
         return msg;
     });

--- a/module-services/service-evtmgr/backlight-handler/BacklightHandler.hpp
+++ b/module-services/service-evtmgr/backlight-handler/BacklightHandler.hpp
@@ -15,38 +15,23 @@ namespace settings
 
 namespace backlight
 {
-    class SettingsInterface
-    {
-      public:
-        virtual ~SettingsInterface() = default;
-
-      protected:
-        virtual auto getValue(std::string path) const -> std::string = 0;
-        virtual void setValue(std::string path, std::string value)   = 0;
-    };
-
     /// @brief Backlight events handler
-    class Handler : public SettingsInterface
+    class Handler
     {
       public:
         Handler(std::shared_ptr<settings::Settings> settings, sys::Service *parent);
 
-        /// initiaise in InitHandler when Service is ready
+        /// initialise in InitHandler when Service is ready
         void init();
 
         /// Process request of the screen light control
         /// @screen_light_control::Action an action to perform
-        void processScreenRequest(screen_light_control::Action action);
-
-        /// Process request of the screen light control with specified parameters
-        /// @screen_light_control::ParameterizedAction an action to perform
         /// @screen_light_control::Parameters parameters being set
-        void processScreenRequest(screen_light_control::ParameterizedAction action,
-                                  screen_light_control::Parameters params);
+        void processScreenRequest(screen_light_control::Action action, const screen_light_control::Parameters &params);
 
         void handleKeyPressed();
         /// Process request of the keypad light control
-        /// @screen_light_control::ParameterizedAction an action to perform
+        /// @keypad_backlight::action an action to perform
         /// @return True if request was processed successfully, false otherwise
         auto processKeypadRequest(bsp::keypad_backlight::Action action) -> bool;
 
@@ -55,8 +40,8 @@ namespace backlight
         [[nodiscard]] auto getScreenBrightnessValue() const noexcept -> bsp::eink_frontlight::BrightnessPercentage;
 
       protected:
-        [[nodiscard]] auto getValue(std::string path) const -> std::string override;
-        void setValue(std::string path, std::string value) override;
+        [[nodiscard]] auto getValue(const std::string &path) const -> std::string;
+        void setValue(const std::string &path, const std::string &value);
 
       private:
         std::shared_ptr<settings::Settings> settings;
@@ -76,8 +61,7 @@ namespace backlight
         void restoreKeypadLightState();
         void handleKeypadLightRefresh();
         void handleScreenLightRefresh();
-        void handleScreenLightSettings(screen_light_control::Action action);
-        void handleScreenLightSettings(screen_light_control::ParameterizedAction action,
-                                       screen_light_control::Parameters params);
+        void handleScreenLightSettings(screen_light_control::Action action,
+                                       const screen_light_control::Parameters &params);
     };
 } // namespace backlight

--- a/module-services/service-evtmgr/screen-light-control/ScreenLightControl.hpp
+++ b/module-services/service-evtmgr/screen-light-control/ScreenLightControl.hpp
@@ -3,10 +3,9 @@
 
 #pragma once
 
-#include "ControlFunctions.hpp"
+#include "ScreenLightControlParameters.hpp"
 #include <memory>
 #include <module-sys/Timers/TimerHandle.hpp>
-
 namespace settings
 {
     class Settings;
@@ -21,61 +20,19 @@ namespace sys
 /// Processing of ambient light sensor input to screen brightness output.
 namespace screen_light_control
 {
-    /// Modes in which front light can operate
-    enum ScreenLightMode
-    {
-        Automatic, /// Automally sets screen brightness based on sensor data
-        Manual     /// Manually set brightness level
-    };
-
-    /// Set of actions to control the screen light
-    enum class Action
-    {
-        turnOff,             ///< Turn off screen frontlight
-        turnOn,              ///< Turn on screen frontlight
-        enableAutomaticMode, ///< Enable automatic mode of screen frontlight
-        disableAutomaticMode ///< Disable automatic mode of screen frontlight
-    };
-
-    /// Set of actions to control the screen light using specified parameters
-    enum class ParameterizedAction
-    {
-        setManualModeBrightness,   ///< Set screen brightness in manual mode control
-        setAutomaticModeParameters ///< Set parameters for automatic mode of screen frontlight
-    };
-
-    struct Parameters
-    {
-        static constexpr auto MAX_BRIGHTNESS = 100.0;
-
-        /// Screen brightness 0-100% in manual mode
-        bsp::eink_frontlight::BrightnessPercentage manualModeBrightness = 50.0f;
-        /// Vector of points for screen brightness [%] in relation to ambient light [Lux] function. Points have to be in
-        /// ascending order of ambient light values.
-        functions::BrightnessFunction functionPoints = functions::BrightnessFunction({{0.0f, 50.0f}});
-        /// Ramp time of screen brightness in miliseconds per 0-100% change
-        unsigned int rampTimeMS = 1500;
-        /// Hysteresis value of screen brightness control
-        float brightnessHysteresis = 10.0f;
-        /// Gamma factor for screen brightness correction
-        float gammaFactor = 2.5f;
-    };
-
     /// Control screen light and keeps it's current state
     class ScreenLightControl
     {
       public:
-        explicit ScreenLightControl(std::shared_ptr<settings::Settings> settings, sys::Service *parent);
+        explicit ScreenLightControl(sys::Service *parent);
         ~ScreenLightControl();
 
         void processRequest(Action action);
-        void processRequest(ParameterizedAction action, Parameters params);
+        void processRequest(Action action, const Parameters &params);
 
-        [[nodiscard]] auto getLightState() const noexcept -> bool;
+        [[nodiscard]] auto isLightOn() const noexcept -> bool;
         [[nodiscard]] auto getAutoModeState() const noexcept -> ScreenLightMode;
         [[nodiscard]] auto getBrightnessValue() const noexcept -> bsp::eink_frontlight::BrightnessPercentage;
-
-        void initFromSettings();
 
       private:
         void controlTimerCallback();
@@ -84,8 +41,9 @@ namespace screen_light_control
         void enableTimers();
         void disableTimers();
 
-        void setAutomaticModeParameters(const Parameters &params);
-        void setBrightnessLevel(bsp::eink_frontlight::BrightnessPercentage brightnessPercentage);
+        void setParameters(const AutomaticModeParameters &params);
+        void setParameters(ManualModeParameters params);
+        void setManualBrightnessLevel();
 
         void turnOff();
         void turnOn();
@@ -102,8 +60,6 @@ namespace screen_light_control
         bool lightOn                                               = false;
         screen_light_control::ScreenLightMode automaticMode        = ScreenLightMode::Manual;
         bsp::eink_frontlight::BrightnessPercentage brightnessValue = 0.0;
-
-        std::shared_ptr<settings::Settings> settings;
     };
 
 } // namespace screen_light_control

--- a/module-services/service-evtmgr/screen-light-control/ScreenLightControlParameters.hpp
+++ b/module-services/service-evtmgr/screen-light-control/ScreenLightControlParameters.hpp
@@ -1,0 +1,87 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "ControlFunctions.hpp"
+#include <gsl_assert>
+#include <optional>
+
+namespace screen_light_control
+{
+    /// Modes in which front light can operate
+    enum class ScreenLightMode
+    {
+        Automatic, /// Automatically sets screen brightness based on sensor data
+        Manual     /// Manually set brightness level
+    };
+
+    /// Set of actions to control the screen light
+    enum class Action
+    {
+        turnOff,                   ///< Turn off screen frontlight
+        turnOn,                    ///< Turn on screen frontlight
+        enableAutomaticMode,       ///< Enable automatic mode of screen frontlight
+        disableAutomaticMode,      ///< Disable automatic mode of screen frontlight
+        setManualModeBrightness,   ///< Set screen brightness in manual mode control
+        setAutomaticModeParameters ///< Set parameters for automatic mode of screen frontlight
+    };
+
+    struct ManualModeParameters
+    {
+        static constexpr auto MAX_BRIGHTNESS = 100.0;
+        /// Screen brightness 0-100% in manual mode
+        bsp::eink_frontlight::BrightnessPercentage manualModeBrightness = 50.0f;
+    };
+
+    struct AutomaticModeParameters
+    {
+        /// Vector of points for screen brightness [%] in relation to ambient light [Lux] function. Points have to be in
+        /// ascending order of ambient light values.
+        functions::BrightnessFunction functionPoints =
+            functions::BrightnessFunction({{0.0f, 70.0f}, {250.0f, 70.0f}, {450.0f, 40.0f}, {500.0f, 0.0f}});
+        /// Ramp time of screen brightness in milliseconds per 0-100% change
+        unsigned int rampTimeMS = 1500;
+        /// Hysteresis value of screen brightness control
+        float brightnessHysteresis = 10.0f;
+        /// Gamma factor for screen brightness correction
+        float gammaFactor = 2.5f;
+    };
+
+    class Parameters
+    {
+        std::optional<ManualModeParameters> manualModeParams;
+        std::optional<AutomaticModeParameters> autoModeParams;
+
+      public:
+        Parameters() = default;
+        explicit Parameters(ManualModeParameters manualModeParams)
+            : manualModeParams{std::make_optional(manualModeParams)}
+        {}
+        explicit Parameters(const AutomaticModeParameters &autoModeParams)
+            : autoModeParams{std::make_optional(autoModeParams)}
+        {}
+
+        [[nodiscard]] bool hasManualModeParams() const noexcept
+        {
+            return manualModeParams.has_value();
+        }
+
+        [[nodiscard]] auto getManualModeParams() const noexcept -> ManualModeParameters
+        {
+            Expects(hasManualModeParams());
+            return manualModeParams.value();
+        }
+
+        [[nodiscard]] bool hasAutoModeParams() const noexcept
+        {
+            return autoModeParams.has_value();
+        }
+
+        [[nodiscard]] auto getAutoModeParams() const noexcept -> const AutomaticModeParameters &
+        {
+            Expects(hasAutoModeParams());
+            return autoModeParams.value();
+        }
+    };
+} // namespace screen_light_control

--- a/module-services/service-evtmgr/service-evtmgr/ScreenLightControlMessage.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/ScreenLightControlMessage.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "module-services/service-evtmgr/screen-light-control/ScreenLightControl.hpp"
+#include <service-evtmgr/screen-light-control/ScreenLightControlParameters.hpp>
 
 #include <Service/Message.hpp>
 #include <Service/Service.hpp>
@@ -13,23 +13,48 @@ namespace sevm
 {
     class ScreenLightControlMessage : public sys::DataMessage
     {
+        const screen_light_control::Action action;
+
       public:
         explicit ScreenLightControlMessage(screen_light_control::Action act)
             : sys::DataMessage(MessageType::ScreenLightControlAction), action(act)
         {}
 
-        const screen_light_control::Action action;
+        [[nodiscard]] auto getAction() const noexcept -> screen_light_control::Action
+        {
+            return action;
+        }
     };
 
-    class ScreenLightSetParameters : public sys::DataMessage
+    class ScreenLightSetAutoModeParams : public ScreenLightControlMessage
     {
+        screen_light_control::AutomaticModeParameters params;
+
       public:
-        ScreenLightSetParameters(screen_light_control::ParameterizedAction act, screen_light_control::Parameters params)
-            : sys::DataMessage(MessageType::ScreenLightControlAction), action(act), parameters(std::move(params))
+        explicit ScreenLightSetAutoModeParams(screen_light_control::AutomaticModeParameters params)
+            : ScreenLightControlMessage(screen_light_control::Action::setAutomaticModeParameters), params{std::move(
+                                                                                                       params)}
         {}
 
-        const screen_light_control::ParameterizedAction action;
-        const screen_light_control::Parameters parameters;
+        [[nodiscard]] auto getParams() const noexcept -> const screen_light_control::AutomaticModeParameters &
+        {
+            return params;
+        }
+    };
+
+    class ScreenLightSetManualModeParams : public ScreenLightControlMessage
+    {
+        screen_light_control::ManualModeParameters params;
+
+      public:
+        explicit ScreenLightSetManualModeParams(screen_light_control::ManualModeParameters params)
+            : ScreenLightControlMessage(screen_light_control::Action::setManualModeBrightness), params{params}
+        {}
+
+        [[nodiscard]] auto getParams() const noexcept -> screen_light_control::ManualModeParameters
+        {
+            return params;
+        }
     };
 
     class ScreenLightControlRequestParameters : public sys::DataMessage
@@ -41,19 +66,29 @@ namespace sevm
 
     class ScreenLightControlParametersResponse : public sys::DataMessage
     {
-      public:
-        ScreenLightControlParametersResponse() : sys::DataMessage(MessageType::ScreenLightControlParametersResponse)
-        {}
-
-        ScreenLightControlParametersResponse(bool lightOn,
-                                             screen_light_control::ScreenLightMode mode,
-                                             screen_light_control::Parameters params)
-            : sys::DataMessage(MessageType::ScreenLightControlParametersResponse), lightOn(lightOn), mode(mode),
-              parameters(std::move(params))
-        {}
-
         bool lightOn;
         screen_light_control::ScreenLightMode mode;
-        screen_light_control::Parameters parameters;
+        screen_light_control::ManualModeParameters parameters;
+
+      public:
+        ScreenLightControlParametersResponse(bool lightOn,
+                                             screen_light_control::ScreenLightMode mode,
+                                             screen_light_control::ManualModeParameters params)
+            : sys::DataMessage(MessageType::ScreenLightControlParametersResponse), lightOn(lightOn), mode(mode),
+              parameters(params)
+        {}
+
+        [[nodiscard]] bool isLightOn() const noexcept
+        {
+            return lightOn;
+        }
+        [[nodiscard]] auto getMode() const noexcept -> screen_light_control::ScreenLightMode
+        {
+            return mode;
+        }
+        [[nodiscard]] auto getParams() const noexcept -> screen_light_control::ManualModeParameters
+        {
+            return parameters;
+        }
     };
 } // namespace sevm


### PR DESCRIPTION
This commit provides the flowing fixes in display light functionality:
 - Settings-path bug causing lack of display light settings on "fresh"
 image. Solved with proper paths definition
 - Invalid settings after phone restart. Solved with proper handling
 of enums and booleans on the Event manager side.
 - No turning off light just after turning on light functionality with
 manual brightness setting in ApplicationSettings bug (required
 another key press to start timer that turns off the light after 5s).
 Solved by starting timer explicitly on Action::turnOn
 - No turning off light just after turning on the phone bug (required
 --as above --). Solved by starting timer explicitly on `Settings
 ValueChange` callback with Action::turnOn.
 - No autoMode until entered `AppSettings::DisplayLight` Window. 
 Bug caused by curve parameters being provided by the window rather
 than on the functionality back-end initialization. 

 Commit also provides some code cleanup