### PR TITLE
[EGD-4394] Added minimum tests for bluetooth stored data

### DIFF
--- a/module-bluetooth/Bluetooth/Device.hpp
+++ b/module-bluetooth/Bluetooth/Device.hpp
@@ -91,6 +91,16 @@ struct Devicei : public Device
     }
 };
 
+inline bool operator==(const Devicei &dev, bd_addr_t addr)
+{
+    return memcmp(&dev.address, addr, sizeof dev.address) == 0;
+}
+
+inline bool operator==(const Devicei &lhs, const Devicei &rhs)
+{
+    return memcmp(&lhs.address, rhs.address, sizeof lhs.address) == 0;
+}
+
 struct DeviceMetadata_t
 {
     unsigned int sampleRate;

--- a/module-bluetooth/Bluetooth/interface/profiles/ProfileManager.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/ProfileManager.cpp
@@ -45,6 +45,7 @@ namespace bluetooth
                 LOG_DEBUG("Connecting device %s to A2DP", bd_addr_to_str(address));
                 profilePtr->setDeviceAddress(remoteAddr);
                 profilePtr->connect();
+                return Error::Success;
             }
         }
         if (GAP::isServiceSupportedByRemote(address, TYPE_OF_SERVICE::AUDIO)) {
@@ -53,9 +54,18 @@ namespace bluetooth
                 LOG_DEBUG("Connecting device %s to HSP", bd_addr_to_str(address));
                 profilePtr->setDeviceAddress(remoteAddr);
                 profilePtr->connect();
+                return Error::Success;
             }
         }
-        return Error::Success;
+
+        for (const auto &dev : GAP::getDevicesList()) {
+            if (dev == address) {
+                LOG_ERROR("Not supported device on Paired list: %s", dev.name.c_str());
+                return Error::SystemError;
+            }
+        }
+        LOG_ERROR("Not supported type of service on list %d!", static_cast<int>(GAP::getDevicesList().size()));
+        return Error::SystemError;
     }
 
     auto ProfileManager::disconnect() -> Error::Code

--- a/module-bluetooth/tests/CMakeLists.txt
+++ b/module-bluetooth/tests/CMakeLists.txt
@@ -7,3 +7,14 @@ add_catch2_executable(
     LIBS
         module-bluetooth
 )
+
+add_catch2_executable(
+    NAME
+        bt-abstracts
+    SRCS
+        tests-main.cpp
+        tests-device.cpp
+    INCLUDE
+        ${PROJECT_SOURCE_DIR}/Bluetooth/
+    LIBS
+)

--- a/module-bluetooth/tests/tests-device.cpp
+++ b/module-bluetooth/tests/tests-device.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <catch2/catch.hpp>
+#include <Device.hpp>
+
+TEST_CASE("Device test")
+{
+    auto name = "lol";
+    auto dev  = Device(name);
+    REQUIRE(dev.name == name);
+}
+
+TEST_CASE("Devicei test")
+{
+    auto name = "lol";
+    auto dev  = Devicei(name);
+    SECTION("name")
+    {
+        REQUIRE(dev.name == name);
+    }
+
+    SECTION("address size of BD size")
+    {
+        REQUIRE(BD_ADDR_LEN == sizeof dev.address);
+    }
+
+    SECTION("compare")
+    {
+        Devicei rhs, lhs;
+
+        REQUIRE(Devicei() == Devicei());
+        REQUIRE(Devicei("lol") == Devicei("xxx"));
+        bd_addr_t addr1{1, 2, 3, 4, 5, 6};
+        rhs.setAddress(&addr1);
+        REQUIRE(!(lhs == rhs));
+        lhs.setAddress(&addr1);
+        REQUIRE(lhs == rhs);
+    }
+}

--- a/module-services/service-bluetooth/CMakeLists.txt
+++ b/module-services/service-bluetooth/CMakeLists.txt
@@ -24,3 +24,7 @@ target_link_libraries(${PROJECT_NAME}
         module-sys
         json::json
 )
+ 
+if (${ENABLE_TESTS})
+    add_subdirectory(test)
+endif()

