### PR TITLE
[EGD-7021] Fix calculator comma crash

### DIFF
--- a/module-apps/application-calculator/data/CalculatorUtility.cpp
+++ b/module-apps/application-calculator/data/CalculatorUtility.cpp
@@ -29,9 +29,7 @@ namespace calc
                 output = getValueThatFitsOnScreen(result);
             }
             if (symbols::strings::decimal_separator_str() == symbols::strings::comma) {
-                output.replace(output.find(symbols::strings::full_stop),
-                               std::size(std::string_view(symbols::strings::full_stop)),
-                               symbols::strings::comma);
+                output = replaceAllOccurrences(output, symbols::strings::full_stop, symbols::strings::comma);
             }
             return Result{source, output, false};
         }

--- a/module-apps/application-calculator/tests/CalculatorUtility_tests.cpp
+++ b/module-apps/application-calculator/tests/CalculatorUtility_tests.cpp
@@ -95,6 +95,15 @@ TEST_CASE("Calculator utilities")
         REQUIRE(!result.isError);
     }
 
+    SECTION("Fraction with comma - crash case [EGD-7021]")
+    {
+        utils::setDisplayLanguage("Polski");
+        auto result = calculator.calculate("30");
+        REQUIRE(result.value == "30");
+        REQUIRE(result.equation == "30");
+        REQUIRE(!result.isError);
+    }
+
     SECTION("Division by 0")
     {
         auto result = calculator.calculate("15+5÷0");


### PR DESCRIPTION
There was a crash when system separator was set as a comma -
replace function was throwing out-of-range error while converting
from full-stop to comma