### PR TITLE
[BH-953] Fix BGSounds windows UI

### DIFF
--- a/products/BellHybrid/apps/application-bell-background-sounds/data/BGSoundsStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/data/BGSoundsStyle.hpp
@@ -7,13 +7,16 @@
 
 namespace gui::bgSoundsStyle
 {
-    inline constexpr auto descriptionFont = style::window::font::largelight;
+    inline constexpr auto descriptionFont = style::window::font::verybiglight;
+    inline constexpr auto titleFont       = style::window::font::largelight;
     inline constexpr auto timerValueFont  = style::window::font::supersizemelight;
     inline constexpr auto valumeValueFont = style::window::font::supersizemelight;
     namespace progress
     {
-        inline constexpr auto bottomDescTopMargin = 20U;
-        inline constexpr auto boxesCount          = 16;
+        inline constexpr auto bottomDescTopMargin = 15U;
+        inline constexpr auto maxProgressValue    = 16;
+        inline constexpr auto titleMaxLines       = 2;
+        inline constexpr auto titleWidth          = 400U;
     } // namespace progress
 
     namespace pause

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsProgressWindow.cpp
@@ -8,7 +8,7 @@
 #include <apps-common/widgets/BarGraph.hpp>
 #include <apps-common/widgets/ProgressTimer.hpp>
 #include <apps-common/GuiTimer.hpp>
-#include <Text.hpp>
+#include <TextFixedSize.hpp>
 
 namespace
 {
@@ -23,18 +23,23 @@ namespace
     }
     gui::Text *createTitle(gui::VBox *parent)
     {
-        auto title = new gui::Text(parent, 0, 0, parent->getWidth(), parent->getHeight() / 2);
-        title->setFont(gui::bgSoundsStyle::descriptionFont);
+        namespace bgStyle = gui::bgSoundsStyle;
+        auto title        = new gui::TextFixedSize(parent, 0, 0, 0, 0);
+        title->setFont(bgStyle::titleFont);
+        title->setMinimumWidth(bgStyle::progress::titleWidth);
+        title->setMinimumHeightToFitText(bgStyle::progress::titleMaxLines);
+        title->drawUnderline(false);
 
         decorateProgressItem(title, gui::Alignment::Vertical::Top);
         return title;
     }
     gui::HBarGraph *createProgress(gui::VBox *parent)
     {
-        auto progressBox = new gui::HBox(parent, 0, 0, parent->getWidth(), parent->getHeight() / 2);
+        auto progressBox = new gui::HBox(parent, 0, 0, 0, 0);
         decorateProgressItem(progressBox, gui::Alignment::Vertical::Bottom);
-        auto progressBar =
-            new gui::HBarGraph(progressBox, 0, 0, gui::bgSoundsStyle::progress::boxesCount, gui::BarGraphStyle::Heavy);
+        progressBox->setMaximumSize(parent->getWidth(), parent->getHeight() / 2);
+        auto progressBar = new gui::HBarGraph(
+            progressBox, 0, 0, gui::bgSoundsStyle::progress::maxProgressValue, gui::BarGraphStyle::Heavy);
         decorateProgressItem(progressBar, gui::Alignment::Vertical::Center);
         return progressBar;
     }
@@ -91,6 +96,7 @@ namespace gui
         title       = createTitle(vBox);
         progressBar = createProgress(vBox);
         timerText   = createTimer(body->lastBox);
+        vBox->resizeItems();
 
         dimensionChangedCallback = [&](Item &, const BoundingBox &newDim) -> bool {
             body->setArea({0, 0, newDim.w, newDim.h});

--- a/products/BellHybrid/apps/common/include/common/options/BellOptionWindow.hpp
+++ b/products/BellHybrid/apps/common/include/common/options/BellOptionWindow.hpp
@@ -9,7 +9,7 @@
 
 namespace style::bell_options_list
 {
-    inline constexpr auto w                    = 380U;
+    inline constexpr auto w                    = 400U;
     inline constexpr auto h                    = 400U;
     inline constexpr auto outer_layouts_h      = 64U;
     inline constexpr auto outer_layouts_margin = 7U;


### PR DESCRIPTION
The following commit fixes BGSounds UI:
* app's name not fitting in MainWindow by extending BellOptionsWindow width
* soundtrack title set to occupy up to two lines in progress window