### PR TITLE
[EGD-7026] Fix nullptr calls and unlock behaviour

### DIFF
--- a/module-apps/apps-common/locks/handlers/PhoneLockHandler.cpp
+++ b/module-apps/apps-common/locks/handlers/PhoneLockHandler.cpp
@@ -57,9 +57,6 @@ namespace locks
 
     void PhoneLockHandler::phoneUnlockPopupsCloseAction()
     {
-        app::manager::Controller::sendAction(owner,
-                                             app::manager::actions::AbortPopup,
-                                             std::make_unique<gui::PopupRequestParams>(gui::popup::ID::PhoneLockInput));
         if (!isPhoneLocked()) {
             app::manager::Controller::sendAction(owner,
                                                  app::manager::actions::AbortPopup,
@@ -69,6 +66,10 @@ namespace locks
                 app::manager::actions::AbortPopup,
                 std::make_unique<gui::PopupRequestParams>(gui::popup::ID::PhoneLockInfo));
         }
+
+        app::manager::Controller::sendAction(owner,
+                                             app::manager::actions::AbortPopup,
+                                             std::make_unique<gui::PopupRequestParams>(gui::popup::ID::PhoneLockInput));
     }
 
     void PhoneLockHandler::phoneUnlockAction()

--- a/module-apps/apps-common/popups/lock-popups/PhoneLockedInfoWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/PhoneLockedInfoWindow.cpp
@@ -60,7 +60,6 @@ bool PhoneLockedInfoWindow::onInput(const InputEvent &inputEvent)
     // Pnd key = go to PIN code screen
     else if (inputEvent.isShortRelease(KeyCode::KEY_PND) && mStage == PhoneLockedInfoData::Stage::Waiting) {
         detachTimerIfExists();
-        application->returnToPreviousWindow();
         application->getPhoneLockSubject().unlock();
         return true;
     }

--- a/module-sys/Timers/TimerHandle.cpp
+++ b/module-sys/Timers/TimerHandle.cpp
@@ -2,6 +2,7 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TimerHandle.hpp"
+#include <module-utils/log/log.hpp>
 
 namespace sys
 {
@@ -44,17 +45,32 @@ namespace sys
 
     void TimerHandle::start()
     {
-        timer->start();
+        if (isValid()) {
+            timer->start();
+        }
+        else {
+            LOG_ERROR("Cannot start, null timer pointer");
+        }
     }
 
     void TimerHandle::stop()
     {
-        timer->stop();
+        if (isValid()) {
+            timer->stop();
+        }
+        else {
+            LOG_ERROR("Cannot stop, null timer pointer");
+        }
     }
 
     void TimerHandle::restart(std::chrono::milliseconds newInterval)
     {
-        timer->restart(newInterval);
+        if (isValid()) {
+            timer->restart(newInterval);
+        }
+        else {
+            LOG_ERROR("Cannot restart, null timer pointer");
+        }
     }
 
     bool TimerHandle::isActive() const noexcept


### PR DESCRIPTION
When unlocking there was unnecessary screen blink between unlock and PIN
code actions. Also nullptr calls removed from TimerHandle.