### PR TITLE
[CP-315] Remove old fat only partition layout

### DIFF
--- a/module-vfs/src/purefs/vfs_subsystem.cpp
+++ b/module-vfs/src/purefs/vfs_subsystem.cpp
@@ -18,15 +18,16 @@ namespace purefs::subsystem
 {
     namespace
     {
-        constexpr auto default_blkdev_name = "emmc0";
+        constexpr auto default_blkdev_name      = "emmc0";
         constexpr auto default_nvrom_name       = "nvrom0";
-        constexpr auto fat_part_code         = 0x0b;
-        constexpr auto lfs_part_code         = 0x9e;
-        constexpr auto old_layout_part_count = 2;
-        constexpr auto new_layout_part_count = 3;
-        constexpr auto boot_size_limit       = 16384L;
-        constexpr auto block_size_max_shift  = 21;
-        constexpr auto block_size_min_shift  = 8;
+        constexpr auto fat_part_code            = 0x0b;
+        constexpr auto lfs_part_code            = 0x9e;
+        constexpr auto layout_part_count        = 3;
+        constexpr auto boot_part_index          = 0;
+        constexpr auto user_part_index          = 2;
+        constexpr auto boot_size_limit          = 16384L;
+        constexpr auto block_size_max_shift     = 21;
+        constexpr auto block_size_min_shift     = 8;
         constexpr uint32_t nvrom_lfs_block_size = 128U;
         namespace json
         {
@@ -147,8 +148,8 @@ namespace purefs::subsystem
             return {};
         }
 
-        g_disk_mgr   = disk_mgr;
-        g_fs_core    = fs_core;
+        g_disk_mgr = disk_mgr;
+        g_fs_core  = fs_core;
         return {disk_mgr, fs_core};
     }
 
@@ -169,52 +170,43 @@ namespace purefs::subsystem
             LOG_FATAL("Unable to lock disk");
             return -EIO;
         }
-        auto parts = disk->partitions(default_blkdev_name);
-        if (parts.size() != old_layout_part_count && parts.size() != new_layout_part_count) {
+        const auto parts = disk->partitions(default_blkdev_name);
+        if (parts.size() != layout_part_count) {
             LOG_FATAL("Unknown partitions layout part size is %u", unsigned(parts.size()));
             return -EIO;
         }
-        auto boot_it = std::end(parts);
-        auto lfs_it  = std::end(parts);
-        for (auto it = std::begin(parts); it != std::end(parts); ++it) {
-            if (it->bootable && boot_it == std::end(parts)) {
-                boot_it = it;
-            }
-            else if (it->type == lfs_part_code && lfs_it == std::end(parts)) {
-                lfs_it = it;
-            }
+        const auto &boot_part = parts[boot_part_index];
+        const auto &user_part = parts[user_part_index];
+        if (!boot_part.bootable) {
+            LOG_FATAL("First partition is not bootable");
+            return -EIO;
         }
-        bool vfat_ro = true;
-        if (lfs_it == std::end(parts) && parts.size() == old_layout_part_count) {
-            vfat_ro = false;
-            LOG_ERROR("!!!! Caution !!!! eMMC is formated with vFAT old layout scheme. Filesystem may be currupted on "
-                      "power loss.");
-            LOG_WARN("Please upgrade to new partition scheme based on the LittleFS filesystem.");
+        if (boot_part.type != fat_part_code) {
+            LOG_FATAL("Invalid boot partition type expected code: %i current code: %i", fat_part_code, boot_part.type);
+            return -EIO;
         }
-        if (boot_it == std::end(parts)) {
-            LOG_FATAL("Unable to find boot partition");
-            return -ENOENT;
+        if (user_part.type != lfs_part_code) {
+            LOG_FATAL("Invalid user partition type expected code: %i current code: %i", lfs_part_code, user_part.type);
+            return -EIO;
         }
         auto vfs = g_fs_core.lock();
         if (!vfs) {
             LOG_FATAL("Unable to lock vfs core");
             return -EIO;
         }
-        auto err = vfs->mount(
-            boot_it->name, purefs::dir::getRootDiskPath().string(), "vfat", vfat_ro ? fs::mount_flags::read_only : 0);
+        auto err =
+            vfs->mount(boot_part.name, purefs::dir::getRootDiskPath().string(), "vfat", fs::mount_flags::read_only);
         if (err) {
             return err;
         }
-        if (lfs_it != std::end(parts)) {
-            int lfs_block_log2           = read_mbr_lfs_erase_size(disk, default_blkdev_name, lfs_it->physical_number);
-            uint32_t lfs_block_size      = 0;
-            uint32_t *lfs_block_size_ptr = nullptr;
-            if (lfs_block_log2 >= block_size_min_shift && lfs_block_log2 <= block_size_max_shift) {
-                lfs_block_size     = 1U << lfs_block_log2;
-                lfs_block_size_ptr = &lfs_block_size;
-            }
-            err = vfs->mount(lfs_it->name, purefs::dir::getUserDiskPath().string(), "littlefs", 0, lfs_block_size_ptr);
+        const int lfs_block_log2     = read_mbr_lfs_erase_size(disk, default_blkdev_name, user_part.physical_number);
+        uint32_t lfs_block_size      = 0;
+        uint32_t *lfs_block_size_ptr = nullptr;
+        if (lfs_block_log2 >= block_size_min_shift && lfs_block_log2 <= block_size_max_shift) {
+            lfs_block_size     = 1U << lfs_block_log2;
+            lfs_block_size_ptr = &lfs_block_size;
         }
+        err = vfs->mount(user_part.name, purefs::dir::getUserDiskPath().string(), "littlefs", 0, lfs_block_size_ptr);
         const std::string json_file = (dir::getRootDiskPath() / file::boot_json).string();
         const auto boot_dir_name    = parse_boot_json_directory(json_file);
         const auto user_dir         = (dir::getRootDiskPath() / boot_dir_name).string();


### PR DESCRIPTION
Remove support for FAT only pattitions layout.
The fat only partition scheme support was needed
only in transition to the new VFS, now is not
longer required