### PR TITLE
[EGD-7081] Disconnect forgotten BT device

### DIFF
--- a/module-bluetooth/Bluetooth/CommandHandler.cpp
+++ b/module-bluetooth/Bluetooth/CommandHandler.cpp
@@ -158,7 +158,7 @@ namespace bluetooth
     Error::Code CommandHandler::unpair(uint8_t *addr)
     {
         LOG_INFO("Unpairing...");
-
+        profileManager->disconnect();
         return driver->unpair(addr) ? Error::Success : Error::LibraryError;
     }
 


### PR DESCRIPTION
The device has to be disconnected prior forgetting