### PR TITLE
[EGD-7110] Fix BT not fully disconnects HSP profile

### DIFF
--- a/module-bluetooth/Bluetooth/interface/profiles/HSP/HSP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/HSP/HSP.cpp
@@ -301,6 +301,7 @@ namespace bluetooth
 
     void HSP::HSPImpl::disconnect()
     {
+        hsp_ag_release_audio_connection();
         hsp_ag_disconnect();
     }
 


### PR DESCRIPTION
HSP profile was likely to hang up during disconnect if
the audio connection wasn't released before the disconnect