### PR TITLE
[CP-264] Ensure bluetooth logging

### DIFF
--- a/module-bluetooth/Bluetooth/CommandHandler.cpp
+++ b/module-bluetooth/Bluetooth/CommandHandler.cpp
@@ -132,14 +132,16 @@ namespace bluetooth
 
     Error::Code CommandHandler::disconnectAudioConnection()
     {
+        LOG_INFO("Disconnecting audio");
         profileManager->disconnect();
         return Error::Success;
     }
     Error::Code CommandHandler::pair(bd_addr_t addr)
     {
         LOG_INFO("Pairing...");
-
-        return driver->pair(addr) ? Error::Success : Error::LibraryError;
+        const auto error_code = driver->pair(addr) ? Error::Success : Error::LibraryError;
+        LOG_INFO("Pairing result: %s", magic_enum::enum_name(error_code).data());
+        return error_code;
     }
     Error::Code CommandHandler::switchAudioProfile()
     {
@@ -161,7 +163,9 @@ namespace bluetooth
         if (profileManager->isAddressActuallyUsed(addr)) {
             profileManager->disconnect();
         }
-        return driver->unpair(addr) ? Error::Success : Error::LibraryError;
+        const auto error_code = driver->unpair(addr) ? Error::Success : Error::LibraryError;
+        LOG_INFO("Unpairing result: %s", magic_enum::enum_name(error_code).data());
+        return error_code;
     }
 
     Error::Code CommandHandler::availableDevices()


### PR DESCRIPTION
Add missing logs with required information:
- pairing result
- disconnecting bt device
Already logged and required:
- RSSI of scanned devices
- Controls state
- All other BT states