--- a/module-services/service-bluetooth/service-bluetooth/SettingsHolder.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/SettingsHolder.hpp
@@ -46,26 +46,73 @@ namespace bluetooth
     {
         auto operator()(const std::string &input) const -> int
         {
-            int value;
-            utils::toNumeric(input, value);
+            int value = 0;
+            if (not utils::toNumeric(input, value)) {
+                LOG_FATAL("Fail on: %s", input.c_str());
+                throw std::runtime_error("utils::toNumeric failed");
+            }
             return value;
         }
+
+        /// please do not remove to avoid implicit char* to bool conversion
+        /// which with char* would check bool operator and return on non null ptr
+        auto operator()(const char *input) const -> int
+        {
+            if (input == nullptr) {
+                throw std::runtime_error("utils::toNumeric failed - nullptr");
+            }
+            return operator()(std::string(input));
+        }
+
         auto operator()(bool input) const -> int
         {
-            return input;
+            return static_cast<int>(input);
         }
+
         auto operator()(int input) const -> int
         {
             return input;
         }
     };
 
+    /// Please mind that :
+    /// bool visitor returns true when:
+    /// - there is trueStr
+    /// - there is non zero integral value in ( default bool behaviour, the same as with int visitation in
+    /// operator(int))
     struct BoolVisitor
     {
+
+        // - should we check: atoi != 0 ?
+        // - should we check to_lower TRUE / True?
         auto operator()(const std::string &input) const -> bool
         {
-            return input == trueStr;
+            auto data = input;
+            std::transform(data.begin(), data.end(), data.begin(), [](unsigned char c) { return std::tolower(c); });
+            if (data == trueStr) {
+                return true;
+            }
+            if (data == falseStr) {
+                return false;
+            }
+            int value    = 0;
+            auto success = utils::toNumeric(data, value);
+            if (not success) {
+                return false;
+            }
+            return value != 0;
         }
+
+        /// please do not remove to avoid implicit char* to bool conversion
+        /// which with char* would check bool operator and return on non null ptr
+        auto operator()(const char *input) const -> bool
+        {
+            if (input == nullptr) {
+                throw std::runtime_error("bool visitor nullptr c_str");
+            }
+            return operator()(std::string{input});
+        }
+
         auto operator()(bool input) const -> bool
         {
             return input;

--- a/module-services/service-bluetooth/service-bluetooth/SettingsSerializer.cpp
+++ b/module-services/service-bluetooth/service-bluetooth/SettingsSerializer.cpp
@@ -10,14 +10,16 @@ namespace strings
     constexpr inline auto addr    = "addr";
     constexpr inline auto name    = "name";
     constexpr inline auto devices = "devices";
+    constexpr inline auto classOfDevice = "classOfDevice";
 } // namespace strings
 
 auto SettingsSerializer::toString(const std::vector<Devicei> &devices) -> std::string
 {
     json11::Json::array devicesJson;
     for (auto &device : devices) {
-        auto deviceEntry =
-            json11::Json::object{{strings::addr, bd_addr_to_str(device.address)}, {strings::name, device.name}};
+        auto deviceEntry = json11::Json::object{{strings::addr, bd_addr_to_str(device.address)},
+                                                {strings::name, device.name},
+                                                {strings::classOfDevice, static_cast<int>(device.classOfDevice)}};
         devicesJson.emplace_back(deviceEntry);
     }
     json11::Json finalJson = json11::Json::object{{strings::devices, devicesJson}};
@@ -33,14 +35,14 @@ auto SettingsSerializer::fromString(const std::string &jsonStr) -> std::vector<D
         LOG_ERROR("Failed parsing device string!");
         return std::vector<Devicei>();
     }
-    json11::Json::array devicesArray;
-    devicesArray = std::move(devicesJson[strings::devices].array_items());
+    auto devices = devicesJson[strings::devices].array_items();
 
     std::vector<Devicei> devicesVector;
-    for (auto &device : devicesArray) {
+    for (auto &device : devices) {
         Devicei temp;
         sscanf_bd_addr(device[strings::addr].string_value().c_str(), temp.address);
         temp.name = device[strings::name].string_value();
+        temp.classOfDevice = device[strings::classOfDevice].int_value();
         devicesVector.emplace_back(temp);
     }
     return devicesVector;

--- a/module-services/service-bluetooth/test/CMakeLists.txt
+++ b/module-services/service-bluetooth/test/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_catch2_executable(
+    NAME
+        bt-storage
+    SRCS
+        tests-main.cpp
+        test-SettingsSerializer.cpp
+        test-SettingsVisitors.cpp
+        test-SettingsHolder.cpp
+
+        # this lib crap, without dependency to the whole world
+        ${PROJECT_SOURCE_DIR}/service-bluetooth/SettingsSerializer.cpp
+        ${PROJECT_SOURCE_DIR}/service-bluetooth/SettingsHolder.cpp
+
+        # external crap
+        ${CMAKE_SOURCE_DIR}/module-utils/json/json11.cpp
+        ${CMAKE_SOURCE_DIR}/module-bluetooth/lib/btstack/src/btstack_util.c
+        ${CMAKE_SOURCE_DIR}/module-services/service-db/agents/settings/Settings.cpp
+        ${CMAKE_SOURCE_DIR}/module-services/service-db/EntryPath.cpp
+    INCLUDE
+        ${PROJECT_SOURCE_DIR}/service-bluetooth/
+        ${CMAKE_SOURCE_DIR}/module-utils
+        ${CMAKE_SOURCE_DIR}/module-bluetooth/Bluetooth/
+        ${CMAKE_SOURCE_DIR}/module-bluetooth/lib/btstack/src/
+        ${CMAKE_SOURCE_DIR}/module-services/service-db/ # for: service-db/
+        ${CMAKE_SOURCE_DIR}/module-sys/ # for: Service/ServiceProxy.hpp
+        ${CMAKE_SOURCE_DIR}/third-party/magic_enum/include/ #magic_enum.hpp
+        ${CMAKE_SOURCE_DIR}/source/ # MessageType.hpp
+    LIBS
+)

--- a/module-services/service-bluetooth/test/test-SettingsHolder.cpp
+++ b/module-services/service-bluetooth/test/test-SettingsHolder.cpp
@@ -1,0 +1,133 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <service-db/Settings.hpp>
+#include <service-db/SettingsCache.hpp>
+#include <catch2/catch.hpp>
+#include <SettingsHolder.hpp>
+#include <variant>
+
+// this is settings empty stub copied from Settings tets
+namespace settings
+{
+    SettingsProxy::~SettingsProxy()
+    {}
+    SettingsProxy::SettingsProxy(const service::ServiceProxy &interface) : service::ServiceProxy(interface)
+    {}
+    void SettingsProxy::init(std::function<void(EntryPath, std::string)> onChangeHandler)
+    {
+        this->onChangeHandler = std::move(onChangeHandler);
+    }
+    void SettingsProxy::deinit()
+    {}
+
+    void SettingsProxy::onChange(EntryPath path, std::string value)
+    {
+        if (onChangeHandler) {
+            onChangeHandler(std::move(path), std::move(value));
+        }
+    };
+    bool SettingsProxy::isValid() const noexcept
+    {
+        return true;
+    }
+    void SettingsProxy::registerValueChange(EntryPath){};
+    void SettingsProxy::unregisterValueChange(EntryPath){};
+    void SettingsProxy::setValue(const EntryPath &path, const std::string &value){};
+    std::string SettingsProxy::ownerName()
+    {
+        return "";
+    }
+
+    const std::string &SettingsCache::getValue(const EntryPath &path) const
+    {
+        static const std::string val;
+        return val;
+    }
+    void SettingsCache::setValue(const EntryPath &path, const std::string &value)
+    {}
+
+    SettingsCache *SettingsCache::getInstance()
+    {
+        static SettingsCache s;
+        return &s;
+    }
+
+} // namespace settings
+
+TEST_CASE("Settings Holder")
+{
+    auto s      = std::make_unique<settings::Settings>();
+    auto holder = bluetooth::SettingsHolder(std::move(s));
+
+    SECTION("Single thread use")
+    {
+        SECTION("initial value")
+        {
+            auto value = holder.getValue(bluetooth::Settings::State);
+            value      = {""};
+            SECTION("std::get throws - no value")
+            {
+                REQUIRE_THROWS(std::get<bool>(value));
+            }
+
+            SECTION("std::visit doesn't throw but has something defaut")
+            {
+                auto visibility = std::visit(bluetooth::BoolVisitor(), value);
+                REQUIRE(visibility == false);
+            }
+
+            SECTION("std::visit doesn't throw but has something defaut on Visit")
+            {
+                auto visibility = std::visit(bluetooth::IntVisitor(), value);
+                REQUIRE(visibility == 0);
+            }
+        }
+
+        SECTION("what's set that's set")
+        {
+            holder.setValue(bluetooth::Settings::Visibility, {"true"});
+            auto value = holder.getValue(bluetooth::Settings::Visibility);
+
+            SECTION("with std::visit")
+            {
+                auto visibility = std::visit(bluetooth::BoolVisitor(), value);
+                REQUIRE(visibility == true);
+            }
+
+            SECTION("with std::get - success, set string -> variant string")
+            {
+                REQUIRE(std::get<std::string>(value) == "true");
+            }
+
+            SECTION("non matching returns - need to get with visit")
+            {
+                REQUIRE_THROWS(std::get<bool>(value) != true);
+                REQUIRE_THROWS(std::get<int>(value) != 1);
+            }
+        }
+    }
+}
+
+// This test is disabled - as it doesn't work as I would except
+// instead stateChanged is called when callback to DB is executed
+// 1. it doesn't seem intuitive
+// 2. it's pass through
+// 3. might be problematic
+TEST_CASE("Settings Holder - callbacks", "[.]")
+{
+    auto s      = std::make_unique<settings::Settings>();
+    auto holder = bluetooth::SettingsHolder(std::move(s));
+
+    SECTION("state changed cb")
+    {
+        bool stateChanged    = false;
+        holder.onStateChange = [&stateChanged]() { stateChanged = true; };
+        auto val             = holder.getValue(bluetooth::Settings::State);
+
+        holder.setValue(bluetooth::Settings::State, {true});
+
+        // !
+        REQUIRE(stateChanged == true);
+    }
+}

--- a/module-services/service-bluetooth/test/test-SettingsSerializer.cpp
+++ b/module-services/service-bluetooth/test/test-SettingsSerializer.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <catch2/catch.hpp>
+#include <SettingsSerializer.hpp>
+
+bool operator==(const Devicei &lhs, const Devicei &rhs)
+{
+    return std::memcmp(lhs.address, rhs.address, sizeof lhs.address) == 0 && lhs.name == rhs.name;
+}
+
+TEST_CASE("Settings serializer")
+{
+    auto name = "lol";
+    auto dev  = Devicei(name);
+    bd_addr_t addr{0x01, 0x02, 0x03, 0, 0, 0};
+    dev.setAddress(&addr);
+
+    auto s = SettingsSerializer();
+
+    auto serialized = s.toString({dev});
+
+    SECTION("compare stringified device to same stringified device")
+    {
+        REQUIRE(s.toString({dev}) == s.toString({dev}));
+    }
+
+    SECTION("empty string -results in empty parse")
+    {
+        REQUIRE(s.fromString("").size() == 0);
+    }
+
+    SECTION("non empty string -results in non empty parse")
+    {
+        REQUIRE(s.fromString(serialized).size() == 1);
+    }
+
+    SECTION("vector of devices is the same after serialization and deserialization")
+    {
+        REQUIRE(std::vector<Devicei>{dev} == s.fromString(serialized));
+        REQUIRE(std::vector<Devicei>{dev, dev} == s.fromString(s.toString({dev, dev})));
+        REQUIRE(std::memcmp(s.fromString(serialized)[0].address, addr, 6) == 0);
+        REQUIRE(s.fromString(serialized)[0].name == name);
+    }
+}

--- a/module-services/service-bluetooth/test/test-SettingsVisitors.cpp
+++ b/module-services/service-bluetooth/test/test-SettingsVisitors.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <catch2/catch.hpp>
+#include <SettingsHolder.hpp>
+
+TEST_CASE("Settings Visitors")
+{
+
+    SECTION("StringVisitor")
+    {
+        auto s = bluetooth::StringVisitor();
+
+        SECTION("bool")
+        {
+            REQUIRE(s(true) == bluetooth::trueStr);
+            REQUIRE(s(false) == bluetooth::falseStr);
+        }
+
+        SECTION("string")
+        {
+            REQUIRE(s("true") == bluetooth::trueStr);
+        }
+
+        SECTION("int")
+        {
+            REQUIRE(s(1) == "1");
+            REQUIRE(s(-1) == "-1");
+        }
+    }
+
+    SECTION("IntVisitor")
+    {
+        auto i          = bluetooth::IntVisitor();
+        const char *lol = nullptr;
+        SECTION("string")
+        {
+            CHECK_THROWS_AS(i(lol), std::runtime_error);
+            REQUIRE(i("1000") != 1);
+            REQUIRE(i("1000") == 1000);
+            REQUIRE(i("-1000") == -1000);
+            REQUIRE(i("10.00") == 10);
+            REQUIRE(i("10tuByłem00") == 10);
+
+            CHECK_THROWS(i("1000000000000000000000"));
+        }
+
+        SECTION("bool")
+        {
+            REQUIRE(i(bool(1000)) == 1);
+            REQUIRE(i(bool(0)) == 0);
+            REQUIRE(i(true) == 1);
+        }
+
+        SECTION("int")
+        {
+            REQUIRE(i(1000) == 1000);
+            REQUIRE(i(-1000) == -1000);
+        }
+    }
+
+    SECTION("BoolVisitor")
+    {
+        auto b          = bluetooth::BoolVisitor();
+        const char *lol = nullptr;
+        SECTION("string")
+        {
+            CHECK_THROWS(b(lol));
+            REQUIRE(b("000") == false);
+            REQUIRE(b("0") == false);
+
+            /// TODO is it intended?
+            REQUIRE(b("1") == true);
+            REQUIRE(b("010") == true);
+            REQUIRE(b(1) == true);
+
+            REQUIRE(b("bluetooth::trueStr") == false);
+
+            REQUIRE(b(bluetooth::trueStr) == true);
+            REQUIRE(b(bluetooth::falseStr) == false);
+        }
+    }
+}

--- a/module-services/service-bluetooth/test/tests-main.cpp
+++ b/module-services/service-bluetooth/test/tests-main.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#define CATCH_CONFIG_MAIN // This tells Catch to provide a main() - only do this in one cpp file
+#include <catch2/catch.hpp>
+
+/// empty stub just to compile without including whole module-bt
+extern "C"
+{
+    void bt_log_custom(const char *file, int line, const char *foo, const char *fmt, ...)
+    {}
+
+    int log_Log(int level, const char *file, int line, const char *function, const char *fmt, ...)
+    {
+        return 0;
+    }
+}

--- a/module-services/service-db/agents/settings/SettingsAgent.hpp
+++ b/module-services/service-db/agents/settings/SettingsAgent.hpp
@@ -41,6 +41,8 @@ class SettingsAgent : public DatabaseAgent
 
     using MapOfRecipentsToBeNotified = std::map<std::string, std::set<settings::EntryPath>>;
     MapOfRecipentsToBeNotified variableChangeRecipients;
+    /// adds unique path to variableChangeRecipients or returns false
+    bool addUniquePath(const settings::EntryPath &);
     using SetOfRecipents = std::set<std::string>;
     SetOfRecipents profileChangedRecipients;
     SetOfRecipents modeChangeRecipients;

--- a/module-services/service-db/service-db/SettingsMessages.hpp
+++ b/module-services/service-db/service-db/SettingsMessages.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <MessageType.hpp>
 #include <Service/Message.hpp>
 #include "EntryPath.hpp"
 
@@ -21,7 +20,7 @@ namespace settings
         class SettingsMessage : public sys::DataMessage
         {
           public:
-            explicit SettingsMessage(MessageType type = MessageType::Settings) : sys::DataMessage(type){};
+            explicit SettingsMessage() : sys::DataMessage(){};
             ~SettingsMessage() override = default;
         };
 

--- a/module-utils/Utils.hpp
+++ b/module-utils/Utils.hpp
@@ -164,8 +164,12 @@ namespace utils
         try {
             value = std::stoi(text);
         }
-        catch (const std::exception &e) {
-            LOG_ERROR("toNumeric exception %s", e.what());
+        catch (const std::out_of_range &e) {
+            LOG_ERROR("toNumeric exception - out_or_range >%s<", e.what());
+            return false;
+        }
+        catch (const std::invalid_argument &e) {
+            LOG_ERROR("toNumeric exception - invalid_argument >%s<", e.what());
             return false;
         }
         return true;


### PR DESCRIPTION
EGD-4394 Added minimum tests for Bluetooth stored data
    
    - SettingsHolder seems fine, except callbacks
    - SettingsVisitors fixed a small issue
    - Bluetooth device saved in the nonvolatile device
    - Added device capability to save
    - Added some tests