### PR TITLE
[EGD-7096] Add reaction after changing BT device name

### DIFF
--- a/module-apps/application-settings-new/windows/PhoneNameWindow.cpp
+++ b/module-apps/application-settings-new/windows/PhoneNameWindow.cpp
@@ -57,6 +57,7 @@ namespace gui
 
         if (inputEvent.isShortRelease(gui::KeyCode::KEY_ENTER) && !inputField->isEmpty()) {
             bluetoothSettingsModel->setDeviceName(inputField->getText());
+            application->returnToPreviousWindow();
             return true;
         }
 


### PR DESCRIPTION
There was no reaction after saving the BT name. Now phone returns
to the previous window