### PR TITLE
[EGD-7279] Use custom branch when building daily

### DIFF
--- a/tools/daily_release.sh
+++ b/tools/daily_release.sh
@@ -10,13 +10,17 @@ LOGIN=${LOGIN}
 TOKEN=${TOKEN}
 IMAGE_NAME=${IMAGE_NAME:-wearemudita/mudita_os_builder:1.9}
 WORK_DIR=${WORK_DIR:-MuditaOS}
-ARTEFACTS_DIR=${ARTEFACTS_DIR:-/artefacts}
 REPOSITORY_URL=${REPOSITORY_URL:-https://${TOKEN}:x-oauth-basic@github.com/mudita/MuditaOS}
+REPOSITORY_BRANCH=${REPOSITORY_BRANCH:-master}
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-/artifacts/${REPOSITORY_BRANCH}}
+PRODUCT=${PRODUCT:-PurePhone}
 
 CONFIG_LOG=config.log
 
 VARS_TO_CHECK=(
+        PRODUCT
         REPOSITORY_URL
+        REPOSITORY_BRANCH
         LOGIN
         TOKEN
         IMAGE_NAME
@@ -52,12 +56,15 @@ function addTokens(){
     git config user.apitoken ${TOKEN}
 }
 
-
 ##################### script ####################
 checkVariables
 
+if [ ! -d ${ARTIFACTS_DIR} ]; then
+    mkdir -p ${ARTIFACTS_DIR}
+fi
+
 if [ ! -d ${WORK_DIR} ]; then
-    mkdir ${WORK_DIR}
+    mkdir -p ${WORK_DIR}
 fi
 
 pushd ${WORK_DIR}
@@ -67,7 +74,7 @@ if checkIfGit; then
     git pull --ff-only 
 else
     echo "not a git dir"
-    git clone ${REPOSITORY_URL} .
+    git clone -b ${REPOSITORY_BRANCH} ${REPOSITORY_URL} .
     git checkout master
 fi
 
@@ -78,25 +85,20 @@ fi
 CCACHE_DIR=$(pwd)/ccache
 export CCACHE_DIR
 
-
 DATE=$(date "+%Y.%m.%d")
 
 addTokens
 git submodule update --init --recursive
 git tag -f daily-${DATE}
 git push --tags origin
-./configure.sh rt1051 RelWithDebInfo -G Ninja &> ${CONFIG_LOG}
-cat ${CONFIG_LOG}
-PKG_NAME_PREFIX=$(cat ${CONFIG_LOG} | grep CPACK_PACKAGE_FILE_NAME  | cut -f2 -d: | tr -d "'")
-cd build-rt1051-RelWithDebInfo
+./configure.sh ${PRODUCT} rt1051 RelWithDebInfo -G Ninja
+cd build-${PRODUCT,,}-rt1051-RelWithDebInfo
 ninja
-ninja package-standalone
-ninja package-update
+ninja ${PRODUCT}-StandaloneImage
+ninja ${PRODUCT}-UpdatePackage
 
-cp ${PKG_NAME_PREFIX}-image.tar.xz ${ARTEFACTS_DIR}
-cp ${PKG_NAME_PREFIX}-Update.tar ${ARTEFACTS_DIR}
+PKG_NAME_PREFIX=${PRODUCT}-${DATE}-RT1051
+cp ${PKG_NAME_PREFIX}-image.tar.xz ${ARTIFACTS_DIR}
+cp ${PKG_NAME_PREFIX}-Update.tar ${ARTIFACTS_DIR}
 
 popd
-
-
-


### PR DESCRIPTION
Allow using custom branch when building daily releases.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>