### PR TITLE
[EGD-7054] Changed the default focused app in the menu

### DIFF
--- a/module-apps/application-desktop/windows/MenuWindow.hpp
+++ b/module-apps/application-desktop/windows/MenuWindow.hpp
@@ -38,7 +38,7 @@ namespace gui
       public:
         bool first_time_selection = true;
         /// position of element which should be selected on start
-        const unsigned int first_time_selected = 3;
+        const unsigned int first_time_selected = 4;
 
         UTF8 title;
         MenuPage(gui::Item *parent, UTF8 title, std::vector<Tile *> tiles);


### PR DESCRIPTION
The focused app on entering the menu for the first time is now "contacts".