### PR TITLE
[EGD-7715] Revert Alarm settings window

### DIFF
--- a/module-apps/application-settings/windows/apps/AppsWindow.cpp
+++ b/module-apps/application-settings/windows/apps/AppsWindow.cpp
@@ -33,10 +33,7 @@ namespace gui
 
         addMenu(i18("app_settings_apps_phone"), gui::window::name::phone);
         addMenu(i18("app_settings_apps_messages"), gui::window::name::messages);
-
-#if DISABLED_SETTINGS_OPTIONS == 1
         addMenu(i18("app_settings_apps_alarm_clock"), gui::window::name::alarm_clock);
-#endif // DISABLED_SETTINGS_OPTIONS
 
         return optionList;
     }


### PR DESCRIPTION
Added prevoiusly hidden alarm settings window. Pure revert of this window. Detected a bug to be fixed after: https://appnroll.atlassian.net/browse/EGD-7719