### PR TITLE
[EGD-6917] Screen light in automode does not turnoff itself

### DIFF
--- a/module-services/service-evtmgr/backlight-handler/BacklightHandler.cpp
+++ b/module-services/service-evtmgr/backlight-handler/BacklightHandler.cpp
@@ -28,7 +28,7 @@ namespace backlight
           screenLightTimer{sys::TimerFactory::createSingleShotTimer(
               parent, timers::screenLightTimerName, timers::keypadLightTimerTimeout, [this](sys::Timer &t) {
                   if (getScreenLightState() &&
-                      getScreenAutoModeState() == screen_light_control::ScreenLightMode::Manual &&
+                      getScreenAutoModeState() == screen_light_control::ScreenLightMode::Automatic &&
                       screenLightControl->isLightOn()) {
                       screenLightControl->processRequest(screen_light_control::Action::turnOff);
                   }
@@ -190,7 +190,7 @@ namespace backlight
 
     void Handler::handleScreenLightRefresh()
     {
-        if (getScreenLightState() && getScreenAutoModeState() == screen_light_control::ScreenLightMode::Manual) {
+        if (getScreenLightState() && getScreenAutoModeState() == screen_light_control::ScreenLightMode::Automatic) {
             if (!screenLightControl->isLightOn()) {
                 screenLightControl->processRequest(screen_light_control::Action::turnOn);
             }


### PR DESCRIPTION
The bug was introduced by EGD-6794. The bug is caused by wrong mode
selection in `ScreenLightTimer`'s definition. The current design
defines auto-turn-off only for automatic mode (EGD-6655).