### PR TITLE
[EGD-7485] Fix cellular behaviour in offline mode

### DIFF
--- a/module-apps/apps-common/notifications/NotificationsHandler.cpp
+++ b/module-apps/apps-common/notifications/NotificationsHandler.cpp
@@ -49,7 +49,7 @@ void NotificationsHandler::incomingCallHandler(sys::Message *request)
 
 void NotificationsHandler::callerIdHandler(sys::Message *request)
 {
-    auto msg = static_cast<CellularIncominCallMessage *>(request);
+    auto msg = static_cast<CellularCallerIdMessage *>(request);
 
     if (currentCallPolicy.isNumberCheckRequired()) {
         policyNumberCheck(msg->number);

--- a/module-services/service-cellular/connection-manager/ConnectionManager.cpp
+++ b/module-services/service-cellular/connection-manager/ConnectionManager.cpp
@@ -8,8 +8,10 @@
 auto ConnectionManager::onPhoneModeChange(sys::phone_modes::PhoneMode mode) -> bool
 {
     if (mode == sys::phone_modes::PhoneMode::Offline) {
+        forceDismissCallsFlag = true;
         return handleModeChangeToCommonOffline();
     }
+    forceDismissCallsFlag = false;
     return handleModeChangeToConnected();
 }
 
@@ -104,4 +106,9 @@ auto ConnectionManager::handleModeChangeToConnected() -> bool
         cellular->connectToNetwork();
     }
     return true;
+}
+
+auto ConnectionManager::forceDismissCalls() -> bool
+{
+    return forceDismissCallsFlag;
 }

--- a/module-services/service-cellular/service-cellular/CellularCall.hpp
+++ b/module-services/service-cellular/service-cellular/CellularCall.hpp
@@ -85,7 +85,7 @@ namespace CellularCall
 
         bool isValid() const
         {
-            return call.ID != 0;
+            return call.ID != DB_ID_NONE;
         }
 
         bool isActive() const

--- a/module-services/service-cellular/service-cellular/connection-manager/ConnectionManager.hpp
+++ b/module-services/service-cellular/service-cellular/connection-manager/ConnectionManager.hpp
@@ -51,6 +51,11 @@ class ConnectionManager
      */
     void onTimerTick();
 
+    /// Should we always dismiss incoming calls?
+    /// @return true or false depending on state of forceDismissCallsMode flag
+    /// @see forceDismissCallsMode
+    auto forceDismissCalls() -> bool;
+
   private:
     bool isFlightMode;
     std::chrono::minutes connectionInterval{0};
@@ -58,6 +63,11 @@ class ConnectionManager
     std::chrono::minutes minutesOnlineElapsed{0};
     std::shared_ptr<ConnectionManagerCellularCommandsInterface> cellular;
     bool onlinePeriod = false;
+
+    /// Flag determining if we should always dismiss incoming calls - even when
+    /// we are in offline mode (messages only) and we connect to network to poll
+    /// for new messages
+    bool forceDismissCallsFlag = false;
 
     /**
      * @brief Checks if flightMode and connection interval are set as Messages only mode

--- a/module-services/service-cellular/tests/unittest_connection-manager.cpp
+++ b/module-services/service-cellular/tests/unittest_connection-manager.cpp
@@ -12,7 +12,7 @@ using namespace testing;
 class MockCellular : public ConnectionManagerCellularCommandsInterface
 {
   public:
-    MOCK_METHOD(bool, disconnectFromNetwork, ());
+    MOCK_METHOD(bool, disconnectFromNetwork, (), (override));
     MOCK_METHOD(bool, connectToNetwork, (), (override));
     MOCK_METHOD(bool, isConnectedToNetwork, (), (override));
     MOCK_METHOD(bool, clearNetworkIndicator, (), (override));


### PR DESCRIPTION
When in offline/message only, while Pure is in message poll mode and
incoming call will happen CellularService will start answering call thus
resulting to show the incorrect info in call log and not showing the
first call after Online mode is switched back.
This PR is cherry-picked from EGD-7332.