### PR TITLE
[EGD-7355] Update clang tools to version 12 in the docker image

### DIFF
--- a/config/bootstrap_config
+++ b/config/bootstrap_config
@@ -29,8 +29,8 @@ INSTALL_PACKAGES="
         build-essential \
         ca-certificates \
         ccache \
-        clang-format-10 \
-        clang-tidy \
+        clang-format-12 \
+        clang-tidy-12 \
         curl \
         doxygen \
         g++-10 \

--- a/docker/jenkins-docker/Dockerfile
+++ b/docker/jenkins-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM wearemudita/mudita_os_builder:1.11
+FROM wearemudita/mudita_os_builder:1.12
 
 MAINTAINER ops@mudita.com
 # Docker runner for MuditaOS builds


### PR DESCRIPTION
Update is required to be up to date with local benches, so all checks
are the same (issues with version 10)