### PR TITLE
[CP-211] Prevent autolocking just before OS update start

### DIFF
--- a/module-services/service-desktop/endpoints/update/UpdateEndpoint.cpp
+++ b/module-services/service-desktop/endpoints/update/UpdateEndpoint.cpp
@@ -7,7 +7,8 @@
 #include <service-desktop/DesktopMessages.hpp>
 #include <service-desktop/ServiceDesktop.hpp>
 #include <endpoints/Context.hpp>
-#include <endpoints/messages/MessageHelper.hpp>
+#include <service-appmgr/messages/PreventBlockingRequest.hpp>
+#include <service-appmgr/model/ApplicationManager.hpp>
 
 #include <json11.hpp>
 #include <purefs/filesystem_paths.hpp>
@@ -21,9 +22,11 @@ auto UpdateEndpoint::handle(Context &context) -> void
 {
     switch (context.getMethod()) {
     case http::Method::post:
+        preventBlockingDevice();
         run(context);
         break;
     case http::Method::get:
+        preventBlockingDevice();
         getUpdates(context);
         break;
     default:
@@ -103,4 +106,10 @@ auto UpdateEndpoint::getUpdates(Context &context) -> sys::ReturnCodes
     MessageHandler::putToSendQueue(context.createSimpleResponse());
 
     return sys::ReturnCodes::Success;
+}
+
+void UpdateEndpoint::preventBlockingDevice()
+{
+    auto msg = std::make_shared<app::manager::PreventBlockingRequest>(service::name::service_desktop);
+    ownerServicePtr->bus.sendUnicast(std::move(msg), app::manager::ApplicationManager::ServiceName);
 }

--- a/module-services/service-desktop/endpoints/update/UpdateEndpoint.hpp
+++ b/module-services/service-desktop/endpoints/update/UpdateEndpoint.hpp
@@ -31,4 +31,7 @@ class UpdateEndpoint : public parserFSM::Endpoint
     auto handle(parserFSM::Context &context) -> void override;
     auto run(parserFSM::Context &context) -> sys::ReturnCodes;
     auto getUpdates(parserFSM::Context &context) -> sys::ReturnCodes;
+
+  private:
+    void preventBlockingDevice();
 };


### PR DESCRIPTION
Phone could be autolocked just before OS update
process, if autolock time was set below 30 seconds.