### PR TITLE
[BH-756] Frontlight on alarm ringing

### DIFF
--- a/products/BellHybrid/alarms/BellAlarmHandler.cpp
+++ b/products/BellHybrid/alarms/BellAlarmHandler.cpp
@@ -40,7 +40,7 @@ namespace alarms
         Actions actions;
         actions.emplace_back(std::make_unique<PlayToneAction>(*service));
         actions.emplace_back(std::make_unique<NotifyGUIAction>(*service));
-        actions.emplace_back(std::make_unique<FrontlightAction>());
+        actions.emplace_back(std::make_unique<FrontlightAction>(*service));
         return actions;
     }
 

--- a/products/BellHybrid/alarms/src/actions/FrontlightAction.cpp
+++ b/products/BellHybrid/alarms/src/actions/FrontlightAction.cpp
@@ -3,17 +3,26 @@
 
 #include "FrontlightAction.hpp"
 
+#include <service-evtmgr/Constants.hpp>
+#include <service-evtmgr/ScreenLightControlMessage.hpp>
+
 namespace alarms
 {
+    FrontlightAction::FrontlightAction(sys::Service &service) : service{service}
+    {}
+
     bool FrontlightAction::execute()
     {
-        // turnOnFrontlight after it will be implemented [BH-756]
+        service.bus.sendUnicast(std::make_shared<sevm::ScreenLightControlMessage>(screen_light_control::Action::turnOn),
+                                service::name::evt_manager);
         return true;
     }
 
     bool FrontlightAction::turnOff()
     {
-        // turnOffFrontlight after it will be implemented [BH-756]
+        service.bus.sendUnicast(
+            std::make_shared<sevm::ScreenLightControlMessage>(screen_light_control::Action::turnOff),
+            service::name::evt_manager);
         return true;
     }
 } // namespace alarms

--- a/products/BellHybrid/alarms/src/actions/FrontlightAction.hpp
+++ b/products/BellHybrid/alarms/src/actions/FrontlightAction.hpp
@@ -5,14 +5,19 @@
 
 #include "AbstractAlarmAction.hpp"
 
+#include <Service/Service.hpp>
+
 namespace alarms
 {
-
     class FrontlightAction : public AbstractAlarmAction
     {
       public:
+        explicit FrontlightAction(sys::Service &service);
         bool execute() override;
         bool turnOff() override;
+
+      private:
+        sys::Service &service;
     };
 
 } // namespace alarms


### PR DESCRIPTION
Frontlight on alarm ringing

Tested on hw, flashes with light for 5s.
Changing it to constant light requires changes in frontlight backend, since its Pure'ish logic to set frontlight timer to 5s.
This is being done in:
https://github.com/mudita/MuditaOS/pull/2830