### PR TITLE
[EGD-7761] Fix HFP reconnect

### DIFF
--- a/module-bluetooth/Bluetooth/interface/profiles/HFP/HFP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/HFP/HFP.cpp
@@ -387,10 +387,11 @@ namespace bluetooth
 
     void HFP::HFPImpl::connect()
     {
-        if (!isConnected) {
-            LOG_DEBUG("Connecting the HFP profile");
-            hfp_ag_establish_service_level_connection(device.address);
+        if (isConnected) {
+            disconnect();
         }
+        LOG_DEBUG("Connecting the HFP profile");
+        hfp_ag_establish_service_level_connection(device.address);
     }
 
     void HFP::HFPImpl::disconnect()


### PR DESCRIPTION
After connecting to another device while it was connected
HFP didn't disconnect from the previous one