### PR TITLE
[CP-194] Intercept all input when OS update window is displayed

### DIFF
--- a/module-apps/application-desktop/windows/UpdateProgress.cpp
+++ b/module-apps/application-desktop/windows/UpdateProgress.cpp
@@ -54,6 +54,11 @@ namespace gui
         setVisibleState();
     }
 
+    bool UpdateProgressWindow::onInput(const InputEvent & /*inputEvent*/)
+    {
+        return true;
+    }
+
     void UpdateProgressWindow::setVisibleState()
     {
         percentLabel->setVisible(true);

--- a/module-apps/application-desktop/windows/UpdateProgress.hpp
+++ b/module-apps/application-desktop/windows/UpdateProgress.hpp
@@ -32,8 +32,9 @@ namespace gui
         void invalidate() noexcept;
 
       public:
-        UpdateProgressWindow(app::Application *app);
+        explicit UpdateProgressWindow(app::Application *app);
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
+        bool onInput(const InputEvent &inputEvent) override;
         bool handleSwitchData(SwitchData *data) override;
         void rebuild() override;
         void buildInterface() override;


### PR DESCRIPTION
Block user interaction with phone during OS update,
by intercepting all inputs from phone keyboard when OS
update screen is displayed.