### PR TITLE
[EGD-6446] Fix notes delete window

### DIFF
--- a/module-apps/application-notes/windows/NotesOptions.cpp
+++ b/module-apps/application-notes/windows/NotesOptions.cpp
@@ -27,7 +27,7 @@ namespace app::notes
         void removeNote(const NotesRecord &record, Application *application, AbstractNotesRepository &notesRepository)
         {
             auto metaData = std::make_unique<gui::DialogMetadataMessage>(
-                gui::DialogMetadata{utils::translate("app_alarm_clock_title_main"),
+                gui::DialogMetadata{record.snippet,
                                     "phonebook_contact_delete_trashcan",
                                     utils::translate("app_notes_note_delete_confirmation"),
                                     "",


### PR DESCRIPTION
Fix of title in note delete window to use note beginning as a title. There was a bug that "Alarm Clock" title was visible.
![obraz](https://user-images.githubusercontent.com/74544942/121137067-96e03f80-c836-11eb-9bc7-7c8b1b890c38.png)
