### PR TITLE
[BH-739] Split EventManager

### DIFF
--- a/products/BellHybrid/services/evtmgr/EventManager.cpp
+++ b/products/BellHybrid/services/evtmgr/EventManager.cpp
@@ -12,8 +12,13 @@ sys::ReturnCodes EventManager::InitHandler()
     using namespace std::string_literals;
     std::list<sys::WorkerQueueInfo> list;
     list.emplace_back("qIrq"s, sizeof(uint8_t), 10);
+    list.emplace_back("qHeadset"s, sizeof(uint8_t), 10);
     list.emplace_back("qBattery"s, sizeof(uint8_t), 10);
     list.emplace_back("qRTC"s, sizeof(uint8_t), 20);
+    list.emplace_back("qSIM"s, sizeof(uint8_t), 5);
+    list.emplace_back("qMagnetometer"s, sizeof(uint8_t), 5);
+    list.emplace_back(WorkerEvent::MagnetometerNotifyQueue, sizeof(uint8_t), 1);
+    list.emplace_back("qTorch"s, sizeof(uint8_t), 5);
     list.emplace_back("qLightSensor"s, sizeof(uint8_t), 5);
     list.emplace_back("qChargerDetect"s, sizeof(uint8_t), 5);
 


### PR DESCRIPTION
Temporary fix for Bell EventManager EventWorker queues.
Queues in WorkerEvent::init are accessed by
index based on `WorkerEventQueues` enum which causes
that all queues must be inserted and the order of queues
must be correct.