### PR TITLE
[EGD-6916] Makefile build fix

### DIFF
--- a/board/rt1051/ldscripts/sections.ld
+++ b/board/rt1051/ldscripts/sections.ld
@@ -80,9 +80,9 @@ SECTIONS
     {
         *(NonCacheable)
         *(COMMON)
-        lib/libmodule-os.a:*(.bss*)
-        lib/libmodule-sys.a:*(.bss*)
-        lib/libmodule-bsp.a:*(.bss*)
+        *libmodule-os.a:*(.bss*)
+        *libmodule-sys.a:*(.bss*)
+        *libmodule-bsp.a:*(.bss*)
     } > SRAM_DTC
 
     /* System initialized data */
@@ -90,9 +90,9 @@ SECTIONS
     {
         *(NonCacheable.init)
         *(.ramfunc*)
-        lib/libmodule-os.a:*(.data*)
-        lib/libmodule-sys.a:*(.data*)
-        lib/libmodule-bsp.a:*(.data*)
+        *libmodule-os.a:*(.data*)
+        *libmodule-sys.a:*(.data*)
+        *libmodule-bsp.a:*(.data*)
     } > SRAM_DTC AT > BOARD_SDRAM_TEXT
 
     /* MAIN TEXT SECTION */


### PR DESCRIPTION
Changed the way libraries are assigned to specific sections in linker script, because relative paths in GCC linker invoke made linker unable to find those libraries mentioned in linker script