### PR TITLE
[EGD-7048] Remove "Automatic time zone" from settings

### DIFF
--- a/module-apps/application-settings-new/windows/ChangeTimeZone.cpp
+++ b/module-apps/application-settings-new/windows/ChangeTimeZone.cpp
@@ -32,9 +32,10 @@ namespace gui
             options.emplace_back(std::make_unique<gui::option::OptionSettings>(
                 zone,
                 [=](const gui::Item &item) {
-                    application->bus.sendUnicast(
-                        std::make_shared<stm::message::SetTimezoneRequest>(extractTimeZoneName(zone)),
-                        service::name::service_time);
+                    selectedTimeZone = extractTimeZoneName(zone);
+                    application->bus.sendUnicast(std::make_shared<stm::message::SetTimezoneRequest>(selectedTimeZone),
+                                                 service::name::service_time);
+                    refreshOptionsList(setTimeZoneIndex());
                     return true;
                 },
                 nullptr,

--- a/module-apps/application-settings-new/windows/DateAndTimeMainWindow.cpp
+++ b/module-apps/application-settings-new/windows/DateAndTimeMainWindow.cpp
@@ -17,7 +17,6 @@ namespace gui
         setTitle(utils::translate("app_settings_date_and_time"));
 
         automaticDateAndTimeIsOn = stm::api::isAutomaticDateAndTime();
-        automaticTimeZoneIsOn    = stm::api::isAutomaticTimezone();
         timeFormat               = stm::api::timeFormat();
         dateFormat               = stm::api::dateFormat();
         changeDateAndTimeWindow  = window::name::change_date_and_time;
@@ -63,21 +62,6 @@ namespace gui
                 application->switchWindow(changeDateAndTimeWindow, nullptr);
                 return true;
             });
