### PR TITLE
[EGD-6841] Add more sanity check in the pureflash

### DIFF
--- a/host-tools/pure-flash/CMakeLists.txt
+++ b/host-tools/pure-flash/CMakeLists.txt
@@ -9,4 +9,4 @@ set(PUREFLASH_SRCS
 
 add_executable(${PROJECT_NAME} ${PUREFLASH_SRCS})
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall -pedantic -Werror -Wextra )
-target_compile_definitions(${PROJECT_NAME} PRIVATE _GNU_SOURCE )
+target_compile_definitions(${PROJECT_NAME} PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)


### PR DESCRIPTION
Add more sanity check before flashing to the
block device. Add additional checks against:

* Write image partition is mounted in a linux
* Write image into the partition instead of blkdev

Signed-off-by: Lucjan Bryndza <lucjan.bryndza@mudita.com>