### PR TITLE
[BH-880] Fix of missing minus in PowerNap

### DIFF
--- a/module-apps/apps-common/widgets/ProgressTimerImpl.hpp
+++ b/module-apps/apps-common/widgets/ProgressTimerImpl.hpp
@@ -21,6 +21,11 @@ namespace gui
 
 namespace app
 {
+    enum class ProgressCountdownMode
+    {
+        Decreasing,
+        Increasing
+    };
 
     class ProgressTimerImpl : public ProgressTimer
     {
@@ -41,6 +46,7 @@ namespace app
 
         std::function<void()> onFinishedCallback = nullptr;
         std::function<void()> onIntervalCallback = nullptr;
+        ProgressCountdownMode countdownMode;
 
         void startTimer();
         void update();
@@ -55,7 +61,8 @@ namespace app
         ProgressTimerImpl(app::ApplicationCommon *app,
                           gui::Item *parent,
                           std::string timerName,
-                          std::chrono::milliseconds baseTick);
+                          std::chrono::milliseconds baseTick,
+                          ProgressCountdownMode countdownMode = ProgressCountdownMode::Decreasing);
         void reset(std::chrono::seconds _duration,
                    std::chrono::seconds _interval = std::chrono::seconds::zero()) override;
         void start() override;

--- a/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.cpp
@@ -32,7 +32,8 @@ namespace app::powernap
 
     void PowerNapProgressPresenter::initTimer(gui::Item *parent)
     {
-        timer = std::make_unique<app::ProgressTimerImpl>(app, parent, powernapTimerName, timerTick);
+        timer = std::make_unique<app::ProgressTimerImpl>(
+            app, parent, powernapTimerName, timerTick, app::ProgressCountdownMode::Increasing);
         timer->registerOnFinishedCallback([this]() { onNapFinished(); });
     }
     void PowerNapProgressPresenter::activate()


### PR DESCRIPTION
The bug could be noticed on the PowerNap's
progress window. The countdown there is supposed
to be increasing in value, that means the minus
sign should be visible at all non-zero value
![Screenshot from 2021-09-18 15-10-19](https://user-images.githubusercontent.com/70628259/133890219-7a802e39-6805-4f2e-b878-e1e6dcf1b110.png)
![Screenshot from 2021-09-18 15-09-15](https://user-images.githubusercontent.com/70628259/133890220-7d15f39f-527f-4692-9bcf-70ad679d83fe.png)
s.