### PR TITLE
[EGD-6979] Fix for "Unable to catch hard faults on rt1051 via GDB"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,8 @@ add_subdirectory(third-party)
 
 if (${PROJECT_TARGET} STREQUAL "TARGET_Linux")
     add_subdirectory(board/linux/libiosyscalls)
+elseif(${PROJECT_TARGET} STREQUAL "TARGET_RT1051")
+    add_subdirectory(board/rt1051)
 endif()
 
 add_subdirectory(source)

--- a/Target_RT1051.cmake
+++ b/Target_RT1051.cmake
@@ -68,7 +68,6 @@ set(TARGET_COMPILE_FEATURES
         CACHE INTERNAL "" )
 
 
-set_property(SOURCE ${CMAKE_CURRENT_LIST_DIR}/board/rt1051/crashdump/CrashCatcher_armv7m.S PROPERTY LANGUAGE C)
 set(TARGET_SOURCES
 
         ${CMAKE_CURRENT_LIST_DIR}/board/rt1051/_exit.c
@@ -78,7 +77,6 @@ set(TARGET_SOURCES
         ${CMAKE_CURRENT_LIST_DIR}/board/rt1051/xip/evkbimxrt1050_flexspi_nor_config.c
         ${CMAKE_CURRENT_LIST_DIR}/board/rt1051/xip/evkbimxrt1050_sdram_ini_dcd.c
         ${CMAKE_CURRENT_LIST_DIR}/board/rt1051/xip/fsl_flexspi_nor_boot.c
-        ${CMAKE_CURRENT_LIST_DIR}/board/rt1051/crashdump/CrashCatcher_armv7m.S
         ${CMAKE_CURRENT_LIST_DIR}/board/rt1051/crashdump/crashcatcher_impl.cpp
         ${CMAKE_CURRENT_LIST_DIR}/board/rt1051/crashdump/crashdumpwriter_vfs.cpp
         ${CMAKE_CURRENT_LIST_DIR}/board/rt1051/crashdump/consoledump.cpp

--- a/board/rt1051/CMakeLists.txt
+++ b/board/rt1051/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(CrashCatcherARM STATIC)
+
+target_sources(CrashCatcherARM
+    PRIVATE
+        crashdump/CrashCatcher_armv7m.S
+)
+
+set_source_files_properties(crashdump/CrashCatcher_armv7m.S PROPERTIES LANGUAGE C)
+
+target_link_libraries(CrashCatcherARM
+    PRIVATE
+        CrashCatcher::CrashCatcher
+)

--- a/products/PurePhone/CMakeLists.txt
+++ b/products/PurePhone/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(PurePhone
         messagetype
         "$<$<STREQUAL:${PROJECT_TARGET},TARGET_Linux>:iosyscalls>"
         "$<$<STREQUAL:${PROJECT_TARGET},TARGET_RT1051>:CrashCatcher::CrashCatcher>"
+        "$<$<STREQUAL:${PROJECT_TARGET},TARGET_RT1051>:CrashCatcherARM>"
     )
 
 target_link_options(PurePhone PUBLIC ${TARGET_LINK_OPTIONS})


### PR DESCRIPTION
`CrashCatcher_armv7m.S` wasn't properly linked to
`CrashCatcher::CrashCatcher`, which cause that HFs on rt1051
wasn't caught via GDB.
Added `CrashCatcherARM` library that solves
above issue.