### PR TITLE
[CP-312] Add reboot to update function

### DIFF
--- a/module-bsp/board/linux/lpm/LinuxLPM.cpp
+++ b/module-bsp/board/linux/lpm/LinuxLPM.cpp
@@ -15,7 +15,7 @@ namespace bsp
         return 0;
     }
 
-    int32_t LinuxLPM::Reboot()
+    int32_t LinuxLPM::Reboot(RebootType)
     {
         return 0;
     }
@@ -31,7 +31,6 @@ namespace bsp
     }
 
     void LinuxLPM::SwitchOscillatorSource(bsp::LowPowerMode::OscillatorSource source)
-    {
-    }
+    {}
 
 } // namespace bsp

--- a/module-bsp/board/linux/lpm/LinuxLPM.h
+++ b/module-bsp/board/linux/lpm/LinuxLPM.h
@@ -13,7 +13,7 @@ namespace bsp
     {
       public:
         int32_t PowerOff() override final;
-        int32_t Reboot() override final;
+        int32_t Reboot(RebootType reason) override final;
         void SetCpuFrequency(CpuFrequencyHz freq) final;
         [[nodiscard]] uint32_t GetCpuFrequency() const noexcept final;
         void SwitchOscillatorSource(OscillatorSource source) final;

--- a/module-bsp/board/rt1051/bsp/lpm/RT1051LPM.cpp
+++ b/module-bsp/board/rt1051/bsp/lpm/RT1051LPM.cpp
@@ -39,8 +39,18 @@ namespace bsp
         return 0;
     }
 
-    int32_t RT1051LPM::Reboot()
+    int32_t RT1051LPM::Reboot(RebootType reason)
     {
+        constexpr uint32_t rebootToUpdaterCode{0xdeadbeaf};
+        constexpr uint32_t rebootNormalCode{0};
+        switch (reason) {
+        case RebootType::GoToUpdater:
+            SNVS->LPGPR[0] = rebootToUpdaterCode;
+            break;
+        case RebootType::NormalRestart:
+            SNVS->LPGPR[0] = rebootNormalCode;
+            break;
+        }
         NVIC_SystemReset();
         return 0;
     }

--- a/module-bsp/board/rt1051/bsp/lpm/RT1051LPM.hpp
+++ b/module-bsp/board/rt1051/bsp/lpm/RT1051LPM.hpp
@@ -15,7 +15,7 @@ namespace bsp
       public:
         RT1051LPM();
         int32_t PowerOff() override final;
-        int32_t Reboot() override final;
+        int32_t Reboot(RebootType reason) override final;
         void SetCpuFrequency(CpuFrequencyHz freq) final;
         [[nodiscard]] uint32_t GetCpuFrequency() const noexcept final;
         void SwitchOscillatorSource(OscillatorSource source) final;

--- a/module-bsp/bsp/lpm/bsp_lpm.hpp
+++ b/module-bsp/bsp/lpm/bsp_lpm.hpp
@@ -7,7 +7,8 @@
 #include <memory>
 #include <bsp/common.hpp>
 
