### PR TITLE
[EGD-7141] Fix GUI googletest

### DIFF
--- a/module-gui/test/test-google/CMakeLists.txt
+++ b/module-gui/test/test-google/CMakeLists.txt
@@ -1,36 +1,15 @@
-project(googletest-gui)
-
-include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
-include_directories(${gmock_SOURCE_DIR}/include ${gmock_SOURCE_DIR})
-
-add_executable(${PROJECT_NAME} EXCLUDE_FROM_ALL
-        test-gui-listview.cpp
-        test-gui-boxlayout.cpp
-        test-gui-gridlayout.cpp
-        test-gui-depthfirst-itemtree.cpp
-        test-gui-visitor-call.cpp
-        test-gui-dom-dump.cpp
-        ../mock/TestListViewProvider.cpp
-        )
-
-target_include_directories(${PROJECT_NAME}
-        PUBLIC
-        "${CMAKE_CURRENT_LIST_DIR}"
-        "${CMAKE_SOURCE_DIR}/module-utils"
-        "${CMAKE_SOURCE_DIR}/module-gui/test/"
-        )
-
-target_link_directories(${PROJECT_NAME} PUBLIC "${PROJECT_LIB_DIRECTORY}")
-
-target_link_libraries(${PROJECT_NAME} PUBLIC module-utils module-gui)
-
-target_link_libraries(${PROJECT_NAME} PUBLIC gtest gtest_main)
-target_link_libraries(${PROJECT_NAME} PUBLIC gmock gmock_main)
-
-add_test(NAME ${PROJECT_NAME}
-        COMMAND ${PROJECT_NAME}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        )
-
-add_dependencies(check ${PROJECT_NAME})
-add_dependencies(unittests ${PROJECT_NAME})
+add_gtest_executable(
+        NAME
+                gui
+        SRCS
+                test-gui-listview.cpp
+                test-gui-boxlayout.cpp
+                test-gui-gridlayout.cpp
+                test-gui-depthfirst-itemtree.cpp
+                test-gui-visitor-call.cpp
+                test-gui-dom-dump.cpp
+                ../mock/TestListViewProvider.cpp
+        LIBS
+                module-utils
+                module-gui
+)

--- a/module-gui/test/test-google/TestBoxLayout.hpp
+++ b/module-gui/test/test-google/TestBoxLayout.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <module-gui/gui/widgets/BoxLayout.hpp>
+
+class TestBoxLayout : public gui::BoxLayout
+{
+
+  public:
+    friend class BoxLayoutTesting;
+
+    FRIEND_TEST(BoxLayoutTesting, Constructor_Destructor_Test);
+    FRIEND_TEST(BoxLayoutTesting, Fill_Box_Test);
+    FRIEND_TEST(BoxLayoutTesting, Navigate_Test);
+    FRIEND_TEST(BoxLayoutTesting, Border_Callback_Test);
+    FRIEND_TEST(BoxLayoutTesting, Box_Alignment_Test);
+    FRIEND_TEST(BoxLayoutTesting, Box_Widget_Min_Max_Resize_Test);
+    FRIEND_TEST(BoxLayoutTesting, Box_Widgets_Alignment_Test);
+    FRIEND_TEST(BoxLayoutTesting, Box_Widgets_Alignment_Magrin_Test);
+    FRIEND_TEST(BoxLayoutTesting, Box_Margins_Test);
+
+    TestBoxLayout(Item *parent, uint32_t x, uint32_t y, uint32_t w, uint32_t h) : BoxLayout(parent, x, y, w, h){};
+    ~TestBoxLayout() = default;
+};

--- a/module-gui/test/test-google/TestListView.hpp
+++ b/module-gui/test/test-google/TestListView.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <gui/widgets/ListView.hpp>
+
+class TestListView : public gui::ListView
+{
+
+  public:
+    friend class ListViewTesting;
+    FRIEND_TEST(ListViewTesting, Constructor_Destructor_Test);
+    FRIEND_TEST(ListViewTesting, Fill_List_And_Item_Magin_Test);
+    FRIEND_TEST(ListViewTesting, Not_Equal_Items_Test);
+    FRIEND_TEST(ListViewTesting, List_Clear_Test);
+    FRIEND_TEST(ListViewTesting, Scroll_Test);
+    FRIEND_TEST(ListViewTesting, Navigate_Test);
+    FRIEND_TEST(ListViewTesting, Continuous_Type_Test);
+    FRIEND_TEST(ListViewTesting, Data_Deletion_Test);
+    FRIEND_TEST(ListViewTesting, Rebuild_Type_Test);
+
+    bool listBorderReached = false;
+
+    bool requestNextPage() override
+    {
+        listBorderReached = true;
+        return ListView::requestNextPage();
+    }
+
+    bool requestPreviousPage() override
+    {
+        listBorderReached = true;
+        return ListView::requestPreviousPage();
+    }
+
+    TestListView(
+        Item *parent, uint32_t x, uint32_t y, uint32_t w, uint32_t h, std::shared_ptr<gui::ListItemProvider> prov)
+        : ListView(parent, x, y, w, h, prov){};
+    ~TestListView() = default;
+};

