### PR TITLE
Fix script name spelling error

### DIFF
--- a/eepromgen.sh
+++ b/eepromgen.sh
@@ -25,7 +25,7 @@ IMAGE_NAME=$(realpath "$1")
 #Find genlittlefs tool
 GENLFS=$(find $SDIR -type f -iname genlittlefs -executable -print -quit)
 if [ -z ${GENLFS} ]; then
-    echo "Error: Unable to find genlilttlefs..."
+    echo "Error: Unable to find genlittlefs..."
     exit 1
 fi
 

--- a/flash_emmc_experimental_littlefs.sh
+++ b/flash_emmc_experimental_littlefs.sh
@@ -64,7 +64,7 @@ fi
 SDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 GENLFS=$(find $SDIR -type f -iname genlittlefs -executable -print -quit)
 if [ -z ${GENLFS} ]; then
-    echo "Unable to find genlilttlefs..."
+    echo "Unable to find genlittlefs..."
     exit -1
 fi
 

--- a/host-tools/genlittlefs/parse_args.c
+++ b/host-tools/genlittlefs/parse_args.c
@@ -88,7 +88,7 @@ static void help(const char *name)
                                     "general options:\n"
                                     "    -h   --help              print help\n"
                                     "\n"
-                                    "genlilttlefs options:\n"
+                                    "genlittlefs options:\n"
                                     "    -i   --image             partition file image\n"
                                     "    -b   --block_size        logical block size, overrides the block device\n"
                                     "    -s   --filesystem_size   filesystem size when creating the new file\n"


### PR DESCRIPTION
When using an external build directory, I would receive the following error message before the script exited.
> Error: Unable to find genlilttlefs...

Appending `$BUILDDIR` to the list of searched paths resolved this error.

Additionally, this corrects the spelling from `genlilttlefs` to the proper `genlittlefs` in multiple locations.