### PR TITLE
[EGD-7306] Fix files for CI clang-format tool

### DIFF
--- a/module-cellular/at/cmd/CLCC.hpp
+++ b/module-cellular/at/cmd/CLCC.hpp
@@ -81,7 +81,7 @@ namespace at
           protected:
             [[nodiscard]] static auto toBool(const std::string &text) -> bool;
             [[nodiscard]] static auto toUInt(const std::string &text) -> std::uint8_t;
-            template <typename T> [[nodiscard]] static auto toEnum(const std::string &text) -> std::optional<T>;
+            template <typename T>[[nodiscard]] static auto toEnum(const std::string &text) -> std::optional<T>;
 
           public:
             CLCC() noexcept;

--- a/module-cellular/test/unittest_parse_result.cpp
+++ b/module-cellular/test/unittest_parse_result.cpp
@@ -31,7 +31,7 @@ namespace at::cmd
             return CLCC::toUInt(text);
         }
 
-        template <typename T> [[nodiscard]] static auto toEnum(const std::string &text) -> std::optional<T>
+        template <typename T>[[nodiscard]] static auto toEnum(const std::string &text) -> std::optional<T>
         {
             return CLCC::toEnum<T>(text);
         }

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -190,8 +190,8 @@ void ServiceCellular::SleepTimerHandler()
     auto currentTime                = cpp_freertos::Ticks::TicksToMs(cpp_freertos::Ticks::GetTicks());
     auto lastCommunicationTimestamp = cmux->getLastCommunicationTimestamp();
     auto timeOfInactivity           = currentTime >= lastCommunicationTimestamp
-                                          ? currentTime - lastCommunicationTimestamp
-                                          : std::numeric_limits<TickType_t>::max() - lastCommunicationTimestamp + currentTime;
+                                ? currentTime - lastCommunicationTimestamp
+                                : std::numeric_limits<TickType_t>::max() - lastCommunicationTimestamp + currentTime;
 
     if (!ongoingCall.isValid() && priv->state->get() == State::ST::Ready &&
         timeOfInactivity >= constants::enterSleepModeTime.count()) {


### PR DESCRIPTION
As CI's clang-format tool is in lower version than on local
benches, there was a need to fix them using CI tools