### PR TITLE
[EGD-6966] Fixed a switch from call window back

### DIFF
--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -84,6 +84,7 @@ namespace gui
             app::manager::Controller::switchBack(app,
                                                  std::make_unique<app::manager::SwitchBackRequest>(
                                                      application->GetName(), std::make_unique<SMSTemplateSent>()));
+            app->popCurrentWindow();
             return true;
         };
     }

--- a/module-services/service-appmgr/CMakeLists.txt
+++ b/module-services/service-appmgr/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES
     model/ApplicationsRegistry.cpp
     model/ActionsRegistry.cpp
     model/ApplicationStack.cpp
+    model/OnActionPolicy.cpp
     messages/ActionRequest.cpp
     messages/FinishRequest.cpp
     messages/ApplicationCloseRequest.cpp

--- a/module-services/service-appmgr/model/ApplicationManager.cpp
+++ b/module-services/service-appmgr/model/ApplicationManager.cpp
@@ -867,7 +867,8 @@ namespace app::manager
         // Inform that target app switch is caused by Action
         targetApp->startupReason = StartupReason::OnAction;
 
-        const auto focusedAppClose = !(actionParams && actionParams->disableAppClose);
+        const auto focusedAppClose = !(actionPolicy(action.actionId) == Reaction::KeepFocusedAppInBackground ||
+                                       (actionParams && actionParams->disableAppClose));
         SwitchRequest switchRequest(
             ServiceName, targetApp->name(), targetApp->switchWindow, std::move(targetApp->switchData));
         return handleSwitchApplication(&switchRequest, focusedAppClose) ? ActionProcessStatus::Accepted

--- a/module-services/service-appmgr/model/OnActionPolicy.cpp
+++ b/module-services/service-appmgr/model/OnActionPolicy.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <service-appmgr/model/OnActionPolicy.hpp>
+
+namespace app::manager
+{
+    Reaction OnActionPolicy::operator()(actions::Action action) const noexcept
+    {
+        if (action == actions::HandleIncomingCall) {
+            return Reaction::KeepFocusedAppInBackground;
+        }
+        return Reaction::None;
+    }
+} // namespace app::manager

--- a/module-services/service-appmgr/service-appmgr/model/ApplicationManager.hpp
+++ b/module-services/service-appmgr/service-appmgr/model/ApplicationManager.hpp
@@ -7,6 +7,7 @@
 #include "ApplicationsRegistry.hpp"
 #include "ActionsRegistry.hpp"
 #include "ApplicationStack.hpp"
+#include "OnActionPolicy.hpp"
 
 #include <apps-common/Application.hpp>
 #include <apps-common/ApplicationLauncher.hpp>
@@ -172,6 +173,7 @@ namespace app::manager
 
         ApplicationName rootApplicationName;
         ActionsRegistry actionsRegistry;
+        OnActionPolicy actionPolicy;
         notifications::NotificationProvider notificationProvider;
 
         sys::TimerHandle autoLockTimer; //< auto-lock timer to count time from last user's activity.

--- a/module-services/service-appmgr/service-appmgr/model/OnActionPolicy.hpp
+++ b/module-services/service-appmgr/service-appmgr/model/OnActionPolicy.hpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <service-appmgr/Actions.hpp>
+
+namespace app::manager
+{
+    enum class Reaction
+    {
+        None,
+        KeepFocusedAppInBackground
+    };
+
+    class OnActionPolicy
+    {
+      public:
+        Reaction operator()(actions::Action action) const noexcept;
+    };
+} // namespace app::manager


### PR DESCRIPTION
It was possible to enter phonebook even if the phone's locked.
Focused application is not killed on incoming call.