### PR TITLE
[EGD-7671] Break the windows loop in the phonebook.

### DIFF
--- a/module-apps/application-phonebook/windows/PhonebookContactOptions.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookContactOptions.cpp
@@ -110,10 +110,12 @@ namespace gui
                                 dialogText,
                                 "",
                                 [=]() -> bool {
-                                    this->application->switchWindow(gui::name::window::main_window);
+                                    auto data                        = std::make_unique<SwitchData>();
+                                    data->ignoreCurrentWindowOnStack = true;
+                                    this->application->switchWindow(gui::name::window::main_window, std::move(data));
                                     return true;
                                 }});
-
+        metaData->ignoreCurrentWindowOnStack = true;
         application->switchWindow(gui::window::name::dialog_confirm, std::move(metaData));
         return true;
     }


### PR DESCRIPTION
The problem occurs when a user removes a contact from sms thread.
It's not possible to get out of the phonebook app.