### PR TITLE
[BH-863] Fix PowerNap's spinner arrows

### DIFF
--- a/module-apps/apps-common/widgets/BellBaseLayout.cpp
+++ b/module-apps/apps-common/widgets/BellBaseLayout.cpp
@@ -85,4 +85,12 @@ namespace gui
         rightArrow->setVisible(true);
         rightArrow->setEdges(RectangleEdge::None);
     }
+
+    void BellBaseLayout::setArrowVisible(Arrow arrow, bool isVisible)
+    {
+        auto item = arrow == Arrow::Left ? leftArrow : rightArrow;
+        if (item != nullptr) {
+            item->setVisible(isVisible);
+        }
+    }
 } // namespace gui

--- a/module-apps/apps-common/widgets/BellBaseLayout.hpp
+++ b/module-apps/apps-common/widgets/BellBaseLayout.hpp
@@ -30,10 +30,18 @@ namespace gui
     class BellBaseLayout : public VThreeBox<VBox, VBox, VBox>
     {
       public:
+        enum class Arrow
+        {
+            Left,
+            Right
+        };
+
         explicit BellBaseLayout(
             Item *parent, Position x = 0, Position y = 0, Length w = 0, Length h = 0, bool withSideArrows = true);
 
         [[nodiscard]] Item *getCenterBox() const noexcept;
+
+        void setArrowVisible(Arrow arrow, bool isVisible);
 
       private:
         HThreeBox<HBox, HBox, HBox> *centerThreeBox{nullptr};

--- a/module-gui/gui/widgets/Spinner.cpp
+++ b/module-gui/gui/widgets/Spinner.cpp
@@ -11,8 +11,9 @@
 namespace gui
 {
 
-    Spinner::Spinner(int minValue, int maxValue, int step, Boundaries boundaries)
-        : minValue(minValue), maxValue(maxValue), step(step), currentValue(minValue), boundaries(boundaries)
+    Spinner::Spinner(int minValue, int maxValue, int step, Boundaries boundaries, OnUpdateCallback cb)
+        : minValue(minValue), maxValue(maxValue), step(step), currentValue(minValue),
+          boundaries(boundaries), onUpdate{std::move(cb)}
     {
         setEditMode(EditMode::Browse);
         drawUnderline(false);
@@ -106,6 +107,9 @@ namespace gui
         }
         outStream << currentValue;
         setText(outStream.str());
+        if (onUpdate) {
+            onUpdate(currentValue);
+        }
     }
     void Spinner::setMinValue(int newMinValue)
     {

--- a/module-gui/gui/widgets/Spinner.hpp
+++ b/module-gui/gui/widgets/Spinner.hpp
@@ -10,7 +10,8 @@ namespace gui
     class Spinner : public TextFixedSize
     {
       public:
-        Spinner(int minValue, int maxValue, int step, Boundaries boundaries);
+        using OnUpdateCallback = std::function<void(int _currentValue)>;
+        Spinner(int minValue, int maxValue, int step, Boundaries boundaries, OnUpdateCallback cb = nullptr);
 
         void setCurrentValue(int newCurrent);
         void setFixedFieldWidth(unsigned char newFixedFieldWidth);
@@ -40,5 +41,7 @@ namespace gui
         ///< value of 0 means no fixed width.
         RectangleEdge focusEdges = RectangleEdge::Bottom;
         void updateSpinner();
+
+        OnUpdateCallback onUpdate{nullptr};
     };
 } // namespace gui

--- a/products/BellHybrid/apps/application-bell-powernap/data/PowerNapListItem.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/data/PowerNapListItem.cpp
@@ -29,21 +29,41 @@ namespace gui
         setEdges(RectangleEdge::None);
         setFocusItem(body);
 
-        spinner = new Spinner(spinnerMin, spinnerMax, spinnerStep, Boundaries::Fixed);
+        createSpinner();
+        createBottomDescription();
+        registerCallbacks();
+    }
+
+    void PowerNapListItem::createSpinner()
+    {
+        auto onUpdate = [this](int currentValue) {
+            const auto isMin = currentValue == spinnerMin;
+            const auto isMax = currentValue == spinnerMax;
+            body->setArrowVisible(BellBaseLayout::Arrow::Left, not isMin);
+            body->setArrowVisible(BellBaseLayout::Arrow::Right, not isMax);
+        };
+
+        spinner = new Spinner(spinnerMin, spinnerMax, spinnerStep, Boundaries::Fixed, std::move(onUpdate));
         spinner->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::h);
         spinner->setFont(powerNapStyle::napPeriodFont);
         spinner->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
         spinner->setEdges(RectangleEdge::None);
         spinner->setFocusEdges(RectangleEdge::None);
         body->getCenterBox()->addWidget(spinner);
+    }
 
+    void PowerNapListItem::createBottomDescription()
+    {
         bottomDescription = new Label(body->lastBox);
         bottomDescription->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::outer_layouts_h);
         bottomDescription->setFont(powerNapStyle::descriptionFont);
         bottomDescription->setEdges(RectangleEdge::None);
         bottomDescription->activeItem = false;
         bottomDescription->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
+    }
 
+    void PowerNapListItem::registerCallbacks()
+    {
         dimensionChangedCallback = [&](Item &, const BoundingBox &newDim) -> bool {
             body->setArea({0, 0, newDim.w, newDim.h});
             return true;

--- a/products/BellHybrid/apps/application-bell-powernap/data/PowerNapListItem.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/data/PowerNapListItem.hpp
@@ -14,8 +14,12 @@ namespace gui
         Spinner *spinner         = nullptr;
         Label *bottomDescription = nullptr;
 
+        void createSpinner();
+        void createBottomDescription();
+        void registerCallbacks();
+
       public:
-        explicit PowerNapListItem();
+        PowerNapListItem();
 
         [[nodiscard]] int getSpinnerValue() const noexcept;
         void setSpinnerValue(int value);

--- a/products/BellHybrid/apps/application-bell-powernap/models/PowerNapModel.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/models/PowerNapModel.cpp
@@ -58,5 +58,6 @@ namespace app::powernap
         powerNapItem = new gui::PowerNapListItem();
         internalData.push_back(powerNapItem);
         powerNapItem->deleteByList = false;
+        setValue(spinnerDefaultValue);
     }
 } // namespace app::powernap


### PR DESCRIPTION
There were an issue in the PowerNap's main window,
that the spinner's arrows would not disappear on reaching
extremums. To solve this the commit adds a setArrowVisible
functionality to the gui::BellBaseLayout, a onValueChange
callback to gui::Spinner and employs both to the
gui::PowerNapListItem to solve the issue.