### PR TITLE
[EGD-7199] Switch weekly releases to T6

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -40,7 +40,7 @@ jobs:
       run: |
         export JOBS=${JOBS:-$(nproc)} && \
         echo "JOBS=${JOBS}" &&  \
-        ./configure.sh rt1051 RelWithDebInfo -G Ninja && \
+        ./configure.sh rt1051 RelWithDebInfo -DPURE_HW_TARGET=T6 -G Ninja && \
         pushd build-rt1051-RelWithDebInfo && \
         ninja -j ${JOBS} Pure&& \
         ninja -j ${JOBS} PurePhone-UpdatePackage && \


### PR DESCRIPTION
We want weekly releases to be built for T6 hardware, while daily for T7.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>
