### PR TITLE
[EGD-7228] Tune up headphones gain

### DIFF
--- a/module-bsp/board/rt1051/bsp/audio/CodecMAX98090.cpp
+++ b/module-bsp/board/rt1051/bsp/audio/CodecMAX98090.cpp
@@ -373,7 +373,7 @@ CodecRetCode CodecMAX98090::SetOutputVolume(const float vol)
         // @note:
         // In order to pass certification max value is limited and taken from measurements 0x0B: -28dB
         // Be carefull when changing it !!!
-        constexpr auto scale_factor      = 1.1f;
+        constexpr auto scale_factor      = 1.24f;
         uint8_t volume                   = static_cast<float>(vol * scale_factor);
         max98090_reg_lhp_vol_ctrl_t lvol = {};
         max98090_reg_rhp_vol_ctrl_t rvol = {};


### PR DESCRIPTION
Headphones gain set up to satisfy certification requirements.
Right channel has 24.32mV, left 24.23mV.