### PR TITLE
[EGD-7311] Fixed log use on Linux to be the same as on Rt1051

### DIFF
--- a/module-os/board/linux/port.c
+++ b/module-os/board/linux/port.c
@@ -915,3 +915,9 @@ unsigned long ulPortGetTimerValue( void )
      */
     return ( unsigned long ) xTimes.tms_utime;
 }
+
+
+BaseType_t xPortIsInsideInterrupt(void)
+{
+    return pdFALSE;
+}

--- a/module-os/board/linux/portmacro.h
+++ b/module-os/board/linux/portmacro.h
@@ -180,6 +180,8 @@ extern void vPortAddTaskHandle( void *pxTaskHandle );
 #define SIG_TICK					SIGPROF
 #define TIMER_TYPE					ITIMER_PROF */
 
+BaseType_t xPortIsInsideInterrupt(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/module-utils/board/linux/log_linux.cpp
+++ b/module-utils/board/linux/log_linux.cpp
@@ -9,30 +9,6 @@
 
 namespace Log
 {
-    void Logger::addLogHeader(logger_level level, const char *file, int line, const char *function)
-    {
-        loggerBufferCurrentPos += snprintf(&loggerBuffer[loggerBufferCurrentPos],
-                                           LOGGER_BUFFER_SIZE - loggerBufferCurrentPos,
-                                           "%d ms ",
-                                           cpp_freertos::Ticks::TicksToMs(cpp_freertos::Ticks::GetTicks()));
-
-        loggerBufferCurrentPos += snprintf(&loggerBuffer[loggerBufferCurrentPos],
-                                           LOGGER_BUFFER_SIZE - loggerBufferCurrentPos,
-                                           "%s%-5s %s%s:%s:%d:%s ",
-                                           logColors->levelColors[level].data(),
-                                           levelNames[level],
-                                           logColors->callerInfoColor.data(),
-                                           file,
-                                           function,
-                                           line,
-                                           logColors->resetColor.data());
-    }
-
-    bool Logger::filterLogs(logger_level _level)
-    {
-        return _level >= level;
-    }
-
     void Logger::logToDevice(const char *, va_list)
     {
         assert(false && "Not implemented");

--- a/module-utils/board/rt1051/log_rt1051.cpp
+++ b/module-utils/board/rt1051/log_rt1051.cpp
@@ -9,45 +9,8 @@
 #include <SEGGER_RTT.h>
 #include <ticks.hpp>
 
-/// get string description:
-/// - in critical seciton - return CRIT
-/// - in interrupt return - IRQ
-/// - else return thread name
-static inline const char *getTaskDesc()
-{
-    return xTaskGetCurrentTaskHandle() == nullptr
-               ? Log::Logger::CRIT_STR
-               : xPortIsInsideInterrupt() ? Log::Logger::IRQ_STR : pcTaskGetName(xTaskGetCurrentTaskHandle());
-}
-
 namespace Log
 {
-    void Logger::addLogHeader(logger_level level, const char *file, int line, const char *function)
-    {
-        loggerBufferCurrentPos += snprintf(&loggerBuffer[loggerBufferCurrentPos],
-                                           loggerBufferSizeLeft(),
-                                           "%lu ms ",
-                                           cpp_freertos::Ticks::TicksToMs(cpp_freertos::Ticks::GetTicks()));
-
-        loggerBufferCurrentPos += snprintf(&loggerBuffer[loggerBufferCurrentPos],
-                                           loggerBufferSizeLeft(),
-                                           "%s%-5s %s[%s] %s%s:%s:%d:%s ",
-                                           logColors->levelColors[level].data(),
-                                           levelNames[level],
-                                           logColors->serviceNameColor.data(),
-                                           getTaskDesc(),
-                                           logColors->callerInfoColor.data(),
-                                           file,
-                                           function,
-                                           line,
-                                           logColors->resetColor.data());
-    }
-
-    bool Logger::filterLogs(logger_level level)
-    {
-        return getLogLevel(getTaskDesc()) <= level;
-    }
-
     void Logger::logToDevice(const char *fmt, va_list args)
     {
         loggerBufferCurrentPos = 0;

--- a/module-utils/log/Logger.hpp
+++ b/module-utils/log/Logger.hpp
@@ -94,4 +94,6 @@ namespace Log
         static const char *levelNames[];
         static std::map<std::string, logger_level> filtered;
     };
+
+    const char *getTaskDesc();
 } // namespace Log


### PR DESCRIPTION
- Log headers were incomplete
- Log filtering was broken on Linux


Log on Linux:
![image](https://user-images.githubusercontent.com/6411862/132020131-8c9ae775-d9ac-4652-93a6-874fcf814eca.png)
1st arrow - see filtered by default logs
2nd arrow - see that service name is being logged 