### PR TITLE
[BH-851] PowerNap alarms implementation

### DIFF
--- a/products/BellHybrid/apps/application-bell-powernap/CMakeLists.txt
+++ b/products/BellHybrid/apps/application-bell-powernap/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(application-bell-powernap
         presenter/PowerNapMainWindowPresenter.cpp
         presenter/PowerNapProgressPresenter.cpp
         presenter/PowerNapSessionEndedPresenter.cpp
+        widgets/PowerNapAlarm.cpp
         windows/PowerNapMainWindow.cpp
         windows/PowerNapProgressWindow.cpp
         windows/PowerNapSessionEndedWindow.cpp
@@ -28,6 +29,7 @@ target_sources(application-bell-powernap
         presenter/PowerNapMainWindowPresenter.hpp
         presenter/PowerNapProgressPresenter.hpp
         presenter/PowerNapSessionEndedPresenter.hpp
+        widgets/PowerNapAlarm.hpp
         windows/PowerNapMainWindow.hpp
         windows/PowerNapProgressWindow.hpp
         windows/PowerNapSessionEndedWindow.hpp

--- a/products/BellHybrid/apps/application-bell-powernap/include/application-bell-powernap/ApplicationBellPowerNap.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/include/application-bell-powernap/ApplicationBellPowerNap.hpp
@@ -12,17 +12,24 @@ namespace gui::window::name
 }
 namespace app
 {
+    namespace powernap
+    {
+        class PowerNapAlarmImpl;
+    }
+
     inline constexpr auto applicationBellPowerNapName = "ApplicationBellPowerNap";
 
     class ApplicationBellPowerNap : public ApplicationBell
     {
+        std::unique_ptr<powernap::PowerNapAlarmImpl> alarm;
+
       public:
         ApplicationBellPowerNap(std::string name                            = applicationBellPowerNapName,
                                 std::string parent                          = "",
                                 sys::phone_modes::PhoneMode mode            = sys::phone_modes::PhoneMode::Offline,
                                 sys::bluetooth::BluetoothMode bluetoothMode = sys::bluetooth::BluetoothMode::Disabled,
                                 StartInBackground startInBackground         = {false});
-
+        ~ApplicationBellPowerNap();
         sys::ReturnCodes InitHandler() override;
 
         void createUserInterface() override;

--- a/products/BellHybrid/apps/application-bell-powernap/models/PowerNapModel.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/models/PowerNapModel.cpp
@@ -9,7 +9,7 @@
 namespace
 {
     constexpr std::chrono::minutes emptyValue{0};
-    constexpr std::chrono::minutes spinnerDefaultValue{20};
+    constexpr std::chrono::minutes spinnerDefaultValue{15};
 } // namespace
 
 namespace app::powernap

--- a/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.hpp
@@ -22,6 +22,7 @@ namespace settings
 
 namespace app::powernap
 {
+    class PowerNapAlarm;
     class PowerNapProgressContract
     {
       public:
@@ -29,7 +30,7 @@ namespace app::powernap
         {
           public:
             ~View() = default;
-            virtual void switchWindow() = 0;
+            virtual void napEnded() = 0;
         };
 
         class Presenter : public BasePresenter<PowerNapProgressContract::View>
@@ -38,24 +39,29 @@ namespace app::powernap
             virtual void initTimer(gui::Item *parent)                              = 0;
             virtual app::ProgressTimerUIConfigurator &getUIConfigurator() noexcept = 0;
             virtual void activate()                                                = 0;
+            virtual void endNap()                                                  = 0;
         };
     };
+
+    class AlarmController;
 
     class PowerNapProgressPresenter : public PowerNapProgressContract::Presenter
     {
         app::Application *app        = nullptr;
         settings::Settings *settings = nullptr;
+        PowerNapAlarm &alarm;
         std::unique_ptr<app::ProgressTimer> timer;
         sys::TimerHandle napAlarmTimer;
 
         void initTimer(gui::Item *parent) override;
         app::ProgressTimerUIConfigurator &getUIConfigurator() noexcept override;
         void activate() override;
+        void endNap() override;
 
         void onNapFinished();
         void onNapAlarmFinished();
 
       public:
-        PowerNapProgressPresenter(app::Application *app, settings::Settings *settings);
+        PowerNapProgressPresenter(app::Application *app, settings::Settings *settings, PowerNapAlarm &alarm);
     };
 } // namespace app::powernap

--- a/products/BellHybrid/apps/application-bell-powernap/widgets/PowerNapAlarm.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/widgets/PowerNapAlarm.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "PowerNapAlarm.hpp"
+
+#include <purefs/filesystem_paths.hpp>
+#include <service-audio/AudioServiceAPI.hpp>
+
+namespace
+{
+    constexpr auto alarmAudioPath = "assets/audio/alarm/alarm_mudita_bell.mp3";
+}
+
+namespace app::powernap
+{
+    PowerNapAlarmImpl::PowerNapAlarmImpl(app::Application *app) : app{app}
+    {}
+
+    void PowerNapAlarmImpl::start()
+    {
+        AudioServiceAPI::PlaybackStart(
+            app, audio::PlaybackType::Alarm, purefs::dir::getCurrentOSPath() / alarmAudioPath);
+    }
+
+    void PowerNapAlarmImpl::stop()
+    {
+        if (token.IsValid()) {
+            AudioServiceAPI::Stop(app, token);
+            token = audio::Token::MakeBadToken();
+        }
+    }
+
+    void PowerNapAlarmImpl::registerAudioStream(audio::Token _token)
+    {
+        token = _token;
+    }
+} // namespace app::powernap

--- a/products/BellHybrid/apps/application-bell-powernap/widgets/PowerNapAlarm.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/widgets/PowerNapAlarm.hpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+#include <module-audio/Audio/AudioCommon.hpp>
+
+namespace app
+{
+    class Application;
+}
+
+namespace app::powernap
+{
+    class PowerNapAlarm
+    {
+      public:
+        virtual ~PowerNapAlarm() = default;
+
+        virtual void start() = 0;
+        virtual void stop()  = 0;
+    };
+
+    class PowerNapAlarmImpl : public PowerNapAlarm
+    {
+        app::Application *app{};
+        audio::Token token;
+
+        void start() override;
+        void stop() override;
+
+      public:
+        explicit PowerNapAlarmImpl(app::Application *app);
+        void registerAudioStream(audio::Token _token);
+    };
+
+} // namespace app::powernap

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
@@ -54,6 +54,7 @@ namespace gui
         : AppWindow(app, gui::window::name::powernapProgress), presenter{std::move(presenter)}
     {
         buildInterface();
+        this->presenter->attach(this);
     }
 
     void PowerNapProgressWindow::onBeforeShow(ShowMode mode, SwitchData *data)
@@ -93,13 +94,13 @@ namespace gui
     {
         if (inputEvent.isShortRelease()) {
             if (inputEvent.is(KeyCode::KEY_RF) || inputEvent.is(KeyCode::KEY_ENTER)) {
-                switchWindow();
+                presenter->endNap();
                 return true;
             }
         }
         return AppWindow::onInput(inputEvent);
     }
-    void PowerNapProgressWindow::switchWindow()
+    void PowerNapProgressWindow::napEnded()
     {
         application->switchWindow(gui::window::name::powernapSessionEnded, std::make_unique<gui::PowerNapSwitchData>());
     }

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.hpp
@@ -23,7 +23,7 @@ namespace gui
         void buildLayout();
         void configureTimer();
 
-        void switchWindow() override;
+        void napEnded() override;
 
       public:
         PowerNapProgressWindow(app::Application *app,


### PR DESCRIPTION
The following commit provides an implementation to
an PowerNap's alarm, that provides appropriate abstraction
 for an alarm mechanics.

As the PowerNap's alarm can be active only on the
application, the implementation does not make use of
Bell's AlarmHandlers.