### PR TITLE
[EGD-6952] Refuse tethering mode on low battery

### DIFF
--- a/module-sys/SystemManager/SystemManager.cpp
+++ b/module-sys/SystemManager/SystemManager.cpp
@@ -755,6 +755,12 @@ namespace sys
     MessagePointer SystemManager::handleTetheringStateRequest(TetheringStateRequest *request)
     {
         LOG_INFO("Tethering state change requested");
+
+        if (Store::Battery::get().levelState != Store::Battery::LevelState::Normal) {
+            LOG_INFO("Tethering state change refused - battery too low");
+            return MessageNone{};
+        }
+
         if (const auto requestedState = request->getTetheringState(); requestedState == phone_modes::Tethering::On) {
             bus.sendUnicast(std::make_shared<TetheringQuestionRequest>(),
                             app::manager::ApplicationManager::ServiceName);


### PR DESCRIPTION
Added prevention of tethering mode change while battery is below critical level. It prevents the tethering state dialog popup to show up when low-battery screen is visible.