### PR TITLE
[BH-884] Add Background Sounds Timer window

### DIFF
--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -606,5 +606,7 @@
   "app_bell_settings_advanced_frontlight": "Frontlight",
   "app_bell_settings_frontlight_top_message": "Frontlight intensity",
   "app_bell_settings_frontlight_finished_message": "Frontlight is set",
-  "app_bell_powernap_session_ended_message": "<text>Hello!<br />Rise & shine</text>"
+  "app_bell_powernap_session_ended_message": "<text>Hello!<br />Rise & shine</text>",
+  "app_bell_background_sounds_timer_off": "OFF",
+  "app_bell_background_sounds_timer_title": "Timer"
 }

--- a/products/BellHybrid/apps/application-bell-background-sounds/ApplicationBellBackgroundSounds.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/ApplicationBellBackgroundSounds.cpp
@@ -3,7 +3,9 @@
 
 #include "ApplicationBellBackgroundSounds.hpp"
 #include "presenter/BGSoundsMainWindowPresenter.hpp"
+#include "presenter/BGSoundsTimerSelectPresenter.hpp"
 #include "windows/BGSoundsMainWindow.hpp"
+#include "windows/BGSoundsTimerSelectWindow.hpp"
 
 namespace app
 {
@@ -31,6 +33,11 @@ namespace app
             auto presenter = std::make_unique<bgSounds::BGSoundsMainWindowPresenter>();
             return std::make_unique<gui::BGSoundsMainWindow>(app, std::move(presenter));
         });
