### PR TITLE
[EGD-7091] Forgetting forgets incorrect BT device

### DIFF
--- a/module-apps/application-settings-new/windows/AllDevicesWindow.cpp
+++ b/module-apps/application-settings-new/windows/AllDevicesWindow.cpp
@@ -100,8 +100,8 @@ namespace gui
                           devices.end());
             bottomBar->setActive(BottomBar::Side::LEFT, false);
             bottomBar->setActive(BottomBar::Side::CENTER, false);
-            refreshOptionsList();
             bluetoothSettingsModel->requestDeviceUnpair(addressOfDeviceSelected);
+            refreshOptionsList();
             return true;
         }
         return AppWindow::onInput(inputEvent);


### PR DESCRIPTION
There was a bug in forgetting flow - before reqesting forgeting in the BT stack
the device has been removed from the internal list and the view has been
refreshed, thus actually focused device was different - then the address of
the selected device has been requested to unpairing