### PR TITLE
[BH-369] Fixed UTF8 unit test CI run

### DIFF
--- a/enabled_unittests
+++ b/enabled_unittests
@@ -379,7 +379,7 @@ TESTS_LIST["catch2-utils-ucs2"]="
     UTF8 to UCS2 long string conversion;
 "
 #---------
-TESTS_LIST["catch2-utils-utf8"]="
+TESTS_LIST["catch2-utf8"]="
     UTF8: operator index returns value;
     UTF8: operator index exceeds string size;
     UTF8: operator== returns properly;


### PR DESCRIPTION
Fixed name of UTF8 unit test to make it run on CI