### PR TITLE
[CP-215] Expose current operator name in service desktop API

### DIFF
--- a/module-services/service-cellular/CellularUrcHandler.cpp
+++ b/module-services/service-cellular/CellularUrcHandler.cpp
@@ -42,8 +42,9 @@ void CellularUrcHandler::Handle(Creg &urc)
                  utils::enumToString(status).c_str(),
                  utils::enumToString(accessTechnology).c_str());
 
-        Store::Network network{status, accessTechnology};
+        CellularServiceAPI::GetCurrentOperator(&cellularService);
 
+        Store::Network network{status, accessTechnology};
         Store::GSM::get()->setNetwork(network);
         response = std::make_unique<CellularNetworkStatusUpdateNotification>();
         urc.setHandled(true);

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -1757,7 +1757,9 @@ std::shared_ptr<CellularGetCurrentOperatorResponse> ServiceCellular::handleCellu
 {
     LOG_INFO("CellularGetCurrentOperator handled");
     NetworkSettings networkSettings(*this);
-    return std::make_shared<CellularGetCurrentOperatorResponse>(networkSettings.getCurrentOperator());
+    const auto currentNetworkOperatorName = networkSettings.getCurrentOperator();
+    Store::GSM::get()->setNetworkOperatorName(currentNetworkOperatorName);
+    return std::make_shared<CellularGetCurrentOperatorResponse>(currentNetworkOperatorName);
 }
 
 std::shared_ptr<CellularGetAPNResponse> ServiceCellular::handleCellularGetAPNMessage(CellularGetAPNMessage *msg)

--- a/module-services/service-desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
+++ b/module-services/service-desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
@@ -54,6 +54,7 @@ auto DeviceInfoEndpoint::getDeviceInfo(Context &context) -> bool
          {json::signalStrength, std::to_string(static_cast<int>(Store::GSM::get()->getSignalStrength().rssiBar))},
          {json::accessTechnology, std::to_string(static_cast<int>(Store::GSM::get()->getNetwork().accessTechnology))},
          {json::networkStatus, std::to_string(static_cast<int>(Store::GSM::get()->getNetwork().status))},
+         {json::networkOperatorName, Store::GSM::get()->getNetworkOperatorName()},
          {json::fsTotal, std::to_string(totalMbytes)},
          {json::fsFree, std::to_string(freeMbytes)},
          {json::fsFreePercent, std::to_string(freePercent)},

