### PR TITLE
[EGD-7145] Fix mp3 tags fetch

### DIFF
--- a/module-audio/Audio/decoder/Decoder.cpp
+++ b/module-audio/Audio/decoder/Decoder.cpp
@@ -42,7 +42,7 @@ namespace audio
     std::unique_ptr<Tags> Decoder::fetchTags()
     {
         if (fd) {
-            auto inPos = std::ftell(fd);
+            const auto inPos = std::ftell(fd);
             std::rewind(fd);
             TagLib::FileStream fileStream(fd);
             TagLib::FileRef tagReader(&fileStream);
@@ -64,8 +64,6 @@ namespace audio
                 tag->num_channel      = properties->channels();
                 tag->bitrate          = properties->bitrate();
             }
-            std::rewind(fd);
-            fetchTagsSpecific();
             std::fseek(fd, inPos, SEEK_SET);
         }
 

--- a/module-audio/Audio/decoder/Decoder.hpp
+++ b/module-audio/Audio/decoder/Decoder.hpp
@@ -120,7 +120,6 @@ namespace audio
 
       protected:
         virtual auto getBitWidth() -> unsigned int = 0;
-        virtual void fetchTagsSpecific(){};
 
         void convertmono2stereo(int16_t *pcm, uint32_t samplecount);
 

--- a/module-audio/Audio/decoder/decoderMP3.cpp
+++ b/module-audio/Audio/decoder/decoderMP3.cpp
@@ -41,28 +41,6 @@ namespace audio
         // position += (float) ((float) (samplesToReadChann / chanNumber) / (float) sampleRate);
     }
 
-    void decoderMP3::fetchTagsSpecific()
-    {
-
-        std::fseek(fd, firstValidFrameFileOffset + 4, SEEK_SET);
-        auto buff = std::make_unique<uint8_t[]>(firstValidFrameByteSize);
-
-        std::fread(buff.get(), 1, firstValidFrameByteSize, fd);
-
-        xing_info_t xinfo = {};
-        if (parseXingHeader(buff.get(), firstValidFrameByteSize, &xinfo)) {
-            // valid xing header found
-            tag->total_duration_s = xinfo.TotalFrames * (samplesPerFrame) / sampleRate;
-        }
-        else {
-            // Scan through whole file and count frames
-            uint32_t frames_count = get_frames_count();
-            tag->total_duration_s = frames_count * (samplesPerFrame) / sampleRate;
-        }
-
-        std::rewind(fd);
-    }
-
     bool decoderMP3::find_first_valid_frame()
     {
 

--- a/module-audio/Audio/decoder/decoderMP3.hpp
+++ b/module-audio/Audio/decoder/decoderMP3.hpp
@@ -26,7 +26,6 @@ namespace audio
         void setPosition(float pos) override;
 
       private:
-        void fetchTagsSpecific() override;
         auto getBitWidth() -> unsigned int override;
 
         bool find_first_valid_frame();


### PR DESCRIPTION
Fixed problem with some mp3 files which wasn't available in the list
of tracks. Issue was occuring due to the large buffer allocation.