### PR TITLE
[EGD-7267] Fix product reconfiguration

### DIFF
--- a/cmake/modules/Product.cmake
+++ b/cmake/modules/Product.cmake
@@ -1,4 +1,4 @@
-option(PRODUCT "The product to be configured and built." PurePhone)
+set(PRODUCT "PurePhone" CACHE STRING "The product to be configured and built.")
 
 macro(validate_product_selection)
     # create list of valid products


### PR DESCRIPTION
Product should be stored as a string, not boolean.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>