### PR TITLE
[EGD-7149] Fix connecting BT devices

### DIFF
--- a/module-bluetooth/Bluetooth/Device.hpp
+++ b/module-bluetooth/Bluetooth/Device.hpp
@@ -36,7 +36,7 @@ namespace TYPE_OF_SERVICE
     inline constexpr uint32_t INFORMATION     = 0x00800000;
 
     ///> At least one of this class has to be supported by remote device in order to establish connection
-    inline constexpr uint32_t REMOTE_SUPPORTED_SERVICES = (AUDIO | POSITIONING);
+    inline constexpr uint32_t REMOTE_SUPPORTED_SERVICES = (AUDIO | POSITIONING | RENDERING);
 
 } // namespace TYPE_OF_SERVICE
 

--- a/module-bluetooth/Bluetooth/interface/profiles/GAP/GAP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/GAP/GAP.cpp
@@ -176,6 +176,7 @@ namespace bluetooth
             return; // already in our list
         }
         uint32_t classOfDevice = gap_event_inquiry_result_get_class_of_device(packet);
+        LOG_INFO("Device CoD: %" PRIx32 "", classOfDevice);
         ///> Device has to support services: AUDIO for HFP and HSP profiles, and RENDERING for SNK of A2DP profile
         if (!(classOfDevice & TYPE_OF_SERVICE::REMOTE_SUPPORTED_SERVICES)) {
             LOG_INFO("Ignoring device with incompatible services: %s, ",
@@ -294,15 +295,6 @@ namespace bluetooth
         ownerService->bus.sendUnicast(
             std::make_shared<message::bluetooth::UnpairResult>(std::move(unpairedDevAddr), true), app::name_settings);
         return true;
-    }
-    auto GAP::isServiceSupportedByRemote(bd_addr_t addr, uint32_t typeOfService) -> bool
-    {
-        for (const auto &device : devices) {
-            if (bd_addr_cmp(device.address, addr) == 0) {
-                return (device.classOfDevice & typeOfService);
-            }
-        }
-        return false;
     }
     void GAP::respondPinCode(const std::string &pin)
     {

--- a/module-bluetooth/Bluetooth/interface/profiles/ProfileManager.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/ProfileManager.cpp
@@ -38,23 +38,13 @@ namespace bluetooth
     auto ProfileManager::connect(bd_addr_t address) -> Error::Code
     {
         bd_addr_copy(remoteAddr, address);
-        ///> connect to remote only if we are sure that remote side supports our profiles
-        if (GAP::isServiceSupportedByRemote(address, TYPE_OF_SERVICE::RENDERING)) {
-            auto profilePtr = profilesList[AudioProfile::A2DP].get();
-            if (profilePtr != nullptr) {
-                LOG_DEBUG("Connecting device to A2DP");
-                profilePtr->setDeviceAddress(remoteAddr);
-                profilePtr->connect();
+        for (auto &[profileName, ptr] : profilesList) {
+            if (ptr != nullptr) {
+                ptr->setDeviceAddress(remoteAddr);
+                ptr->connect();
             }
         }
-        if (GAP::isServiceSupportedByRemote(address, TYPE_OF_SERVICE::AUDIO)) {
-            auto profilePtr = profilesList[AudioProfile::HSP].get();
-            if (profilePtr != nullptr) {
-                LOG_DEBUG("Connecting device to HSP");
-                profilePtr->setDeviceAddress(remoteAddr);
-                profilePtr->connect();
-            }
-        }
+
         return Error::Success;
     }
 


### PR DESCRIPTION
Some devices were giving different results after querying for
Class of Device (CoD) and our filters were too restrictive.

Now filtering only take place at pairing, so every suitable
device can be connected