### PR TITLE
[CP-371] Updater miscelanous developer mode and logs changes

### DIFF
--- a/module-os/board/linux/portmacro.h
+++ b/module-os/board/linux/portmacro.h
@@ -58,7 +58,7 @@ extern "C" {
 #endif
 
 #include <unistd.h>
-#include <stdint.h>    
+#include <stdint.h>
 
 /*-----------------------------------------------------------
  * Port specific definitions.
@@ -149,7 +149,7 @@ extern void vPortExitCritical( void );
 
 #if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
 #error We are not supporting configUSE_PORT_OPTIMISED_TASK_SELECTION in the Linux Simulator.
-#endif 
+#endif
 
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
@@ -170,15 +170,17 @@ extern void vPortAddTaskHandle( void *pxTaskHandle );
 #define SIG_SUSPEND					SIGUSR1
 #define SIG_RESUME					SIGUSR2
 
-/* Enable the following hash defines to make use of the real-time tick where time progresses at real-time.*/ 
+/* Enable the following hash defines to make use of the real-time tick where time progresses at real-time.*/
 #define SIG_TICK					SIGALRM
-#define TIMER_TYPE					ITIMER_REAL 
+#define TIMER_TYPE					ITIMER_REAL
 /* Enable the following hash defines to make use of the process tick where time progresses only when the process is executing.
 #define SIG_TICK					SIGVTALRM
 #define TIMER_TYPE					ITIMER_VIRTUAL */
 /* Enable the following hash defines to make use of the profile tick where time progresses when the process or system calls are executing.
 #define SIG_TICK					SIGPROF
 #define TIMER_TYPE					ITIMER_PROF */
+
+#define xPortIsInsideInterrupt()			isIRQ()
 
 #ifdef __cplusplus
 }

