### PR TITLE
[EGD-5011] set headphones maximal sound level

### DIFF
--- a/module-bsp/board/rt1051/bsp/audio/CodecMAX98090.cpp
+++ b/module-bsp/board/rt1051/bsp/audio/CodecMAX98090.cpp
@@ -336,8 +336,11 @@ CodecRetCode CodecMAX98090::SetOutputVolume(const float vol)
     switch (currentParams.outputPath) {
     case CodecParamsMAX98090::OutputPath::Headphones:
     case CodecParamsMAX98090::OutputPath::HeadphonesMono: {
-        // Scale input volume(range 0 - 100) to MAX98090 range(decibels hardcoded as specific hex values)
-        constexpr float scale_factor     = .31f * 10.f;
+        // Scale input volume(range 0 - 10) to MAX98090 range(decibels hardcoded as specific hex values)
+        // @note:
+        // In order to pass certification max value is limited and taken from measurements 0x0B: -28dB
+        // Be carefull when changing it !!!
+        constexpr auto scale_factor      = 1.1f;
         uint8_t volume                   = static_cast<float>(vol * scale_factor);
         max98090_reg_lhp_vol_ctrl_t lvol = {};
         max98090_reg_rhp_vol_ctrl_t rvol = {};
@@ -355,8 +358,8 @@ CodecRetCode CodecMAX98090::SetOutputVolume(const float vol)
     } break;
 
     case CodecParamsMAX98090::OutputPath::Earspeaker: {
-        // Scale input volume(range 0 - 100) to MAX98090 range(decibels hardcoded as specific hex values)
-        constexpr float scale_factor     = .31f * 10.f;
+        // Scale input volume(range 0 - 10) to MAX98090 range(decibels hardcoded as specific hex values)
+        constexpr auto scale_factor      = 3.1f; // take the whole scale
         uint8_t volume                   = static_cast<float>(vol * scale_factor);
         max98090_reg_recv_vol_ctrl_t vol = {};
 
@@ -369,8 +372,8 @@ CodecRetCode CodecMAX98090::SetOutputVolume(const float vol)
 
     case CodecParamsMAX98090::OutputPath::Loudspeaker:
     case CodecParamsMAX98090::OutputPath::LoudspeakerMono: {
-        // Scale input volume(range 0 - 100) to MAX98090 range(decibels hardcoded as specific hex values)
-        constexpr float scale_factor = .39f * 10.f;
+        // Scale input volume(range 0 - 10) to MAX98090 range(decibels hardcoded as specific hex values)
+        constexpr auto scale_factor  = 3.9f;
         uint8_t volume               = static_cast<float>(vol * scale_factor) + 0x18;
 
         max98090_reg_lspk_vol_ctrl_t lvol = {};

--- a/module-services/service-audio/ServiceAudio.cpp
+++ b/module-services/service-audio/ServiceAudio.cpp
@@ -27,7 +27,7 @@ using namespace audio;
 inline constexpr auto audioServiceStackSize = 1024 * 4;
 
 static constexpr auto defaultVolumeHigh              = "10";
-static constexpr auto defaultVolumeLow               = "2";
+static constexpr auto defaultVolumeLow               = "5";
 static constexpr auto defaultVolumeMuted             = "0";
 static constexpr auto defaultTrue                    = "1";
 static constexpr auto defaultFalse                   = "0";


### PR DESCRIPTION
In order to pass certification IEC 62368-1, set maximal headphones sound
level accordinly to measurements done by 7layers laboratory.