### PR TITLE
[EGD-6986] Add Store timezone in settings db

### DIFF
--- a/image/user/db/settings_v2_002.sql
+++ b/image/user/db/settings_v2_002.sql
@@ -35,4 +35,6 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('\EventManager\\br_state', '0'),
     ('\EventManager\\br_auto_mode', '0'),
     ('\EventManager\\br_level', '50.0f'),
-    ('keypad_light_state', '0');
+    ('keypad_light_state', '0'),
+    ('gs_current_timezone', '');
+

--- a/module-services/service-db/agents/settings/SystemSettings.hpp
+++ b/module-services/service-db/agents/settings/SystemSettings.hpp
@@ -21,6 +21,7 @@ namespace settings
         constexpr inline auto eulaAccepted             = "gs_eula_accepted";
         constexpr inline auto osCurrentVersion         = "gs_os_current_version";
         constexpr inline auto osUpdateVersion          = "gs_os_update_version";
+        constexpr inline auto currentTimezone          = "gs_current_timezone";
     } // namespace SystemProperties
     namespace Bluetooth
     {

--- a/module-services/service-time/ServiceTime.hpp
+++ b/module-services/service-time/ServiceTime.hpp
@@ -42,7 +42,8 @@ namespace stm
         auto handleSetAutomaticTimezoneRequest(sys::Message *request) -> std::shared_ptr<sys::ResponseMessage>;
         auto handleSetTimeFormatRequest(sys::Message *request) -> std::shared_ptr<sys::ResponseMessage>;
         auto handleSetDateFormatRequest(sys::Message *request) -> std::shared_ptr<sys::ResponseMessage>;
-
+        auto handleSetTimezoneRequest(sys::Message *request) -> std::shared_ptr<sys::ResponseMessage>;
+        auto handleCellularTimeNotificationMessage(sys::Message *request) -> std::shared_ptr<sys::ResponseMessage>;
         void initStaticData();
 
       public:

--- a/module-services/service-time/TimeManager.cpp
+++ b/module-services/service-time/TimeManager.cpp
@@ -4,12 +4,10 @@
 #include <service-time/TimeManager.hpp>
 #include <service-time/TimezoneHandler.hpp>
 
-#include <chrono>
-#include "time.h"
+#include <ctime>
 
-void TimeManager::handleCellularTimeUpdate(struct tm time, std::chrono::minutes timezoneOffset)
+void TimeManager::handleCellularTimeUpdate(struct tm time, const std::string &timezone)
 {
-    auto timezone = TimezoneHandler(timezoneOffset).getTimezone();
     rtcCommand->setTime(time);
     rtcCommand->setTimezone(timezone);
 }
@@ -17,4 +15,9 @@ void TimeManager::handleCellularTimeUpdate(struct tm time, std::chrono::minutes 
 void TimeManager::handleTimeChangeRequest(const time_t &time)
 {
     rtcCommand->setTime(time);
+}
+
+void TimeManager::handleTimezoneChangeRequest(const std::string &timezone)
+{
+    rtcCommand->setTimezone(timezone);
 }

--- a/module-services/service-time/api/TimeSettingsApi.cpp
+++ b/module-services/service-time/api/TimeSettingsApi.cpp
@@ -31,4 +31,8 @@ namespace stm::api
     {
         return stm::internal::StaticData::get().getTimeFormat() == utils::time::Locale::TimeFormat::FormatTime12H;
     }
+    const std::string getCurrentTimezone()
+    {
+        return stm::internal::StaticData::get().getCurrentTimezone();
+    }
 } // namespace stm::api

--- a/module-services/service-time/api/TimeSettingsApi.hpp
+++ b/module-services/service-time/api/TimeSettingsApi.hpp
@@ -32,4 +32,9 @@ namespace stm::api
      * @return true when 12h format is set, false when 24h format is set
      */
     bool isTimeFormat12h();
+    /**
+     * Gets value corresponded to current timezone setting stored in DB
+     * @return current timezone
+     */
+    const std::string getCurrentTimezone();
 } // namespace stm::api

--- a/module-services/service-time/internal/StaticData.cpp
+++ b/module-services/service-time/internal/StaticData.cpp
@@ -51,5 +51,13 @@ namespace stm::internal
     {
         return timeFormat;
     }
+    void StaticData::setTimezone(const std::string &newTimezone)
+    {
+        timezone = newTimezone;
+    }
+    std::string StaticData::getCurrentTimezone() const
+    {
+        return timezone;
+    }
 
 } // namespace stm::internal

--- a/module-services/service-time/internal/StaticData.hpp
+++ b/module-services/service-time/internal/StaticData.hpp
@@ -17,6 +17,7 @@ namespace stm::internal
         bool isAutomaticTimezoneOn                 = false;
         utils::time::Locale::DateFormat dateFormat = utils::time::Locale::DateFormat::DD_MM_YYYY;
         utils::time::Locale::TimeFormat timeFormat = utils::time::Locale::TimeFormat::FormatTime12H;
+        std::string timezone;
 
         StaticData() = default;
 
@@ -68,5 +69,15 @@ namespace stm::internal
          * @return actual setting value
          */
         [[nodiscard]] utils::time::Locale::TimeFormat getTimeFormat() const noexcept;
+        /**
+         * Sets value corresponded to current Timezone setting
+         * @param timezone new timezone to set
+         */
+        void setTimezone(const std::string &newTimezone);
+        /**
+         * Gets value corresponded to current Timezone setting
+         * @retrun actual timezone setting
+         */
+        [[nodiscard]] std::string getCurrentTimezone() const;
     };
 } // namespace stm::internal

--- a/module-services/service-time/service-time/TimeManager.hpp
+++ b/module-services/service-time/service-time/TimeManager.hpp
@@ -6,7 +6,6 @@
 #include "RTCCommandInterface.hpp"
 
 #include <ctime>
-#include <chrono>
 
 class TimeManager
 {
@@ -22,14 +21,19 @@ class TimeManager
     /**
      * Handles GSM time update notification. Sets custom timezone.
      * @param time new UTC time
-     * @param timezoneOffset timezone offset related to UTC time
+     * @param timezone formatted timezone string
      */
-    void handleCellularTimeUpdate(const struct tm time, std::chrono::minutes timezoneOffset);
+    void handleCellularTimeUpdate(const struct tm time, const std::string &timezone);
     /**
      * Handles time change request.
      * @param time UTC time to set
      * **/
     void handleTimeChangeRequest(const time_t &time);
+    /**
+     * Handles timezone change request
+     * @param timezone formatted timezone string
+     */
+    void handleTimezoneChangeRequest(const std::string &timezone);
 
   private:
     std::unique_ptr<RTCCommandInterface> rtcCommand;

--- a/module-services/service-time/service-time/TimeMessage.hpp
+++ b/module-services/service-time/service-time/TimeMessage.hpp
@@ -182,4 +182,19 @@ namespace stm::message
       private:
         utils::time::Locale::DateFormat dateFormat;
     };
+
+    class SetTimezoneRequest : public sys::DataMessage
+    {
+      public:
+        explicit SetTimezoneRequest(const std::string &timezoneRules)
+            : sys::DataMessage(MessageType::MessageTypeUninitialized), timezone(timezoneRules)
+        {}
+        auto getTimezone() const -> std::string
+        {
+            return timezone;
+        }
+
+      private:
+        std::string timezone;
+    };
 } // namespace stm::message


### PR DESCRIPTION
Adds storing current timezone in settings database.
It allows to proper handling of timezone on system startup.