### PR TITLE
[CP-319] Extends reboot reason code

### DIFF
--- a/module-bsp/board/rt1051/bsp/lpm/RT1051LPM.cpp
+++ b/module-bsp/board/rt1051/bsp/lpm/RT1051LPM.cpp
@@ -41,11 +41,22 @@ namespace bsp
 
     int32_t RT1051LPM::Reboot(RebootType reason)
     {
-        constexpr uint32_t rebootToUpdaterCode{0xdeadbeaf};
-        constexpr uint32_t rebootNormalCode{0};
+        enum rebootCode : std::uint32_t
+        {
+            rebootNormalCode       = std::uint32_t{0},
+            rebootToUpdateCode     = std::uint32_t{0xdead0000},
+            rebootToRecoveryCode   = std::uint32_t{0xdead0001},
+            rebootToFactoryRstCode = std::uint32_t{0xdead0002}
+        };
         switch (reason) {
-        case RebootType::GoToUpdater:
-            SNVS->LPGPR[0] = rebootToUpdaterCode;
+        case RebootType::GoToUpdaterUpdate:
+            SNVS->LPGPR[0] = rebootToUpdateCode;
+            break;
+        case RebootType::GoToUpdaterRecovery:
+            SNVS->LPGPR[0] = rebootToRecoveryCode;
+            break;
+        case RebootType::GoToUpdaterFactoryReset:
+            SNVS->LPGPR[0] = rebootToFactoryRstCode;
             break;
         case RebootType::NormalRestart:
             SNVS->LPGPR[0] = rebootNormalCode;

--- a/module-bsp/bsp/lpm/bsp_lpm.hpp
+++ b/module-bsp/bsp/lpm/bsp_lpm.hpp
@@ -18,9 +18,12 @@ namespace bsp
             External,
             Internal
         };
-        enum class RebootType {
+        enum class RebootType
+        {
             NormalRestart,
-            GoToUpdater,
+            GoToUpdaterUpdate,       //! Goto updater into the update mode
+            GoToUpdaterFactoryReset, //! GOto updater into the factory reset mode
+            GoToUpdaterRecovery      //! Goto to updater into recovery mode
         };
 
         LowPowerMode()          = default;
@@ -28,7 +31,7 @@ namespace bsp
 
         static std::optional<std::unique_ptr<LowPowerMode>> Create();
 
-        virtual int32_t PowerOff()              = 0;
+        virtual int32_t PowerOff()                = 0;
         virtual int32_t Reboot(RebootType reason) = 0;
 
         virtual void SetCpuFrequency(CpuFrequencyHz freq) = 0;

--- a/module-sys/Service/Common.hpp
+++ b/module-sys/Service/Common.hpp
@@ -50,6 +50,14 @@ namespace sys
         LowBattery
     };
 
+    // Updater reason code
+    enum class UpdateReason
+    {
+        Update,
+        Recovery,
+        FactoryReset
+    };
+
 } // namespace sys
 
 inline const char *c_str(sys::ReturnCodes code)

--- a/module-sys/SystemManager/PowerManager.cpp
+++ b/module-sys/SystemManager/PowerManager.cpp
@@ -27,9 +27,18 @@ namespace sys
         return lowPowerControl->Reboot(bsp::LowPowerMode::RebootType::NormalRestart);
     }
 
-    int32_t PowerManager::RebootToUpdate()
+    int32_t PowerManager::RebootToUpdate(UpdateReason reason)
     {
-        return lowPowerControl->Reboot(bsp::LowPowerMode::RebootType::GoToUpdater);
+        switch (reason) {
+        case UpdateReason::FactoryReset:
+            return lowPowerControl->Reboot(bsp::LowPowerMode::RebootType::GoToUpdaterFactoryReset);
+        case UpdateReason::Recovery:
+            return lowPowerControl->Reboot(bsp::LowPowerMode::RebootType::GoToUpdaterRecovery);
+        case UpdateReason::Update:
+            return lowPowerControl->Reboot(bsp::LowPowerMode::RebootType::GoToUpdaterUpdate);
+        default:
+            return -1;
+        }
     }
 
     void PowerManager::UpdateCpuFrequency(uint32_t cpuLoad)

--- a/module-sys/SystemManager/PowerManager.hpp
+++ b/module-sys/SystemManager/PowerManager.hpp
@@ -26,7 +26,7 @@ namespace sys
 
         int32_t PowerOff();
         int32_t Reboot();
-        int32_t RebootToUpdate();
+        int32_t RebootToUpdate(UpdateReason reason);
 
         /// called periodically to calculate the CPU requirement
         ///

--- a/module-sys/SystemManager/SystemManager.hpp
+++ b/module-sys/SystemManager/SystemManager.hpp
@@ -63,16 +63,23 @@ namespace sys
     class SystemManagerCmd : public DataMessage
     {
       public:
-        explicit SystemManagerCmd(Code type = Code::None, CloseReason closeReason = CloseReason::RegularPowerDown)
-            : DataMessage(BusChannel::SystemManagerRequests), type(type), closeReason(closeReason)
+        explicit SystemManagerCmd(Code type                 = Code::None,
+                                  CloseReason closeReason   = CloseReason::RegularPowerDown,
+                                  UpdateReason updateReason = UpdateReason::Update)
+            : DataMessage(BusChannel::SystemManagerRequests), type(type), closeReason(closeReason),
+              updateReason(updateReason)
         {}
 
         Code type;
         CloseReason closeReason;
+        UpdateReason updateReason;
     };
 
     class SystemManager : public Service
     {
+      private:
+        UpdateReason updateReason{UpdateReason::Update};
+
       public:
         using InitFunction = std::function<bool()>;
 
@@ -104,7 +111,7 @@ namespace sys
 
         static bool Reboot(Service *s);
 
-        static bool RebootToUpdate(Service *s);
+        static bool RebootToUpdate(Service *s, UpdateReason updateReason);
 
         static void storeOsVersion(Service *s, const std::string &updateOSVer, const std::string &currentOSVer);
 
@@ -180,7 +187,7 @@ namespace sys
 
         void RestoreSystemHandler();
 
-        void RebootHandler(State state);
+        void RebootHandler(State state, std::optional<UpdateReason> updateReason = std::nullopt);
 
         /// loop to handle prior to full system close
         /// for now for rt1051 we need to


### PR DESCRIPTION
Extends reboot reason codes after reboot to updater
to detect updater command requests: Update, FactoryReset
and the Recovery.

Signed-off-by: Lucjan Bryndza <lucjan.bryndza@mudita.com>