-        }
-
-        addSwitchOption(
-            utils::translate("app_settings_date_and_time_automatic_time_zone"),
-            [=](Item &item) {
-                automaticTimeZoneIsOn = !automaticTimeZoneIsOn;
-                application->bus.sendUnicast(
-                    std::make_shared<stm::message::SetAutomaticTimezoneRequest>(automaticDateAndTimeIsOn),
-                    service::name::service_time);
-                refreshOptionsList();
-                return true;
-            },
-            automaticTimeZoneIsOn ? option::SettingRightItem::On : option::SettingRightItem::Off);
-
-        if (!automaticTimeZoneIsOn) {
             addOption(utils::translate("app_settings_date_and_time_change_time_zone"), [=](Item &item) {
                 LOG_INFO("switching to %s page", window::name::change_time_zone);
                 application->switchWindow(window::name::change_time_zone, nullptr);

--- a/module-apps/application-settings-new/windows/DateAndTimeMainWindow.hpp
+++ b/module-apps/application-settings-new/windows/DateAndTimeMainWindow.hpp
@@ -18,7 +18,6 @@ namespace gui
         virtual bool bottomBarCallback(Item &item);
 
         bool automaticDateAndTimeIsOn = false;
-        bool automaticTimeZoneIsOn    = false;
 
         utils::time::Locale::TimeFormat timeFormat = utils::time::Locale::defaultTimeFormat;
         utils::time::Locale::DateFormat dateFormat = utils::time::Locale::defaultDateFormat;

--- a/module-services/service-db/agents/settings/SystemSettings.hpp
+++ b/module-services/service-db/agents/settings/SystemSettings.hpp
@@ -14,7 +14,6 @@ namespace settings
         constexpr inline auto displayLanguage          = "gs_display_language";
         constexpr inline auto inputLanguage            = "gs_input_language";
         constexpr inline auto automaticDateAndTimeIsOn = "gs_automatic_date_and_time_is_on";
-        constexpr inline auto automaticTimeZoneIsOn    = "gs_automatic_time_zone_is_on";
         constexpr inline auto timeFormat               = "gs_time_format";
         constexpr inline auto dateFormat               = "gs_date_format";
         constexpr inline auto onboardingDone           = "gs_onboarding_done";

--- a/module-services/service-time/ServiceTime.hpp
+++ b/module-services/service-time/ServiceTime.hpp
@@ -39,7 +39,6 @@ namespace stm
 
         void registerMessageHandlers();
         auto handleSetAutomaticDateAndTimeRequest(sys::Message *request) -> std::shared_ptr<sys::ResponseMessage>;
-        auto handleSetAutomaticTimezoneRequest(sys::Message *request) -> std::shared_ptr<sys::ResponseMessage>;
         auto handleSetTimeFormatRequest(sys::Message *request) -> std::shared_ptr<sys::ResponseMessage>;
         auto handleSetDateFormatRequest(sys::Message *request) -> std::shared_ptr<sys::ResponseMessage>;
         auto handleSetTimezoneRequest(sys::Message *request) -> std::shared_ptr<sys::ResponseMessage>;

--- a/module-services/service-time/api/TimeSettingsApi.cpp
+++ b/module-services/service-time/api/TimeSettingsApi.cpp
@@ -13,11 +13,6 @@ namespace stm::api
         return stm::internal::StaticData::get().getAutomaticDateAndTime();
     }
 
-    bool isAutomaticTimezone()
-    {
-        return stm::internal::StaticData::get().getAutomaticTimezone();
-    }
-
     utils::time::Locale::DateFormat dateFormat()
     {
         return stm::internal::StaticData::get().getDateFormat();

--- a/module-services/service-time/api/TimeSettingsApi.hpp
+++ b/module-services/service-time/api/TimeSettingsApi.hpp
@@ -13,11 +13,6 @@ namespace stm::api
      */
     bool isAutomaticDateAndTime();
     /**
-     * Gets value corresponded to current Automatic Timezone stored in DB
-     * @return actual setting value
-     */
-    bool isAutomaticTimezone();
-    /**
      * Gets value corresponded to current Time format stored in DB
      * @return actual setting value
      */

--- a/module-services/service-time/internal/StaticData.cpp
+++ b/module-services/service-time/internal/StaticData.cpp
@@ -22,16 +22,6 @@ namespace stm::internal
         return isAutomaticDateAndTimeOn;
     }
 
-    void StaticData::setAutomaticTimezoneOn(bool value)
-    {
-        isAutomaticTimezoneOn = value;
-    }
-
-    bool StaticData::getAutomaticTimezone() const noexcept
-    {
-        return isAutomaticTimezoneOn;
-    }
-
     void StaticData::setDateFormat(utils::time::Locale::DateFormat format)
     {
         dateFormat = format;

--- a/module-services/service-time/internal/StaticData.hpp
+++ b/module-services/service-time/internal/StaticData.hpp
@@ -14,7 +14,6 @@ namespace stm::internal
     {
       private:
         bool isAutomaticDateAndTimeOn              = false;
-        bool isAutomaticTimezoneOn                 = false;
         utils::time::Locale::DateFormat dateFormat = utils::time::Locale::DateFormat::DD_MM_YYYY;
         utils::time::Locale::TimeFormat timeFormat = utils::time::Locale::TimeFormat::FormatTime12H;
         std::string timezoneName;
@@ -40,16 +39,6 @@ namespace stm::internal
          * @return actual setting value
          */
         [[nodiscard]] bool getAutomaticDateAndTime() const noexcept;
-        /**
-         * ASets value corresponded to current Automatic Timezone setting
-         * @param value new setting value
-         */
-        void setAutomaticTimezoneOn(bool value);
-        /**
-         * Gets value corresponded to current Automatic Timezone setting
-         * @return actual setting value
-         */
-        [[nodiscard]] bool getAutomaticTimezone() const noexcept;
         /**
          * Sets value corresponded to current Date format setting
          * @param format new setting value

--- a/module-services/service-time/service-time/TimeMessage.hpp
+++ b/module-services/service-time/service-time/TimeMessage.hpp
@@ -141,20 +141,6 @@ namespace stm::message
         bool value;
     };
 
-    class SetAutomaticTimezoneRequest : public sys::DataMessage
-    {
-      public:
-        explicit SetAutomaticTimezoneRequest(const bool value)
-            : sys::DataMessage(MessageType::MessageTypeUninitialized), value(value){};
-        auto getValue() const -> bool
-        {
-            return value;
-        }
-
-      private:
-        bool value;
-    };
-
     class SetTimeFormatRequest : public sys::DataMessage
     {
       public:


### PR DESCRIPTION
From now on in the settings, instead of the two options:
"Automatic date and time", and "Automatic time zone"
there will be only the first one, which allows to
manually set the time and time zone.