### PR TITLE
[EGD-7111] Restore calendarEvents endpoint number

### DIFF
--- a/module-services/service-desktop/parser/ParserUtils.hpp
+++ b/module-services/service-desktop/parser/ParserUtils.hpp
@@ -25,6 +25,7 @@ namespace parserFSM
         contacts,
         messages,
         calllog,
+        calendarEventsPlaceholder,
         developerMode,
         bluetooth,
         usbSecurity


### PR DESCRIPTION
Added dummy calendarEvents entry to restore EP numbering