-namespace bsp {
+namespace bsp
+{
 
     class LowPowerMode
     {
@@ -17,14 +18,18 @@ namespace bsp {
             External,
             Internal
         };
+        enum class RebootType {
+            NormalRestart,
+            GoToUpdater,
+        };
 
         LowPowerMode()          = default;
         virtual ~LowPowerMode() = default;
 
         static std::optional<std::unique_ptr<LowPowerMode>> Create();
 
-        virtual int32_t PowerOff() = 0;
-        virtual int32_t Reboot() = 0;
+        virtual int32_t PowerOff()              = 0;
+        virtual int32_t Reboot(RebootType reason) = 0;
 
         virtual void SetCpuFrequency(CpuFrequencyHz freq) = 0;
         [[nodiscard]] CpuFrequencyHz GetCurrentFrequencyLevel() const noexcept;
@@ -32,8 +37,7 @@ namespace bsp {
 
         virtual void SwitchOscillatorSource(OscillatorSource source) = 0;
 
-    protected:
+      protected:
         CpuFrequencyHz currentFrequency = CpuFrequencyHz::Level_6;
     };
 } // namespace bsp
-

--- a/module-sys/SystemManager/PowerManager.cpp
+++ b/module-sys/SystemManager/PowerManager.cpp
@@ -24,7 +24,12 @@ namespace sys
 
     int32_t PowerManager::Reboot()
     {
-        return lowPowerControl->Reboot();
+        return lowPowerControl->Reboot(bsp::LowPowerMode::RebootType::NormalRestart);
+    }
+
+    int32_t PowerManager::RebootToUpdate()
+    {
+        return lowPowerControl->Reboot(bsp::LowPowerMode::RebootType::GoToUpdater);
     }
 
     void PowerManager::UpdateCpuFrequency(uint32_t cpuLoad)
@@ -58,7 +63,7 @@ namespace sys
 
     void PowerManager::IncreaseCpuFrequency() const
     {
-        const auto freq      = lowPowerControl->GetCurrentFrequencyLevel();
+        const auto freq = lowPowerControl->GetCurrentFrequencyLevel();
 
         if (freq == bsp::CpuFrequencyHz::Level_1) {
             // switch osc source first

--- a/module-sys/SystemManager/PowerManager.hpp
+++ b/module-sys/SystemManager/PowerManager.hpp
@@ -26,6 +26,7 @@ namespace sys
 
         int32_t PowerOff();
         int32_t Reboot();
+        int32_t RebootToUpdate();
 
         /// called periodically to calculate the CPU requirement
         ///

--- a/module-sys/SystemManager/SystemManager.hpp
+++ b/module-sys/SystemManager/SystemManager.hpp
@@ -40,8 +40,8 @@ namespace sys
         inline constexpr auto restoreTimeout{5000};
     } // namespace constants
 
-    class PhoneModeRequest; // Forward declaration
-    class TetheringStateRequest; // Forward declaration
+    class PhoneModeRequest;         // Forward declaration
+    class TetheringStateRequest;    // Forward declaration
     class TetheringEnabledResponse; // Forward declaration
 
     enum class Code
@@ -50,6 +50,7 @@ namespace sys
         Update,
         Restore,
         Reboot,
+        RebootToUpdate,
         None,
     };
 
@@ -81,7 +82,8 @@ namespace sys
             Suspend,
             Shutdown,
             ShutdownReady,
-            Reboot
+            Reboot,
+            RebootToUpdate
         } state = State::Running;
 
         explicit SystemManager(std::vector<std::unique_ptr<BaseServiceCreator>> &&creators);
@@ -101,6 +103,8 @@ namespace sys
         static bool Restore(Service *s);
 
         static bool Reboot(Service *s);
+
+        static bool RebootToUpdate(Service *s);
 
         static void storeOsVersion(Service *s, const std::string &updateOSVer, const std::string &currentOSVer);
 
@@ -176,7 +180,7 @@ namespace sys
 
         void RestoreSystemHandler();
 
-        void RebootHandler();
+        void RebootHandler(State state);
 
         /// loop to handle prior to full system close
         /// for now for rt1051 we need to
@@ -234,6 +238,8 @@ inline const char *c_str(sys::SystemManager::State state)
         return "Shutdown";
     case sys::SystemManager::State::Reboot:
         return "Reboot";
+    case sys::SystemManager::State::RebootToUpdate:
+        return "RebootToUpdate";
     case sys::SystemManager::State::ShutdownReady:
         return "ShutdownReady";
     }


### PR DESCRIPTION
Because update procedure it is splitted to the two stages
downloading and update throught separate binary we need
to pass ecoboot special flag to request reboot to updater
bin after update procedure.
This patch adds this functionality to the PureOS

Signed-off-by: Lucjan Bryndza <lucjan.bryndza@mudita.com>