--- a/module-gui/test/test-google/test-gui-boxlayout.cpp
+++ b/module-gui/test/test-google/test-gui-boxlayout.cpp
@@ -2,8 +2,10 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "gtest/gtest.h"
+
+#include "TestBoxLayout.hpp"
+
 #include <log.hpp>
-#include <module-gui/gui/widgets/BoxLayout.hpp>
 #include <module-gui/test/mock/TestListViewProvider.hpp>
 #include <gui/input/InputEvent.hpp>
 
@@ -31,25 +33,6 @@ class TestItem : public gui::Rect
     unsigned int ID = 0;
     TestItem(Item *parent, uint32_t x, uint32_t y, uint32_t w, uint32_t h) : Rect(parent, x, y, w, h){};
     ~TestItem() = default;
-};
-
-class TestBoxLayout : public gui::BoxLayout
-{
-
-  public:
-    friend class BoxLayoutTesting;
-    FRIEND_TEST(BoxLayoutTesting, Constructor_Destructor_Test);
-    FRIEND_TEST(BoxLayoutTesting, Fill_Box_Test);
-    FRIEND_TEST(BoxLayoutTesting, Navigate_Test);
-    FRIEND_TEST(BoxLayoutTesting, Border_Callback_Test);
-    FRIEND_TEST(BoxLayoutTesting, Box_Alignment_Test);
-    FRIEND_TEST(BoxLayoutTesting, Box_Widget_Min_Max_Resize_Test);
-    FRIEND_TEST(BoxLayoutTesting, Box_Widgets_Alignment_Test);
-    FRIEND_TEST(BoxLayoutTesting, Box_Widgets_Alignment_Magrin_Test);
-    FRIEND_TEST(BoxLayoutTesting, Box_Margins_Test);
-
-    TestBoxLayout(Item *parent, uint32_t x, uint32_t y, uint32_t w, uint32_t h) : BoxLayout(parent, x, y, w, h){};
-    ~TestBoxLayout() = default;
 };
 
 class BoxLayoutTesting : public ::testing::Test

--- a/module-gui/test/test-google/test-gui-listview.cpp
+++ b/module-gui/test/test-google/test-gui-listview.cpp
@@ -2,45 +2,14 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "gtest/gtest.h"
-#include <module-gui/gui/widgets/ListView.hpp>
-#include <log.hpp>
-#include <mock/TestListViewProvider.hpp>
+
+#include "TestListView.hpp"
+
 #include <gui/input/InputEvent.hpp>
+#include <gui/widgets/ListView.hpp>
+#include <test/mock/TestListViewProvider.hpp>
 
-class TestListView : public gui::ListView
-{
-
-  public:
-    friend class ListViewTesting;
-    FRIEND_TEST(ListViewTesting, Constructor_Destructor_Test);
-    FRIEND_TEST(ListViewTesting, Fill_List_And_Item_Magin_Test);
-    FRIEND_TEST(ListViewTesting, Not_Equal_Items_Test);
-    FRIEND_TEST(ListViewTesting, List_Clear_Test);
-    FRIEND_TEST(ListViewTesting, Scroll_Test);
-    FRIEND_TEST(ListViewTesting, Navigate_Test);
-    FRIEND_TEST(ListViewTesting, Continuous_Type_Test);
-    FRIEND_TEST(ListViewTesting, Data_Deletion_Test);
-    FRIEND_TEST(ListViewTesting, Rebuild_Type_Test);
-
-    bool listBorderReached = false;
-
-    bool requestNextPage() override
-    {
-        listBorderReached = true;
-        return ListView::requestNextPage();
-    }
-
-    bool requestPreviousPage() override
-    {
-        listBorderReached = true;
-        return ListView::requestPreviousPage();
-    }
-
-    TestListView(
-        Item *parent, uint32_t x, uint32_t y, uint32_t w, uint32_t h, std::shared_ptr<gui::ListItemProvider> prov)
-        : ListView(parent, x, y, w, h, prov){};
-    ~TestListView() = default;
-};
+#include <log.hpp>
 
 class ListViewTesting : public ::testing::Test
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,11 +74,19 @@ function(add_gtest_executable)
     add_dependencies(unittests ${_TESTNAME})
     add_dependencies(check ${_TESTNAME})
 
+    set(_TEST_LABELS "")
     if(_TEST_ENTITY)
         add_dependencies(unittests-${_TEST_ENTITY} ${_TESTNAME})
+        list(APPEND _TEST_LABELS ${_TEST_ENTITY})
     endif()
 
-    gtest_add_tests(${_TESTNAME} "" AUTO)
+    gtest_add_tests(
+        TARGET ${_TESTNAME}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        TEST_LIST _TEST_LIST
+    )
+
+    set_tests_properties(${_TEST_LIST} PROPERTIES LABELS ${_TEST_ENTITY})
 endfunction()
 
 function(add_catch2_executable)


### PR DESCRIPTION
Fix invalidly added GUI gtest. Test dummies moved to individual files to
deal with a bug in cmake test discovery for gtest.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>
