### PR TITLE
[EGD-7052] Unique window identifier

### DIFF
--- a/module-apps/apps-common/windows/AppWindow.cpp
+++ b/module-apps/apps-common/windows/AppWindow.cpp
@@ -275,4 +275,10 @@ namespace gui
         visitor.visit(*this);
     }
 
+    std::string AppWindow::getUniqueName()
+    {
+        constexpr auto separator = "/";
+        return application->GetName() + separator + getName();
+    }
+
 } /* namespace gui */

--- a/module-apps/apps-common/windows/AppWindow.hpp
+++ b/module-apps/apps-common/windows/AppWindow.hpp
@@ -69,6 +69,8 @@ namespace gui
             return application;
         };
 
+        std::string getUniqueName() override;
+
         virtual bool onDatabaseMessage(sys::Message *msg);
 
         bool updateSim();

--- a/module-gui/gui/dom/Item2JsonSerializingVisitor.cpp
+++ b/module-gui/gui/dom/Item2JsonSerializingVisitor.cpp
@@ -74,7 +74,7 @@ void Item2JsonSerializingVisitor::visit(gui::Window &item)
     if (itemName.empty()) {
         itemName = magic_enum::enum_name(visitor::Names::Window);
     }
-    sink.emplace(magic_enum::enum_name(visitor::Window::WindowName), std::string{item.getName()});
+    sink.emplace(magic_enum::enum_name(visitor::Window::WindowName), std::string{item.getUniqueName()});
     visit(static_cast<gui::Item &>(item));
 }
 

--- a/module-gui/gui/widgets/Window.hpp
+++ b/module-gui/gui/widgets/Window.hpp
@@ -67,10 +67,17 @@ namespace gui
 
         void buildDrawListImplementation(std::list<Command> &commands) override;
 
+        /// used for window switching purposes
         std::string getName()
         {
             return name;
         };
+
+        /// used for fetching unique name of window
+        virtual std::string getUniqueName()
+        {
+            return name;
+        }
     };
 
 } /* namespace gui */


### PR DESCRIPTION
Added application name identifier to the DOM JSON. From now, each JSON containing DOM will be easily distinguishable even if the applications use the same window names.

This solution seems the cleanest. There is also an option for prepending the 'WindowName' field with the application name. Unfortunately, it would require altering the JSON visitor class.

Please, check the generated test DOM.
[test_dom.txt](https://github.com/mudita/MuditaOS/files/6782068/test_dom.txt)


Filip, please could you check if such a solution satisfies your requirements?