### PR TITLE
[BH-885] Fix Bell hw

### DIFF
--- a/module-bsp/board/rt1051/bellpx/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/rt1051/bellpx/hal/battery_charger/BatteryCharger.cpp
@@ -17,7 +17,6 @@ namespace hal::battery
         // Mocking initial state to make system run
         Store::Battery::modify().state = Store::Battery::State::Discharging;
         Store::Battery::modify().level = getBatteryVoltage();
-        eventsHandler.onStatusChanged();
     }
 
     int BatteryCharger::getBatteryVoltage()

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -233,7 +233,6 @@ sys::ReturnCodes EventManagerCommon::DeinitHandler()
 
 void EventManagerCommon::ProcessCloseReason(sys::CloseReason closeReason)
 {
-    bsp::torch::turn(bsp::torch::State::off);
     sendCloseReadyMessage(this);
 }
 

--- a/products/BellHybrid/apps/application-bell-alarm/ApplicationBellAlarm.cpp
+++ b/products/BellHybrid/apps/application-bell-alarm/ApplicationBellAlarm.cpp
@@ -26,8 +26,9 @@ namespace app
                                                std::string parent,
                                                sys::phone_modes::PhoneMode mode,
                                                sys::bluetooth::BluetoothMode bluetoothMode,
-                                               StartInBackground startInBackground)
-        : Application(std::move(name), std::move(parent), mode, bluetoothMode, startInBackground),
+                                               StartInBackground startInBackground,
+                                               uint32_t stackDepth)
+        : Application(std::move(name), std::move(parent), mode, bluetoothMode, startInBackground, stackDepth),
           priv{std::make_unique<app::internal::BellAlarmPriv>()}
     {}
     ApplicationBellAlarm::~ApplicationBellAlarm() = default;

--- a/products/BellHybrid/apps/application-bell-alarm/include/application-bell-alarm/ApplicationBellAlarm.hpp
+++ b/products/BellHybrid/apps/application-bell-alarm/include/application-bell-alarm/ApplicationBellAlarm.hpp
@@ -30,7 +30,8 @@ namespace app
             std::string parent                          = "",
             sys::phone_modes::PhoneMode mode            = sys::phone_modes::PhoneMode::Offline,
             sys::bluetooth::BluetoothMode bluetoothMode = sys::bluetooth::BluetoothMode::Disabled,
-            StartInBackground startInBackground         = {false});
+            StartInBackground startInBackground         = {false},
+            std::uint32_t stackDepth                    = 8192);
 
         ~ApplicationBellAlarm() override;
         sys::ReturnCodes InitHandler() override;

--- a/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
+++ b/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
@@ -19,8 +19,9 @@ namespace app
                                              std::string parent,
                                              sys::phone_modes::PhoneMode mode,
                                              sys::bluetooth::BluetoothMode bluetoothMode,
-                                             StartInBackground startInBackground)
-        : Application(name, parent, mode, bluetoothMode, startInBackground)
+                                             StartInBackground startInBackground,
+                                             std::uint32_t stackDepth)
+        : Application(name, parent, mode, bluetoothMode, startInBackground, stackDepth)
     {
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
         addActionReceiver(manager::actions::ShowAlarm, [this](auto &&data) {

--- a/products/BellHybrid/apps/application-bell-main/include/application-bell-main/ApplicationBellMain.hpp
+++ b/products/BellHybrid/apps/application-bell-main/include/application-bell-main/ApplicationBellMain.hpp
@@ -24,7 +24,8 @@ namespace app
             std::string parent                          = "",
             sys::phone_modes::PhoneMode mode            = sys::phone_modes::PhoneMode::Offline,
             sys::bluetooth::BluetoothMode bluetoothMode = sys::bluetooth::BluetoothMode::Disabled,
-            StartInBackground startInBackground         = {false});
+            StartInBackground startInBackground         = {false},
+            std::uint32_t stackDepth                    = 8192);
 
         sys::ReturnCodes InitHandler() override;
 

--- a/products/PurePhone/services/evtmgr/EventManager.cpp
+++ b/products/PurePhone/services/evtmgr/EventManager.cpp
@@ -133,6 +133,12 @@ void EventManager::toggleTorchColor()
     }
 }
 
+void EventManager::ProcessCloseReason(sys::CloseReason closeReason)
+{
+    bsp::torch::turn(bsp::torch::State::off);
+    EventManagerCommon::ProcessCloseReason(closeReason);
+}
+
 sys::MessagePointer EventManager::DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp)
 {
 

--- a/products/PurePhone/services/evtmgr/include/evtmgr/EventManager.hpp
+++ b/products/PurePhone/services/evtmgr/include/evtmgr/EventManager.hpp
@@ -20,6 +20,7 @@ class EventManager : public EventManagerCommon
     sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;
     void toggleTorchOnOff();
     void toggleTorchColor();
+    void ProcessCloseReason(sys::CloseReason closeReason) override;
     void handleKeyEvent(sys::Message *msg) override;
     void handleKeyMoveEvent(RawKey key);
 


### PR DESCRIPTION
When we started using alarms on HW, our stack sizes became too small. Thats because we use icallib underneath which uses big data structures (~3KB). Increasing stack size for service and applications that use alarms helps for now, but future investigation will be needed. We need to know why we need 8KB of stack and 4KB is not enough