### PR TITLE
[EGD 7281] fix menu refresh

### DIFF
--- a/module-apps/application-desktop/windows/MenuWindow.cpp
+++ b/module-apps/application-desktop/windows/MenuWindow.cpp
@@ -319,6 +319,7 @@ namespace gui
 
         setTitle(page->title);
         setFocusItem(page);
+        application->refreshWindow(RefreshModes::GUI_REFRESH_DEEP);
     }
 
     void MenuWindow::refresh()


### PR DESCRIPTION
Add deep refresh when switching between main menu<->submenu to clear artifacts. 