### PR TITLE
[CP-326] Reformat recovery partition as littlefs

### DIFF
--- a/generate_image.sh
+++ b/generate_image.sh
@@ -74,16 +74,14 @@ label-id: 0x09650eb4
 unit: sectors
 
 /dev/sdx1 : start=    $PART1_START,  size=    $PART1_SIZE, type=b, bootable
-/dev/sdx2 : start=    $PART2_START,  size=    $PART2_SIZE, type=b
+/dev/sdx2 : start=    $PART2_START,  size=    $PART2_SIZE, type=9e
 /dev/sdx3 : start=    $PART3_START,  size=    $PART3_SIZE, type=9e
 ==sfdisk
 
 
 # Format FAT partitions
 PART1="$IMAGE_NAME@@$(($PART1_START * $DEVICE_BLK_SIZE))"
-PART2="$IMAGE_NAME@@$(($PART2_START * $DEVICE_BLK_SIZE))"
 mformat -i "$PART1" -F -T $PART1_SIZE -M $DEVICE_BLK_SIZE -v MUDITAOS
-mformat -i "$PART2" -F -T $PART2_SIZE -M $DEVICE_BLK_SIZE -v RECOVER
 
 if [ ! -d "$BUILDDIR/sys" ]; then
 	echo "Fatal! Image folder sys/ missing in build. Check build system."
@@ -120,9 +118,8 @@ mcopy -s -i "$PART1" .boot.json.crc32 ::
 
 #Littlefs generate image
 $GENLFS --image=$IMAGE_NAME --block_size=32768  --overwrite  --partition_num=3 -- user/*
+$GENLFS --image=$IMAGE_NAME --block_size=4096  --overwrite  --partition_num=2
 
 # back to previous dir
 cd -
 sync
-sleep 7
-

--- a/module-vfs/tests/unittest_filesystem_core.cpp
+++ b/module-vfs/tests/unittest_filesystem_core.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #define CATCH_CONFIG_MAIN
@@ -33,20 +33,20 @@ TEST_CASE("Corefs: Registering and unregistering block device")
     REQUIRE(vfs_vfat->mount_count() == 0);
     auto ret = fscore.register_filesystem("vfat", vfs_vfat);
     REQUIRE(ret == 0);
-    ret = fscore.mount("emmc0part1", "/sys", "vfat");
+    ret = fscore.mount("emmc0part0", "/sys", "vfat");
     REQUIRE(ret == 0);
     REQUIRE(vfs_vfat->mount_count() == 1);
     REQUIRE(fscore.umount("/ala") == -ENOENT);
-    ret = fscore.mount("emmc0part1", "/sys", "vfat");
+    ret = fscore.mount("emmc0part0", "/sys", "vfat");
     REQUIRE(ret == -EBUSY);
-    ret = fscore.mount("emmc0part1", "/path", "vfat");
+    ret = fscore.mount("emmc0part0", "/path", "vfat");
     REQUIRE(ret == -EBUSY);
     ret = fscore.mount("emmc0part2", "/path", "nonexisting_fs");
     REQUIRE(ret == -ENODEV);
     ret = fscore.umount("/sys");
     REQUIRE(ret == 0);
     REQUIRE(vfs_vfat->mount_count() == 0);
-    ret = fscore.mount("emmc0part1", "/path", "vfat");
+    ret = fscore.mount("emmc0part0", "/path", "vfat");
     REQUIRE(ret == 0);
     REQUIRE(vfs_vfat->mount_count() == 1);
     ret = fscore.umount("/path");


### PR DESCRIPTION
Recovery partition will be needed by update process for store and
process update data recovery etc
But using fat partition is due to
problem with power loss in not
recommended.
This patch change BACKUP partition to the LFS

NOTE: Please do not merge before ecoboot (bootloade)r changes announcement 