### PR TITLE
[EGD-7382] Fix no devel assets in devel build

### DIFF
--- a/cmake/modules/Assets.cmake
+++ b/cmake/modules/Assets.cmake
@@ -3,8 +3,8 @@ set(ASSETS_SOURCE_DIR ${CMAKE_SOURCE_DIR}/image)
 function(add_assets_target)
     cmake_parse_arguments(
         _ASSETS
-        "DEVEL"
-        "TARGET;SOURCE_DIR;DEST_DIR"
+        ""
+        "TARGET;SOURCE_DIR;DEST_DIR;DEVEL"
         ""
         ${ARGN}
     )

--- a/image/CMakeLists.txt
+++ b/image/CMakeLists.txt
@@ -8,6 +8,7 @@ add_assets_target(
     TARGET assets
     SOURCE_DIR ${ASSETS_SOURCE_DIR}
     DEST_DIR ${ASSETS_DEST_DIR}
+    DEVEL ${WITH_DEVELOPMENT_FEATURES}
 )
 
 multicomp_install(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,7 @@ add_assets_target(
     TARGET test-assets
     SOURCE_DIR ${ASSETS_SOURCE_DIR}
     DEST_DIR ${TEST_ASSETS_DEST_DIR}
-    DEVEL
+    DEVEL ON
 )
 
 add_image(


### PR DESCRIPTION
Fix lack of development assets in development build causing onboarding
screen to show on startup.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>