### PR TITLE
[EGD-7099] Fix text backspace long press

### DIFF
--- a/module-gui/gui/widgets/Text.cpp
+++ b/module-gui/gui/widgets/Text.cpp
@@ -265,6 +265,10 @@ namespace gui
             debug_text("handleBackspace");
             return true;
         }
+        if (handleWholeTextRemoval(evt)) {
+            debug_text("handleLongBackspace");
+            return true;
+        }
         if (handleAddChar(evt)) {
             debug_text("handleAddChar");
             return true;
@@ -548,6 +552,20 @@ namespace gui
                 onTextChanged();
             }
             return true;
+        }
+        return false;
+    }
+
+    bool Text::handleWholeTextRemoval(const InputEvent &inputEvent)
+    {
+        if (!isMode(EditMode::Edit)) {
+            return false;
+        }
+        if (inputEvent.isLongRelease(key_signs_remove)) {
+            if (!document->isEmpty()) {
+                clear();
+                return true;
+            }
         }
         return false;
     }

--- a/module-gui/gui/widgets/Text.hpp
+++ b/module-gui/gui/widgets/Text.hpp
@@ -87,6 +87,7 @@ namespace gui
         auto handleActivation(const InputEvent &inputEvent) -> bool;
         auto handleNavigation(const InputEvent &inputEvent) -> bool;
         auto handleRemovalChar(const InputEvent &inputEvent) -> bool;
+        auto handleWholeTextRemoval(const InputEvent &inputEvent) -> bool;
         auto handleDigitLongPress(const InputEvent &inputEvent) -> bool;
         auto handleAddChar(const InputEvent &inputEvent) -> bool;
 

--- a/module-gui/test/test-catch-text/test-gui-Text.cpp
+++ b/module-gui/test/test-catch-text/test-gui-Text.cpp
@@ -237,6 +237,28 @@ TEST_CASE("handle longpress for digit in ABC mode")
     REQUIRE(str == text.getText());
 }
 
+TEST_CASE("Handle backspace longpress")
+{
+    auto text          = gui::TestText();
+    auto key_backspace = gui::InputEvent({}, gui::InputEvent::State::keyReleasedLong, gui::KeyCode::KEY_PND);
+    text.setInputMode(new InputMode({InputMode::ABC}));
+
+    SECTION("Empty text")
+    {
+        REQUIRE(text.getText().empty());
+        auto input_handled = text.onInput(key_backspace);
+        REQUIRE(input_handled == false);
+    }
+
+    SECTION("Not empty text")
+    {
+        text.addText("test");
+        REQUIRE(text.getText() == "test");
+        text.onInput(key_backspace);
+        REQUIRE(text.getText().empty());
+    }
+}
+
 TEST_CASE("handle text expand")
 {
     mockup::fontManager();


### PR DESCRIPTION
This commit fixes behavior of text field backspace long press when focusing text field.

Added behavior:
1. If there is text in the field, first long release deletes all text. 
2. If there is no text, long release locks the phone.