### PR TITLE
[CP-174] Remove limit of maximum attempts of unlocking the phone

### DIFF
--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -447,7 +447,7 @@
   "phone_lock_unlock": "<text>Enter the passcode<br></br>to unlock:</text>",
   "phone_lock_unlock_last_attempt": "<text>Wrong passcode.<br></br>You have 1 attempt left.</text>",
   "phone_lock_unlock_last_attempt_warning": "<text>If the passcode is wrong this time,<br></br>you'll have to wait <token>$MINUTES</token> minutes<br></br>before trying again.</text>",
-  "phone_lock_unlock_invalid": "<text>Wrong passcode.<br></br>You have <token>$ATTEMPTS</token> attempts left.</text>",
+  "phone_lock_unlock_invalid": "<text>Wrong passcode.</text>",
   "phone_lock_blocked": "Sorry, phone blocked",
   "phone_lock_current": "Type current passcode",
   "phone_lock_enter_new": "Enter new passcode",

--- a/image/assets/lang/Svenska.json
+++ b/image/assets/lang/Svenska.json
@@ -383,7 +383,7 @@
   "phone_lock_unlock": "<text>Lösenord:</text>",
   "phone_lock_unlock_last_attempt": "<text>Fel lösenord.<br></br>Du har 1 försök kvar.</text>",
   "phone_lock_unlock_last_attempt_warning": "<text>Om lösenordet är fel den här gången,<br></br>måste du vänta <token>$MINUTES</token> minuter<br></br>innan nästa försök.</text>",
-  "phone_lock_unlock_invalid": "<text>Fel lösenord.<br></br>Du har <token>$ATTEMPTS</token> försök kvar.</text>",
+  "phone_lock_unlock_invalid": "<text>Fel lösenord.</text>",
   "phone_lock_blocked": "Tyvärr, telefonen blockerad.",
   "phone_lock_current": "Det förra lösenordet",
   "phone_lock_enter_new": "Det nya lösenordet",

--- a/module-apps/apps-common/locks/handlers/PhoneLockHandler.cpp
+++ b/module-apps/apps-common/locks/handlers/PhoneLockHandler.cpp
@@ -13,10 +13,8 @@
 
 namespace locks
 {
-    constexpr unsigned int default_attempts = 4;
-
     PhoneLockHandler::PhoneLockHandler(sys::Service *owner, std::shared_ptr<settings::Settings> settings)
-        : owner(owner), lock(Lock::LockState::InputRequired, default_attempts), settings(std::move(settings))
+        : owner(owner), lock(Lock::LockState::InputRequired), settings(std::move(settings))
     {}
 
     void PhoneLockHandler::enablePhoneLock(bool _phoneLockEnabled)
@@ -38,7 +36,7 @@ namespace locks
     {
         if (phoneLockInputTypeAction != _phoneLockInputTypeAction) {
             phoneLockInputTypeAction = _phoneLockInputTypeAction;
-            lock.attemptsLeft        = default_attempts;
+            lock.attemptsLeft        = Lock::unlimitedNumOfAttempts;
             storedInputData.clear();
         }
     }
@@ -263,7 +261,7 @@ namespace locks
 
         if (phoneLockHash == hash) {
             lock.lockState    = Lock::LockState::Unlocked;
-            lock.attemptsLeft = default_attempts;
+            lock.attemptsLeft = Lock::unlimitedNumOfAttempts;
         }
         else if (lock.attemptsLeft > 0) {
             lock.lockState = Lock::LockState::InputInvalid;


### PR DESCRIPTION
Limit of 4 attempts of unlocking phone is disabled
due to requirements change. This is a temporary solution until
time intervals between attempts will be introduced.
Old logic remains untouched on purpose.
It will be reused in final implementation.