### PR TITLE
[EGD-6990] No autolock when battery is low

### DIFF
--- a/module-apps/application-desktop/windows/ChargingBatteryWindow.cpp
+++ b/module-apps/application-desktop/windows/ChargingBatteryWindow.cpp
@@ -21,6 +21,7 @@ namespace gui
         : AppWindow(app, app::window::name::dead_battery)
     {
         buildInterface();
+        preventsAutoLock = true;
     }
 
     void ChargingBatteryWindow::rebuild()

--- a/module-apps/application-desktop/windows/DeadBatteryWindow.cpp
+++ b/module-apps/application-desktop/windows/DeadBatteryWindow.cpp
@@ -21,6 +21,7 @@ namespace gui
     DeadBatteryWindow::DeadBatteryWindow(app::Application *app) : AppWindow(app, app::window::name::dead_battery)
     {
         buildInterface();
+        preventsAutoLock = true;
     }
 
     void DeadBatteryWindow::rebuild()


### PR DESCRIPTION
Prevent autolock actions on DeadBatteryWindow and ChargingBatteryWindow