### PR TITLE
[EGD-7173] Added e164 format support to Messages

### DIFF
--- a/module-gui/gui/widgets/Text.cpp
+++ b/module-gui/gui/widgets/Text.cpp
@@ -273,7 +273,7 @@ namespace gui
             debug_text("handleAddChar");
             return true;
         }
-        if (handleDigitLongPress(evt)) {
+        if (handleLongPressAddChar(evt)) {
             debug_text("handleDigitLongPress");
             return true;
         }
@@ -600,19 +600,30 @@ namespace gui
         return false;
     }
 
-    bool Text::handleDigitLongPress(const InputEvent &inputEvent)
+    auto Text::handleLongPressAddChar(const InputEvent &inputEvent) -> bool
     {
         if (!inputEvent.isLongRelease()) {
             return false;
         }
-
-        if (!inputEvent.isDigit()) {
+        if (!isMode(EditMode::Edit)) {
             return false;
         }
 
-        if (const auto val = inputEvent.numericValue(); checkAdditionBounds(val) == AdditionBound::CanAddAll) {
+        // check input event handling accordingly to input mode
+        auto code = text::npos;
+
+        // phone mode
+        if (mode->is(InputMode::phone) && inputEvent.is(KeyCode::KEY_0)) {
+            code = '+';
+        }
+        // all other modes only handle digits
+        else if (inputEvent.isDigit()) {
+            code = intToAscii(inputEvent.numericValue());
+        }
+
+        if (code != text::npos && checkAdditionBounds(code) == AdditionBound::CanAddAll) {
             setCursorStartPosition(CursorStartPosition::Offset);
-            addChar(intToAscii(val));
+            addChar(code);
             onTextChanged();
             return true;
         }

--- a/module-gui/gui/widgets/Text.hpp
+++ b/module-gui/gui/widgets/Text.hpp
@@ -88,8 +88,8 @@ namespace gui
         auto handleNavigation(const InputEvent &inputEvent) -> bool;
         auto handleRemovalChar(const InputEvent &inputEvent) -> bool;
         auto handleWholeTextRemoval(const InputEvent &inputEvent) -> bool;
-        auto handleDigitLongPress(const InputEvent &inputEvent) -> bool;
         auto handleAddChar(const InputEvent &inputEvent) -> bool;
+        auto handleLongPressAddChar(const InputEvent &inputEvent) -> bool;
 
         [[nodiscard]] auto getSizeMinusPadding(Axis axis, Area val) -> Length;
         auto applyParentSizeRestrictions() -> void;

--- a/module-gui/test/test-catch-text/test-gui-Text.cpp
+++ b/module-gui/test/test-catch-text/test-gui-Text.cpp
@@ -237,6 +237,16 @@ TEST_CASE("handle longpress for digit in ABC mode")
     REQUIRE(str == text.getText());
 }
 
+TEST_CASE("handle longpress for digit in phone mode")
+{
+    auto text  = gui::TestText();
+    auto str   = text.getText() + "+";
+    auto key_0 = gui::InputEvent({}, gui::InputEvent::State::keyReleasedLong, gui::KeyCode::KEY_0);
+    text.setInputMode(new InputMode({InputMode::phone}));
+    text.onInput(key_0);
+    REQUIRE(str == text.getText());
+}
+
 TEST_CASE("Handle backspace longpress")
 {
     auto text          = gui::TestText();


### PR DESCRIPTION
When sending new message user is able to insert '+' sign by long
pressing 0 button. It allows to enter recipient number in e164 format.