### PR TITLE
[CP-282] Compute MD5 of the correct boot.bin file

### DIFF
--- a/cmake/modules/AddBootBin.cmake
+++ b/cmake/modules/AddBootBin.cmake
@@ -1,6 +1,12 @@
 function(add_boot_bin SOURCE_TARGET)
     set(BIN_FILE ${CMAKE_BINARY_DIR}/sysroot/sys/current/${SOURCE_TARGET}-boot.bin)
 
+    set_target_properties(
+            ${SOURCE_TARGET}
+        PROPERTIES
+            BIN_FILE ${BIN_FILE}
+    )
+
     if (ENABLE_SECURE_BOOT)
         set (SREC_FILE ${CMAKE_PROJECT_NAME}.srec)
         # .srec file required by elftosb

--- a/cmake/modules/AddVersionJson.cmake
+++ b/cmake/modules/AddVersionJson.cmake
@@ -8,7 +8,7 @@ function(add_version_json SOURCE_TARGET)
             -DBOOTLOADER_FILE=${CMAKE_BINARY_DIR}/ecoboot.bin
             -DBOOTLOADER_VERSION_FILE=${CMAKE_BINARY_DIR}/ecoboot.version
             -DBOOT_FILENAME=boot.bin
-            -DBOOT_FILE=$<TARGET_FILE:${SOURCE_TARGET}>
+            -DBOOT_FILE=$<TARGET_PROPERTY:${SOURCE_TARGET},BIN_FILE>
             -DBOOT_VERSION=${CMAKE_PROJECT_VERSION}
             -DUPDATER_FILENAME=updater.bin
             -DUPDATER_FILE=${CMAKE_BINARY_DIR}/updater.bin


### PR DESCRIPTION
The version file must store the checksum of the secured boot.bin file.