### PR TITLE
[EGD-7204] Set msp register and clear IRQ flags

### DIFF
--- a/module-bsp/board/rt1051/common/startup_mimxrt1052.cpp
+++ b/module-bsp/board/rt1051/common/startup_mimxrt1052.cpp
@@ -701,6 +701,11 @@ __attribute__((section(".after_vectors.reset"))) void ResetISR(void)
     // Disable interrupts
     __asm volatile("cpsid i");
 
+    // set msp register to point to stack top & invalidete caches
+    __set_MSP((uint32_t)g_pfnVectors[0]);
+    __DSB();
+    __ISB();
+
     SystemInit();
 
     unsigned int LoadAddr, ExeAddr, SectionLen;
@@ -734,6 +739,12 @@ __attribute__((section(".after_vectors.reset"))) void ResetISR(void)
     //
     __libc_init_array();
 #endif
+
+    // Clear all pending interrupt flags & disable all NVIC interrupts
+    for (int irqn = 0; irqn <= NMI_WAKEUP_IRQn; ++irqn) {
+        NVIC_DisableIRQ((IRQn_Type)irqn);
+        NVIC_ClearPendingIRQ((IRQn_Type)irqn);
+    }
 
     // Reenable interrupts
     __asm volatile("cpsie i");


### PR DESCRIPTION
Setting msp register to stack top and clearing pending
interrupt flags before enabling them