### PR TITLE
[EGD-7669] Fixed a crash while searching for notes

### DIFF
--- a/module-apps/application-notes/windows/SearchResultsWindow.cpp
+++ b/module-apps/application-notes/windows/SearchResultsWindow.cpp
@@ -15,6 +15,7 @@ namespace app::notes
                                              std::unique_ptr<NotesSearchWindowContract::Presenter> &&windowPresenter)
         : AppWindow(application, gui::name::window::notes_search_result), presenter(std::move(windowPresenter))
     {
+        presenter->attach(this);
         buildInterface();
     }
 


### PR DESCRIPTION
The view was not attached to its presenter.