### PR TITLE
[EGD-6955] Add calls notifications in DND

### DIFF
--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -250,12 +250,6 @@ namespace app
         AudioServiceAPI::StopAll(this);
     }
 
-    void ApplicationCall::startAudioRinging()
-    {
-        const auto filePath = AudioServiceAPI::GetSound(this, audio::PlaybackType::CallRingtone);
-        AudioServiceAPI::PlaybackStart(this, audio::PlaybackType::CallRingtone, filePath);
-    }
-
     void ApplicationCall::startAudioRouting()
     {
         AudioServiceAPI::RoutingStart(this);

--- a/module-apps/application-call/ApplicationCall.hpp
+++ b/module-apps/application-call/ApplicationCall.hpp
@@ -45,7 +45,6 @@ namespace app
         };
 
         virtual void stopAudio()                           = 0;
-        virtual void startAudioRinging()                   = 0;
         virtual void startAudioRouting()                   = 0;
         virtual void sendAudioEvent(AudioEvent audioEvent) = 0;
 
@@ -117,7 +116,6 @@ namespace app
         }
 
         void stopAudio() override;
-        void startAudioRinging() override;
         void startAudioRouting() override;
         void sendAudioEvent(AudioEvent audioEvent) override;
 

--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -174,7 +174,6 @@ namespace gui
 
         switch (state) {
         case State::INCOMING_CALL: {
-            interface->startAudioRinging();
             bottomBar->setText(gui::BottomBar::Side::LEFT, utils::translate(strings::answer), true);
             bottomBar->setText(gui::BottomBar::Side::RIGHT, utils::translate(strings::reject), true);
             durationLabel->setText(utils::translate(strings::iscalling));

--- a/module-apps/apps-common/CMakeLists.txt
+++ b/module-apps/apps-common/CMakeLists.txt
@@ -16,6 +16,10 @@ target_sources(apps-common
         notifications/NotificationListItem.cpp
         notifications/NotificationProvider.cpp
         notifications/NotificationsModel.cpp
+        notifications/NotificationsHandler.cpp
+        notifications/NotificationsConfiguration.cpp
+        notifications/policies/CallNotificationPolicy.cpp
+        notifications/policies/NotificationsListPolicy.cpp
         options/OptionsModel.cpp
         options/type/OptionCall.cpp
         options/type/OptionContact.cpp

--- a/module-apps/apps-common/notifications/NotificationProvider.hpp
+++ b/module-apps/apps-common/notifications/NotificationProvider.hpp
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "NotificationData.hpp"
+#include "NotificationsConfiguration.hpp"
+#include "policies/NotificationsListPolicy.hpp"
 #include <PhoneModes/Common.hpp>
 
 namespace sys
@@ -30,7 +32,7 @@ namespace notifications
         template <NotificationType type, typename T> bool handleNotSeenWithCounter(NotificationsRecord &&record);
 
       public:
-        explicit NotificationProvider(sys::Service *ownerService);
+        explicit NotificationProvider(sys::Service *ownerService, NotificationsConfiguration &notifcationConfig);
 
         void handle(db::query::notifications::GetAllResult *msg);
         void handle(db::NotificationMessage *msg);
@@ -42,6 +44,8 @@ namespace notifications
 
       private:
         sys::Service *ownerService;
+        NotificationsConfiguration &notifcationConfig;
+        NotificationsListPolicy listPolicy;
         Notifications notifications;
     };
 

--- a/module-apps/apps-common/notifications/NotificationsConfiguration.cpp
+++ b/module-apps/apps-common/notifications/NotificationsConfiguration.cpp
@@ -1,0 +1,43 @@
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "NotificationsConfiguration.hpp"
+#include <Utils.hpp>
+#include <agents/settings/SystemSettings.hpp>
+
+using namespace notifications;
+
+NotificationsConfiguration::NotificationsConfiguration(std::shared_ptr<sys::phone_modes::Observer> phoneModeObserver,
+                                                       std::shared_ptr<settings::Settings> settings,
+                                                       const locks::PhoneLockHandler &phoneLockHandler)
+    : phoneModeObserver{phoneModeObserver}, settings{settings}, phoneLockHandler{phoneLockHandler}
+{}
+
+void NotificationsConfiguration::updateCurrentCall(CallNotificationPolicy &policy)
+{
+    policy.updateCurrentCall(phoneModeObserver->getCurrentPhoneMode());
+}
+
+void NotificationsConfiguration::callNumberCheck(CallNotificationPolicy &policy, bool contactInFavourites)
+{
+    policy.numberCheck(getDNDCallsFromFavourites(), contactInFavourites);
+}
+
+void NotificationsConfiguration::updateCurrentList(NotificationsListPolicy &policy)
+{
+    policy.updateCurrentList(phoneModeObserver->getCurrentPhoneMode(),
+                             phoneLockHandler.isPhoneLocked(),
+                             getDNDNotificationsOnLockedScreen());
+}
+
+auto NotificationsConfiguration::getDNDNotificationsOnLockedScreen() const noexcept -> bool
+{
+    return utils::getNumericValue<bool>(
+        settings->getValue(settings::Offline::notificationsWhenLocked, settings::SettingsScope::Global));
+}
+
+auto NotificationsConfiguration::getDNDCallsFromFavourites() const noexcept -> bool
+{
+    return utils::getNumericValue<bool>(
+        settings->getValue(settings::Offline::callsFromFavorites, settings::SettingsScope::Global));
+}

--- a/module-apps/apps-common/notifications/NotificationsConfiguration.hpp
+++ b/module-apps/apps-common/notifications/NotificationsConfiguration.hpp
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "policies/CallNotificationPolicy.hpp"
+#include "policies/NotificationsListPolicy.hpp"
+#include <service-db/Settings.hpp>
+#include <PhoneModes/Observer.hpp>
+#include <apps-common/locks/handlers/PhoneLockHandler.hpp>
+
+namespace notifications
+{
+    class NotificationsConfiguration
+    {
+      public:
+        NotificationsConfiguration(std::shared_ptr<sys::phone_modes::Observer> phoneModeObserver,
+                                   std::shared_ptr<settings::Settings> settings,
+                                   const locks::PhoneLockHandler &phoneLockHandler);
+        void updateCurrentCall(CallNotificationPolicy &policy);
+        void callNumberCheck(CallNotificationPolicy &policy, bool contactInFavourites);
+        void updateCurrentList(NotificationsListPolicy &policy);
+
+      private:
+        auto getDNDNotificationsOnLockedScreen() const noexcept -> bool;
+        auto getDNDCallsFromFavourites() const noexcept -> bool;
+        std::shared_ptr<sys::phone_modes::Observer> phoneModeObserver;
+        std::shared_ptr<settings::Settings> settings;
+        const locks::PhoneLockHandler &phoneLockHandler;
+    };
+} // namespace notifications

--- a/module-apps/apps-common/notifications/NotificationsHandler.cpp
+++ b/module-apps/apps-common/notifications/NotificationsHandler.cpp
@@ -1,0 +1,75 @@
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "NotificationsHandler.hpp"
+#include <service-db/DBServiceAPI.hpp>
+#include <log.hpp>
+#include <service-cellular/service-cellular/CellularMessage.hpp>
+#include <service-appmgr/service-appmgr/Controller.hpp>
+#include <service-audio/AudioServiceAPI.hpp>
+#include <service-cellular/CellularServiceAPI.hpp>
+
+using namespace notifications;
+
+NotificationsHandler::NotificationsHandler(sys::Service *parentService, NotificationsConfiguration &notifcationConfig)
+    : parentService{parentService}, notifcationConfig{notifcationConfig}
+{}
+
+void NotificationsHandler::registerMessageHandlers()
+{
+    parentService->connect(typeid(CellularIncominCallMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        incomingCallHandler(request);
+        return sys::msgHandled();
+    });
+
+    parentService->connect(typeid(CellularCallerIdMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        callerIdHandler(request);
+        return sys::msgHandled();
+    });
+}
+
+void NotificationsHandler::incomingCallHandler(sys::Message *request)
+{
+    notifcationConfig.updateCurrentCall(currentCallPolicy);
+
+    if (currentCallPolicy.isPopupAllowed()) {
+        auto msg = static_cast<CellularIncominCallMessage *>(request);
+        app::manager::Controller::sendAction(parentService,
+                                             app::manager::actions::HandleIncomingCall,
+                                             std::make_unique<app::manager::actions::CallParams>(msg->number));
+
+        playbackCallRingtone();
+    }
+}
+
+void NotificationsHandler::callerIdHandler(sys::Message *request)
+{
+    auto msg = static_cast<CellularIncominCallMessage *>(request);
+
+    if (currentCallPolicy.isNumberCheckRequired()) {
+        policyNumberCheck(msg->number);
+    }
+    if (currentCallPolicy.isPopupAllowed()) {
+        app::manager::Controller::sendAction(parentService,
+                                             app::manager::actions::HandleCallerId,
+                                             std::make_unique<app::manager::actions::CallParams>(msg->number));
+        playbackCallRingtone();
+    }
+    else {
+        CellularServiceAPI::DismissCall(parentService);
+    }
+}
+
+void NotificationsHandler::policyNumberCheck(const utils::PhoneNumber::View &number)
+{
+    auto isContactInFavourites = DBServiceAPI::IsContactInFavourites(parentService, number);
+    notifcationConfig.callNumberCheck(currentCallPolicy, isContactInFavourites);
+}
+
+void NotificationsHandler::playbackCallRingtone()
+{
+    if (currentCallPolicy.isRingtoneAllowed()) {
+        const auto filePath = AudioServiceAPI::GetSound(parentService, audio::PlaybackType::CallRingtone);
+        AudioServiceAPI::PlaybackStart(parentService, audio::PlaybackType::CallRingtone, filePath);
+    }
+}

--- a/module-apps/apps-common/notifications/NotificationsHandler.hpp
+++ b/module-apps/apps-common/notifications/NotificationsHandler.hpp
@@ -1,0 +1,30 @@
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "NotificationsConfiguration.hpp"
+#include "policies/CallNotificationPolicy.hpp"
+#include <PhoneModes/Observer.hpp>
+#include <Service/Service.hpp>
+#include <PhoneNumber.hpp>
+
+namespace notifications
+{
+    class NotificationsHandler
+    {
+      public:
+        NotificationsHandler(sys::Service *parentService, NotificationsConfiguration &notifcationConfig);
+        void registerMessageHandlers();
+
+      private:
+        void policyNumberCheck(const utils::PhoneNumber::View &number);
+        void playbackCallRingtone();
+        void incomingCallHandler(sys::Message *request);
+        void callerIdHandler(sys::Message *request);
+
+        sys::Service *parentService = nullptr;
+        NotificationsConfiguration &notifcationConfig;
+        CallNotificationPolicy currentCallPolicy;
+    };
+} // namespace notifications

--- a/module-apps/apps-common/notifications/NotificationsModel.hpp
+++ b/module-apps/apps-common/notifications/NotificationsModel.hpp
@@ -13,7 +13,11 @@
 
 namespace gui
 {
-
+    enum class NotificationsListPlacement
+    {
+        Desktop,
+        LockedScreen
+    };
     class NotificationsModel : public app::InternalModel<gui::NotificationListItem *>, public gui::ListItemProvider
     {
         [[nodiscard]] unsigned int requestRecordsCount() final;
@@ -23,6 +27,7 @@ namespace gui
 
       protected:
         bool tetheringOn = false;
+        const NotificationsListPlacement listPlacement;
         [[nodiscard]] virtual auto create(const notifications::NotSeenSMSNotification *notification)
             -> NotificationListItem *;
         [[nodiscard]] virtual auto create(const notifications::NotSeenCallNotification *notification)
@@ -31,6 +36,7 @@ namespace gui
             -> NotificationListItem *;
 
       public:
+        explicit NotificationsModel(NotificationsListPlacement listPlacement = NotificationsListPlacement::Desktop);
         [[nodiscard]] bool isEmpty() const noexcept;
         [[nodiscard]] bool hasDismissibleNotification() const noexcept;
         [[nodiscard]] bool isTetheringOn() const noexcept;

--- a/module-apps/apps-common/notifications/policies/CallNotificationPolicy.cpp
+++ b/module-apps/apps-common/notifications/policies/CallNotificationPolicy.cpp
@@ -1,0 +1,47 @@
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "CallNotificationPolicy.hpp"
+
+using namespace notifications;
+
+void CallNotificationPolicy::updateCurrentCall(sys::phone_modes::PhoneMode phoneMode)
+{
+    popupOn           = false;
+    ringtoneOn        = false;
+    numberCheckNeeded = false;
+
+    switch (phoneMode) {
+    case sys::phone_modes::PhoneMode::Connected:
+        popupOn    = true;
+        ringtoneOn = true;
+        break;
+    case sys::phone_modes::PhoneMode::DoNotDisturb:
+        numberCheckNeeded = true;
+        break;
+    case sys::phone_modes::PhoneMode::Offline:
+        break;
+    }
+}
+
+bool CallNotificationPolicy::isPopupAllowed() const noexcept
+{
+    return popupOn && !numberCheckNeeded;
+}
+
+bool CallNotificationPolicy::isRingtoneAllowed() const noexcept
+{
+    return ringtoneOn;
+}
+
+bool CallNotificationPolicy::isNumberCheckRequired() const noexcept
+{
+    return numberCheckNeeded;
+}
+
+void CallNotificationPolicy::numberCheck(bool callsFromFavouritesSetting, bool isNumberinFavourites)
+{
+    numberCheckNeeded = false;
+    popupOn           = callsFromFavouritesSetting && isNumberinFavourites;
+    ringtoneOn        = callsFromFavouritesSetting && isNumberinFavourites;
+}

--- a/module-apps/apps-common/notifications/policies/CallNotificationPolicy.hpp
+++ b/module-apps/apps-common/notifications/policies/CallNotificationPolicy.hpp
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <PhoneNumber.hpp>
+#include <PhoneModes/Common.hpp>
+
+namespace notifications
+{
+    class CallNotificationPolicy
+    {
+      public:
+        void updateCurrentCall(sys::phone_modes::PhoneMode phoneMode);
+        bool isPopupAllowed() const noexcept;
+        bool isRingtoneAllowed() const noexcept;
+        bool isNumberCheckRequired() const noexcept;
+        void numberCheck(bool callsFromFavouritesSetting, bool isNumberInFavourites);
+
+      private:
+        bool popupOn;
+        bool ringtoneOn;
+        bool numberCheckNeeded;
+    };
+} // namespace notifications

--- a/module-apps/apps-common/notifications/policies/NotificationsListPolicy.cpp
+++ b/module-apps/apps-common/notifications/policies/NotificationsListPolicy.cpp
@@ -1,0 +1,37 @@
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "NotificationsListPolicy.hpp"
+
+using namespace notifications;
+
+void NotificationsListPolicy::updateCurrentList(sys::phone_modes::PhoneMode phoneMode,
+                                                bool isLocked,
+                                                bool lockedScreenNotificationSetting)
+{
+    updateAllowed  = true;
+    showWhenLocked = true;
+
+    switch (phoneMode) {
+    case sys::phone_modes::PhoneMode::DoNotDisturb:
+        showWhenLocked = lockedScreenNotificationSetting;
+        updateAllowed  = (isLocked && lockedScreenNotificationSetting) || (!isLocked);
+        break;
+    case sys::phone_modes::PhoneMode::Connected:
+        [[fallthrough]];
+    case sys::phone_modes::PhoneMode::Offline:
+        updateAllowed  = true;
+        showWhenLocked = true;
+        break;
+    }
+}
+
+bool NotificationsListPolicy::updateListAllowed() const noexcept
+{
+    return updateAllowed;
+}
+
+bool NotificationsListPolicy::showListWhenLocked() const noexcept
+{
+    return showWhenLocked;
+}

--- a/module-apps/apps-common/notifications/policies/NotificationsListPolicy.hpp
+++ b/module-apps/apps-common/notifications/policies/NotificationsListPolicy.hpp
@@ -1,0 +1,24 @@
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <PhoneNumber.hpp>
+#include <PhoneModes/Common.hpp>
+
+namespace notifications
+{
+    class NotificationsListPolicy
+    {
+      public:
+        void updateCurrentList(sys::phone_modes::PhoneMode phoneMode,
+                               bool isLocked,
+                               bool lockedScreenNotificationSetting);
+        bool updateListAllowed() const noexcept;
+        bool showListWhenLocked() const noexcept;
+
+      private:
+        bool showWhenLocked = true;
+        bool updateAllowed  = true;
+    };
+} // namespace notifications

--- a/module-apps/apps-common/popups/lock-popups/PhoneLockedWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/PhoneLockedWindow.cpp
@@ -12,7 +12,8 @@
 namespace gui
 {
     PhoneLockedWindow::PhoneLockedWindow(app::Application *app, const std::string &name)
-        : AppWindow(app, name), notificationsModel(std::make_shared<NotificationsModel>())
+        : AppWindow(app, name),
+          notificationsModel(std::make_shared<NotificationsModel>(NotificationsListPlacement::LockedScreen))
     {
         buildInterface();
 

--- a/module-apps/tests/CMakeLists.txt
+++ b/module-apps/tests/CMakeLists.txt
@@ -1,9 +1,10 @@
 add_catch2_executable(
     NAME
-        callback-storage-test
+        apps-common
     SRCS
         tests-main.cpp
         test-CallbackStorage.cpp
+        test-PhoneModesPolicies.cpp
     LIBS
         module-apps
 )

--- a/module-apps/tests/test-PhoneModesPolicies.cpp
+++ b/module-apps/tests/test-PhoneModesPolicies.cpp
@@ -1,0 +1,114 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <catch2/catch.hpp>
+
+#include "notifications/policies/CallNotificationPolicy.hpp"
+#include "notifications/policies/NotificationsListPolicy.hpp"
+
+using namespace notifications;
+
+TEST_CASE("Connected Mode notifications - calls policy test")
+{
+    CallNotificationPolicy callPolicy;
+
+    callPolicy.updateCurrentCall(sys::phone_modes::PhoneMode::Connected);
+    REQUIRE(callPolicy.isPopupAllowed());
+    REQUIRE(callPolicy.isRingtoneAllowed());
+    REQUIRE(!callPolicy.isNumberCheckRequired());
+}
+
+TEST_CASE("Connected Mode notifications - list policy test")
+{
+    NotificationsListPolicy listPolicy;
+
+    auto phoneLocked             = true;
+    auto notificationsWhenLocked = true;
+    listPolicy.updateCurrentList(sys::phone_modes::PhoneMode::Connected, phoneLocked, notificationsWhenLocked);
+    REQUIRE(listPolicy.updateListAllowed());
+    REQUIRE(listPolicy.showListWhenLocked());
+
+    phoneLocked             = true;
+    notificationsWhenLocked = false;
+    listPolicy.updateCurrentList(sys::phone_modes::PhoneMode::Connected, phoneLocked, notificationsWhenLocked);
+    REQUIRE(listPolicy.updateListAllowed());
+    REQUIRE(listPolicy.showListWhenLocked());
+
+    phoneLocked             = false;
+    notificationsWhenLocked = false;
+    listPolicy.updateCurrentList(sys::phone_modes::PhoneMode::Connected, phoneLocked, notificationsWhenLocked);
+    REQUIRE(listPolicy.updateListAllowed());
+    REQUIRE(listPolicy.showListWhenLocked());
+
+    phoneLocked             = false;
+    notificationsWhenLocked = true;
+    listPolicy.updateCurrentList(sys::phone_modes::PhoneMode::Connected, phoneLocked, notificationsWhenLocked);
+    REQUIRE(listPolicy.updateListAllowed());
+    REQUIRE(listPolicy.showListWhenLocked());
+}
+
+TEST_CASE("DoNotDisturb Mode notifications  - calls policy test")
+{
+    CallNotificationPolicy callPolicy;
+
+    callPolicy.updateCurrentCall(sys::phone_modes::PhoneMode::DoNotDisturb);
+    REQUIRE(!callPolicy.isPopupAllowed());
+    REQUIRE(!callPolicy.isRingtoneAllowed());
+    REQUIRE(callPolicy.isNumberCheckRequired());
+
+    SECTION("Number in/not in Favourites")
+    {
+        auto numberInFavourites   = true;
+        auto callsFromFavsAllowed = true;
+        callPolicy.numberCheck(callsFromFavsAllowed, numberInFavourites);
+        REQUIRE(callPolicy.isPopupAllowed());
+        REQUIRE(callPolicy.isRingtoneAllowed());
+
+        numberInFavourites   = true;
+        callsFromFavsAllowed = false;
+        callPolicy.numberCheck(callsFromFavsAllowed, numberInFavourites);
+        REQUIRE(!callPolicy.isPopupAllowed());
+        REQUIRE(!callPolicy.isRingtoneAllowed());
+
+        numberInFavourites   = false;
+        callsFromFavsAllowed = true;
+        callPolicy.numberCheck(callsFromFavsAllowed, numberInFavourites);
+        REQUIRE(!callPolicy.isPopupAllowed());
+        REQUIRE(!callPolicy.isRingtoneAllowed());
+
+        numberInFavourites   = false;
+        callsFromFavsAllowed = false;
+        callPolicy.numberCheck(callsFromFavsAllowed, numberInFavourites);
+        REQUIRE(!callPolicy.isPopupAllowed());
+        REQUIRE(!callPolicy.isRingtoneAllowed());
+    }
+}
+
+TEST_CASE("DoNotDisturb Mode notifications  - list policy test")
+{
+    NotificationsListPolicy listPolicy;
+
+    auto phoneLocked             = true;
+    auto notificationsWhenLocked = true;
+    listPolicy.updateCurrentList(sys::phone_modes::PhoneMode::DoNotDisturb, phoneLocked, notificationsWhenLocked);
+    REQUIRE(listPolicy.updateListAllowed());
+    REQUIRE(listPolicy.showListWhenLocked());
+
+    phoneLocked             = true;
+    notificationsWhenLocked = false;
+    listPolicy.updateCurrentList(sys::phone_modes::PhoneMode::DoNotDisturb, phoneLocked, notificationsWhenLocked);
+    REQUIRE(!listPolicy.updateListAllowed());
+    REQUIRE(!listPolicy.showListWhenLocked());
+
+    phoneLocked             = false;
+    notificationsWhenLocked = false;
+    listPolicy.updateCurrentList(sys::phone_modes::PhoneMode::DoNotDisturb, phoneLocked, notificationsWhenLocked);
+    REQUIRE(listPolicy.updateListAllowed());
+    REQUIRE(!listPolicy.showListWhenLocked());
+
+    phoneLocked             = false;
+    notificationsWhenLocked = true;
+    listPolicy.updateCurrentList(sys::phone_modes::PhoneMode::DoNotDisturb, phoneLocked, notificationsWhenLocked);
+    REQUIRE(listPolicy.updateListAllowed());
+    REQUIRE(listPolicy.showListWhenLocked());
+}

--- a/module-services/service-appmgr/data/NotificationsChangedActionsParams.cpp
+++ b/module-services/service-appmgr/data/NotificationsChangedActionsParams.cpp
@@ -7,11 +7,16 @@
 
 using namespace app::manager::actions;
 
-NotificationsChangedParams::NotificationsChangedParams(Notifications notifications)
-    : notifications{std::move(notifications)}
+NotificationsChangedParams::NotificationsChangedParams(Notifications notifications, bool showNotificationsWhenLocked)
+    : notifications{std::move(notifications)}, showWhenLocked{showNotificationsWhenLocked}
 {}
 
 auto NotificationsChangedParams::getNotifications() const noexcept -> const Notifications &
 {
     return notifications;
+}
+
+auto NotificationsChangedParams::showNotificationsWhenLocked() const noexcept -> bool
+{
+    return showWhenLocked;
 }

--- a/module-services/service-appmgr/service-appmgr/data/NotificationsChangedActionsParams.hpp
+++ b/module-services/service-appmgr/service-appmgr/data/NotificationsChangedActionsParams.hpp
@@ -17,11 +17,13 @@ namespace app::manager::actions
     {
       public:
         using Notifications = std::list<std::shared_ptr<const notifications::Notification>>;
-        explicit NotificationsChangedParams(Notifications notifications);
+        explicit NotificationsChangedParams(Notifications notifications, bool showWhenLocked);
 
         [[nodiscard]] auto getNotifications() const noexcept -> const Notifications &;
+        [[nodiscard]] auto showNotificationsWhenLocked() const noexcept -> bool;
 
       private:
         Notifications notifications;
+        const bool showWhenLocked;
     };
 } // namespace app::manager::actions

--- a/module-services/service-appmgr/service-appmgr/model/ApplicationManager.hpp
+++ b/module-services/service-appmgr/service-appmgr/model/ApplicationManager.hpp
@@ -35,6 +35,8 @@
 #include <notifications/NotificationProvider.hpp>
 #include <apps-common/locks/handlers/PhoneLockHandler.hpp>
 #include <apps-common/locks/handlers/SimLockHandler.hpp>
+#include <apps-common/notifications/NotificationsHandler.hpp>
+#include <apps-common/notifications/NotificationsConfiguration.hpp>
 
 namespace app
 {
@@ -174,17 +176,20 @@ namespace app::manager
         ApplicationName rootApplicationName;
         ActionsRegistry actionsRegistry;
         OnActionPolicy actionPolicy;
-        notifications::NotificationProvider notificationProvider;
 
         sys::TimerHandle autoLockTimer; //< auto-lock timer to count time from last user's activity.
                                         // If it reaches time defined in settings database application
                                         // manager is sending signal to Application Desktop in order to
                                         // lock screen.
         std::shared_ptr<settings::Settings> settings;
-        std::unique_ptr<sys::phone_modes::Observer> phoneModeObserver;
+        std::shared_ptr<sys::phone_modes::Observer> phoneModeObserver;
 
         locks::PhoneLockHandler phoneLockHandler;
         locks::SimLockHandler simLockHandler;
+
+        notifications::NotificationsConfiguration notificationsConfig;
+        notifications::NotificationsHandler notificationsHandler;
+        notifications::NotificationProvider notificationProvider;
 
         void displayLanguageChanged(std::string value);
         void lockTimeChanged(std::string value);

--- a/module-services/service-cellular/CellularServiceAPI.cpp
+++ b/module-services/service-cellular/CellularServiceAPI.cpp
@@ -47,6 +47,12 @@ bool CellularServiceAPI::HangupCall(sys::Service *serv)
     return true;
 }
 
+bool CellularServiceAPI::DismissCall(sys::Service *serv)
+{
+    auto msg = std::make_shared<CellularDismissCallMessage>();
+    return serv->bus.sendUnicast(msg, ServiceCellular::serviceName);
+}
+
 std::string CellularServiceAPI::GetIMSI(sys::Service *serv, bool getFullIMSINumber)
 {
 

--- a/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
+++ b/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
@@ -27,6 +27,7 @@ namespace CellularServiceAPI
 
     bool AnswerIncomingCall(sys::Service *serv);
     bool HangupCall(sys::Service *serv);
+    bool DismissCall(sys::Service *serv);
     /*
      * @brief Its calls sercive-cellular for selected SIM IMSI number.
      * @param serv pointer to caller service.

--- a/module-services/service-cellular/service-cellular/ServiceCellular.hpp
+++ b/module-services/service-cellular/service-cellular/ServiceCellular.hpp
@@ -269,6 +269,7 @@ class ServiceCellular : public sys::Service
     auto handleCellularAnswerIncomingCallMessage(CellularMessage *msg) -> std::shared_ptr<CellularResponseMessage>;
     auto handleCellularCallRequestMessage(CellularCallRequestMessage *msg) -> std::shared_ptr<CellularResponseMessage>;
     void handleCellularHangupCallMessage(CellularHangupCallMessage *msg);
+    void handleCellularDismissCallMessage(sys::Message *msg);
     auto handleDBQueryResponseMessage(db::QueryResponse *msg) -> std::shared_ptr<sys::ResponseMessage>;
     auto handleCellularListCallsMessage(CellularMessage *msg) -> std::shared_ptr<sys::ResponseMessage>;
     auto handleDBNotificatioMessage(db::NotificationMessage *msg) -> std::shared_ptr<sys::ResponseMessage>;
@@ -309,8 +310,6 @@ class ServiceCellular : public sys::Service
     auto handleCellularRingNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>;
     auto handleCellularCallerIdNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>;
     auto handleCellularSetConnectionFrequencyMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>;
-
-    auto isIncommingCallAllowed() -> bool;
 
     auto hangUpCall() -> bool;
     auto hangUpCallBusy() -> bool;

--- a/module-services/service-db/DBServiceAPI.cpp
+++ b/module-services/service-db/DBServiceAPI.cpp
@@ -90,6 +90,19 @@ auto DBServiceAPI::MatchContactByPhoneNumber(sys::Service *serv, const utils::Ph
     return std::move(contactResponse->contact);
 }
 
+auto DBServiceAPI::IsContactInFavourites(sys::Service *serv, const utils::PhoneNumber::View &numberView) -> bool
+{
+    auto msg = std::make_shared<DBContactNumberMessage>(numberView);
+
+    auto ret             = serv->bus.sendUnicastSync(std::move(msg), service::name::db, DefaultTimeoutInMs);
+    auto contactResponse = dynamic_cast<DBContactNumberResponseMessage *>(ret.second.get());
+    if (contactResponse == nullptr || contactResponse->retCode != sys::ReturnCodes::Success) {
+        LOG_ERROR("DB response error, return code: %s", c_str(ret.first));
+        return false;
+    }
+    return contactResponse->contact->isOnFavourites();
+}
+
 auto DBServiceAPI::verifyContact(sys::Service *serv, const ContactRecord &rec)
     -> DBServiceAPI::ContactVerificationResult
 {

--- a/module-services/service-db/service-db/DBServiceAPI.hpp
+++ b/module-services/service-db/service-db/DBServiceAPI.hpp
@@ -109,6 +109,7 @@ class DBServiceAPI
 
     static auto DBBackup(sys::Service *serv, std::string backupPath) -> bool;
 
+    static auto IsContactInFavourites(sys::Service *serv, const utils::PhoneNumber::View &numberView) -> bool;
     /**
      * @brief Add sms via DBService interface
      *


### PR DESCRIPTION
Add notifications for incoming calls in DND phone mode according to design. NotificationsGuard class introduced to provide quite complicated business logic which combines settings, contacts DB and phone lock state. https://appnroll.atlassian.net/wiki/spaces/MFP/pages/1409089537/EGD-6955+Notifications+on+incoming+call+-+DND+mode