### PR TITLE
[EGD-6435] Fix delayed sms on call reject

### DIFF
--- a/module-services/service-antenna/ServiceAntenna.cpp
+++ b/module-services/service-antenna/ServiceAntenna.cpp
@@ -126,7 +126,9 @@ sys::MessagePointer ServiceAntenna::DataReceivedHandler(sys::DataMessage *msgl, 
                                                                        antenna::lockState::locked);
             bus.sendUnicast(std::move(message), service::name::antenna);
         } break;
-        case CellularMessage::Type::HangupCall: {
+        case CellularMessage::Type::HangupCall:
+            [[fallthrough]];
+        case CellularMessage::Type::DismissCall: {
             auto message = std::make_shared<AntennaLockRequestMessage>(MessageType::AntennaLockService,
                                                                        antenna::lockState::unlocked);
             bus.sendUnicast(std::move(message), service::name::antenna);

--- a/module-services/service-cellular/CellularServiceAPI.cpp
+++ b/module-services/service-cellular/CellularServiceAPI.cpp
@@ -50,7 +50,8 @@ bool CellularServiceAPI::HangupCall(sys::Service *serv)
 bool CellularServiceAPI::DismissCall(sys::Service *serv, bool addNotificationToDB)
 {
     auto msg = std::make_shared<CellularDismissCallMessage>(addNotificationToDB);
-    return serv->bus.sendUnicast(msg, ServiceCellular::serviceName);
+    serv->bus.sendMulticast(std::move(msg), sys::BusChannel::ServiceCellularNotifications);
+    return true;
 }
 
 std::string CellularServiceAPI::GetIMSI(sys::Service *serv, bool getFullIMSINumber)

--- a/module-services/service-cellular/service-cellular/ServiceCellular.hpp
+++ b/module-services/service-cellular/service-cellular/ServiceCellular.hpp
@@ -110,6 +110,7 @@ class ServiceCellular : public sys::Service
 
     // used for polling for call state
     sys::TimerHandle callStateTimer;
+    sys::TimerHandle callEndedRecentlyTimer;
     sys::TimerHandle stateTimer;
     sys::TimerHandle ussdTimer;
 

--- a/module-services/service-cellular/src/SMSSendHandler.hpp
+++ b/module-services/service-cellular/src/SMSSendHandler.hpp
@@ -63,8 +63,9 @@ namespace cellular::internal::sms
          * External action events
          */
         void handleDBNotification();
-        void handleIncomingDbRecord(SMSRecord &record);
+        void handleIncomingDbRecord(SMSRecord &record, bool onDelay);
         void handleNoMoreDbRecords();
+        void sendMessageIfDelayed();
 
         /**
          * User defined callbacks/events
@@ -83,6 +84,8 @@ namespace cellular::internal::sms
         void handleStateChange(OptionalState state);
 
         std::unique_ptr<State> currentState;
+        std::function<void()> actionOnDelay;
+        bool delayedMessage;
     };
 
 } // namespace cellular::internal::sms

--- a/module-sys/Timers/SystemTimer.cpp
+++ b/module-sys/Timers/SystemTimer.cpp
@@ -101,6 +101,9 @@ namespace sys::timer
             return;
         }
         log_debug("Timer %s runs callback", name.c_str());
+        if (type == timer::Type::SingleShot) {
+            stop();
+        }
         callback(*this);
     }
 


### PR DESCRIPTION
Speed up of the sms send while rejecting the phonecall.

Removed one of excessive antenna lock request. It was causing long period of the connection stabilization until SMS is sent.
Added missing antenna unlock in hangupcall().