### PR TITLE
[EGD-7332] Missed call from private number should not be displayed

### DIFF
--- a/module-apps/apps-common/notifications/NotificationsHandler.cpp
+++ b/module-apps/apps-common/notifications/NotificationsHandler.cpp
@@ -49,7 +49,7 @@ void NotificationsHandler::incomingCallHandler(sys::Message *request)
 
 void NotificationsHandler::callerIdHandler(sys::Message *request)
 {
-    auto msg = static_cast<CellularIncominCallMessage *>(request);
+    auto msg = static_cast<CellularCallerIdMessage *>(request);
 
     if (currentCallPolicy.isNumberCheckRequired()) {
         policyNumberCheck(msg->number);

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -1829,7 +1829,10 @@ void ServiceCellular::handleCellularHangupCallMessage(CellularHangupCallMessage 
 
 void ServiceCellular::handleCellularDismissCallMessage(sys::Message *msg)
 {
+    LOG_INFO("%s", __PRETTY_FUNCTION__);
+
     auto message = static_cast<CellularDismissCallMessage *>(msg);
+
     hangUpCall();
     if (message->addNotificationRequired()) {
         handleCallAbortedNotification(msg);
@@ -1890,6 +1893,7 @@ auto ServiceCellular::handleDBNotificationMessage(db::NotificationMessage *msg) 
 
 auto ServiceCellular::handleCellularRingingMessage(CellularRingingMessage *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
+    LOG_INFO("%s", __PRETTY_FUNCTION__);
     return std::make_shared<CellularResponseMessage>(ongoingCall.startCall(msg->number, CallType::CT_OUTGOING));
 }
 
@@ -1898,6 +1902,7 @@ auto ServiceCellular::handleCellularIncomingCallMessage(sys::Message *msg) -> st
     LOG_INFO("%s", __PRETTY_FUNCTION__);
     auto ret     = true;
     auto message = static_cast<CellularIncominCallMessage *>(msg);
+
     if (!ongoingCall.isValid()) {
         ret = ongoingCall.startCall(message->number, CallType::CT_INCOMING);
     }
@@ -1906,7 +1911,6 @@ auto ServiceCellular::handleCellularIncomingCallMessage(sys::Message *msg) -> st
 
 auto ServiceCellular::handleCellularCallerIdMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
-
     auto message = static_cast<CellularCallerIdMessage *>(msg);
     ongoingCall.setNumber(message->number);
     return sys::MessageNone{};
@@ -2171,8 +2175,9 @@ auto ServiceCellular::handleCellularRingNotification(sys::Message *msg) -> std::
 {
     LOG_INFO("%s", __PRETTY_FUNCTION__);
 
-    if (phoneModeObserver->isTetheringOn())
+    if (phoneModeObserver->isTetheringOn() || connectionManager->forceDismissCalls()) {
         return std::make_shared<CellularResponseMessage>(hangUpCall());
+    }
 
     if (!callManager.isIncomingCallPropagated()) {
         auto message = static_cast<CellularRingNotification *>(msg);
@@ -2185,6 +2190,10 @@ auto ServiceCellular::handleCellularRingNotification(sys::Message *msg) -> std::
 
 auto ServiceCellular::handleCellularCallerIdNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
+    if (connectionManager->forceDismissCalls()) {
+        return std::make_shared<CellularResponseMessage>(hangUpCall());
+    }
+
     auto message = static_cast<CellularCallerIdNotification *>(msg);
     if (phoneModeObserver->isTetheringOn()) {
         tetheringCalllog.push_back(CalllogRecord{CallType::CT_MISSED, message->getNubmer()});

--- a/module-services/service-cellular/connection-manager/ConnectionManager.cpp
+++ b/module-services/service-cellular/connection-manager/ConnectionManager.cpp
@@ -8,8 +8,10 @@
 auto ConnectionManager::onPhoneModeChange(sys::phone_modes::PhoneMode mode) -> bool
 {
     if (mode == sys::phone_modes::PhoneMode::Offline) {
+        forceDismissCallsFlag = true;
         return handleModeChangeToCommonOffline();
     }
+    forceDismissCallsFlag = false;
     return handleModeChangeToConnected();
 }
 
@@ -104,4 +106,9 @@ auto ConnectionManager::handleModeChangeToConnected() -> bool
         cellular->connectToNetwork();
     }
     return true;
+}
+
+auto ConnectionManager::forceDismissCalls() -> bool
+{
+    return forceDismissCallsFlag;
 }

--- a/module-services/service-cellular/service-cellular/CellularCall.hpp
+++ b/module-services/service-cellular/service-cellular/CellularCall.hpp
@@ -85,7 +85,7 @@ namespace CellularCall
 
         bool isValid() const
         {
-            return call.ID != 0;
+            return call.ID != DB_ID_NONE;
         }
 
         bool isActive() const

--- a/module-services/service-cellular/service-cellular/connection-manager/ConnectionManager.hpp
+++ b/module-services/service-cellular/service-cellular/connection-manager/ConnectionManager.hpp
@@ -51,6 +51,11 @@ class ConnectionManager
      */
     void onTimerTick();
 
+    /// Should we always dismiss incoming calls?
+    /// @return true or false depending on state of forceDismissCallsMode flag
+    /// @see forceDismissCallsMode
+    auto forceDismissCalls() -> bool;
+
   private:
     bool isFlightMode;
     std::chrono::minutes connectionInterval{0};
@@ -58,6 +63,11 @@ class ConnectionManager
     std::chrono::minutes minutesOnlineElapsed{0};
     std::shared_ptr<ConnectionManagerCellularCommandsInterface> cellular;
     bool onlinePeriod = false;
+
+    /// Flag determining if we should always dismiss incoming calls - even when
+    /// we are in offline mode (messages only) and we connect to network to poll
+    /// for new messages
+    bool forceDismissCallsFlag = false;
 
     /**
      * @brief Checks if flightMode and connection interval are set as Messages only mode

--- a/module-services/service-cellular/tests/unittest_connection-manager.cpp
+++ b/module-services/service-cellular/tests/unittest_connection-manager.cpp
@@ -12,7 +12,7 @@ using namespace testing;
 class MockCellular : public ConnectionManagerCellularCommandsInterface
 {
   public:
-    MOCK_METHOD(bool, disconnectFromNetwork, ());
+    MOCK_METHOD(bool, disconnectFromNetwork, (), (override));
     MOCK_METHOD(bool, connectToNetwork, (), (override));
     MOCK_METHOD(bool, isConnectedToNetwork, (), (override));
     MOCK_METHOD(bool, clearNetworkIndicator, (), (override));


### PR DESCRIPTION
When making call to Pure and it is in Offline/Message only it might
happen that missed call from private number will be shown in log. This
commit makes a fix to this.