### PR TITLE
[EGD-6958] Fix rssibar oor exception

### DIFF
--- a/module-gui/gui/widgets/status-bar/SignalStrengthBar.cpp
+++ b/module-gui/gui/widgets/status-bar/SignalStrengthBar.cpp
@@ -24,7 +24,7 @@ namespace gui::status_bar
         constexpr auto signal3_roaming = "signal3_roaming";
         constexpr auto signal4_roaming = "signal4_roaming";
 
-        using SignalMap           = std::unordered_map<Store::RssiBar, std::string>;
+        using SignalMap = std::unordered_map<Store::RssiBar, std::string>;
 
         const SignalMap signalMapHomeCon = {{Store::RssiBar::zero, signal0},
                                             {Store::RssiBar::one, signal1},
@@ -48,15 +48,24 @@ namespace gui::status_bar
 
     void SignalStrengthBar::update(const Store::SignalStrength &signal, const Store::Network::Status &status)
     {
-        if (status == Store::Network::Status::RegisteredRoaming) {
-            img->set(signalMapRoaming.at(signal.rssiBar));
+        try {
+            if (img == nullptr) {
+                LOG_ERROR("SignalStrength Image nullptr");
+                return;
+            }
+
+            if (status == Store::Network::Status::RegisteredRoaming) {
+                img->set(signalMapRoaming.at(signal.rssiBar));
+            }
+            else if (status == Store::Network::Status::RegisteredHomeNetwork) {
+                img->set(signalMapHomeCon.at(signal.rssiBar));
+            }
+            else {
+                img->set(signal_none);
+            }
         }
-        else if (status == Store::Network::Status::RegisteredHomeNetwork) {
-            img->set(signalMapHomeCon.at(signal.rssiBar));
-        }
-        else {
-            img->set(signal_none);
+        catch (const std::exception &exception) {
+            LOG_ERROR("%s", exception.what());
         }
     }
-
 } // namespace gui::status_bar

--- a/module-services/service-cellular/SignalStrength.cpp
+++ b/module-services/service-cellular/SignalStrength.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "service-cellular/SignalStrength.hpp"
@@ -33,9 +33,6 @@ Store::RssiBar SignalStrength::rssidBmToBar(const int rssidBm)
 
     if (rssidBm == rssidBm_invalid) {
         return RssiBar::zero;
-    }
-    else if (rssidBm >= rssidBm_five_bar_margin) {
-        return RssiBar::five;
     }
     else if (rssidBm >= rssidBm_four_bar_margin) {
         return RssiBar::four;

--- a/module-services/service-cellular/service-cellular/SignalStrength.hpp
+++ b/module-services/service-cellular/service-cellular/SignalStrength.hpp
@@ -33,11 +33,10 @@ class SignalStrength
     static const auto rssi_tdscmda_step = (rssi_tdscmda_low_dBm - rssi_tdscmda_max_dBm) / (rssi_tdscmda_max - rssi_low);
 
     static const auto rssidBm_invalid          = 0;
-    static const auto rssidBm_five_bar_margin  = -60;
-    static const auto rssidBm_four_bar_margin  = -75;
-    static const auto rssidBm_three_bar_margin = -90;
-    static const auto rssidBm_two_bar_margin   = -100;
-    static const auto rssidBm_one_bar_margin   = -110;
+    static const auto rssidBm_four_bar_margin  = -60;
+    static const auto rssidBm_three_bar_margin = -75;
+    static const auto rssidBm_two_bar_margin   = -90;
+    static const auto rssidBm_one_bar_margin   = -100;
 
   public:
     SignalStrength(int rssi);

--- a/module-utils/EventStore/EventStore.hpp
+++ b/module-utils/EventStore/EventStore.hpp
@@ -50,7 +50,6 @@ namespace Store
         two   = 2,
         three = 3,
         four  = 4,
-        five  = 5,
         noOfSupprtedBars
     };
 


### PR DESCRIPTION
This PR introduces a simple fix for out of range exception in topbar rssi indicator.
It also removes lowest RSSI threshold to follow current design.
The other thresholds may be fine tuned if needed.