### PR TITLE
[EGD-6684] Fix call ended message

### DIFF
--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -452,13 +452,13 @@ namespace gui
     void CallWindow::setCallEndMessage()
     {
         switch (callEndType) {
+        case CallEndType::None:
+            [[fallthrough]];
         case CallEndType::Ended:
             durationLabel->setText(utils::translate(strings::callended));
             break;
         case CallEndType::Rejected:
             durationLabel->setText(utils::translate(strings::callrejected));
-            break;
-        case CallEndType::None:
             break;
         }
     }


### PR DESCRIPTION
Tiny fix for call ended message missing in case of ending call by the other phone.