--- a/module-services/service-desktop/parser/ParserUtils.hpp
+++ b/module-services/service-desktop/parser/ParserUtils.hpp
@@ -79,44 +79,45 @@ namespace parserFSM
 
     namespace json
     {
-        inline constexpr auto batteryLevel     = "batteryLevel";
-        inline constexpr auto batteryState     = "batteryState";
-        inline constexpr auto selectedSim      = "selectedSim";
-        inline constexpr auto sim              = "sim";
-        inline constexpr auto trayState        = "trayState";
-        inline constexpr auto signalStrength   = "signalStrength";
-        inline constexpr auto fsTotal          = "fsTotal";
-        inline constexpr auto fsFreePercent    = "fsFreePercent";
-        inline constexpr auto fsFree           = "fsFree";
-        inline constexpr auto gitRevision      = "gitRevision";
-        inline constexpr auto gitBranch        = "gitBranch";
-        inline constexpr auto gitTag           = "gitTag";
-        inline constexpr auto currentRTCTime   = "currentRTCTime";
-        inline constexpr auto updateReady      = "updateReady";
-        inline constexpr auto updateFileList   = "updateFileList";
-        inline constexpr auto factoryRequest   = "factoryRequest";
-        inline constexpr auto networkStatus    = "networkStatus";
-        inline constexpr auto accessTechnology = "accessTechnology";
-        inline constexpr auto fileName         = "fileName";
-        inline constexpr auto fileSize         = "fileSize";
-        inline constexpr auto fileCrc32        = "fileCrc32";
-        inline constexpr auto update           = "update";
-        inline constexpr auto updateInfo       = "updateInfo";
-        inline constexpr auto updateError      = "updateError";
-        inline constexpr auto errorCode        = "errorCode";
-        inline constexpr auto statusCode       = "statusCode";
-        inline constexpr auto updateHistory    = "updateHistory";
-        inline constexpr auto versionString    = "string";
-        inline constexpr auto fileExists       = "fileExists";
-        inline constexpr auto version          = "version";
-        inline constexpr auto task             = "task";
-        inline constexpr auto state            = "state";
-        inline constexpr auto success          = "success";
-        inline constexpr auto request          = "request";
-        inline constexpr auto finished         = "finished";
-        inline constexpr auto pending          = "pending";
-        inline constexpr auto location         = "location";
-        inline constexpr auto reason           = "reason";
+        inline constexpr auto batteryLevel        = "batteryLevel";
+        inline constexpr auto batteryState        = "batteryState";
+        inline constexpr auto selectedSim         = "selectedSim";
+        inline constexpr auto sim                 = "sim";
+        inline constexpr auto trayState           = "trayState";
+        inline constexpr auto signalStrength      = "signalStrength";
+        inline constexpr auto fsTotal             = "fsTotal";
+        inline constexpr auto fsFreePercent       = "fsFreePercent";
+        inline constexpr auto fsFree              = "fsFree";
+        inline constexpr auto gitRevision         = "gitRevision";
+        inline constexpr auto gitBranch           = "gitBranch";
+        inline constexpr auto gitTag              = "gitTag";
+        inline constexpr auto currentRTCTime      = "currentRTCTime";
+        inline constexpr auto updateReady         = "updateReady";
+        inline constexpr auto updateFileList      = "updateFileList";
+        inline constexpr auto factoryRequest      = "factoryRequest";
+        inline constexpr auto networkStatus       = "networkStatus";
+        inline constexpr auto networkOperatorName = "networkOperatorName";
+        inline constexpr auto accessTechnology    = "accessTechnology";
+        inline constexpr auto fileName            = "fileName";
+        inline constexpr auto fileSize            = "fileSize";
+        inline constexpr auto fileCrc32           = "fileCrc32";
+        inline constexpr auto update              = "update";
+        inline constexpr auto updateInfo          = "updateInfo";
+        inline constexpr auto updateError         = "updateError";
+        inline constexpr auto errorCode           = "errorCode";
+        inline constexpr auto statusCode          = "statusCode";
+        inline constexpr auto updateHistory       = "updateHistory";
+        inline constexpr auto versionString       = "string";
+        inline constexpr auto fileExists          = "fileExists";
+        inline constexpr auto version             = "version";
+        inline constexpr auto task                = "task";
+        inline constexpr auto state               = "state";
+        inline constexpr auto success             = "success";
+        inline constexpr auto request             = "request";
+        inline constexpr auto finished            = "finished";
+        inline constexpr auto pending             = "pending";
+        inline constexpr auto location            = "location";
+        inline constexpr auto reason              = "reason";
 
         namespace filesystem
         {
@@ -139,7 +140,7 @@ namespace parserFSM
             {
                 inline constexpr auto fileDoesNotExist = "file does not exist";
             }
-        }     // namespace filesystem
+        } // namespace filesystem
 
         namespace updateprocess
         {
@@ -185,10 +186,10 @@ namespace parserFSM
 
         namespace usb
         {
-            inline constexpr auto config   = "config";
-            inline constexpr auto locked   = "locked";
-            inline constexpr auto unlocked = "unlocked";
-            inline constexpr auto security = "usbSecurity";
+            inline constexpr auto config        = "config";
+            inline constexpr auto locked        = "locked";
+            inline constexpr auto unlocked      = "unlocked";
+            inline constexpr auto security      = "usbSecurity";
             inline constexpr auto phoneLockCode = "phoneLockCode";
         } // namespace usb
 

--- a/module-utils/EventStore/EventStore.cpp
+++ b/module-utils/EventStore/EventStore.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "EventStore.hpp"
@@ -44,7 +44,6 @@ namespace Store
     SignalStrength GSM::getSignalStrength() const
     {
         cpp_freertos::LockGuard lock(mutex);
-
         return signalStrength;
     }
 
@@ -57,12 +56,22 @@ namespace Store
     Network GSM::getNetwork() const
     {
         cpp_freertos::LockGuard lock(mutex);
-
         return network;
     }
 
     bool GSM::simCardInserted()
     {
+        cpp_freertos::LockGuard lock(mutex);
         return (sim == SIM::SIM1 || sim == SIM::SIM2);
+    }
+    void GSM::setNetworkOperatorName(const std::string &newNetworkOperatorName)
+    {
+        cpp_freertos::LockGuard lock(mutex);
+        networkOperatorName = newNetworkOperatorName;
+    }
+    std::string GSM::getNetworkOperatorName() const
+    {
+        cpp_freertos::LockGuard lock(mutex);
+        return networkOperatorName;
     }
 }; // namespace Store

--- a/module-utils/EventStore/EventStore.hpp
+++ b/module-utils/EventStore/EventStore.hpp
@@ -11,6 +11,7 @@
 
 #include <cstddef>
 #include <service-cellular/api/common.hpp>
+#include <string>
 
 namespace cpp_freertos
 {
@@ -91,6 +92,7 @@ namespace Store
         GSM() = default;
         SignalStrength signalStrength;
         Network network;
+        std::string networkOperatorName;
 
         static cpp_freertos::MutexStandard mutex;
 
@@ -131,6 +133,9 @@ namespace Store
 
         void setNetwork(const Network &signalStrength);
         Network getNetwork() const;
+
+        void setNetworkOperatorName(const std::string &newNetworkOperatorName);
+        std::string getNetworkOperatorName() const;
 
         static GSM *get();
     };

--- a/test/pytest/service-desktop/test_device_info.py
+++ b/test/pytest/service-desktop/test_device_info.py
@@ -18,6 +18,7 @@ def test_device_info(harness):
     assert ret["body"]["signalStrength"] is not None
     assert ret["body"]["accessTechnology"] is not None
     assert ret["body"]["networkStatus"] is not None
+    assert ret["body"]["networkOperatorName"] is not None
     assert ret["body"]["fsTotal"] is not None
     assert ret["body"]["fsFree"] is not None
     assert 0 < int(ret["body"]["fsFreePercent"]) <= 100


### PR DESCRIPTION
Get current operator name from cellular modem,
and expose it in service desktop API to let
Mudtia Center use it.