### PR TITLE
[EGD-6970] Autolock default value

### DIFF
--- a/image/user/db/settings_v2_002.sql
+++ b/image/user/db/settings_v2_002.sql
@@ -15,7 +15,7 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('gs_active_sim', 'SIM1'),
     ('gs_lock_pass_hash', '3333'),
     ('gs_lock_screen_passcode_is_on', '1'),
-    ('gs_lock_time', '180'),
+    ('gs_lock_time', '30'),
     ('gs_display_language', 'English'),
     ('gs_input_language', 'English'),
     ('gs_eula_accepted', '0'),


### PR DESCRIPTION
Set autolock default value to 30 seconds.