### PR TITLE
[BH-831] Show popup on Alarm activation - part II

### DIFF
--- a/module-apps/apps-common/Application.cpp
+++ b/module-apps/apps-common/Application.cpp
@@ -856,8 +856,7 @@ namespace app
                     return std::make_unique<gui::SimNotReadyWindow>(app, window::sim_not_ready_window);
                 });
                 break;
-            case ID::AlarmActivated:
-                LOG_DEBUG("TODO");
+            default:
                 break;
             }
         }

--- a/module-apps/apps-common/Application.hpp
+++ b/module-apps/apps-common/Application.hpp
@@ -351,7 +351,7 @@ namespace app
         void popWindow(const std::string &window);
 
         /// Method used to attach popups windows to application
-        void attachPopups(const std::vector<gui::popup::ID> &popupsList);
+        virtual void attachPopups(const std::vector<gui::popup::ID> &popupsList);
         virtual void showPopup(gui::popup::ID id, const gui::PopupRequestParams *params);
         void abortPopup(gui::popup::ID id);
 

--- a/products/BellHybrid/CMakeLists.txt
+++ b/products/BellHybrid/CMakeLists.txt
@@ -37,11 +37,12 @@ set_target_properties(BellHybrid
 
 target_link_libraries(BellHybrid
     PRIVATE
-        bell::app-alarm
-        bell::app-main
-        bell::app-settings
-        bell::app-powernap
         appmgr
+        bell::app-alarm
+        bell::app-common
+        bell::app-main
+        bell::app-powernap
+        bell::app-settings
         bell::db
         evtmgr
         messagetype

--- a/products/BellHybrid/apps/application-bell-alarm/ApplicationBellAlarm.cpp
+++ b/products/BellHybrid/apps/application-bell-alarm/ApplicationBellAlarm.cpp
@@ -12,7 +12,7 @@ namespace app
                                                sys::phone_modes::PhoneMode mode,
                                                sys::bluetooth::BluetoothMode bluetoothMode,
                                                StartInBackground startInBackground)
-        : Application(std::move(name), std::move(parent), mode, bluetoothMode, startInBackground)
+        : ApplicationBell(std::move(name), std::move(parent), mode, bluetoothMode, startInBackground)
     {}
 
     sys::ReturnCodes ApplicationBellAlarm::InitHandler()
@@ -33,6 +33,8 @@ namespace app
             auto presenter = std::make_unique<bell_alarm::BellAlarmWindowPresenter>();
             return std::make_unique<gui::BellAlarmWindow>(app, std::move(presenter));
         });
+
+        attachPopups({gui::popup::ID::AlarmActivated});
     }
 
     sys::MessagePointer ApplicationBellAlarm::DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp)

