### PR TITLE
[EGD-2949] Add fallback image in case of missing asset

### DIFF
--- a/module-gui/gui/core/ImageManager.hpp
+++ b/module-gui/gui/core/ImageManager.hpp
@@ -1,25 +1,20 @@
 // Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
-
 #pragma once
 
+#include "ImageMap.hpp"
 #include <vector>
 #include <string>
 #include <cstdint>
-#include <cstring>
-
-#include "ImageMap.hpp"
 
 namespace gui
 {
-    class ImageNotFound : public std::runtime_error
-    {
-      public:
-        using std::runtime_error::runtime_error;
-    };
-
     class ImageManager
     {
+      private:
+        ImageMap *createFallbackImage();
+        std::uint32_t fallbackImageId{0};
+
       protected:
         std::string mapFolder;
         std::vector<ImageMap *> imageMaps;
@@ -28,6 +23,7 @@ namespace gui
 
         ImageMap *loadPixMap(std::string filename);
         ImageMap *loadVecMap(std::string filename);
+        void addFallbackImage();
         void loadImageMaps(std::string baseDirectory);
 
         ImageManager();

--- a/module-gui/test/test-catch/test-gui-image.cpp
+++ b/module-gui/test/test-catch/test-gui-image.cpp
@@ -35,12 +35,20 @@ TEST_CASE("Setting an incorrect image name")
 {
     constexpr auto imageName = "ABC";
     gui::Image image{};
-    REQUIRE_THROWS(image.set(imageName));
+    image.set(imageName);
+
+    std::list<gui::Command> commands;
+    image.buildDrawListImplementation(commands);
+    REQUIRE(!commands.empty());
 }
 
 TEST_CASE("Setting an incorrect image id")
 {
     constexpr auto imageId = 1000;
     gui::Image image{};
-    REQUIRE_THROWS(image.set(imageId));
+    image.set(imageId);
+
+    std::list<gui::Command> commands;
+    image.buildDrawListImplementation(commands);
+    REQUIRE(!commands.empty());
 }


### PR DESCRIPTION
Added fallback image in case
of missing image asset
![obraz](https://user-images.githubusercontent.com/74544942/122045911-8e5faa00-cdde-11eb-84ce-87d6ff21f730.png)

