### PR TITLE
[EGD-7227] Fix update package generation

### DIFF
--- a/cmake/modules/AddBootBin.cmake
+++ b/cmake/modules/AddBootBin.cmake
@@ -1,5 +1,5 @@
 function(add_boot_bin SOURCE_TARGET)
-    set(BIN_FILE ${CMAKE_BINARY_DIR}/sys/current/${SOURCE_TARGET}-boot.bin)
+    set(BIN_FILE ${CMAKE_BINARY_DIR}/sysroot/sys/current/${SOURCE_TARGET}-boot.bin)
 
     if (ENABLE_SECURE_BOOT)
         set (SREC_FILE ${CMAKE_PROJECT_NAME}.srec)

--- a/cmake/modules/DiskImage.cmake
+++ b/cmake/modules/DiskImage.cmake
@@ -19,7 +19,7 @@ function(add_image)
 
     if(HAS_BOOTFILE)
         set(BIN_FILE_TARGET ${_ARG_PRODUCT}-boot.bin)
-        set(BIN_FILE_PATH ${CMAKE_BINARY_DIR}/sys/current/${_ARG_PRODUCT}-boot.bin)
+        set(BIN_FILE_PATH ${CMAKE_BINARY_DIR}/sysroot/sys/current/${_ARG_PRODUCT}-boot.bin)
     else()
         set(BIN_FILE_PATH "")
     endif()

--- a/tools/generate_update_image.sh
+++ b/tools/generate_update_image.sh
@@ -29,11 +29,11 @@ function setVars() {
     STAGEING_DIR="${SOURCE_TARGET}-${VERSION}-${PLATFORM}-Update"
     PACKAGE_FILE="${STAGEING_DIR}.tar"
     DEPS=(
-        "sys/current/assets"
-        "sys/user"
-        "sys/current/${SOURCE_TARGET}-boot.bin"
-        "sys/current/country-codes.db"
-        "sys/current/Luts.bin"
+        "sysroot/sys/current/assets"
+        "sysroot/sys/user"
+        "sysroot/sys/current/${SOURCE_TARGET}-boot.bin"
+        "sysroot/sys/current/country-codes.db"
+        "sysroot/sys/current/Luts.bin"
         "version.json"
         "ecoboot.bin"
         )
@@ -64,11 +64,11 @@ function cleanStagingDir(){
 
 function linkInStageing(){
     pushd ${STAGEING_DIR} 1> /dev/null
-    ln -s ../sys/current/assets
-    ln -s ../sys/user
-    ln -s ../sys/current/${SOURCE_TARGET}-boot.bin boot.bin
-    ln -s ../sys/current/country-codes.db
-    ln -s ../sys/current/Luts.bin
+    ln -s ../sysroot/sys/current/assets
+    ln -s ../sysroot/sys/user
+    ln -s ../sysroot/sys/current/${SOURCE_TARGET}-boot.bin boot.bin
+    ln -s ../sysroot/sys/current/country-codes.db
+    ln -s ../sysroot/sys/current/Luts.bin
     ln -s ../ecoboot.bin
     ln -s ../${SOURCE_TARGET}-version.json version.json
     popd 1> /dev/null


### PR DESCRIPTION
Adjust paths in update image generation script to point to a new
sysroot.
Fix boot.bin file path to point to a new sysroot.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>