### PR TITLE
[EGD-7486] Increase stack sizes

### DIFF
--- a/module-services/service-eink/ServiceEink.cpp
+++ b/module-services/service-eink/ServiceEink.cpp
@@ -24,7 +24,7 @@ namespace service::eink
 {
     namespace
     {
-        constexpr auto ServceEinkStackDepth = 2048U;
+        constexpr auto ServceEinkStackDepth = 4096U;
         constexpr std::chrono::milliseconds displayPowerOffTimeout{3800};
     } // namespace
 

--- a/module-sys/SystemWatchdog/SystemWatchdog.cpp
+++ b/module-sys/SystemWatchdog/SystemWatchdog.cpp
@@ -12,7 +12,7 @@ namespace sys
 {
     using namespace cpp_freertos;
 
-    static constexpr uint16_t stackDepthWords = 64;
+    static constexpr uint16_t stackDepthWords = 256;
 
     SystemWatchdog::SystemWatchdog()
         : Thread(threadName, stackDepthWords, static_cast<UBaseType_t>(ServicePriority::High))


### PR DESCRIPTION
Increase stack sizes of the eink service and the system watchdog. During
stability tests stack-overflows were observed for both threads.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>