### PR TITLE
[BH-458] Pureflash turned to ExternalProject

### DIFF
--- a/host-tools/CMakeLists.txt
+++ b/host-tools/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(ExternalProject)
+
 if (CMAKE_CROSSCOMPILING)
     # Littlefs fuse is needed in rt1051 and Linux for manipulate images
     # genlittlefs is needed only on the Linux image for generate emulator target image
@@ -19,19 +21,15 @@ if (CMAKE_CROSSCOMPILING)
         -H"${CMAKE_SOURCE_DIR}/host-tools/genlittlefs"
         COMMAND ${CMAKE_COMMAND} --build genlittlefs --config Release
     )
-    add_custom_target(
-        pureflash
-        COMMAND ${CMAKE_COMMAND}
-        -DCMAKE_BUILD_TYPE:STRING="Release"
-        -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE:PATH="${CMAKE_BINARY_DIR}"
-        -B"pureflash"
-        -H"${CMAKE_SOURCE_DIR}/host-tools/pure-flash"
-        COMMAND ${CMAKE_COMMAND} --build pureflash --config Release
+    ExternalProject_Add(pureflash
+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/pure-flash
+        INSTALL_DIR ${PROJECT_BINARY_DIR}
+        CMAKE_ARGS
+            -D CMAKE_BUILD_TYPE=Release
+            -D CMAKE_INSTALL_PREFIX=<INSTALL_DIR>
     )
-
 else()
     set(_genlittlefs "${CMAKE_BINARY_DIR}/genlittlefs${CMAKE_EXECUTABLE_SUFFIX}")
     add_subdirectory(genlittlefs)
     add_subdirectory(littlefs-fuse)
 endif()
-

--- a/host-tools/pure-flash/CMakeLists.txt
+++ b/host-tools/pure-flash/CMakeLists.txt
@@ -9,4 +9,9 @@ set(PUREFLASH_SRCS
 
 add_executable(${PROJECT_NAME} ${PUREFLASH_SRCS})
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall -pedantic -Werror -Wextra )
+
 target_compile_definitions(${PROJECT_NAME} PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+
+install(TARGETS pureflash
+    RUNTIME DESTINATION .
+)


### PR DESCRIPTION
Changed way the pureflash utility is linked to  project. Now
it is builded as cmake ExternalProject