### PR TITLE
[EGD-7163] Disable auto locking when playing music

### DIFF
--- a/module-apps/application-music-player/ApplicationMusicPlayer.cpp
+++ b/module-apps/application-music-player/ApplicationMusicPlayer.cpp
@@ -32,6 +32,14 @@ namespace app
             handleStopResponse(msg);
             return sys::MessageNone{};
         });
+
+        std::function<bool()> stateLockCallback = [this]() -> bool {
+            if (isTrackPlaying) {
+                LOG_DEBUG("Preventing autolock while playing track.");
+            }
+            return isTrackPlaying;
+        };
+        lockPolicyHandler.setPreventsAutoLockByStateCallback(std::move(stateLockCallback));
     }
 
     void ApplicationMusicPlayer::handlePlayResponse(sys::Message *msg)

--- a/module-apps/application-music-player/include/application-music-player/ApplicationMusicPlayer.hpp
+++ b/module-apps/application-music-player/include/application-music-player/ApplicationMusicPlayer.hpp
@@ -68,7 +68,8 @@ namespace app
     {
         static auto GetManifest() -> manager::ApplicationManifest
         {
-            return {{manager::actions::Launch, manager::actions::PhoneModeChanged}};
+            return {{manager::actions::Launch, manager::actions::PhoneModeChanged},
+                    locks::AutoLockPolicy::DetermineByAppState};
         }
     };
 } /* namespace app */


### PR DESCRIPTION
When Music Player app is playing a track the phone should not be auto
locked.