### PR TITLE
[BH-909] Add BGSounds volume MVP

### DIFF
--- a/products/BellHybrid/apps/application-bell-background-sounds/ApplicationBellBackgroundSounds.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/ApplicationBellBackgroundSounds.cpp
@@ -5,10 +5,12 @@
 #include "presenter/BGSoundsMainWindowPresenter.hpp"
 #include "presenter/BGSoundsTimerSelectPresenter.hpp"
 #include "presenter/BGSoundsProgressPresenter.hpp"
+#include "presenter/BGSoundsVolumePresenter.hpp"
 #include "windows/BGSoundsMainWindow.hpp"
 #include "windows/BGSoundsPausedWindow.hpp"
 #include "windows/BGSoundsProgressWindow.hpp"
 #include "windows/BGSoundsTimerSelectWindow.hpp"
+#include "windows/BGSoundsVolumeWindow.hpp"
 
 namespace app
 {
@@ -48,6 +50,10 @@ namespace app
             });
         windowsFactory.attach(gui::window::name::bgSoundsPaused, [](ApplicationCommon *app, const std::string &name) {
             return std::make_unique<gui::BGSoundsPausedWindow>(app);
+        });
+        windowsFactory.attach(gui::window::name::bgSoundsVolume, [](ApplicationCommon *app, const std::string &name) {
+            auto presenter = std::make_unique<bgSounds::BGSoundsVolumePresenter>();
+            return std::make_unique<gui::BGSoundsVolumeWindow>(app, std::move(presenter));
         });
     }
 

