### PR TITLE
[EGD-7641] Disable service desktop tests

### DIFF
--- a/module-services/service-desktop/CMakeLists.txt
+++ b/module-services/service-desktop/CMakeLists.txt
@@ -57,8 +57,8 @@ target_link_libraries(service-desktop
         desktop-endpoints
 )
 
-
 if (${ENABLE_TESTS})
-    add_subdirectory(tests)
+    # EGD-7371 - tests are disabled until dependency issues are solved
+    #add_subdirectory(tests)
 endif ()
 


### PR DESCRIPTION
Disable tests due to linkage problems.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>
