### PR TITLE
[BH-464] Fix make all

### DIFF
--- a/products/BellHybrid/CMakeLists.txt
+++ b/products/BellHybrid/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(BellHybrid)
 
-add_custom_target(Bell
+add_custom_target(Bell ALL
     DEPENDS BellHybrid BellHybrid.img
     )
 

--- a/products/PurePhone/CMakeLists.txt
+++ b/products/PurePhone/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(PurePhone)
 
-add_custom_target(Pure
+add_custom_target(Pure ALL
     DEPENDS PurePhone PurePhone.img
     )
 

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
 add_subdirectory(base64)
 add_subdirectory(date)
 add_subdirectory(fatfs)
@@ -16,9 +19,9 @@ add_subdirectory(re2)
 add_subdirectory(sml)
 add_subdirectory(taglib)
 add_subdirectory(tinyexpr)
-add_subdirectory(usb_stack)
 add_subdirectory(utz)
 
 if (${PROJECT_TARGET} STREQUAL "TARGET_RT1051")
     add_subdirectory(CrashDebug)
+    add_subdirectory(usb_stack)
 endif()


### PR DESCRIPTION
Fixed make all functionality, now it builds both products top
targets, made usb stack compile only in rt1051 builds (see also
a related issue raised by community)

Smoke tests: https://appnroll.atlassian.net/browse/EGDT-1166
Please run cellular smoke tests for me

Fixes #2334