### PR TITLE
BugFix: add search path for genlittlefs

### DIFF
--- a/generate_image.sh
+++ b/generate_image.sh
@@ -49,7 +49,7 @@ if [ ! $MTOOLS_OK ]; then
 	exit -1
 fi
 
-SDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd && echo $BUILDDIR )"
 GENLFS=$(find $SDIR -type f -iname genlittlefs -executable -print -quit)
 if [ -z ${GENLFS} ]; then
     echo "Error: Unable to find genlilttlefs..."


### PR DESCRIPTION
When using an external build directory, I would get
> Error: Unable to find genlilttlefs...

Mine was located in `$BUILDDIR` so I just added that to the list of searched paths.