+        windowsFactory.attach(
+            gui::window::name::bgSoundsTimerSelect, [this](ApplicationCommon *app, const std::string &name) {
+                auto presenter = std::make_unique<bgSounds::BGSoundsTimerSelectPresenter>(settings.get());
+                return std::make_unique<gui::BGSoundsTimerSelectWindow>(app, std::move(presenter));
+            });
     }
 
     sys::MessagePointer ApplicationBellBackgroundSounds::DataReceivedHandler(sys::DataMessage *msgl,

--- a/products/BellHybrid/apps/application-bell-background-sounds/CMakeLists.txt
+++ b/products/BellHybrid/apps/application-bell-background-sounds/CMakeLists.txt
@@ -13,10 +13,16 @@ target_include_directories(application-bell-background-sounds
 target_sources(application-bell-background-sounds
     PRIVATE
         ApplicationBellBackgroundSounds.cpp
+        presenter/BGSoundsTimerSelectPresenter.cpp
         windows/BGSoundsMainWindow.cpp
+        windows/BGSoundsTimerSelectWindow.cpp
 
+        data/BGSoundsCommon.hpp
+        data/BGSoundsStyle.hpp
         presenter/BGSoundsMainWindowPresenter.hpp
+        presenter/BGSoundsTimerSelectPresenter.hpp
         windows/BGSoundsMainWindow.hpp
+        windows/BGSoundsTimerSelectWindow.hpp
 
     PUBLIC
         include/application-bell-background-sounds/ApplicationBellBackgroundSounds.hpp

--- a/products/BellHybrid/apps/application-bell-background-sounds/data/BGSoundsCommon.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/data/BGSoundsCommon.hpp
@@ -1,0 +1,9 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+namespace app::bgSounds
+{
+    constexpr auto timerValueDBRecordName = "BGSoundsTimerValue";
+}

--- a/products/BellHybrid/apps/application-bell-background-sounds/data/BGSoundsStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/data/BGSoundsStyle.hpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <Style.hpp>
+
+namespace gui::bgSoundsStyle
+{
+    inline constexpr auto descriptionFont = style::window::font::largelight;
+    inline constexpr auto timerValueFont  = style::window::font::supersizemelight;
+} // namespace gui::bgSoundsStyle

--- a/products/BellHybrid/apps/application-bell-background-sounds/include/application-bell-background-sounds/ApplicationBellBackgroundSounds.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/include/application-bell-background-sounds/ApplicationBellBackgroundSounds.hpp
@@ -5,6 +5,11 @@
 
 #include <Application.hpp>
 
+namespace gui::window::name
+{
+    inline constexpr auto bgSoundsTimerSelect = "BGSoundsTimerSelectWindow";
+}
+
 namespace app
 {
     inline constexpr auto applicationBellBackgroundSoundsName = "ApplicationBellBackgroundSounds";

--- a/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsTimerSelectPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsTimerSelectPresenter.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "BGSoundsTimerSelectPresenter.hpp"
+#include "data/BGSoundsCommon.hpp"
+
+#include <ApplicationBellBackgroundSounds.hpp>
+#include <apps-common/ApplicationCommon.hpp>
+#include <service-db/agents/settings/SystemSettings.hpp>
+#include <service-db/Settings.hpp>
+
+namespace
+{
+    using namespace std::chrono_literals;
+    constexpr auto timerDefaultValue{15min};
+    const static std::vector<std::chrono::minutes> valuesRange{0min, 5min, 10min, 15min, 30min, 45min, 60min, 90min};
+} // namespace
+
+namespace app::bgSounds
+{
+    BGSoundsTimerSelectPresenter::BGSoundsTimerSelectPresenter(settings::Settings *settings) : settings{settings}
+    {}
+    const BGSoundsTimerSelectContract::Range &BGSoundsTimerSelectPresenter::getTimerValuesRange() const noexcept
+    {
+        return valuesRange;
+    }
+    std::chrono::minutes BGSoundsTimerSelectPresenter::getCurrentTimerValue() const
+    {
+        const auto value = settings->getValue(timerValueDBRecordName, settings::SettingsScope::AppLocal);
+        if (not value.empty()) {
+            return std::chrono::minutes{utils::getNumericValue<int>(value)};
+        }
+        return timerDefaultValue;
+    }
+    void BGSoundsTimerSelectPresenter::setTimerValue(std::chrono::minutes value)
+    {
+        settings->setValue(timerValueDBRecordName, utils::to_string(value.count()), settings::SettingsScope::AppLocal);
+    }
+} // namespace app::bgSounds

--- a/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsTimerSelectPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsTimerSelectPresenter.hpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <apps-common/BasePresenter.hpp>
+#include <chrono>
+#include <vector>
+
+namespace gui
+{
+    class ListItemProvider;
+}
+
+namespace app
+{
+    class ApplicationCommon;
+}
+
+namespace settings
+{
+    class Settings;
+}
+namespace app::bgSounds
+{
+    class BGSoundsTimerSelectContract
+    {
+      public:
+        using Range = std::vector<std::chrono::minutes>;
+        class View
+        {
+          public:
+            ~View() = default;
+        };
+
+        class Presenter : public BasePresenter<BGSoundsTimerSelectContract::View>
+        {
+          public:
+            virtual const Range &getTimerValuesRange() const noexcept = 0;
+            virtual std::chrono::minutes getCurrentTimerValue() const = 0;
+            virtual void setTimerValue(std::chrono::minutes)          = 0;
+        };
+    };
+
+    class BGSoundsTimerSelectPresenter : public BGSoundsTimerSelectContract::Presenter
+    {
+        settings::Settings *settings = nullptr;
+
+        const BGSoundsTimerSelectContract::Range &getTimerValuesRange() const noexcept override;
+        std::chrono::minutes getCurrentTimerValue() const override;
+        void setTimerValue(std::chrono::minutes) override;
+
+      public:
+        explicit BGSoundsTimerSelectPresenter(settings::Settings *settings);
+    };
+} // namespace app::bgSounds

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsMainWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsMainWindow.cpp
@@ -2,7 +2,8 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BGSoundsMainWindow.hpp"
-
+#include <application-bell-background-sounds/ApplicationBellBackgroundSounds.hpp>
+#include <module-gui/gui/input/InputEvent.hpp>
 namespace gui
 {
     BGSoundsMainWindow::BGSoundsMainWindow(
@@ -11,5 +12,14 @@ namespace gui
     {
         this->presenter->attach(this);
         buildInterface();
+    }
+
+    auto BGSoundsMainWindow::onInput(const InputEvent &inputEvent) -> bool
+    {
+        if (inputEvent.isShortRelease(KeyCode::KEY_ENTER)) {
+            application->switchWindow(gui::window::name::bgSoundsTimerSelect);
+            return true;
+        }
+        return AppWindow::onInput(inputEvent);
     }
 } // namespace gui

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsMainWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsMainWindow.hpp
@@ -11,6 +11,8 @@ namespace gui
     {
         std::unique_ptr<app::bgSounds::BGSoundsMainWindowContract::Presenter> presenter;
 
+        auto onInput(const InputEvent &inputEvent) -> bool override;
+
       public:
         BGSoundsMainWindow(app::ApplicationCommon *app,
                            std::unique_ptr<app::bgSounds::BGSoundsMainWindowContract::Presenter> &&presenter);

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsTimerSelectWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsTimerSelectWindow.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "BGSoundsTimerSelectWindow.hpp"
+#include <application-bell-background-sounds/ApplicationBellBackgroundSounds.hpp>
+#include <apps-common/widgets/BellBaseLayout.hpp>
+#include <data/BGSoundsStyle.hpp>
+#include <gui/input/InputEvent.hpp>
+#include <i18n/i18n.hpp>
+#include <SideListView.hpp>
+#include <Utils.hpp>
+namespace
+{
+    using minutes = std::chrono::minutes;
+    constexpr minutes offValue{minutes::zero()};
+
+    const std::string &getOffValueText()
+    {
+        static const std::string offValueText = utils::translate("app_bell_background_sounds_timer_off");
+        return offValueText;
+    }
+
+    UTF8 timerValueToUTF8(minutes value)
+    {
+        if (value == offValue) {
+            return getOffValueText();
+        }
+        return utils::to_string(value.count());
+    }
+
+    minutes UTF8ToTimerValue(const UTF8 &str)
+    {
+        if (str == getOffValueText()) {
+            return offValue;
+        }
+        return minutes(utils::getNumericValue<int>(str));
+    }
+
+    std::vector<UTF8> toUTF8Range(const std::vector<minutes> &spinnerRange)
+    {
+        std::vector<UTF8> range;
+        range.reserve(spinnerRange.size());
+        for (auto value : spinnerRange) {
+            range.push_back(timerValueToUTF8(value));
+        }
+        return range;
+    }
+} // namespace
+namespace gui
+{
+
+    BGSoundsTimerSelectWindow::BGSoundsTimerSelectWindow(
+        app::ApplicationCommon *app, std::unique_ptr<app::bgSounds::BGSoundsTimerSelectContract::Presenter> &&presenter)
+        : AppWindow(app, gui::window::name::bgSoundsTimerSelect), presenter(std::move(presenter))
+    {
+        this->presenter->attach(this);
+        buildInterface();
+    }
+
+    void BGSoundsTimerSelectWindow::buildInterface()
+    {
+        AppWindow::buildInterface();
+        statusBar->setVisible(false);
+
+        body = new BellBaseLayout(this, 0, 0, style::window_width, style::window_height, true);
+        createTopMessage();
+        createSpinner();
+        createBottomDescription();
+        registerCallbacks();
+    }
+
+    void BGSoundsTimerSelectWindow::createTopMessage()
+    {
+        auto topMessage = new TextFixedSize(body->firstBox);
+        topMessage->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::outer_layouts_h);
+        topMessage->setFont(style::window::font::largelight);
+        topMessage->setEdges(gui::RectangleEdge::None);
+        topMessage->activeItem = false;
+        topMessage->setAlignment(Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center));
+        topMessage->setText(utils::translate("app_bell_background_sounds_timer_title"));
+        topMessage->drawUnderline(false);
+    }
+
+    void BGSoundsTimerSelectWindow::createSpinner()
+    {
+        auto range = presenter->getTimerValuesRange();
+
+        spinner = new UTF8Spinner(toUTF8Range(range));
+        spinner->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::h);
+        spinner->setFont(bgSoundsStyle::timerValueFont);
+        spinner->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
+        spinner->setEdges(RectangleEdge::None);
+        spinner->setFocusEdges(RectangleEdge::None);
+        auto currentValue = timerValueToUTF8(presenter->getCurrentTimerValue());
+        spinner->setCurrentValue(std::move(currentValue));
+        body->getCenterBox()->addWidget(spinner);
+    }
+
+    void BGSoundsTimerSelectWindow::createBottomDescription()
+    {
+        bottomDescription = new gui::Text();
+        bottomDescription->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::outer_layouts_h);
+        bottomDescription->setMinimumSize(style::bell_base_layout::w, style::bell_base_layout::outer_layouts_h);
+        bottomDescription->setFont(bgSoundsStyle::descriptionFont);
+        bottomDescription->setEdges(RectangleEdge::All);
+        bottomDescription->activeItem = false;
+        bottomDescription->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
+        bottomDescription->setText(utils::translate("common_minutes_lower"));
+        body->lastBox->addWidget(bottomDescription);
+        updateBottomDescription();
+    }
+    void BGSoundsTimerSelectWindow::updateBottomDescription()
+    {
+        const bool isDescriptionVisible = UTF8ToTimerValue(spinner->getCurrentValue()) != offValue;
+        bottomDescription->setVisible(isDescriptionVisible);
+    }
+
+    void BGSoundsTimerSelectWindow::registerCallbacks()
+    {
+        dimensionChangedCallback = [&](Item &, const BoundingBox &newDim) -> bool {
+            body->setArea({0, 0, newDim.w, newDim.h});
+            return true;
+        };
+
+        focusChangedCallback = [&](Item &) {
+            setFocusItem(focus ? body : nullptr);
+            if (focus) {
+                setFocusItem(body);
+            }
+            else {
+                setFocusItem(nullptr);
+            }
+            return true;
+        };
+    }
+
+    bool BGSoundsTimerSelectWindow::onInput(const gui::InputEvent &inputEvent)
+    {
+        if (spinner->onInput(inputEvent)) {
+            updateBottomDescription();
+            return true;
+        }
+        if (inputEvent.isShortRelease(KeyCode::KEY_ENTER)) {
+            auto currentValue = UTF8ToTimerValue(spinner->getCurrentValue());
+            presenter->setTimerValue(currentValue);
+            return true;
+        }
+
+        return AppWindow::onInput(inputEvent);
+    }
+
+} // namespace gui

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsTimerSelectWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsTimerSelectWindow.hpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "presenter/BGSoundsTimerSelectPresenter.hpp"
+#include <AppWindow.hpp>
+#include <apps-common/widgets/spinners/Spinners.hpp>
+
+namespace gui
+{
+
+    class BellBaseLayout;
+    class Text;
+
+    class BGSoundsTimerSelectWindow : public AppWindow, public app::bgSounds::BGSoundsTimerSelectContract::View
+    {
+        std::unique_ptr<app::bgSounds::BGSoundsTimerSelectContract::Presenter> presenter;
+        BellBaseLayout *body    = nullptr;
+        UTF8Spinner *spinner    = nullptr;
+        Text *bottomDescription = nullptr;
+
+        void buildInterface() override;
+        bool onInput(const gui::InputEvent &inputEvent) override;
+
+        void createTopMessage();
+        void createSpinner();
+        void createBottomDescription();
+        void updateBottomDescription();
+        void registerCallbacks();
+
+      public:
+        BGSoundsTimerSelectWindow(app::ApplicationCommon *app,
+                                  std::unique_ptr<app::bgSounds::BGSoundsTimerSelectContract::Presenter> &&presenter);
+    };
+
+} // namespace gui

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapMainWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapMainWindow.cpp
@@ -19,6 +19,7 @@ namespace gui
     void PowerNapMainWindow::buildInterface()
     {
         AppWindow::buildInterface();
+        statusBar->setVisible(false);
 
         sideListView = new gui::SideListView(
             this, 0, 0, style::window_width, style::window_height, windowPresenter->getNapTimeProvider());
@@ -40,9 +41,4 @@ namespace gui
         return AppWindow::onInput(inputEvent);
     }
 
-    status_bar::Configuration PowerNapMainWindow::configureStatusBar(status_bar::Configuration appConfiguration)
-    {
-        appConfiguration.disable(status_bar::Indicator::Time);
-        return appConfiguration;
-    }
 } // namespace gui

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapMainWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapMainWindow.hpp
@@ -16,7 +16,6 @@ namespace gui
 
         bool onInput(const gui::InputEvent &inputEvent) override;
         void buildInterface() override;
-        status_bar::Configuration configureStatusBar(status_bar::Configuration appConfiguration) override;
 
       public:
         PowerNapMainWindow(app::ApplicationCommon *app,


### PR DESCRIPTION
The commit implements MVP for BackgroundSound's Timer
window. In order to print string values (e.g. OFF)
the Timer is realized by UTF8Spinne
![Screenshot from 2021-09-18 14-20-43](https://user-images.githubusercontent.com/70628259/133888672-8b897f16-a90e-45e7-97e2-ca58af449bc3.png)
![Screenshot from 2021-09-18 14-20-35](https://user-images.githubusercontent.com/70628259/133888673-5ba1a436-4a7d-432e-9e8a-3848c5403dca.png)
r.