### PR TITLE
[CP-439] Add case color to device info endpoint

### DIFF
--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -52,6 +52,11 @@ auto ServiceDesktop::getSerialNumber() const -> std::string
     return settings->getValue(std::string("factory_data/serial"), settings::SettingsScope::Global);
 }
 
+auto ServiceDesktop::getCaseColour() const -> std::string
+{
+    return settings->getValue(std::string("factory_data/case_colour"), settings::SettingsScope::Global);
+}
+
 auto ServiceDesktop::requestLogsFlush() -> void
 {
     int response = 0;

--- a/module-services/service-desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
+++ b/module-services/service-desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
@@ -38,6 +38,11 @@ namespace sdesktop::endpoints
         return dynamic_cast<ServiceDesktop *>(ownerServicePtr)->getSerialNumber();
     }
 
+    auto DeviceInfoEndpoint::getCaseColour() -> std::string
+    {
+        return static_cast<ServiceDesktop *>(ownerServicePtr)->getCaseColour();
+    }
+
     auto DeviceInfoEndpoint::getDeviceInfo(Context &context) -> bool
     {
         if (ownerServicePtr == nullptr) {
@@ -70,7 +75,8 @@ namespace sdesktop::endpoints
              {json::gitBranch, (std::string)GIT_BRANCH},
              {json::currentRTCTime, std::to_string(static_cast<uint32_t>(std::time(nullptr)))},
              {json::version, std::string(VERSION)},
-             {json::serialNumber, getSerialNumber()}}));
+             {json::serialNumber, getSerialNumber()},
+             {json::caseColour, getCaseColour()}}));
 
         sender::putToSendQueue(context.createSimpleResponse());
         return true;

--- a/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
@@ -45,6 +45,7 @@ namespace sdesktop::endpoints::json
     inline constexpr auto location            = "location";
     inline constexpr auto reason              = "reason";
     inline constexpr auto serialNumber        = "serialNumber";
+    inline constexpr auto caseColour          = "caseColour";
 
     namespace filesystem
     {

--- a/module-services/service-desktop/endpoints/include/endpoints/deviceInfo/DeviceInfoEndpoint.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/deviceInfo/DeviceInfoEndpoint.hpp
@@ -15,6 +15,7 @@ namespace sdesktop::endpoints
     class DeviceInfoEndpoint : public Endpoint
     {
         auto getSerialNumber() -> std::string;
+        auto getCaseColour() -> std::string;
 
       public:
         explicit DeviceInfoEndpoint(sys::Service *ownerServicePtr) : Endpoint(ownerServicePtr)

--- a/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
@@ -114,6 +114,7 @@ class ServiceDesktop : public sys::Service
     auto requestLogsFlush() -> void;
 
     auto getSerialNumber() const -> std::string;
+    auto getCaseColour() const -> std::string;
 
   private:
     std::unique_ptr<sdesktop::USBSecurityModel> usbSecurityModel;

--- a/test/pytest/service-desktop/test_device_info.py
+++ b/test/pytest/service-desktop/test_device_info.py
@@ -29,4 +29,5 @@ def test_device_info(harness):
     assert ret["body"]["currentRTCTime"] is not None
     assert ret["body"]["version"] is not None
     assert ret["body"]["serialNumber"] is not None
+    assert ret["body"]["caseColour"] is not None
 


### PR DESCRIPTION
Color of Mudita Pure's case can be now read from
device info endpoint.