### PR TITLE
[BH-819] Fix illegal dependencies in bsp

### DIFF
--- a/module-audio/board/rt1051/CMakeLists.txt
+++ b/module-audio/board/rt1051/CMakeLists.txt
@@ -14,4 +14,5 @@ target_include_directories(${AUDIO_BOARD_LIBRARY} INTERFACE ${CMAKE_CURRENT_SOUR
 target_link_libraries(${AUDIO_BOARD_LIBRARY}
     module-bsp
     module-os
+    module-bluetooth
 )

--- a/module-bluetooth/Bluetooth/BluetoothWorker.cpp
+++ b/module-bluetooth/Bluetooth/BluetoothWorker.cpp
@@ -24,8 +24,6 @@
 #define logHciBytes(...)
 #endif
 
-using namespace bsp;
-
 namespace queues
 {
     constexpr inline auto io      = "qBtIO";
@@ -107,7 +105,7 @@ void BluetoothWorker::registerQueues()
 {
     static_cast<ServiceBluetooth *>(service)->workerQueue = Worker::getQueueHandleByName(queues::cmd);
     runLoop->setTriggerQueue(Worker::getQueueHandleByName(queues::btstack));
-    BlueKitchen::getInstance()->qHandle = queues[queueIO_handle]->GetQueueHandle();
+    bsp::BlueKitchen::getInstance()->qHandle = queues[queueIO_handle]->GetQueueHandle();
 }
 
 void BluetoothWorker::onLinkKeyAdded(const std::string &deviceAddress)
@@ -211,7 +209,7 @@ auto BluetoothWorker::handleMessage(uint32_t queueID) -> bool
         LOG_ERROR("Queue receive failure!");
         return false;
     }
-    auto bt = BlueKitchen::getInstance();
+    auto bt = bsp::BlueKitchen::getInstance();
     switch (notification) {
     case bluetooth::Message::EvtSending:
         logHciComs("[evt] sending");

--- a/module-bluetooth/Bluetooth/BluetoothWorker.hpp
+++ b/module-bluetooth/Bluetooth/BluetoothWorker.hpp
@@ -29,19 +29,7 @@ struct HCI;
 
 namespace bluetooth
 {
-    enum Message : std::uint8_t
-    {
-        /// asynchronous messages to use on event from irq
-        EvtSending,        /// Bt stack ordered a write transaction and it is pending
-        EvtSent,           /// trigger Bt stack wrote, enable writting in HCI in BluetoothWorker task
-        EvtSendingError,   /// bsp error on send
-        EvtReceiving,      /// Bt stack requested a receive transaction and it is pending
-        EvtReceived,       /// trigger Bt stack received, start processing HCI in BluetoothWorker task
-        EvtRecUnwanted,    /// not requested recieve - probably receive came to fast from sent...
-        EvtReceivingError, /// bsp error on receive
-        EvtUartError,      /// generic uart error
-        EvtErrorRec,       /// there was error o queue receive
-    };
+    using namespace bsp::bluetooth;
 
     inline const char *MessageCstr(Message what)
     {

--- a/module-bluetooth/CMakeLists.txt
+++ b/module-bluetooth/CMakeLists.txt
@@ -28,11 +28,7 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Bluetooth/interface/profiles/PhoneInterface.cpp
         )
 
-message("Build with BlueKitchen")
 include(lib/btstack.cmake)
-
-message(${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
-message("Sources: " ${SOURCES})
 add_library(${PROJECT_NAME} STATIC ${SOURCES} ${BOARD_DIR_SOURCES})
 
 
@@ -56,6 +52,7 @@ target_include_directories(
     PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TARGET_LIBRARIES_INCLUDES}
+    ${BT_STACK_ROOT}
     ${BT_STACK_ROOT}/src
     ${BT_STACK_ROOT}/src/classic
 )

--- a/module-bsp/CMakeLists.txt
+++ b/module-bsp/CMakeLists.txt
@@ -70,9 +70,8 @@ target_link_libraries(${PROJECT_NAME}
         hal
         eventstore
         module-os
-        service-bluetooth
         magic_enum
-        ${TARGET_LIBRARIES}
+        utility
     PRIVATE
         purefs-paths
         time-constants

--- a/module-bsp/board/linux/CMakeLists.txt
+++ b/module-bsp/board/linux/CMakeLists.txt
@@ -47,6 +47,8 @@ target_include_directories(
                 >
 )
 
+target_link_libraries(module-bsp PRIVATE sys-common)
+
 set_source_files_properties(board.cpp PROPERTIES COMPILE_FLAGS -Wno-unused-function)
 
 target_compile_options(module-bsp PUBLIC "-Wno-unused-result")

--- a/module-bsp/board/linux/bluetooth/Bluetooth.cpp
+++ b/module-bsp/board/linux/bluetooth/Bluetooth.cpp
@@ -2,7 +2,6 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "bsp/bluetooth/Bluetooth.hpp"
-#include "BluetoothWorker.hpp"
 #include <log/log.hpp>
 
 /// stubs

--- a/module-bsp/board/linux/watchdog/software_watchdog.cpp
+++ b/module-bsp/board/linux/watchdog/software_watchdog.cpp
@@ -2,8 +2,8 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "software_watchdog.hpp"
-#include <module-os/RTOSWrapper/include/critical.hpp>
-#include <module-os/RTOSWrapper/include/ticks.hpp>
+#include <critical.hpp>
+#include <ticks.hpp>
 #include <system/Common.hpp>
 #include <log/log.hpp>
 #include <cstdlib>

--- a/module-bsp/board/rt1051/bluetooth/BlueKitchen.cpp
+++ b/module-bsp/board/rt1051/bluetooth/BlueKitchen.cpp
@@ -2,7 +2,6 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "bsp/bluetooth/Bluetooth.hpp"
-#include "BluetoothWorker.hpp"
 #include <log/log.hpp>
 #include "FreeRTOS.h"
 #include "fsl_lpuart.h"

--- a/module-bsp/board/rt1051/bluetooth/BluetoothCommon.cpp
+++ b/module-bsp/board/rt1051/bluetooth/BluetoothCommon.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include "BluetoothWorker.hpp"
 #include "bsp/bluetooth/Bluetooth.hpp"
 #include <log/log.hpp>
 #include "FreeRTOS.h"

--- a/module-bsp/bsp/bluetooth/Bluetooth.hpp
+++ b/module-bsp/bsp/bluetooth/Bluetooth.hpp
@@ -17,6 +17,23 @@
 
 namespace bsp {
 
+    namespace bluetooth
+    {
+        enum Message : std::uint8_t
+        {
+            /// asynchronous messages to use on event from irq
+            EvtSending,        /// Bt stack ordered a write transaction and it is pending
+            EvtSent,           /// trigger Bt stack wrote, enable writting in HCI in BluetoothWorker task
+            EvtSendingError,   /// bsp error on send
+            EvtReceiving,      /// Bt stack requested a receive transaction and it is pending
+            EvtReceived,       /// trigger Bt stack received, start processing HCI in BluetoothWorker task
+            EvtRecUnwanted,    /// not requested recieve - probably receive came to fast from sent...
+            EvtReceivingError, /// bsp error on receive
+            EvtUartError,      /// generic uart error
+            EvtErrorRec,       /// there was error o queue receive
+        };
+    }
+
     class BTdev {
         public:
             enum Error {

--- a/module-bsp/bsp/vibrator/vibrator.hpp
+++ b/module-bsp/bsp/vibrator/vibrator.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Timers/Timer.hpp>
 #include <Utils.hpp>
 
 #include <chrono>

--- a/module-bsp/hal/include/hal/battery_charger/AbstractBatteryCharger.hpp
+++ b/module-bsp/hal/include/hal/battery_charger/AbstractBatteryCharger.hpp
@@ -5,7 +5,6 @@
 
 #include <FreeRTOS.h>
 #include <queue.h>
-#include <Service/Service.hpp>
 
 #include <memory>
 

--- a/module-db/CMakeLists.txt
+++ b/module-db/CMakeLists.txt
@@ -167,6 +167,7 @@ target_link_libraries(${PROJECT_NAME}
         module-utils
         module-vfs
         utf8
+        desktop-endpoints
     PRIVATE
         application-calendar
         Microsoft.GSL::GSL

--- a/module-gui/CMakeLists.txt
+++ b/module-gui/CMakeLists.txt
@@ -19,8 +19,10 @@ target_link_libraries(${PROJECT_NAME}
         eventstore
         utils-math
         module-utils
+        sys-phonemodes
         sys-service
         sys-watchdog
+        service-bluetooth
         utf8
     PRIVATE
         i18n

--- a/module-services/service-appmgr/CMakeLists.txt
+++ b/module-services/service-appmgr/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(service-appmgr
         json::json
         module-audio
         service-cellular
+        service-desktop
         service-db
         service-gui
     PUBLIC

--- a/module-services/service-desktop/endpoints/CMakeLists.txt
+++ b/module-services/service-desktop/endpoints/CMakeLists.txt
@@ -29,6 +29,8 @@ target_link_libraries(
         desktop-endpoint-base
     PUBLIC
         endpoint-message-sender
+        hash-library::hash-library
+        module-db
         sys-service
 )
 

--- a/module-services/service-evtmgr/CMakeLists.txt
+++ b/module-services/service-evtmgr/CMakeLists.txt
@@ -24,7 +24,6 @@ target_include_directories(${PROJECT_NAME}
         "${CMAKE_CURRENT_LIST_DIR}"
          ${CMAKE_CURRENT_LIST_DIR}/service-evtmgr/include
 )
- 
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
@@ -36,9 +35,15 @@ target_link_libraries(${PROJECT_NAME}
         service-audio
         service-cellular
         service-desktop
+        service-bluetooth
         sml::sml
         Microsoft.GSL::GSL
         eventstore
+    PUBLIC
+        service-db
+        sys-service
+        sys-manager
+        messagetype
 )
 
 if (${ENABLE_TESTS})

--- a/module-services/service-time/CMakeLists.txt
+++ b/module-services/service-time/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(${PROJECT_NAME}
         utils-time
         service-db
         service-time-api
+        service-evtmgr
         module-sys
         module-apps
 )

--- a/module-sys/Service/include/Service/Service.hpp
+++ b/module-sys/Service/include/Service/Service.hpp
@@ -5,7 +5,6 @@
 
 #include "ServiceForward.hpp"
 #include "BusProxy.hpp"
-#include "Common.hpp"  // for ReturnCodes, ServicePriority, BusChannels
 #include "Mailbox.hpp" // for Mailbox
 #include "Message.hpp" // for MessagePointer
 #include "ServiceManifest.hpp"

--- a/module-sys/SystemManager/CMakeLists.txt
+++ b/module-sys/SystemManager/CMakeLists.txt
@@ -29,14 +29,14 @@ target_include_directories(sys-manager
 )
 
 target_link_libraries(sys-manager
-    PRIVATE
+    PUBLIC
         apps-common
         service-evtmgr
-
-    PUBLIC
         eventstore
         sys-service
         sys-common
+    PRIVATE
+        service-desktop
 )
 
 if (${ENABLE_TESTS})

--- a/module-utils/log/board/rt1051/CMakeLists.txt
+++ b/module-utils/log/board/rt1051/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(log
     PRIVATE
         module-bsp
         segger::rtt
+        utils-time
 )
 
 if (${LOG_REDIRECT} STREQUAL "RTT_JLINK")


### PR DESCRIPTION
Break circular dependencies in the BSP module. Fix some missing
dependencies which surfaced after fixing BSP.

Signed-off-by: Marcin Smoczyński <smoczynski.marcin@gmail.com>