--- a/products/BellHybrid/apps/application-bell-background-sounds/CMakeLists.txt
+++ b/products/BellHybrid/apps/application-bell-background-sounds/CMakeLists.txt
@@ -15,20 +15,24 @@ target_sources(application-bell-background-sounds
         ApplicationBellBackgroundSounds.cpp
         presenter/BGSoundsProgressPresenter.cpp
         presenter/BGSoundsTimerSelectPresenter.cpp
+        presenter/BGSoundsVolumePresenter.cpp
         windows/BGSoundsMainWindow.cpp
         windows/BGSoundsPausedWindow.cpp
         windows/BGSoundsProgressWindow.cpp
         windows/BGSoundsTimerSelectWindow.cpp
+        windows/BGSoundsVolumeWindow.cpp
 
         data/BGSoundsCommon.hpp
         data/BGSoundsStyle.hpp
         presenter/BGSoundsMainWindowPresenter.hpp
         presenter/BGSoundsProgressPresenter.hpp
         presenter/BGSoundsTimerSelectPresenter.hpp
+        presenter/BGSoundsVolumePresenter.hpp
         windows/BGSoundsMainWindow.hpp
         windows/BGSoundsPausedWindow.hpp
         windows/BGSoundsProgressWindow.hpp
         windows/BGSoundsTimerSelectWindow.hpp
+        windows/BGSoundsVolumeWindow.hpp
 
     PUBLIC
         include/application-bell-background-sounds/ApplicationBellBackgroundSounds.hpp

--- a/products/BellHybrid/apps/application-bell-background-sounds/data/BGSoundsStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/data/BGSoundsStyle.hpp
@@ -9,6 +9,7 @@ namespace gui::bgSoundsStyle
 {
     inline constexpr auto descriptionFont = style::window::font::largelight;
     inline constexpr auto timerValueFont  = style::window::font::supersizemelight;
+    inline constexpr auto valumeValueFont = style::window::font::supersizemelight;
     namespace progress
     {
         inline constexpr auto bottomDescTopMargin = 20U;

--- a/products/BellHybrid/apps/application-bell-background-sounds/include/application-bell-background-sounds/ApplicationBellBackgroundSounds.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/include/application-bell-background-sounds/ApplicationBellBackgroundSounds.hpp
@@ -10,8 +10,8 @@ namespace gui::window::name
     inline constexpr auto bgSoundsPaused      = "BGSoundsPausedWindow";
     inline constexpr auto bgSoundsProgress    = "BGSoundsProgressWindow";
     inline constexpr auto bgSoundsTimerSelect = "BGSoundsTimerSelectWindow";
+    inline constexpr auto bgSoundsVolume      = "BGSoundsVolumeWindow";
 } // namespace gui::window::name
-
 namespace app
 {
     inline constexpr auto applicationBellBackgroundSoundsName = "ApplicationBellBackgroundSounds";

--- a/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsVolumePresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsVolumePresenter.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "BGSoundsVolumePresenter.hpp"
+
+namespace app::bgSounds
+{
+    BGSoundsVolumePresenter::BGSoundsVolumePresenter()
+    {}
+
+    VolumeData BGSoundsVolumePresenter::getVolumeData()
+    {
+        return volumeData;
+    }
+
+    unsigned int BGSoundsVolumePresenter::getCurrentVolume()
+    {
+        return currentVolume;
+    }
+
+    void BGSoundsVolumePresenter::onVolumeChanged(unsigned int volume)
+    {}
+
+} // namespace app::bgSounds

--- a/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsVolumePresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsVolumePresenter.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <apps-common/BasePresenter.hpp>
+
+namespace app::bgSounds
+{
+    using VolumeData = struct VolumeData
+    {
+        unsigned int min;
+        unsigned int max;
+        unsigned int step;
+    };
+
+    class BGSoundsVolumeContract
+    {
+      public:
+        class View
+        {
+          public:
+            virtual ~View() = default;
+        };
+        class Presenter : public BasePresenter<BGSoundsVolumeContract::View>
+        {
+          public:
+            virtual VolumeData getVolumeData()                = 0;
+            virtual unsigned int getCurrentVolume()           = 0;
+            virtual void onVolumeChanged(unsigned int volume) = 0;
+        };
+    };
+
+    class BGSoundsVolumePresenter : public BGSoundsVolumeContract::Presenter
+    {
+        struct VolumeData volumeData
+        {
+            0U, 10U, 1U
+        };
+        unsigned int currentVolume = 5U;
+
+        VolumeData getVolumeData() override;
+        unsigned int getCurrentVolume() override;
+        void onVolumeChanged(unsigned int volume) override;
+
+      public:
+        BGSoundsVolumePresenter();
+    };
+} // namespace app::bgSounds

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsVolumeWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsVolumeWindow.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "BGSoundsVolumeWindow.hpp"
+#include <ApplicationBellBackgroundSounds.hpp>
+#include <apps-common/widgets/BellBaseLayout.hpp>
+#include <data/BGSoundsStyle.hpp>
+
+namespace gui
+{
+    BGSoundsVolumeWindow::BGSoundsVolumeWindow(
+        app::ApplicationCommon *app, std::unique_ptr<app::bgSounds::BGSoundsVolumeContract::Presenter> &&presenter)
+        : WindowWithTimer(app, gui::window::name::bgSoundsVolume), presenter{std::move(presenter)}
+    {
+        buildInterface();
+        this->presenter->attach(this);
+    }
+
+    void BGSoundsVolumeWindow::buildInterface()
+    {
+        WindowWithTimer::buildInterface();
+
+        statusBar->setVisible(false);
+        header->setTitleVisibility(false);
+        bottomBar->setVisible(false);
+
+        body = new BellBaseLayout(this, 0, 0, style::window_width, style::window_height, true);
+
+        auto topMessage = new TextFixedSize(body->firstBox);
+        topMessage->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::outer_layouts_h);
+        topMessage->setFont(style::window::font::largelight);
+        topMessage->setEdges(gui::RectangleEdge::None);
+        topMessage->activeItem = false;
+        topMessage->setAlignment(Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center));
+        topMessage->setText(utils::translate("app_settings_volume"));
+        topMessage->drawUnderline(false);
+
+        auto data = presenter->getVolumeData();
+        spinner   = new UIntegerSpinner({data.min, data.max, data.step}, Boundaries::Fixed);
+        spinner->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::center_layout_h);
+        spinner->setFont(bgSoundsStyle::valumeValueFont);
+        spinner->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
+        spinner->setFocusEdges(RectangleEdge::None);
+        spinner->setCurrentValue(presenter->getCurrentVolume());
+        body->getCenterBox()->addWidget(spinner);
+
+        setFocusItem(spinner);
+        body->resize();
+    }
+
+    bool BGSoundsVolumeWindow::onInput(const gui::InputEvent &inputEvent)
+    {
+        resetTimer();
+        if (spinner->onInput(inputEvent)) {
+            auto currentVolume = spinner->getCurrentValue();
+            presenter->onVolumeChanged(currentVolume);
+
+            auto isMax = currentVolume == presenter->getVolumeData().max;
+            auto isMin = currentVolume == presenter->getVolumeData().min;
+            body->setArrowVisible(BellBaseLayout::Arrow::Left, isMin);
+            body->setArrowVisible(BellBaseLayout::Arrow::Right, isMax);
+
+            return true;
+        }
+        return WindowWithTimer::onInput(inputEvent);
+    }
+
+} // namespace gui

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsVolumeWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsVolumeWindow.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "presenter/BGSoundsVolumePresenter.hpp"
+
+#include <apps-common/popups/WindowWithTimer.hpp>
+#include <apps-common/widgets/spinners/Spinners.hpp>
+
+namespace gui
+{
+    class BellBaseLayout;
+    class BGSoundsVolumeWindow : public WindowWithTimer, public app::bgSounds::BGSoundsVolumeContract::View
+    {
+        std::unique_ptr<app::bgSounds::BGSoundsVolumeContract::Presenter> presenter;
+
+        BellBaseLayout *body{};
+        UIntegerSpinner *spinner = nullptr;
+
+        void buildInterface() override;
+        bool onInput(const gui::InputEvent &inputEvent) override;
+
+      public:
+        BGSoundsVolumeWindow(app::ApplicationCommon *app,
+                             std::unique_ptr<app::bgSounds::BGSoundsVolumeContract::Presenter> &&windowPresenter);
+    };
+} // namespace gui


### PR DESCRIPTION
The following commit provides an implementation of
MVP pattern for changing volume in Background Sounds app.
The implementation is restricted to basic MVP structure
and does not cover the changing volume functionality
![Screenshot from 2021-09-22 18-21-22](https://user-images.githubusercontent.com/70628259/134383053-f441a367-50c8-474b-a612-875ccefded59.png)
.