### PR TITLE
[EGD-7743] Fix crash on BT device name save

### DIFF
--- a/module-apps/application-settings/ApplicationSettings.cpp
+++ b/module-apps/application-settings/ApplicationSettings.cpp
@@ -398,8 +398,8 @@ namespace app
         windowsFactory.attach(gui::window::name::all_devices, [this](ApplicationCommon *app, const std::string &name) {
             return std::make_unique<gui::AllDevicesWindow>(app, bluetoothSettingsModel);
         });
-        windowsFactory.attach(gui::window::name::phone_name, [](ApplicationCommon *app, const std::string &name) {
-            return std::make_unique<gui::PhoneNameWindow>(app);
+        windowsFactory.attach(gui::window::name::phone_name, [this](ApplicationCommon *app, const std::string &name) {
+            return std::make_unique<gui::PhoneNameWindow>(app, bluetoothSettingsModel);
         });
         windowsFactory.attach(gui::window::name::bluetooth_check_passkey,
                               [](ApplicationCommon *app, const std::string &name) {

--- a/module-apps/application-settings/windows/bluetooth/PhoneNameWindow.cpp
+++ b/module-apps/application-settings/windows/bluetooth/PhoneNameWindow.cpp
@@ -10,9 +10,10 @@
 
 namespace gui
 {
-    PhoneNameWindow::PhoneNameWindow(app::ApplicationCommon *app) : AppWindow(app, gui::window::name::phone_name)
+    PhoneNameWindow::PhoneNameWindow(app::ApplicationCommon *app,
+                                     std::shared_ptr<BluetoothSettingsModel> bluetoothSettingsModel)
+        : AppWindow(app, gui::window::name::phone_name), bluetoothSettingsModel(bluetoothSettingsModel)
     {
-        bluetoothSettingsModel = std::make_unique<BluetoothSettingsModel>(application);
         bluetoothSettingsModel->requestDeviceName();
         buildInterface();
     }

--- a/module-apps/application-settings/windows/bluetooth/PhoneNameWindow.hpp
+++ b/module-apps/application-settings/windows/bluetooth/PhoneNameWindow.hpp
@@ -10,7 +10,7 @@ namespace gui
     class PhoneNameWindow : public AppWindow
     {
       public:
-        explicit PhoneNameWindow(app::ApplicationCommon *app);
+        PhoneNameWindow(app::ApplicationCommon *app, std::shared_ptr<BluetoothSettingsModel> bluetoothSettingsModel);
 
       private:
         void buildInterface() override;
@@ -19,7 +19,7 @@ namespace gui
         auto onInput(const InputEvent &inputEvent) -> bool override;
 
         Text *inputField = nullptr;
-        std::unique_ptr<BluetoothSettingsModel> bluetoothSettingsModel;
+        std::shared_ptr<BluetoothSettingsModel> bluetoothSettingsModel;
 
         static constexpr auto maxNameLength = 248; // Max 248 bytes according to Bluetooth Core Specification v5.2
     };

--- a/module-bluetooth/Bluetooth/interface/BluetoothDriverImpl.cpp
+++ b/module-bluetooth/Bluetooth/interface/BluetoothDriverImpl.cpp
@@ -138,7 +138,7 @@ namespace bluetooth
                 LOG_INFO("Your initscripts is for %s chipset",
                          btstack_chipset_cc256x_lmp_subversion() < lmp_subversion ? "an older" : "a newer");
                 LOG_INFO("Please update Makefile to include the appropriate bluetooth_init_cc256???.c file");
-                exit(10);
+                return;
             }
             LOG_INFO("Using 921600 baud");
             config.baudrate_main = 921600;

--- a/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
@@ -80,7 +80,7 @@ class ServiceBluetooth : public sys::Service
   private:
     std::unique_ptr<BluetoothWorker> worker;
     std::shared_ptr<sys::CpuSentinel> cpuSentinel;
-    sys::TimerHandle connectionTimeoutTimer;
+    sys::TimerHandle connectionTimeoutTimer, btRestartTimer;
     std::shared_ptr<BluetoothDevicesModel> bluetoothDevicesModel{};
 
     void startTimeoutTimer();


### PR DESCRIPTION
Due to enabled EHCILL the shutdown procedure takes longer time
than before, so restarting by turning off and on without a delay
caused crash in the BT stack. Added delay between shutdown and
power on to let the stack turn off completely