### PR TITLE
[BH-828] PowerNap progress implementation

### DIFF
--- a/module-apps/apps-common/widgets/ProgressTimer.hpp
+++ b/module-apps/apps-common/widgets/ProgressTimer.hpp
@@ -14,6 +14,15 @@ namespace gui
 
 namespace app
 {
+    class ProgressTimerUIConfigurator
+    {
+
+      public:
+        virtual ~ProgressTimerUIConfigurator()       = default;
+        virtual void attach(gui::Progress *progress) = 0;
+        virtual void attach(gui::Text *clock)        = 0;
+    };
+
     /** ProgressTimer provides an interface that connect Timer's features to UI representation.
      * The Timer's features consists of:
      * 1) counting time down,
@@ -23,11 +32,9 @@ namespace app
      * 1) ability to present time left on attached Text
      * 2) ability to present timer's progress on attached class realising Progress interface.
      */
-    class ProgressTimer
+    class ProgressTimer : public ProgressTimerUIConfigurator
     {
       public:
-        virtual ~ProgressTimer() = default;
-
         [[nodiscard]] virtual auto isStopped() const noexcept -> bool                    = 0;
         virtual void reset(std::chrono::seconds duration,
                            std::chrono::seconds interval = std::chrono::seconds::zero()) = 0;

--- a/products/BellHybrid/apps/application-bell-powernap/ApplicationBellPowerNap.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/ApplicationBellPowerNap.cpp
@@ -3,7 +3,9 @@
 
 #include "ApplicationBellPowerNap.hpp"
 #include "presenter/PowerNapMainWindowPresenter.hpp"
+#include "presenter/PowerNapProgressPresenter.hpp"
 #include "windows/PowerNapMainWindow.hpp"
+#include "windows/PowerNapProgressWindow.hpp"
 
 namespace app
 {
@@ -31,6 +33,10 @@ namespace app
         windowsFactory.attach(gui::name::window::main_window, [this](Application *app, const std::string &name) {
             auto presenter = std::make_unique<powernap::PowerNapMainWindowPresenter>(app, settings.get());
             return std::make_unique<gui::PowerNapMainWindow>(app, std::move(presenter));
+        });
+        windowsFactory.attach(gui::window::name::powernapProgress, [this](Application *app, const std::string &name) {
+            auto presenter = std::make_unique<powernap::PowerNapProgressPresenter>(app, settings.get());
+            return std::make_unique<gui::PowerNapProgressWindow>(app, std::move(presenter));
         });
     }
 

--- a/products/BellHybrid/apps/application-bell-powernap/CMakeLists.txt
+++ b/products/BellHybrid/apps/application-bell-powernap/CMakeLists.txt
@@ -17,14 +17,19 @@ target_sources(application-bell-powernap
     PRIVATE
         ApplicationBellPowerNap.cpp
         presenter/PowerNapMainWindowPresenter.cpp
+        presenter/PowerNapProgressPresenter.cpp
         windows/PowerNapMainWindow.cpp
+        windows/PowerNapProgressWindow.cpp
         data/PowerNapListItem.cpp
         models/PowerNapModel.cpp
 
         presenter/PowerNapMainWindowPresenter.hpp
+        presenter/PowerNapProgressPresenter.hpp
         windows/PowerNapMainWindow.hpp
+        windows/PowerNapProgressWindow.hpp
         data/PowerNapListItem.hpp
         data/PowerNapStyle.hpp
+        data/PowerNapCommon.hpp
         models/PowerNapModel.hpp
 
     PUBLIC

--- a/products/BellHybrid/apps/application-bell-powernap/data/PowerNapCommon.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/data/PowerNapCommon.hpp
@@ -1,0 +1,9 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+namespace app::powernap
+{
+    constexpr auto powernapDBRecordName = "PowerNapTime";
+}

--- a/products/BellHybrid/apps/application-bell-powernap/data/PowerNapStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/data/PowerNapStyle.hpp
@@ -7,11 +7,17 @@
 
 namespace gui::powerNapStyle
 {
-    inline constexpr auto descriptionFont = style::bell_sidelist_item::description_font;
+    inline constexpr auto descriptionFont = style::window::font::largelight;
     inline constexpr auto napPeriodFont   = style::window::font::supersizemelight;
     namespace listItem
     {
         inline constexpr auto timeUnitSingular = "common_minute_lower";
         inline constexpr auto timeUnitPlural   = "common_minutes_lower";
     } // namespace listItem
+
+    namespace progress
+    {
+        inline constexpr auto bottomDescTopMargin = 20U;
+        inline constexpr auto boxesCount          = 16;
+    } // namespace progress
 } // namespace gui::powerNapStyle

--- a/products/BellHybrid/apps/application-bell-powernap/include/application-bell-powernap/ApplicationBellPowerNap.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/include/application-bell-powernap/ApplicationBellPowerNap.hpp
@@ -5,6 +5,10 @@
 
 #include <apps-common/Application.hpp>
 
+namespace gui::window::name
+{
+    inline constexpr auto powernapProgress = "PowerNapProgressWindow";
+}
 namespace app
 {
     inline constexpr auto applicationBellPowerNapName = "ApplicationBellPowerNap";

--- a/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapMainWindowPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapMainWindowPresenter.cpp
@@ -3,19 +3,16 @@
 
 #include "PowerNapMainWindowPresenter.hpp"
 #include "models/PowerNapModel.hpp"
+#include "data/PowerNapCommon.hpp"
+#include <ApplicationBellPowerNap.hpp>
 #include <apps-common/Application.hpp>
 #include <service-db/agents/settings/SystemSettings.hpp>
 #include <service-db/Settings.hpp>
 
-namespace
-{
-    constexpr auto powernapDBRecordName = "powernapPeriod";
-} // namespace
-
 namespace app::powernap
 {
     PowerNapMainWindowPresenter::PowerNapMainWindowPresenter(app::Application *app, settings::Settings *settings)
-        : model{std::make_shared<PowerNapModel>()}, settings{settings}
+        : app{app}, settings{settings}, model{std::make_shared<PowerNapModel>()}
     {}
 
     auto PowerNapMainWindowPresenter::getNapTimeProvider() -> std::shared_ptr<gui::ListItemProvider>
@@ -35,5 +32,6 @@ namespace app::powernap
         const auto currentValue = model->getCurrentValue();
         settings->setValue(
             powernapDBRecordName, utils::to_string(currentValue.count()), settings::SettingsScope::AppLocal);
+        app->switchWindow(gui::window::name::powernapProgress);
     }
 } // namespace app::powernap

--- a/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapMainWindowPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapMainWindowPresenter.hpp
@@ -45,8 +45,9 @@ namespace app::powernap
 
     class PowerNapMainWindowPresenter : public PowerNapMainWindowContract::Presenter
     {
+        app::Application *app        = nullptr;
+        settings::Settings *settings = nullptr;
         std::shared_ptr<PowerNapModel> model;
-        settings::Settings *settings;
 
       public:
         PowerNapMainWindowPresenter(app::Application *app, settings::Settings *settings);

--- a/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "PowerNapProgressPresenter.hpp"
+#include "data/PowerNapCommon.hpp"
+
+#include <apps-common/widgets/ProgressTimerImpl.hpp>
+#include <apps-common/Application.hpp>
+#include <service-db/Settings.hpp>
+#include <Utils.hpp>
+
+#include <gsl/assert>
+
+namespace
+{
+    inline constexpr auto powernapTimerName = "PowerNapTimer";
+    inline constexpr std::chrono::seconds timerTick{1};
+} // namespace
+namespace app::powernap
+{
+    PowerNapProgressPresenter::PowerNapProgressPresenter(app::Application *app, settings::Settings *settings)
+        : app{app}, settings{settings}
+    {}
+    void PowerNapProgressPresenter::initTimer(gui::Item *parent)
+    {
+        timer = std::make_unique<app::ProgressTimerImpl>(app, parent, powernapTimerName, timerTick);
+    }
+    void PowerNapProgressPresenter::activate()
+    {
+        Expects(timer != nullptr);
+        const auto value = settings->getValue(powernapDBRecordName, settings::SettingsScope::AppLocal);
+        timer->reset(std::chrono::minutes{utils::getNumericValue<int>(value)});
+        timer->start();
+    }
+    app::ProgressTimerUIConfigurator &PowerNapProgressPresenter::getUIConfigurator() noexcept
+    {
+        Expects(timer != nullptr);
+        return *timer;
+    }
+} // namespace app::powernap

--- a/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.hpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <apps-common/BasePresenter.hpp>
+#include <apps-common/widgets/ProgressTimer.hpp>
+#include <memory>
+namespace app
+{
+    class Application;
+} // namespace app
+namespace gui
+{
+    class Item;
+} // namespace gui
+namespace settings
+{
+    class Settings;
+}
+
+namespace app::powernap
+{
+    class PowerNapProgressContract
+    {
+      public:
+        class View
+        {
+          public:
+            ~View() = default;
+        };
+
+        class Presenter : public BasePresenter<PowerNapProgressContract::View>
+        {
+          public:
+            virtual void initTimer(gui::Item *parent)                              = 0;
+            virtual app::ProgressTimerUIConfigurator &getUIConfigurator() noexcept = 0;
+            virtual void activate()                                                = 0;
+        };
+    };
+
+    class PowerNapProgressPresenter : public PowerNapProgressContract::Presenter
+    {
+        app::Application *app        = nullptr;
+        settings::Settings *settings = nullptr;
+        std::unique_ptr<app::ProgressTimer> timer;
+
+        void initTimer(gui::Item *parent) override;
+        void activate() override;
+        app::ProgressTimerUIConfigurator &getUIConfigurator() noexcept override;
+
+      public:
+        PowerNapProgressPresenter(app::Application *app, settings::Settings *settings);
+    };
+} // namespace app::powernap

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "PowerNapProgressWindow.hpp"
+#include "application-bell-powernap/ApplicationBellPowerNap.hpp"
+#include "data/PowerNapStyle.hpp"
+#include <apps-common/widgets/BellBaseLayout.hpp>
+#include <apps-common/widgets/BarGraph.hpp>
+#include <apps-common/GuiTimer.hpp>
+#include <Text.hpp>
+
+namespace
+{
+    void decorateProgressItem(gui::Rect *item, gui::Alignment::Vertical alignment)
+    {
+        item->setEdges(gui::RectangleEdge::None);
+        item->activeItem = false;
+        item->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, alignment));
+    }
+    void createTitle(gui::VBox *parent)
+    {
+        auto title = new gui::Text(parent, 0, 0, parent->getWidth(), parent->getHeight() / 2);
+        title->setFont(gui::powerNapStyle::descriptionFont);
+        title->setText(utils::translate("app_bellmain_power_nap"));
+        decorateProgressItem(title, gui::Alignment::Vertical::Top);
+    }
+    gui::HBarGraph *createProgress(gui::VBox *parent)
+    {
+        auto progressBox = new gui::HBox(parent, 0, 0, parent->getWidth(), parent->getHeight() / 2);
+        decorateProgressItem(progressBox, gui::Alignment::Vertical::Bottom);
+        auto progressBar =
+            new gui::HBarGraph(progressBox, 0, 0, gui::powerNapStyle::progress::boxesCount, gui::BarGraphStyle::Heavy);
+        decorateProgressItem(progressBar, gui::Alignment::Vertical::Center);
+        return progressBar;
+    }
+    gui::Text *createTimer(gui::Item *parent)
+    {
+        using namespace style;
+        using namespace gui::powerNapStyle;
+        auto timer = new gui::Text(
+            parent, 0, 0, bell_base_layout::w, bell_base_layout::outer_layouts_h - progress::bottomDescTopMargin);
+        timer->setFont(descriptionFont);
+        timer->setMargins(gui::Margins(0, progress::bottomDescTopMargin, 0, 0));
+        decorateProgressItem(timer, gui::Alignment::Vertical::Top);
+        return timer;
+    }
+} // namespace
+
+namespace gui
+{
+    PowerNapProgressWindow::PowerNapProgressWindow(
+        app::Application *app, std::shared_ptr<app::powernap::PowerNapProgressContract::Presenter> presenter)
+        : AppWindow(app, gui::window::name::powernapProgress), presenter{std::move(presenter)}
+    {
+        buildInterface();
+    }
+
+    void PowerNapProgressWindow::onBeforeShow(ShowMode mode, SwitchData *data)
+    {
+        presenter->activate();
+    }
+
+    void PowerNapProgressWindow::buildInterface()
+    {
+        AppWindow::buildInterface();
+        buildLayout();
+        configureTimer();
+    }
+    void PowerNapProgressWindow::buildLayout()
+    {
+        auto body = new gui::BellBaseLayout(this, 0, 0, style::bell_base_layout::w, style::bell_base_layout::h, false);
+        auto vBox =
+            new VBox(body->getCenterBox(), 0, 0, style::bell_base_layout::w, style::bell_base_layout::centerbox::h);
+        decorateProgressItem(vBox, gui::Alignment::Vertical::Top);
+        createTitle(vBox);
+        progressBar = createProgress(vBox);
+        timerText   = createTimer(body->lastBox);
+
+        dimensionChangedCallback = [&](Item &, const BoundingBox &newDim) -> bool {
+            body->setArea({0, 0, newDim.w, newDim.h});
+            return true;
+        };
+    }
+    void PowerNapProgressWindow::configureTimer()
+    {
+        presenter->initTimer(this);
+        presenter->getUIConfigurator().attach(progressBar);
+        presenter->getUIConfigurator().attach(timerText);
+    }
+} // namespace gui

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "presenter/PowerNapProgressPresenter.hpp"
+#include <AppWindow.hpp>
+
+namespace gui
+{
+    class HBarGraph;
+    class Text;
+    class PowerNapProgressWindow : public AppWindow, public app::powernap::PowerNapProgressContract::View
+    {
+        std::shared_ptr<app::powernap::PowerNapProgressContract::Presenter> presenter;
+        gui::HBarGraph *progressBar = nullptr;
+        gui::Text *timerText        = nullptr;
+
+        void buildInterface() override;
+        void onBeforeShow(ShowMode mode, SwitchData *data) override;
+
+        void buildLayout();
+        void configureTimer();
+
+      public:
+        PowerNapProgressWindow(app::Application *app,
+                               std::shared_ptr<app::powernap::PowerNapProgressContract::Presenter> presenter);
+    };
+} // namespace gui


### PR DESCRIPTION
The follwoing commit provides an implementation of PowerNap
progress. The impelemntation covers:
* PowerNap's progress presenter
* PowerNap's progress widnow
* Extension of ProgressTimer's UI configuration that allows
to choose between (pseudo)Continuous and Descrete set of points on
Progress view.
![Screenshot from 2021-09-04 15-45-24](https://user-images.githubusercontent.com/70628259/132098334-e79e0cd3-8b57-42ea-80bc-86ce85a94077.png)
