### PR TITLE
[EGD-7474] Fixes for contacts matching

### DIFF
--- a/module-apps/application-calllog/CalllogModel.cpp
+++ b/module-apps/application-calllog/CalllogModel.cpp
@@ -66,8 +66,13 @@ gui::ListItem *CalllogModel::getItem(gui::Order order)
         return nullptr;
     }
 
-    auto contact = DBServiceAPI::MatchContactByPhoneNumber(application, call->phoneNumber);
-    call->name   = contact ? contact->getFormattedName() : UTF8(call->phoneNumber.getFormatted());
+    if (auto contact = DBServiceAPI::MatchContactByPhoneNumber(application, call->phoneNumber);
+        contact && !contact->isTemporary()) {
+        call->name = contact->getFormattedName();
+    }
+    else {
+        call->name = UTF8(call->phoneNumber.getFormatted());
+    }
 
     auto item = new gui::CalllogItem(this);
 

--- a/module-apps/application-calllog/windows/CallLogOptionsWindow.cpp
+++ b/module-apps/application-calllog/windows/CallLogOptionsWindow.cpp
@@ -13,11 +13,12 @@ std::list<gui::Option> calllogWindowOptions(app::ApplicationCallLog *app, const 
     std::list<gui::Option> options;
     if (record.presentation != PresentationType::PR_UNKNOWN) {
         auto searchResults = DBServiceAPI::ContactGetByIDWithTemporary(app, record.getContactId());
-
         if (searchResults->empty() || !searchResults->front().isValid() || searchResults->front().isTemporary()) {
             // add option - add contact
-            options.emplace_back(gui::Option{std::make_unique<gui::option::Contact>(
-                app, gui::option::ContactOperation::Add, searchResults->front())});
+            ContactRecord contact;
+            contact.numbers.emplace_back(record.phoneNumber);
+            options.emplace_back(
+                gui::Option{std::make_unique<gui::option::Contact>(app, gui::option::ContactOperation::Add, contact)});
         }
         else {
             // add option - contact details

--- a/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
@@ -172,7 +172,6 @@ namespace gui
                         }
                     }
                 }
-                return false;
             }
         }
         else {

--- a/module-db/Interface/ContactRecord.cpp
+++ b/module-db/Interface/ContactRecord.cpp
@@ -116,7 +116,7 @@ auto ContactRecordInterface::RemoveByID(uint32_t id) -> bool
                 contactDB->groups.removeContactFromGroup(id, group.ID);
             }
             contact.speedDial = "";
-            //            contactDB->name.removeById(contact.nameID);
+            contactDB->name.removeById(contact.nameID);
             contactDB->address.removeById(contact.addressID);
             contactDB->ringtones.removeById(contact.ringID);
             contactDB->contacts.update(contact);


### PR DESCRIPTION
Contacts matching didn't work correctly in calllog app.
It matched call log records with temporary or non-existing contacts.