### PR TITLE
[EGD-7484] Increase CPU frequency for screen redraw

### DIFF
--- a/products/PurePhone/EinkSentinelPure.cpp
+++ b/products/PurePhone/EinkSentinelPure.cpp
@@ -10,7 +10,7 @@ namespace service::eink
 {
     namespace
     {
-        constexpr auto RedrawLockedEinkCpuFrequency   = bsp::CpuFrequencyHz::Level_3;
+        constexpr auto RedrawLockedEinkCpuFrequency   = bsp::CpuFrequencyHz::Level_4;
         constexpr auto RedrawUnlockedEinkCpuFrequency = bsp::CpuFrequencyHz::Level_6;
     } // namespace
 


### PR DESCRIPTION
Increasing CPU frequency for screen redraw when screen is locked
due to DMA problems at lower frequencies.