### PR TITLE
[EGD-7097] Introduce BT name length limit

### DIFF
--- a/module-apps/application-settings-new/windows/PhoneNameWindow.cpp
+++ b/module-apps/application-settings-new/windows/PhoneNameWindow.cpp
@@ -43,9 +43,9 @@ namespace gui
 
     void PhoneNameWindow::onBeforeShow(ShowMode /*mode*/, SwitchData *data)
     {
-        inputField->clear();
         if (const auto newData = dynamic_cast<PhoneNameData *>(data); data != nullptr) {
             inputField->setText(newData->getName());
+            inputField->setTextLimitType(gui::TextLimitType::MaxSignsCount, maxNameLength);
         }
     }
 

--- a/module-apps/application-settings-new/windows/PhoneNameWindow.hpp
+++ b/module-apps/application-settings-new/windows/PhoneNameWindow.hpp
@@ -21,6 +21,8 @@ namespace gui
 
         Text *inputField = nullptr;
         std::unique_ptr<BluetoothSettingsModel> bluetoothSettingsModel;
+
+        static constexpr auto maxNameLength = 248; // Max 248 bytes according to Bluetooth Core Specification v5.2
     };
 
 } /* namespace gui */


### PR DESCRIPTION
There was no length limit for BT name which could cause crash
Now it's set to 248 bytes, according to the BT docs

Test with 10 bytes limit:

https://user-images.githubusercontent.com/23299649/124931947-f5016d80-e002-11eb-9b39-0c135d348b02.mp4

