### PR TITLE
[CP-187] Fix stack overflow on passcode decoding

### DIFF
--- a/module-services/service-desktop/endpoints/security/SecurityEndpointHelper.hpp
+++ b/module-services/service-desktop/endpoints/security/SecurityEndpointHelper.hpp
@@ -32,6 +32,6 @@ namespace parserFSM
         auto processStatus(Context &context) -> http::Code;
         auto processConfiguration(Context &context) -> http::Code;
 
-        auto passCodeStringToVecOfInts(const std::string &passCode) -> std::vector<unsigned int>;
+        auto passCodeArrayToVecOfInts(const json11::Json::array &passCode) -> std::vector<unsigned int>;
     };
 } // namespace parserFSM

--- a/test/pytest/service-desktop/test_security.py
+++ b/test/pytest/service-desktop/test_security.py
@@ -93,9 +93,21 @@ def test_security_unlock_phone(harness):
     Attempt unlocking with wrong passcode: 1111
     Assuming 1111 is not the actual passcode :-)
     """
-    body = {"phoneLockCode": "1111"}
+    body = {"phoneLockCode": [1, 1, 1, 1]}
     ret = harness.endpoint_request("usbSecurity", "put", body)
     assert ret["status"] == status["OK"]
+
+    time.sleep(.1)
+
+    body = {}
+    ret = harness.endpoint_request("usbSecurity", "get", body)
+    assert ret["status"] == status["Forbidden"]
+
+    time.sleep(.1)
+
+    body = {"phoneLockCode": ['a', 'a', 'a', 'a']}
+    ret = harness.endpoint_request("usbSecurity", "put", body)
+    assert ret["status"] == status["BadRequest"]
 
     time.sleep(.1)
 
@@ -108,7 +120,7 @@ def test_security_unlock_phone(harness):
     """
     Attempt unlocking with too short passcode: 1
     """
-    body = {"phoneLockCode": "1"}
+    body = {"phoneLockCode": [1]}
     ret = harness.endpoint_request("usbSecurity", "put", body)
     assert ret["status"] == status["BadRequest"]
 
@@ -124,7 +136,7 @@ def test_security_unlock_phone(harness):
     Attempt unlocking with correct passcode: 3333
     Assuming 3333 is the actual passcode :-)
     """
-    body = {"phoneLockCode": "3333"}
+    body = {"phoneLockCode": [3, 3, 3, 3]}
     ret = harness.endpoint_request("usbSecurity", "put", body)
     assert ret["status"] == status["OK"]
 


### PR DESCRIPTION
When passcode is passed as json string, each of digits needs to be
parsed as separate character with std::atoi. Replaced the string
with json array of integers to simplify decoding and avoid SO.