### PR TITLE
[EGD-7298] Fix forgetting paired devices after restart

### DIFF
--- a/module-services/service-bluetooth/service-bluetooth/SettingsHolder.cpp
+++ b/module-services/service-bluetooth/service-bluetooth/SettingsHolder.cpp
@@ -22,8 +22,7 @@ namespace bluetooth
     {
         settingsMap[newSetting] = value;
 
-        settingsProvider->setValue(
-            settingString[newSetting], std::visit(StringVisitor(), value), ::settings::SettingsScope::Global);
+        settingsProvider->setValue(settingString[newSetting], std::visit(StringVisitor(), value));
         LOG_INFO("setting %s set", settingString[newSetting].c_str());
     }
     SettingsHolder::SettingsHolder(std::unique_ptr<settings::Settings> settingsPtr)


### PR DESCRIPTION
Fixed settings scope so devices are persistent now