### PR TITLE
[BH-390] app notes as separate lib

### DIFF
--- a/module-apps/application-notes/ApplicationNotes.cpp
+++ b/module-apps/application-notes/ApplicationNotes.cpp
@@ -1,23 +1,22 @@
 ﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include "ApplicationNotes.hpp"
+#include <application-notes/ApplicationNotes.hpp>
+#include <presenter/NoteEditWindowPresenter.hpp>
+#include <presenter/NotePreviewWindowPresenter.hpp>
+#include <presenter/NotesMainWindowPresenter.hpp>
+#include <windows/NoteEditWindow.hpp>
+#include <windows/NoteMainWindow.hpp>
+#include <windows/NotePreviewWindow.hpp>
+#include <windows/SearchEngineWindow.hpp>
+#include <windows/SearchResultsWindow.hpp>
 
-#include "MessageType.hpp"
-#include "windows/NoteMainWindow.hpp"
-#include "windows/NotePreviewWindow.hpp"
-#include "windows/NoteEditWindow.hpp"
-#include "windows/SearchEngineWindow.hpp"
-#include "windows/SearchResultsWindow.hpp"
-
+#include <apps-common/windows/Dialog.hpp>
+#include <apps-common/windows/OptionWindow.hpp>
+#include <MessageType.hpp>
+#include <service-db/DBNotificationMessage.hpp>
 #include <service-db/QueryMessage.hpp>
 
-#include <module-apps/application-notes/presenter/NotesMainWindowPresenter.hpp>
-#include <module-apps/application-notes/presenter/NotePreviewWindowPresenter.hpp>
-#include <module-apps/application-notes/presenter/NoteEditWindowPresenter.hpp>
-#include <apps-common/windows/OptionWindow.hpp>
-#include <apps-common/windows/Dialog.hpp>
-#include <module-services/service-db/service-db/DBNotificationMessage.hpp>
 #include <utility>
 
 namespace app

--- a/module-apps/application-notes/CMakeLists.txt
+++ b/module-apps/application-notes/CMakeLists.txt
@@ -1,60 +1,73 @@
-﻿include_directories( ${CMAKE_PROJECT_NAME}
-	PUBLIC
-		"${CMAKE_CURRENT_LIST_DIR}"
-)
+﻿# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-include_directories( ${PROJECT_NAME}
-	PUBLIC
-		"${CMAKE_CURRENT_LIST_DIR}"
-)
+add_library(application-notes STATIC)
 