--- a/products/BellHybrid/apps/application-bell-alarm/CMakeLists.txt
+++ b/products/BellHybrid/apps/application-bell-alarm/CMakeLists.txt
@@ -24,6 +24,6 @@ target_include_directories(application-bell-alarm
 
 target_link_libraries(application-bell-alarm
     PRIVATE
-        apps-common
+        bell::app-common
         module-gui
 )

--- a/products/BellHybrid/apps/application-bell-alarm/include/application-bell-alarm/ApplicationBellAlarm.hpp
+++ b/products/BellHybrid/apps/application-bell-alarm/include/application-bell-alarm/ApplicationBellAlarm.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <apps-common/Application.hpp>
+#include <common/ApplicationBell.hpp>
 
 namespace gui::window::name
 {
@@ -14,7 +14,7 @@ namespace app
 {
     inline constexpr auto applicationBellAlarmName = "ApplicationBellAlarm";
 
-    class ApplicationBellAlarm : public Application
+    class ApplicationBellAlarm : public ApplicationBell
     {
       public:
         explicit ApplicationBellAlarm(

--- a/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
+++ b/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
@@ -20,7 +20,7 @@ namespace app
                                              sys::phone_modes::PhoneMode mode,
                                              sys::bluetooth::BluetoothMode bluetoothMode,
                                              StartInBackground startInBackground)
-        : Application(name, parent, mode, bluetoothMode, startInBackground)
+        : ApplicationBell(name, parent, mode, bluetoothMode, startInBackground)
     {
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
         addActionReceiver(manager::actions::ShowAlarm, [this](auto &&data) {
@@ -60,6 +60,8 @@ namespace app
         windowsFactory.attach(gui::window::name::bell_main_menu_dialog, [](Application *app, const std::string &name) {
             return std::make_unique<gui::Dialog>(app, name);
         });
+
+        attachPopups({gui::popup::ID::AlarmActivated});
     }
 
     sys::MessagePointer ApplicationBellMain::DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp)

--- a/products/BellHybrid/apps/application-bell-main/CMakeLists.txt
+++ b/products/BellHybrid/apps/application-bell-main/CMakeLists.txt
@@ -44,10 +44,11 @@ target_link_libraries(application-bell-main
         time
         bell::db
         bell::evtmgr
-        bell::app-common
         bell::app-alarm
         bell::app-settings
         bell::app-powernap
         bell::keymap
         ${TARGET_LIBRARIES}
+    PUBLIC
+        bell::app-common
 )

--- a/products/BellHybrid/apps/application-bell-main/include/application-bell-main/ApplicationBellMain.hpp
+++ b/products/BellHybrid/apps/application-bell-main/include/application-bell-main/ApplicationBellMain.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <Application.hpp>
+#include <common/ApplicationBell.hpp>
 
 namespace gui::window::name
 {
@@ -16,7 +16,7 @@ namespace app
 {
     inline constexpr auto applicationBellName = "ApplicationBell";
 
-    class ApplicationBellMain : public Application
+    class ApplicationBellMain : public ApplicationBell
     {
       public:
         explicit ApplicationBellMain(

--- a/products/BellHybrid/apps/application-bell-main/presenters/StateController.cpp
+++ b/products/BellHybrid/apps/application-bell-main/presenters/StateController.cpp
@@ -5,6 +5,8 @@
 #include "HomeScreenPresenter.hpp"
 #include "models/TimeModel.hpp"
 
+#include <common/TimeUtils.hpp>
+
 #include <keymap/KeyMap.hpp>
 
 #include <boost/sml.hpp>
@@ -34,19 +36,6 @@ namespace app::home_screen
             auto showAlarmTime        = [](AbstractView &view) { view.setAlarmTimeVisible(true); };
             auto updateTemperature    = [](AbstractView &view, AbstractTemperatureModel &temperatureModel) {
                 view.setTemperature(temperatureModel.getTemperature());
-            };
-
-            auto calculateTimeDifference = [](AbstractView &view, AbstractTimeModel &timeModel) {
-                const auto now       = timeModel.getCurrentTime();
-                const auto alarmTime = view.getAlarmTime();
-                return utils::time::Duration{alarmTime, now}.get();
-            };
-
-            auto setBottomDescription = [](std::time_t timestamp) {
-                const auto duration = utils::time::Duration{timestamp};
-                const auto prefix   = utils::translate("app_bellmain_home_screen_bottom_desc");
-                return UTF8(prefix + " " + std::to_string(duration.getHours()) + " hrs & " +
-                            std::to_string(duration.getMinutes()) + " min");
             };
 
             auto setDefaultAlarmTime =
@@ -161,8 +150,8 @@ namespace app::home_screen
                 alarmModel.setAlarmTime(view.getAlarmTime());
                 alarmModel.activate(true);
                 presenter.spawnTimer();
-                view.setBottomDescription(
-                    Helpers::setBottomDescription(Helpers::calculateTimeDifference(view, timeModel)));
+                view.setBottomDescription(utils::time::getBottomDescription(
+                    utils::time::calculateTimeDifference(view.getAlarmTime(), timeModel.getCurrentTime())));
                 view.setAlarmActive(true);
                 view.setAlarmVisible(true);
             };

--- a/products/BellHybrid/apps/application-bell-powernap/ApplicationBellPowerNap.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/ApplicationBellPowerNap.cpp
@@ -16,7 +16,7 @@ namespace app
                                                      sys::phone_modes::PhoneMode mode,
                                                      sys::bluetooth::BluetoothMode bluetoothMode,
                                                      StartInBackground startInBackground)
-        : Application(std::move(name), std::move(parent), mode, bluetoothMode, startInBackground)
+        : ApplicationBell(std::move(name), std::move(parent), mode, bluetoothMode, startInBackground)
     {}
 
     sys::ReturnCodes ApplicationBellPowerNap::InitHandler()
@@ -44,6 +44,8 @@ namespace app
             auto presenter = std::make_unique<powernap::PowerNapSessionEndPresenter>(app);
             return std::make_unique<gui::PowerNapSessionEndedWindow>(app, std::move(presenter));
         });
+
+        attachPopups({gui::popup::ID::AlarmActivated});
     }
 
     sys::MessagePointer ApplicationBellPowerNap::DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp)

--- a/products/BellHybrid/apps/application-bell-powernap/CMakeLists.txt
+++ b/products/BellHybrid/apps/application-bell-powernap/CMakeLists.txt
@@ -42,9 +42,9 @@ target_sources(application-bell-powernap
 
 target_link_libraries(application-bell-powernap
     PRIVATE
+        bell::app-common
         bell::app-main
 
     PUBLIC
-        apps-common
         module-gui
 )

--- a/products/BellHybrid/apps/application-bell-powernap/include/application-bell-powernap/ApplicationBellPowerNap.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/include/application-bell-powernap/ApplicationBellPowerNap.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <apps-common/Application.hpp>
+#include <common/ApplicationBell.hpp>
 
 namespace gui::window::name
 {
@@ -14,7 +14,7 @@ namespace app
 {
     inline constexpr auto applicationBellPowerNapName = "ApplicationBellPowerNap";
 
-    class ApplicationBellPowerNap : public Application
+    class ApplicationBellPowerNap : public ApplicationBell
     {
       public:
         ApplicationBellPowerNap(std::string name                            = applicationBellPowerNapName,

--- a/products/BellHybrid/apps/application-bell-settings/ApplicationBellSettings.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/ApplicationBellSettings.cpp
@@ -29,7 +29,7 @@ namespace app
                                                      sys::phone_modes::PhoneMode mode,
                                                      sys::bluetooth::BluetoothMode bluetoothMode,
                                                      StartInBackground startInBackground)
-        : Application(std::move(name), std::move(parent), mode, bluetoothMode, startInBackground)
+        : ApplicationBell(std::move(name), std::move(parent), mode, bluetoothMode, startInBackground)
     {}
 
     sys::ReturnCodes ApplicationBellSettings::InitHandler()
@@ -89,6 +89,8 @@ namespace app
         windowsFactory.attach(gui::window::name::bellSettingsTurnOff, [](Application *app, const std::string &name) {
             return std::make_unique<gui::BellSettingsTurnOffWindow>(app);
         });
+
+        attachPopups({gui::popup::ID::AlarmActivated});
     }
 
     sys::MessagePointer ApplicationBellSettings::DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp)

--- a/products/BellHybrid/apps/application-bell-settings/CMakeLists.txt
+++ b/products/BellHybrid/apps/application-bell-settings/CMakeLists.txt
@@ -68,9 +68,9 @@ target_sources(application-bell-settings
 target_link_libraries(application-bell-settings
     PRIVATE
         bellgui
+        bell::app-common
         bell::db
         service-appmgr
     PUBLIC
-        apps-common
         module-gui
 )

--- a/products/BellHybrid/apps/application-bell-settings/include/application-bell-settings/ApplicationBellSettings.hpp
+++ b/products/BellHybrid/apps/application-bell-settings/include/application-bell-settings/ApplicationBellSettings.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <apps-common/Application.hpp>
+#include <common/ApplicationBell.hpp>
 #include <service-evtmgr/screen-light-control/ScreenLightControl.hpp>
 
 namespace gui::window::name
@@ -46,7 +46,7 @@ namespace app
         };
     }; // namespace settingsInterface
 
-    class ApplicationBellSettings : public Application, public settingsInterface::BellScreenLightSettings
+    class ApplicationBellSettings : public ApplicationBell, public settingsInterface::BellScreenLightSettings
     {
       public:
         ApplicationBellSettings(std::string name                            = applicationBellSettingsName,

--- a/products/BellHybrid/apps/common/CMakeLists.txt
+++ b/products/BellHybrid/apps/common/CMakeLists.txt
@@ -2,28 +2,32 @@ add_library(application-bell-common STATIC)
 add_library(bell::app-common ALIAS application-bell-common)
 
 target_include_directories(application-bell-common
-        PRIVATE
+    PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/common>
-        PUBLIC
+    PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        )
+)
 
 target_sources(application-bell-common
-        PRIVATE
+    PRIVATE
         src/AlarmModel.cpp
+        src/ApplicationBell.cpp
+        src/TimeUtils.cpp
+        src/popups/AlarmActivatedWindow.cpp
 
-        PUBLIC
+    PUBLIC
+        include/common/ApplicationBell.hpp
+        include/common/TimeUtils.hpp
         include/common/models/AlarmModel.hpp
         include/common/models/AbstractAlarmModel.hpp
-        )
-
+        include/common/popups/AlarmActivatedWindow.hpp
+)
 
 target_link_libraries(application-bell-common
-        PUBLIC
+    PUBLIC
         apps-common
 
-        PRIVATE
+    PRIVATE
         module-gui
         service-time
-
-        )
+)

--- a/products/BellHybrid/apps/common/include/common/ApplicationBell.hpp
+++ b/products/BellHybrid/apps/common/include/common/ApplicationBell.hpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <apps-common/Application.hpp>
+
+namespace app
+{
+    class ApplicationBell : public Application
+    {
+      public:
+        using Application::Application;
+
+      protected:
+        void attachPopups(const std::vector<gui::popup::ID> &popupsList) override;
+    };
+} // namespace app

--- a/products/BellHybrid/apps/common/include/common/TimeUtils.hpp
+++ b/products/BellHybrid/apps/common/include/common/TimeUtils.hpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <module-utils/utf8/utf8/UTF8.hpp>
+
+#include <ctime>
+
+namespace utils::time
+{
+    std::time_t getCurrentTime();
+    std::time_t calculateTimeDifference(std::time_t alarmTime, std::time_t currentTime);
+    UTF8 getBottomDescription(std::time_t timestamp);
+} // namespace utils::time

--- a/products/BellHybrid/apps/common/include/common/popups/AlarmActivatedWindow.hpp
+++ b/products/BellHybrid/apps/common/include/common/popups/AlarmActivatedWindow.hpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <apps-common/popups/presenter/PowerOffPresenter.hpp>
+#include <apps-common/windows/Dialog.hpp>
+
+namespace gui
+{
+    class AlarmActivatedWindow : public Dialog
+    {
+      public:
+        explicit AlarmActivatedWindow(app::Application *app);
+        void onBeforeShow(ShowMode mode, SwitchData *data) override;
+    };
+} /* namespace gui */

--- a/products/BellHybrid/apps/common/src/ApplicationBell.cpp
+++ b/products/BellHybrid/apps/common/src/ApplicationBell.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <common/ApplicationBell.hpp>
+#include <common/popups/AlarmActivatedWindow.hpp>
+
+namespace app
+{
+    void ApplicationBell::attachPopups(const std::vector<gui::popup::ID> &popupsList)
+    {
+        using namespace gui::popup;
+        app::Application::attachPopups(popupsList);
+        for (auto popup : popupsList) {
+            switch (popup) {
+            case ID::AlarmActivated:
+                windowsFactory.attach(window::alarm_activated_window,
+                                      [](app::Application *app, const std::string &name) {
+                                          return std::make_unique<gui::AlarmActivatedWindow>(app);
+                                      });
+                break;
+            default:
+                break;
+            }
+        }
+    }
+} // namespace app

--- a/products/BellHybrid/apps/common/src/TimeUtils.cpp
+++ b/products/BellHybrid/apps/common/src/TimeUtils.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <common/TimeUtils.hpp>
+
+#include <time/time_conversion.hpp>
+
+namespace utils::time
+{
+    std::time_t getCurrentTime()
+    {
+        return std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    }
+
+    std::time_t calculateTimeDifference(std::time_t alarmTime, std::time_t currentTime)
+    {
+        return Duration{alarmTime, currentTime}.get();
+    }
+
+    UTF8 getBottomDescription(std::time_t timestamp)
+    {
+        const auto prefix   = translate("app_bellmain_home_screen_bottom_desc");
+        const auto duration = Duration{timestamp};
+        const auto timeText = [](time_t hours, time_t minutes) -> std::string {
+            if (hours == 0 && minutes == 0) {
+                return "1 min";
+            }
+            else if (hours == 0) {
+                return std::to_string(minutes) + " min";
+            }
+            else if (minutes == 0) {
+                return std::to_string(hours) + " hrs";
+            }
+            else {
+                return std::to_string(hours) + " hrs & " + std::to_string(minutes) + " min";
+            }
+        }(duration.getHours(), duration.getMinutes());
+        return UTF8(prefix + " " + timeText);
+    }
+} // namespace utils::time

--- a/products/BellHybrid/apps/common/src/popups/AlarmActivatedWindow.cpp
+++ b/products/BellHybrid/apps/common/src/popups/AlarmActivatedWindow.cpp
@@ -1,0 +1,29 @@
+﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <common/popups/AlarmActivatedWindow.hpp>
+
+#include <apps-common/messages/DialogMetadataMessage.hpp>
+#include <common/TimeUtils.hpp>
+
+namespace gui
+{
+    AlarmActivatedWindow::AlarmActivatedWindow(app::Application *app)
+        : Dialog(app, popup::window::alarm_activated_window)
+    {}
+
+    void AlarmActivatedWindow::onBeforeShow(ShowMode mode, SwitchData *data)
+    {
+        const auto alarmTime = utils::time::getCurrentTime(); // TODO: Get alarm time from db
+        auto msg             = std::make_unique<DialogMetadataMessage>(
+            gui::DialogMetadata{.title = "",
+                                .icon  = "bell_alarm_activated",
+                                .text  = utils::time::getBottomDescription(
+                                    utils::time::calculateTimeDifference(alarmTime, utils::time::getCurrentTime()))});
+        Dialog::onBeforeShow(mode, msg.get());
+
+        statusBar->setVisible(false);
+        header->setTitleVisibility(false);
+        bottomBar->setActive(BottomBar::Side::RIGHT, false);
+    }
+} /* namespace gui */


### PR DESCRIPTION
- create ApplicationBell with `attachPopups` method overridden,
- change parent for all Bell apps from `Application` to `ApplicationBell`,
- create `AlarmActivatedWindow` popup which shows on `AlarmActivated` event

![obraz](https://user-images.githubusercontent.com/22866056/132348395-b144e3bb-401d-43d3-89f9-3acfb907c867.png)
