### PR TITLE
[CP-351] Add reboot result code in SNVS

### DIFF
--- a/module-bsp/board/linux/lpm/LinuxLPM.cpp
+++ b/module-bsp/board/linux/lpm/LinuxLPM.cpp
@@ -36,4 +36,7 @@ namespace bsp
     void LinuxLPM::SwitchOscillatorSource(bsp::LowPowerMode::OscillatorSource source)
     {}
 
+    void LinuxLPM::SetBootSuccess()
+    {}
+
 } // namespace bsp

--- a/module-bsp/board/linux/lpm/LinuxLPM.h
+++ b/module-bsp/board/linux/lpm/LinuxLPM.h
@@ -18,6 +18,7 @@ namespace bsp
         void SetHighestCoreVoltage() final;
         [[nodiscard]] uint32_t GetCpuFrequency() const noexcept final;
         void SwitchOscillatorSource(OscillatorSource source) final;
+        void SetBootSuccess() override;
     };
 
 } // namespace bsp

--- a/module-bsp/board/rt1051/bsp/lpm/RT1051LPM.cpp
+++ b/module-bsp/board/rt1051/bsp/lpm/RT1051LPM.cpp
@@ -4,6 +4,7 @@
 #include "RT1051LPM.hpp"
 
 #include "board.h"
+#include "reboot_codes.hpp"
 #include <log.hpp>
 #include "bsp/BoardDefinitions.hpp"
 #include "bsp/watchdog/watchdog.hpp"
@@ -41,25 +42,18 @@ namespace bsp
 
     int32_t RT1051LPM::Reboot(RebootType reason)
     {
-        enum rebootCode : std::uint32_t
-        {
-            rebootNormalCode       = std::uint32_t{0},
-            rebootToUpdateCode     = std::uint32_t{0xdead0000},
-            rebootToRecoveryCode   = std::uint32_t{0xdead0001},
-            rebootToFactoryRstCode = std::uint32_t{0xdead0002}
-        };
         switch (reason) {
         case RebootType::GoToUpdaterUpdate:
-            SNVS->LPGPR[0] = rebootToUpdateCode;
+            SNVS->LPGPR[0] = bsp::rebootCode::rebootToUpdateCode;
             break;
         case RebootType::GoToUpdaterRecovery:
-            SNVS->LPGPR[0] = rebootToRecoveryCode;
+            SNVS->LPGPR[0] = bsp::rebootCode::rebootToRecoveryCode;
             break;
         case RebootType::GoToUpdaterFactoryReset:
-            SNVS->LPGPR[0] = rebootToFactoryRstCode;
+            SNVS->LPGPR[0] = bsp::rebootCode::rebootToFactoryRstCode;
             break;
         case RebootType::NormalRestart:
-            SNVS->LPGPR[0] = rebootNormalCode;
+            SNVS->LPGPR[0] = bsp::rebootCode::rebootNormalCode;
             break;
         }
         NVIC_SystemReset();
@@ -113,6 +107,11 @@ namespace bsp
             bsp::EnableExternalOscillator();
             cpp_freertos::CriticalSection::Exit();
         }
+    }
+
+    void RT1051LPM::SetBootSuccess()
+    {
+        SNVS->LPGPR[0] = bsp::rebootCode::rebootNormalCode;
     }
 
 } // namespace bsp

--- a/module-bsp/board/rt1051/bsp/lpm/RT1051LPM.hpp
+++ b/module-bsp/board/rt1051/bsp/lpm/RT1051LPM.hpp
@@ -20,6 +20,7 @@ namespace bsp
         void SetHighestCoreVoltage() final;
         [[nodiscard]] uint32_t GetCpuFrequency() const noexcept final;
         void SwitchOscillatorSource(OscillatorSource source) final;
+        void SetBootSuccess() override;
 
       private:
         std::shared_ptr<drivers::DriverGPIO> gpio;

--- a/module-bsp/board/rt1051/common/board.cpp
+++ b/module-bsp/board/rt1051/common/board.cpp
@@ -1,5 +1,7 @@
 
 #include "board.h"
+#include "reboot_codes.hpp"
+
 extern "C"
 {
 #include "fsl_common.h"
@@ -205,6 +207,9 @@ namespace bsp
         SNVS_LP_Init(SNVS);
         SNVS_HP_Init(SNVS);
         SNVS_HP_ChangeSSMState(SNVS);
+
+        // Default flag set on start in non-volatile memory to detect boot fault
+        SNVS->LPGPR[0] = rebootCode::rebootFailedToBoot;
 
         // Set internal DCDC to DCM mode. Switching between DCM and CCM mode will be done automatically.
         DCDC_BootIntoDCM(DCDC);

--- a/module-bsp/board/rt1051/common/reboot_codes.hpp
+++ b/module-bsp/board/rt1051/common/reboot_codes.hpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+// Copyright (c) 2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <cstdint>
+
+namespace bsp
+{
+    enum rebootCode : std::uint32_t
+    {
+        rebootNormalCode       = std::uint32_t{0},
+        rebootToUpdateCode     = std::uint32_t{0xdead0000},
+        rebootToRecoveryCode   = std::uint32_t{0xdead0001},
+        rebootToFactoryRstCode = std::uint32_t{0xdead0002},
+        rebootFailedToBoot     = std::uint32_t{0xdeadFFFF}
+    };
+} // namespace bsp

--- a/module-bsp/bsp/lpm/bsp_lpm.hpp
+++ b/module-bsp/bsp/lpm/bsp_lpm.hpp
@@ -40,6 +40,7 @@ namespace bsp
         [[nodiscard]] virtual uint32_t GetCpuFrequency() const noexcept = 0;
 
         virtual void SwitchOscillatorSource(OscillatorSource source) = 0;
+        virtual void SetBootSuccess() = 0;
 
       protected:
         CpuFrequencyHz currentFrequency = CpuFrequencyHz::Level_6;

--- a/module-sys/SystemManager/PowerManager.cpp
+++ b/module-sys/SystemManager/PowerManager.cpp
@@ -243,4 +243,9 @@ namespace sys
         LOG_INFO("%s", log.c_str());
     }
 
+    void PowerManager::SetBootSuccess()
+    {
+        lowPowerControl->SetBootSuccess();
+    }
+
 } // namespace sys

--- a/module-sys/SystemManager/PowerManager.hpp
+++ b/module-sys/SystemManager/PowerManager.hpp
@@ -53,6 +53,7 @@ namespace sys
         void SetCpuFrequencyRequest(std::string sentinelName, bsp::CpuFrequencyHz request);
         void ResetCpuFrequencyRequest(std::string sentinelName);
         void LogPowerManagerEfficiency();
+        void SetBootSuccess();
 
       private:
         /// called when the CPU frequency needs to be increased

--- a/module-sys/SystemManager/SystemManager.cpp
+++ b/module-sys/SystemManager/SystemManager.cpp
@@ -178,6 +178,8 @@ namespace sys
         if (userInit) {
             userInit();
         }
+
+        powerManager->SetBootSuccess();
     }
 
     void SystemManager::StartSystemServices()


### PR DESCRIPTION
This PR adds additional reboot code saved in SNVS signaling boot failure.
Boot is deemed as successful after all services start. 
To use boot loop break functionality, newest bootloader has to be used.