-target_sources( ${PROJECT_NAME}
-
-	PRIVATE
-		"${CMAKE_CURRENT_LIST_DIR}/ApplicationNotes.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/model/NotesListModel.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/model/NotesSearchListModel.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/model/NotesRepository.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/presenter/NotesMainWindowPresenter.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/presenter/NotePreviewWindowPresenter.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/presenter/NoteEditWindowPresenter.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/presenter/SearchEngineWindowPresenter.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/presenter/NotesSearchResultPresenter.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/widgets/NotesItem.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/windows/NoteMainWindow.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/windows/NotePreviewWindow.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/windows/NoteEditWindow.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/windows/NotesOptions.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/windows/SearchEngineWindow.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/windows/SearchResultsWindow.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/data/NoteSwitchData.cpp"
-		"${CMAKE_CURRENT_LIST_DIR}/data/NotesFoundData.cpp"
-	PUBLIC
-		"${CMAKE_CURRENT_LIST_DIR}/ApplicationNotes.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/model/NotesListModel.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/model/NotesSearchListModel.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/model/NotesRepository.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/presenter/NotesMainWindowPresenter.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/presenter/NotePreviewWindowPresenter.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/presenter/NoteEditWindowPresenter.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/presenter/SearchEngineWindowPresenter.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/presenter/NotesSearchResultPresenter.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/widgets/NotesItem.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/windows/NoteMainWindow.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/windows/NotePreviewWindow.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/windows/NoteEditWindow.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/windows/SearchEngineWindow.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/windows/SearchResultsWindow.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/windows/NotesOptions.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/data/NoteSwitchData.hpp"
-		"${CMAKE_CURRENT_LIST_DIR}/data/NotesFoundData.hpp"
-)
-target_include_directories(${PROJECT_NAME}
+target_include_directories(application-notes
     PRIVATE
-        service-db
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-target_link_libraries(${PROJECT_NAME}
+target_sources(application-notes
 	PRIVATE
+		ApplicationNotes.cpp
+		data/NotesFoundData.cpp
+		data/NoteSwitchData.cpp
+		model/NotesListModel.cpp
+		model/NotesRepository.cpp
+		model/NotesSearchListModel.cpp
+		presenter/NoteEditWindowPresenter.cpp
+		presenter/NotePreviewWindowPresenter.cpp
+		presenter/NotesMainWindowPresenter.cpp
+		presenter/NotesSearchResultPresenter.cpp
+		presenter/SearchEngineWindowPresenter.cpp
+		widgets/NotesItem.cpp
+		windows/NoteEditWindow.cpp
+		windows/NoteMainWindow.cpp
+		windows/NotePreviewWindow.cpp
+		windows/NotesOptions.cpp
+		windows/SearchEngineWindow.cpp
+		windows/SearchResultsWindow.cpp
+	PRIVATE
+		data/NotesFoundData.hpp
+		data/NoteSwitchData.hpp
+		model/NotesListModel.hpp
+		model/NotesRepository.hpp
+		model/NotesSearchListModel.hpp
+		presenter/NoteEditWindowPresenter.hpp
+		presenter/NotePreviewWindowPresenter.hpp
+		presenter/NotesMainWindowPresenter.hpp
+		presenter/NotesSearchResultPresenter.hpp
+		presenter/SearchEngineWindowPresenter.hpp
+		widgets/NotesItem.hpp
+		windows/NoteEditWindow.hpp
+		windows/NoteMainWindow.hpp
+		windows/NotePreviewWindow.hpp
+		windows/NotesOptions.hpp
+		windows/SearchEngineWindow.hpp
+		windows/SearchResultsWindow.hpp
+	PUBLIC
+		include/application-notes/ApplicationNotes.hpp
+)
+
+
+option(ENABLE_APP_NOTES "Enable application notes" ON)
+
+target_compile_definitions(application-notes
+    INTERFACE
+        $<$<BOOL:${ENABLE_APP_NOTES}>:ENABLE_APP_NOTES>
+)
+
+target_link_libraries(application-notes
+	PRIVATE
+		apps-common
 		clipboard
+		module-gui
+		module-db
+		service-db
+		log
+		time
+		i18n		
 )

--- a/module-apps/application-notes/include/application-notes/ApplicationNotes.hpp
+++ b/module-apps/application-notes/include/application-notes/ApplicationNotes.hpp
@@ -3,8 +3,7 @@
 
 #pragma once
 
-#include "module-apps/application-notes/model/NotesListModel.hpp"
-#include "Application.hpp"
+#include <Application.hpp>
 
 namespace gui::name::window
 {

--- a/module-apps/application-notes/windows/NoteEditWindow.cpp
+++ b/module-apps/application-notes/windows/NoteEditWindow.cpp
@@ -7,7 +7,7 @@
 
 #include <Style.hpp>
 
-#include <module-apps/application-notes/ApplicationNotes.hpp>
+#include <application-notes/ApplicationNotes.hpp>
 #include <module-apps/application-notes/windows/NotesOptions.hpp>
 #include <module-apps/application-notes/data/NoteSwitchData.hpp>
 #include <module-apps/application-notes/style/NoteEditStyle.hpp>

--- a/module-apps/application-notes/windows/NoteMainWindow.cpp
+++ b/module-apps/application-notes/windows/NoteMainWindow.cpp
@@ -3,7 +3,7 @@
 
 #include "NoteMainWindow.hpp"
 
-#include <module-apps/application-notes/ApplicationNotes.hpp>
+#include <application-notes/ApplicationNotes.hpp>
 #include <module-apps/application-notes/data/NoteSwitchData.hpp>
 
 #include <InputEvent.hpp>

--- a/module-apps/application-notes/windows/NotePreviewWindow.cpp
+++ b/module-apps/application-notes/windows/NotePreviewWindow.cpp
@@ -3,7 +3,7 @@
 
 #include "NotePreviewWindow.hpp"
 
-#include <module-apps/application-notes/ApplicationNotes.hpp>
+#include <application-notes/ApplicationNotes.hpp>
 #include <module-apps/application-notes/data/NoteSwitchData.hpp>
 #include <module-apps/application-notes/style/NotePreviewStyle.hpp>
 #include <module-apps/application-notes/windows/NotesOptions.hpp>

--- a/module-apps/application-notes/windows/NotesOptions.hpp
+++ b/module-apps/application-notes/windows/NotesOptions.hpp
@@ -1,10 +1,11 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
-#include <module-apps/application-notes/ApplicationNotes.hpp>
+#include <application-notes/ApplicationNotes.hpp>
 #include <module-db/Interface/NotesRecord.hpp>
+#include <model/NotesRepository.hpp>
 
 namespace gui
 {

--- a/module-apps/application-notes/windows/SearchEngineWindow.cpp
+++ b/module-apps/application-notes/windows/SearchEngineWindow.cpp
@@ -3,7 +3,7 @@
 
 #include "SearchEngineWindow.hpp"
 
-#include <module-apps/application-notes/ApplicationNotes.hpp>
+#include <application-notes/ApplicationNotes.hpp>
 #include <module-apps/application-notes/data/NotesFoundData.hpp>
 #include <apps-common/widgets/InputBox.hpp>
 

--- a/module-apps/application-notes/windows/SearchResultsWindow.cpp
+++ b/module-apps/application-notes/windows/SearchResultsWindow.cpp
@@ -3,7 +3,7 @@
 
 #include "SearchResultsWindow.hpp"
 
-#include <module-apps/application-notes/ApplicationNotes.hpp>
+#include <application-notes/ApplicationNotes.hpp>
 #include <module-apps/application-notes/data/NotesFoundData.hpp>
 #include <module-apps/application-notes/style/NotesListStyle.hpp>
 #include <apps-common/windows/DialogMetadata.hpp>

--- a/products/BellHybrid/BellHybridMain.cpp
+++ b/products/BellHybrid/BellHybridMain.cpp
@@ -8,7 +8,6 @@
 #include <application-calllog/ApplicationCallLog.hpp>
 #include <application-desktop/ApplicationDesktop.hpp>
 #include <application-messages/ApplicationMessages.hpp>
-#include <application-notes/ApplicationNotes.hpp>
 #include <application-settings/ApplicationSettings.hpp>
 #include <application-settings-new/ApplicationSettings.hpp>
 #include <application-special-input/ApplicationSpecialInput.hpp>

--- a/products/PurePhone/CMakeLists.txt
+++ b/products/PurePhone/CMakeLists.txt
@@ -52,12 +52,13 @@ target_link_libraries(PurePhone
         application-calculator
         application-music-player
         application-phonebook
+        application-notes
+        messagetype
         module-apps
-        service-desktop
         service-bluetooth
+        service-desktop
         service-lwip
         ${LWIP_LIBRARIES}
-        messagetype
         "$<$<STREQUAL:${PROJECT_TARGET},TARGET_Linux>:iosyscalls>"
         "$<$<STREQUAL:${PROJECT_TARGET},TARGET_RT1051>:CrashCatcher::CrashCatcher>"
         "$<$<STREQUAL:${PROJECT_TARGET},TARGET_RT1051>:CrashCatcherARM>"


### PR DESCRIPTION
Created separate cmake library: application-notes, made all header files except one PRIVATE, fixed include paths (in separate commit) to use own application-notes search path, sorted includes to comply with Mudita internal guideline.

Smoke tests: https://appnroll.atlassian.net/browse/EGDT-1003