### PR TITLE
[BH-896] Add forward navigation callback to BellSideListItemWithCallb…

### DIFF
--- a/products/BellHybrid/apps/application-bell-settings/models/alarm_settings/SnoozeListItemProvider.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/models/alarm_settings/SnoozeListItemProvider.cpp
@@ -24,7 +24,7 @@ namespace app::bell_settings
 
         auto onOff =
             new OnOffListItem(model.getSnoozeOnOff(), utils::translate("app_bell_settings_alarm_settings_snooze"));
-        onOff->onExit = [onOff, this]() {
+        onOff->onProceed = [onOff, this]() {
             if (not onOff->isActive()) {
                 this->onExit();
             }
@@ -49,7 +49,7 @@ namespace app::bell_settings
             new NumWithStringListItem(model.getSnoozeChimeInterval(),
                                       range,
                                       utils::translate("app_bell_settings_alarm_settings_snooze_chime_interval"));
-        chimeInterval->onExit = [chimeInterval, this] {
+        chimeInterval->onProceed = [chimeInterval, this] {
             if (chimeInterval->isOff()) {
                 this->onExit();
             }

--- a/products/BellHybrid/apps/common/include/common/widgets/BellSideListItemWithCallbacks.hpp
+++ b/products/BellHybrid/apps/common/include/common/widgets/BellSideListItemWithCallbacks.hpp
@@ -17,6 +17,7 @@ namespace gui
         /// Set list item's value and perform custom action.
         std::function<void()> setValue;
         std::function<void()> onExit;
+        std::function<void()> onProceed;
     };
 
 } // namespace gui

--- a/products/BellHybrid/apps/common/src/BellSideListItemWithCallbacks.cpp
+++ b/products/BellHybrid/apps/common/src/BellSideListItemWithCallbacks.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
+#include <module-gui/gui/input/InputEvent.hpp>
+
 #include "widgets/BellSideListItemWithCallbacks.hpp"
 
 namespace gui
@@ -28,7 +30,14 @@ namespace gui
             return true;
         };
 
-        inputCallback = [&](Item &, const InputEvent &inputEvent) -> bool { return body->onInput(inputEvent); };
+        inputCallback = [&](Item &, const InputEvent &inputEvent) -> bool {
+            if (inputEvent.isShortRelease(KeyCode::KEY_ENTER)) {
+                if (onProceed) {
+                    onProceed();
+                }
+            }
+            return body->onInput(inputEvent);
+        };
     }
 
 } // namespace gui


### PR DESCRIPTION
The existing onExit callback is executed when current Item loses focus.
It is being triggered when navigating forward and backword through menu items.
New onProceed callback is only executed when navigating forward.

Additionally the focus based callback seems to have an issue when navigating backward. It appears in application crushing when entering and exiting the snooze setting window with snooze option turned off.