### PR TITLE
[EGD-7108] Fix disconnecting all devices during unpairing

### DIFF
--- a/module-bluetooth/Bluetooth/CommandHandler.cpp
+++ b/module-bluetooth/Bluetooth/CommandHandler.cpp
@@ -158,7 +158,9 @@ namespace bluetooth
     Error::Code CommandHandler::unpair(uint8_t *addr)
     {
         LOG_INFO("Unpairing...");
-        profileManager->disconnect();
+        if (profileManager->isAddressActuallyUsed(addr)) {
+            profileManager->disconnect();
+        }
         return driver->unpair(addr) ? Error::Success : Error::LibraryError;
     }
 

--- a/module-bluetooth/Bluetooth/interface/profiles/ProfileManager.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/ProfileManager.cpp
@@ -123,4 +123,9 @@ namespace bluetooth
         profilesList[profileType]->setAudioDevice(device);
         return switchProfile(profileType);
     }
+    auto ProfileManager::isAddressActuallyUsed(bd_addr_t address) -> bool
+    {
+        return static_cast<bool>(bd_addr_cmp(address, remoteAddr));
+    }
+
 } // namespace bluetooth

--- a/module-bluetooth/Bluetooth/interface/profiles/ProfileManager.hpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/ProfileManager.hpp
@@ -42,6 +42,7 @@ namespace bluetooth
         auto startRinging() -> Error::Code;
         auto stopRinging() -> Error::Code;
         auto initializeCall() -> Error::Code;
+        auto isAddressActuallyUsed(bd_addr_t address) -> bool;
 
         auto setAudioDevice(std::shared_ptr<BluetoothAudioDevice> device) -> Error::Code;
 


### PR DESCRIPTION
Due to wrong logic, all devices were disconnecing during unparing
Now, the disconnecting is performed only when the unpaired devices
is the connected one