### PR TITLE
[EGD-6855] Add no modem notification on tethering

### DIFF
--- a/module-apps/notifications/NotificationsModel.hpp
+++ b/module-apps/notifications/NotificationsModel.hpp
@@ -22,6 +22,7 @@ namespace gui
         void requestRecords(uint32_t offset, uint32_t limit) final;
 
       protected:
+        bool tetheringOn = false;
         [[nodiscard]] virtual auto create(const notifications::NotSeenSMSNotification *notification)
             -> NotificationListItem *;
         [[nodiscard]] virtual auto create(const notifications::NotSeenCallNotification *notification)
@@ -32,6 +33,7 @@ namespace gui
       public:
         [[nodiscard]] bool isEmpty() const noexcept;
         [[nodiscard]] bool hasDismissibleNotification() const noexcept;
+        [[nodiscard]] bool isTetheringOn() const noexcept;
 
         void updateData(app::manager::actions::NotificationsChangedParams *params);
         void dismissAll(const InputEvent &event);


### PR DESCRIPTION
This commit provides the implementation of functionality that blocks
sms/calls notifications on home screen when tethering is active.
Previously, the notifications could be visible if the notifications
were visible prior to tethering activation.

By the design, the functionality should not clear the notifications,
rather temporary hide them. That is achieved by implementation of the
functionality in `NotificationModel` which is an UI presenter.