### PR TITLE
[EGD-6697] Fix DateTime::isYesterday() tests

### DIFF
--- a/module-utils/time/test/unittest_time.cpp
+++ b/module-utils/time/test/unittest_time.cpp
@@ -266,6 +266,12 @@ TEST_CASE("DateTime")
                         newTimeTimeinfo.tm_mday = i;
                         auto newTime            = std::mktime(&newTimeTimeinfo);
                         DateTime datetime(timeSettings, newTime);
+
+                        if (currentTimeTimeinfo.tm_mday == 1 &&
+                            newTimeTimeinfo.tm_mon == currentTimeTimeinfo.tm_mon - 1) {
+                            continue;
+                        }
+
                         REQUIRE(!datetime.isYesterday());
                     }
                 }


### PR DESCRIPTION
Skip all days numbered 1 to avoid testing at month boundary.