### PR TITLE
[EGD-7165] Stop playing music when leaving MP

### DIFF
--- a/module-apps/application-music-player/include/application-music-player/ApplicationMusicPlayer.hpp
+++ b/module-apps/application-music-player/include/application-music-player/ApplicationMusicPlayer.hpp
@@ -65,7 +65,7 @@ namespace app
         static auto GetManifest() -> manager::ApplicationManifest
         {
             return {{manager::actions::Launch, manager::actions::PhoneModeChanged},
-                    locks::AutoLockPolicy::DetermineByAppState};
+                    locks::AutoLockPolicy::DetermineByWindow};
         }
     };
 } /* namespace app */

--- a/module-apps/application-music-player/presenters/SongsPresenter.cpp
+++ b/module-apps/application-music-player/presenters/SongsPresenter.cpp
@@ -25,6 +25,10 @@ namespace app::music_player
     bool SongsPresenter::play(const std::string &filePath)
     {
         songsModelInterface->setCurrentSongState(SongState::Playing);
+        if (changePlayingStateCallback != nullptr) {
+            changePlayingStateCallback(SongState::Playing);
+        }
+
         return audioOperations->play(filePath,
                                      [this](audio::Token token) { songsModelInterface->setCurrentFileToken(token); });
     }
@@ -34,6 +38,9 @@ namespace app::music_player
         auto currentFileToken = songsModelInterface->getCurrentFileToken();
         if (currentFileToken) {
             songsModelInterface->setCurrentSongState(SongState::NotPlaying);
+            if (changePlayingStateCallback != nullptr) {
+                changePlayingStateCallback(SongState::NotPlaying);
+            }
             return audioOperations->pause(currentFileToken.value());
         }
         return false;
@@ -44,6 +51,9 @@ namespace app::music_player
         auto currentFileToken = songsModelInterface->getCurrentFileToken();
         if (currentFileToken) {
             songsModelInterface->setCurrentSongState(SongState::Playing);
+            if (changePlayingStateCallback != nullptr) {
+                changePlayingStateCallback(SongState::Playing);
+            }
             return audioOperations->resume(currentFileToken.value());
         }
         return false;
@@ -54,6 +64,10 @@ namespace app::music_player
         auto currentFileToken = songsModelInterface->getCurrentFileToken();
         if (currentFileToken) {
             songsModelInterface->setCurrentSongState(SongState::NotPlaying);
+            if (changePlayingStateCallback != nullptr) {
+                changePlayingStateCallback(SongState::NotPlaying);
+            }
+
             return audioOperations->stop(currentFileToken.value(), [this](audio::Token token) {
                 if (token == songsModelInterface->getCurrentFileToken()) {
                     songsModelInterface->setCurrentFileToken(std::nullopt);
@@ -72,6 +86,11 @@ namespace app::music_player
         else {
             resume();
         }
+    }
+
+    void SongsPresenter::setPlayingStateCallback(std::function<void(SongState)> cb)
+    {
+        changePlayingStateCallback = std::move(cb);
     }
 
 } // namespace app::music_player

--- a/module-apps/application-music-player/presenters/SongsPresenter.hpp
+++ b/module-apps/application-music-player/presenters/SongsPresenter.hpp
@@ -32,6 +32,8 @@ namespace app::music_player
             virtual bool resume()                          = 0;
             virtual bool stop()                            = 0;
             virtual void togglePlaying()                   = 0;
+
+            virtual void setPlayingStateCallback(std::function<void(SongsModelInterface::SongState)> cb) = 0;
         };
     };
 
@@ -50,9 +52,11 @@ namespace app::music_player
         bool resume() override;
         bool stop() override;
         void togglePlaying() override;
+        void setPlayingStateCallback(std::function<void(SongsModelInterface::SongState)> cb) override;
 
       private:
         std::shared_ptr<SongsModelInterface> songsModelInterface;
         std::unique_ptr<AbstractAudioOperations> audioOperations;
+        std::function<void(SongsModelInterface::SongState)> changePlayingStateCallback = nullptr;
     };
 } // namespace app::music_player

--- a/module-apps/apps-common/locks/handlers/LockPolicyHandler.hpp
+++ b/module-apps/apps-common/locks/handlers/LockPolicyHandler.hpp
@@ -23,15 +23,14 @@ namespace locks
 
     class LockPolicyAccessInterface
     {
-        friend class app::ApplicationLauncher;
         AutoLockPolicy autoLockingPolicy = AutoLockPolicy::DetermineByWindow;
-        void set(AutoLockPolicy policy) noexcept;
 
       protected:
         [[nodiscard]] AutoLockPolicy get() const noexcept;
 
       public:
         virtual ~LockPolicyAccessInterface() = default;
+        void set(AutoLockPolicy policy) noexcept;
     };
 
     class LockPolicyHandlerInterface : public LockPolicyAccessInterface


### PR DESCRIPTION
When Music Player (MP) app is closed the currently played track should
be stopped so the music is no longer heard by user.