--- a/module-services/service-desktop/CMakeLists.txt
+++ b/module-services/service-desktop/CMakeLists.txt
@@ -5,6 +5,7 @@ option(ENABLE_DEVELOPER_MODE_ENDPOINT "Enable developer mode endpoint in service
 
 set(SOURCES
     endpoints/BaseHelper.cpp
+    endpoints/Context.cpp
     endpoints/backup/BackupEndpoint.cpp
     endpoints/backup/BackupRestore.cpp
     endpoints/bluetooth/BluetoothEndpoint.cpp
@@ -19,6 +20,7 @@ set(SOURCES
     endpoints/developerMode/DeveloperModeHelper.cpp
     endpoints/developerMode/Mode/UI_Helper.cpp
     endpoints/developerMode/Mode/UpdateHelper.cpp
+    endpoints/developerMode/Mode/LogHelper.cpp
     endpoints/developerMode/event/DomRequest.cpp
     endpoints/developerMode/event/ATRequest.cpp
     endpoints/deviceInfo/DeviceInfoEndpoint.cpp

--- a/module-services/service-desktop/endpoints/BaseHelper.hpp
+++ b/module-services/service-desktop/endpoints/BaseHelper.hpp
@@ -5,6 +5,7 @@
 
 #include <parser/HttpEnums.hpp>
 #include <endpoints/ResponseContext.hpp>
+#include <optional>
 
 namespace sys
 {
@@ -35,6 +36,24 @@ namespace parserFSM
       public:
         using ProcessResult = std::pair<sent, std::optional<endpoint::ResponseContext>>;
 
+        explicit BaseHelper(const std::string &name, sys::Service *p) : owner(p), p_name(name)
+        {}
+
+        /// generall processing function
+        ///
+        /// we should define processing functions, not copy switch cases
+        /// as we are super ambiguous how we should really handle responses
+        /// here we can either:
+        /// return true - to mark that we responded on this request
+        /// return false - and optionally respond that we didn't handle the request
+        /// pre and post processing is available on pre/post process method override
+        [[nodiscard]] auto process(http::Method method, Context &context) -> ProcessResult;
+
+        [[nodiscard]] auto name() const -> const std::string &
+        {
+            return p_name;
+        }
+
       protected:
         sys::Service *owner = nullptr;
         /// by default - result = not sent
@@ -50,18 +69,7 @@ namespace parserFSM
         /// post processing action - in case we want to do something after processing request
         virtual void postProcess(http::Method method, Context &context){};
 
-      public:
-        explicit BaseHelper(sys::Service *p) : owner(p)
-        {}
-
-        /// generall processing function
-        ///
-        /// we should define processing functions, not copy switch cases
-        /// as we are super ambiguous how we should really handle responses
-        /// here we can either:
-        /// return true - to mark that we responded on this request
-        /// return fale - and optionally respond that we didn't handle the request
-        /// pre and post processing is available on pre/post process method override
-        [[nodiscard]] auto process(http::Method method, Context &context) -> ProcessResult;
+      private:
+        std::string p_name;
     };
 }; // namespace parserFSM

--- a/module-services/service-desktop/endpoints/Context.cpp
+++ b/module-services/service-desktop/endpoints/Context.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "Context.hpp"
+
+namespace parserFSM
+{
+    auto Context::createSimpleResponse(const std::string &entryTitle) -> std::string
+    {
+        json11::Json::object contextJsonObject =
+            json11::Json::object{{json::endpoint, static_cast<int>(getEndpoint())},
+                                 {json::status, static_cast<int>(responseContext.status)},
+                                 {json::uuid, getUuid()}};
+        if (!responseContext.body.is_null()) {
+            contextJsonObject[json::body] = responseContext.body;
+        }
+
+        const json11::Json responseJson{std::move(contextJsonObject)};
+
+        return buildResponseStr(responseJson.dump().size(), responseJson.dump());
+    }
+
+    auto Context::createErrorResponse(http::Code code, const std::string &text) -> std::string
+    {
+        setResponseStatus(code);
+        setResponseBody(std::map<std::string, std::string>{{"error", text}});
+        return createSimpleResponse();
+    }
+} // namespace parserFSM

--- a/module-services/service-desktop/endpoints/Context.hpp
+++ b/module-services/service-desktop/endpoints/Context.hpp
@@ -82,20 +82,8 @@ namespace parserFSM
         }
         virtual ~Context() noexcept = default;
 
-        virtual auto createSimpleResponse(const std::string &entryTitle = json::entries) -> std::string
-        {
-            json11::Json::object contextJsonObject =
-                json11::Json::object{{json::endpoint, static_cast<int>(getEndpoint())},
-                                     {json::status, static_cast<int>(responseContext.status)},
-                                     {json::uuid, getUuid()}};
-            if (!responseContext.body.is_null()) {
-                contextJsonObject[json::body] = responseContext.body;
-            }
-
-            const json11::Json responseJson{std::move(contextJsonObject)};
-
-            return buildResponseStr(responseJson.dump().size(), responseJson.dump());
-        }
+        virtual auto createSimpleResponse(const std::string &entryTitle = json::entries) -> std::string;
+        auto createErrorResponse(http::Code code, const std::string &text) -> std::string;
 
         auto setResponse(endpoint::ResponseContext r)
         {

--- a/module-services/service-desktop/endpoints/developerMode/DeveloperModeEndpoint.cpp
+++ b/module-services/service-desktop/endpoints/developerMode/DeveloperModeEndpoint.cpp
@@ -9,6 +9,15 @@
 
 using namespace parserFSM;
 
+DeveloperModeEndpoint::DeveloperModeEndpoint(sys::Service *_ownerServicePtr) : Endpoint(_ownerServicePtr)
+{
+    debugName = "DeveloperModeEndpoint";
+    helpers.emplace_back(std::make_unique<DeveloperModeHelper>("base", ownerServicePtr));
+    helpers.emplace_back(std::make_unique<UI_Helper>("ui", ownerServicePtr));
+    helpers.emplace_back(std::make_unique<UpdateHelper>("update", ownerServicePtr));
+    helpers.emplace_back(std::make_unique<LogHelper>("log", ownerServicePtr));
+}
+
 auto DeveloperModeEndpoint::handle(Context &context) -> void
 {
     auto &p               = helperSwitcher(context);
@@ -34,11 +43,13 @@ auto DeveloperModeEndpoint::handle(Context &context) -> void
 
 auto DeveloperModeEndpoint::helperSwitcher(parserFSM::Context &ctx) -> parserFSM::BaseHelper &
 {
-    if (ctx.getBody()["ui"] == true) {
-        return *uiHelper;
+    std::string body = ctx.getBody().dump();
+    if (auto s =
+            std::find_if(std::begin(helpers),
+                         std::end(helpers),
+                         [&body](const auto &val) { return body.find_first_of(val->name()) != std::string::npos; });
+        s != std::end(helpers)) {
+        return **s;
     }
-    if (ctx.getBody()["update"] == true) {
-        return *updateHelper;
-    }
-    return *helper;
+    return **helpers.begin();
 }

--- a/module-services/service-desktop/endpoints/developerMode/DeveloperModeEndpoint.hpp
+++ b/module-services/service-desktop/endpoints/developerMode/DeveloperModeEndpoint.hpp
@@ -6,6 +6,7 @@
 #include "DeveloperModeHelper.hpp"
 #include "Mode/UI_Helper.hpp"
 #include "Mode/UpdateHelper.hpp"
+#include "Mode/LogHelper.hpp"
 #include <endpoints/Endpoint.hpp>
 #include <parser/ParserUtils.hpp>
 
@@ -26,18 +27,10 @@ namespace sys
 class DeveloperModeEndpoint : public parserFSM::Endpoint
 {
   private:
-    const std::unique_ptr<parserFSM::DeveloperModeHelper> helper;
-    const std::unique_ptr<parserFSM::UI_Helper> uiHelper;
-    const std::unique_ptr<parserFSM::UpdateHelper> updateHelper;
+    std::list<std::unique_ptr<parserFSM::BaseHelper>> helpers;
 
   public:
-    explicit DeveloperModeEndpoint(sys::Service *_ownerServicePtr)
-        : Endpoint(_ownerServicePtr), helper(std::make_unique<parserFSM::DeveloperModeHelper>(ownerServicePtr)),
-          uiHelper(std::make_unique<parserFSM::UI_Helper>(ownerServicePtr)),
-          updateHelper(std::make_unique<parserFSM::UpdateHelper>(ownerServicePtr))
-    {
-        debugName = "DeveloperModeEndpoint";
-    }
+    explicit DeveloperModeEndpoint(sys::Service *_ownerServicePtr);
 
     auto handle(parserFSM::Context &context) -> void override;
 

--- a/module-services/service-desktop/endpoints/developerMode/DeveloperModeHelper.hpp
+++ b/module-services/service-desktop/endpoints/developerMode/DeveloperModeHelper.hpp
@@ -34,7 +34,7 @@ namespace parserFSM
         auto prepareSMS(Context &context) -> ProcessResult;
 
       public:
-        explicit DeveloperModeHelper(sys::Service *p) : BaseHelper(p)
+        explicit DeveloperModeHelper(const std::string &name, sys::Service *p) : BaseHelper(name, p)
         {}
 
       private:

--- a/module-services/service-desktop/endpoints/developerMode/Mode/LogHelper.cpp
+++ b/module-services/service-desktop/endpoints/developerMode/Mode/LogHelper.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "LogHelper.hpp"
+#include "Logger.hpp"
+
+namespace parserFSM
+{
+    auto LogHelper::processPost(Context &context) -> ProcessResult
+    {
+        const auto &body = context.getBody();
+
+        if (body["service"].is_string() and body["level"].is_number()) {
+            return setLogLevel(body["service"].string_value(), body["level"].number_value());
+        }
+        else if (body["device"].is_string()) {
+            return setLogDevice(body["device"].string_value());
+        }
+
+        return {sent::no, std::nullopt};
+    }
+
+    auto LogHelper::processGet(Context &context) -> ProcessResult
+    {
+        const auto &body = context.getBody();
+        if (body["service"].is_string()) {
+            return getLogLevel(body["service"].string_value());
+        }
+        return {sent::no, std::nullopt};
+    }
+
+    BaseHelper::ProcessResult LogHelper::setLogLevel(const std::string &serviceName, double level)
+    {
+        if (Log::Logger::get().setLogLevel(serviceName, static_cast<logger_level>(level))) {
+            return {sent::no, endpoint::ResponseContext{.status = http::Code::OK}};
+        }
+        else {
+            return {sent::no, endpoint::ResponseContext{.status = http::Code::InternalServerError}};
+        }
+        return {sent::no, std::nullopt};
+    }
+
+    BaseHelper::ProcessResult LogHelper::setLogDevice(const std::string & /*device*/)
+    {
+        return {
+            sent::no,
+            endpoint::ResponseContext{http::Code::InternalServerError,
+                                      std::map<std::string, std::string>{{"cause", "Logger is badly implemented"}}}};
+    }
+
+    BaseHelper::ProcessResult LogHelper::getLogLevel(const std::string &serviceName)
+    {
+        auto level = Log::Logger::get().getLogLevel(serviceName);
+        return {sent::no, endpoint::ResponseContext{http::Code::OK, std::map<std::string, double>{{"level", level}}}};
+    }
+
+} // namespace parserFSM

--- a/module-services/service-desktop/endpoints/developerMode/Mode/LogHelper.hpp
+++ b/module-services/service-desktop/endpoints/developerMode/Mode/LogHelper.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <endpoints/Context.hpp>
+#include <Service/Common.hpp>
+#include <endpoints/BaseHelper.hpp>
+
+namespace parserFSM
+{
+
+    class LogHelper : public BaseHelper
+    {
+
+      public:
+        explicit LogHelper(const std::string &name, sys::Service *p) : BaseHelper(name, p)
+        {}
+
+        auto processPost(Context &context) -> ProcessResult final;
+        auto processGet(Context &context) -> ProcessResult final;
+
+      private:
+        [[nodiscard]] auto setLogLevel(const std::string &, double) -> ProcessResult;
+        [[nodiscard]] auto setLogDevice(const std::string &dev) -> ProcessResult;
+        [[nodiscard]] auto getLogLevel(const std::string &) -> ProcessResult;
+    };
+} // namespace parserFSM

--- a/module-services/service-desktop/endpoints/developerMode/Mode/UI_Helper.hpp
+++ b/module-services/service-desktop/endpoints/developerMode/Mode/UI_Helper.hpp
@@ -14,7 +14,7 @@ namespace parserFSM
     {
 
       public:
-        explicit UI_Helper(sys::Service *p) : BaseHelper(p)
+        explicit UI_Helper(const std::string &name, sys::Service *p) : BaseHelper(name, p)
         {}
 
         /// returns DOM async

--- a/module-services/service-desktop/endpoints/developerMode/Mode/UpdateHelper.hpp
+++ b/module-services/service-desktop/endpoints/developerMode/Mode/UpdateHelper.hpp
@@ -14,7 +14,7 @@ namespace parserFSM
     {
 
       public:
-        explicit UpdateHelper(sys::Service *p) : BaseHelper(p)
+        explicit UpdateHelper(const std::string &name, sys::Service *p) : BaseHelper(name, p)
         {}
 
         auto processPost(Context &context) -> ProcessResult final;

--- a/module-services/service-desktop/endpoints/security/SecurityEndpoint.hpp
+++ b/module-services/service-desktop/endpoints/security/SecurityEndpoint.hpp
@@ -28,7 +28,8 @@ class SecurityEndpoint : public parserFSM::Endpoint
 
   public:
     explicit SecurityEndpoint(sys::Service *ownerServicePtr)
-        : Endpoint(ownerServicePtr), helper(std::make_unique<parserFSM::SecurityEndpointHelper>(ownerServicePtr))
+        : Endpoint(ownerServicePtr),
+          helper(std::make_unique<parserFSM::SecurityEndpointHelper>("security", ownerServicePtr))
     {
         debugName = "SecurityEndpoint";
     }

--- a/module-services/service-desktop/endpoints/security/SecurityEndpointHelper.hpp
+++ b/module-services/service-desktop/endpoints/security/SecurityEndpointHelper.hpp
@@ -19,7 +19,7 @@ namespace parserFSM
     class SecurityEndpointHelper : public BaseHelper
     {
       public:
-        explicit SecurityEndpointHelper(sys::Service *p) : BaseHelper(p)
+        explicit SecurityEndpointHelper(const std::string &name, sys::Service *p) : BaseHelper(name, p)
         {}
 
         static constexpr auto PasscodeLength = 4;

--- a/module-services/service-desktop/parser/ParserFSM.cpp
+++ b/module-services/service-desktop/parser/ParserFSM.cpp
@@ -58,7 +58,9 @@ void StateMachine::parseHeader()
 
     auto messageStart = receivedMsg.find(message::endpointChar);
     if (messageStart == std::string::npos) {
-        LOG_ERROR("This is not a valid endpoint message! Type=%c", receivedMsg.at(0));
+        std::string message = "This is not a valid endpoint message! Type=" + receivedMsg.at(0);
+        LOG_ERROR("%s", message.c_str());
+        messageHandler->putToSendQueue(Context().createErrorResponse(http::Code::BadRequest, message));
         return;
     }
 
@@ -73,12 +75,12 @@ void StateMachine::parseHeader()
     payloadLength = message::calcPayloadLength(header);
     if (payloadLength == 0) // failed to obtain payload length from msg
     {
-        LOG_ERROR("Damaged header!");
+        std::string message = "Damaged header!";
+        LOG_ERROR("%s", message.c_str());
+        messageHandler->putToSendQueue(Context().createErrorResponse(http::Code::BadRequest, message));
         state = State::NoMsg;
         return;
     }
-
-    LOG_DEBUG("Payload length: %lu", payloadLength);
 
     message::removeHeader(receivedMsg);
     parseNewMessage();

--- a/module-sys/SystemManager/SystemManager.cpp
+++ b/module-sys/SystemManager/SystemManager.cpp
@@ -190,7 +190,7 @@ namespace sys
 
         LOG_INFO("Order of system services initialization:");
         for (const auto &service : sortedServices) {
-            LOG_INFO("\t> %s", service.get().getName().c_str());
+            LOG_DEBUG("\t> %s", service.get().getName().c_str());
         }
         std::for_each(sortedServices.begin(), sortedServices.end(), [this](const auto &service) {
             const auto startTimeout = service.get().getStartTimeout().count();

--- a/module-utils/board/cross/log_rt1051.cpp
+++ b/module-utils/board/cross/log_rt1051.cpp
@@ -13,13 +13,6 @@
 /// - in critical seciton - return CRIT
 /// - in interrupt return - IRQ
 /// - else return thread name
-static inline const char *getTaskDesc()
-{
-    return xTaskGetCurrentTaskHandle() == nullptr
-               ? Log::Logger::CRIT_STR
-               : xPortIsInsideInterrupt() ? Log::Logger::IRQ_STR : pcTaskGetName(xTaskGetCurrentTaskHandle());
-}
-
 namespace Log
 {
     void Logger::addLogHeader(logger_level level, const char *file, int line, const char *function)
@@ -41,11 +34,6 @@ namespace Log
                                            function,
                                            line,
                                            logColors->resetColor.data());
-    }
-
-    bool Logger::filterLogs(logger_level level)
-    {
-        return getLogLevel(getTaskDesc()) <= level;
     }
 
     void Logger::logToDevice(const char *fmt, va_list args)

--- a/module-utils/board/linux/log_linux.cpp
+++ b/module-utils/board/linux/log_linux.cpp
@@ -28,11 +28,6 @@ namespace Log
                                            logColors->resetColor.data());
     }
 
-    bool Logger::filterLogs(logger_level _level)
-    {
-        return _level >= level;
-    }
-
     void Logger::logToDevice(const char *, va_list)
     {
         assert(false && "Not implemented");

--- a/module-utils/log/Logger.hpp
+++ b/module-utils/log/Logger.hpp
@@ -39,21 +39,25 @@ namespace Log
         static constexpr auto CRIT_STR = "CRIT";
         static constexpr auto IRQ_STR  = "IRQ";
 
+        /// Filter out not interesting logs via thread Name
+        /// its' using fact that:
+        /// - TRACE is level 0, for undefined lookups it will be always trace
+        /// - it will be one time init for apps which doesn't tell what level they should have
+        /// - for others it will be o1 lookup so it's fine
+        /// this function appends to logged services list!
+        [[nodiscard]] auto getLogLevel(const std::string &name) -> logger_level;
+        bool setLogLevel(const std::string &name, logger_level);
+        void logToDevice(const char *fmt, va_list args);
+
       private:
         Logger();
 
+        const char *getTaskDesc();
         void addLogHeader(logger_level level,
                           const char *file     = nullptr,
                           int line             = -1,
                           const char *function = nullptr);
         [[nodiscard]] bool filterLogs(logger_level level);
-        /// Filter out not interesting logs via thread Name
-        /// its' using fact that:
-        /// - TRACE is level 0, for unedfined lookups it will be alvways trace
-        /// - it will be one time init for apps which doesn't tell what level they should have
-        /// - for others it will be o1 lookup so it's fine
-        [[nodiscard]] auto getLogLevel(const std::string &name) -> logger_level;
-        void logToDevice(const char *fmt, va_list args);
         void logToDevice(Device device, std::string_view logMsg, size_t length);
         [[nodiscard]] size_t loggerBufferSizeLeft() const noexcept
         {

--- a/test/get_os_log.py
+++ b/test/get_os_log.py
@@ -6,6 +6,7 @@ import sys
 import os.path
 import atexit
 
+from harness import log
 from harness.harness import Harness
 from harness.interface.error import TestError, Error
 from harness.api.developermode import PhoneModeLock
@@ -21,14 +22,13 @@ def set_passcode(harness: Harness, flag: bool):
 
 def main():
     if len(sys.argv) == 1:
-        print(
-            f'Please pass log storage directory as the parameter: \'python {sys.argv[0]} <log dir>\' ')
+        log.error(f'Please pass log storage directory as the parameter: \'python {sys.argv[0]} <log dir>\' ')
         raise TestError(Error.OTHER_ERROR)
 
     log_dir = str(sys.argv[1])
 
     if (not os.path.exists(log_dir)):
-        print(f'Log storage directory {log_dir} not found')
+        log.error(f'Log storage directory {log_dir} not found')
         raise TestError(Error.OTHER_ERROR)
 
     harness = Harness.from_detect()
@@ -43,5 +43,5 @@ if __name__ == "__main__":
     try:
         main()
     except TestError as err:
-        print(err)
+        log.error(err)
         exit(err.get_error_code())

--- a/test/pytest/conftest.py
+++ b/test/pytest/conftest.py
@@ -16,6 +16,7 @@ from harness import utils
 from harness.interface.error import TestError, Error
 from harness.interface.CDCSerial import Keytype, CDCSerial as serial
 from harness.interface.defs import key_codes
+from harness.rt_harness_discovery import get_rt1051_harness
 
 
 simulator_port = 'simulator'
@@ -68,16 +69,8 @@ def harness(request):
     try:
         if port_name is None:
             log.warning("no port provided! trying automatic detection")
-            harness = None
+            harness = get_rt1051_harness(TIMEOUT)
 
-            with utils.Timeout.limit(seconds=TIMEOUT):
-                while not harness:
-                    try:
-                        harness = Harness.from_detect()
-                    except TestError as e:
-                        if e.get_error_code() == Error.PORT_NOT_FOUND:
-                            log.info(f"waiting for a serial port… ({TIMEOUT- int(time.time() - timeout_started)})")
-                            time.sleep(RETRY_EVERY_SECONDS)
         else:
             assert '/dev' in port_name or simulator_port in port_name
 

--- a/test/pytest/test_updater.py
+++ b/test/pytest/test_updater.py
@@ -33,6 +33,8 @@ def disable_some_logs(harness: Harness):
 def test_update(harness: Harness):
     filename = "update.tar"
 
+    disable_some_logs(harness)
+
     log.info(get_version(harness))
     PhoneModeLock(False).run(harness)
     put_file(harness, filename, "/sys/user/")

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -8,3 +8,5 @@ pyserial==3.5
 pytest==6.1.2
 six==1.15.0
 toml==0.10.2
+tqdm=4.59.0
+dataclass_json=1.3.7

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,3 @@
+gitdb==4.0.5
+requests==2.25.1
+tqdm==4.59.0


### PR DESCRIPTION
Changed:
- Runtime disabled logs which didn't add value from ServiceDesktop
- Runtime disabled logs which didn't add value from SystemManager
- Added possibility to change runtime logging levels
- Integrated ServiceDesktop developer code a bit - it might be used
  as virtual base with little to no modifications for other endpoints
  which would result with less redundant code