### PR TITLE
[BH-1017] Fix BGSounds progress clock

### DIFF
--- a/products/BellHybrid/apps/application-bell-background-sounds/ApplicationBellBackgroundSounds.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/ApplicationBellBackgroundSounds.cpp
@@ -13,6 +13,7 @@
 #include "windows/BGSoundsTimerSelectWindow.hpp"
 #include "windows/BGSoundsVolumeWindow.hpp"
 #include "widgets/BGSoundsPlayer.hpp"
+#include <common/models/TimeModel.hpp>
 #include <service-audio/AudioMessage.hpp>
 
 #include <log/log.hpp>
@@ -57,11 +58,13 @@ namespace app
                 auto presenter = std::make_unique<bgSounds::BGSoundsTimerSelectPresenter>(settings.get());
                 return std::make_unique<gui::BGSoundsTimerSelectWindow>(app, std::move(presenter));
             });
-        windowsFactory.attach(
-            gui::window::name::bgSoundsProgress, [this](ApplicationCommon *app, const std::string &name) {
-                auto presenter = std::make_unique<bgSounds::BGSoundsProgressPresenter>(settings.get(), *player);
-                return std::make_unique<gui::BGSoundsProgressWindow>(app, std::move(presenter));
-            });
+        windowsFactory.attach(gui::window::name::bgSoundsProgress,
+                              [this](ApplicationCommon *app, const std::string &name) {
+                                  auto timeModel = std::make_unique<app::TimeModel>();
+                                  auto presenter = std::make_unique<bgSounds::BGSoundsProgressPresenter>(
+                                      settings.get(), *player, std::move(timeModel));
+                                  return std::make_unique<gui::BGSoundsProgressWindow>(app, std::move(presenter));
+                              });
         windowsFactory.attach(gui::window::name::bgSoundsPaused, [](ApplicationCommon *app, const std::string &name) {
             return std::make_unique<gui::BGSoundsPausedWindow>(app);
         });

--- a/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsProgressPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsProgressPresenter.cpp
@@ -6,6 +6,7 @@
 #include "widgets/BGSoundsPlayer.hpp"
 #include <ApplicationBellBackgroundSounds.hpp>
 #include <apps-common/widgets/ProgressTimer.hpp>
+#include <common/models/TimeModel.hpp>
 #include <service-db/Settings.hpp>
 #include <Timers/TimerFactory.hpp>
 #include <Utils.hpp>
@@ -14,9 +15,12 @@
 
 namespace app::bgSounds
 {
-    BGSoundsProgressPresenter::BGSoundsProgressPresenter(settings::Settings *settings, AbstractBGSoundsPlayer &player)
-        : settings{settings}, player{player}
+    BGSoundsProgressPresenter::BGSoundsProgressPresenter(settings::Settings *settings,
+                                                         AbstractBGSoundsPlayer &player,
+                                                         std::unique_ptr<AbstractTimeModel> timeModel)
+        : settings{settings}, player{player}, timeModel{std::move(timeModel)}
     {}
+    BGSoundsProgressPresenter::~BGSoundsProgressPresenter() = default;
 
     void BGSoundsProgressPresenter::setTimer(std::unique_ptr<app::TimerWithCallbacks> &&_timer)
     {
@@ -81,5 +85,8 @@ namespace app::bgSounds
             player.resume(std::move(onResumeCallback));
         }
     }
-
+    void BGSoundsProgressPresenter::handleUpdateTimeEvent()
+    {
+        getView()->setTime(timeModel->getCurrentTime());
+    }
 } // namespace app::bgSounds

--- a/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsProgressPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsProgressPresenter.hpp
@@ -6,9 +6,11 @@
 #include <apps-common/BasePresenter.hpp>
 #include <apps-common/widgets/TimerWithCallbacks.hpp>
 #include <tags_fetcher/TagsFetcher.hpp>
+#include <time/time_locale.hpp>
 #include <memory>
 namespace app
 {
+    class AbstractTimeModel;
     class ApplicationCommon;
 } // namespace app
 namespace gui
@@ -31,6 +33,8 @@ namespace app::bgSounds
             ~View()                   = default;
             virtual void onFinished() = 0;
             virtual void onPaused()   = 0;
+            virtual void setTime(std::time_t newTime)                       = 0;
+            virtual void setTimeFormat(utils::time::Locale::TimeFormat fmt) = 0;
         };
 
         class Presenter : public BasePresenter<BGSoundsProgressContract::View>
@@ -41,6 +45,7 @@ namespace app::bgSounds
             virtual void pause()                                                    = 0;
             virtual void resume()                                                   = 0;
             virtual void setTimer(std::unique_ptr<app::TimerWithCallbacks> &&timer) = 0;
+            virtual void handleUpdateTimeEvent()                                    = 0;
         };
     };
 
@@ -51,16 +56,21 @@ namespace app::bgSounds
         settings::Settings *settings = nullptr;
         AbstractBGSoundsPlayer &player;
         std::unique_ptr<app::TimerWithCallbacks> timer;
+        std::unique_ptr<AbstractTimeModel> timeModel;
 
         void activate(const tags::fetcher::Tags &tags) override;
         void stop() override;
         void pause() override;
         void resume() override;
         void setTimer(std::unique_ptr<app::TimerWithCallbacks> &&_timer) override;
+        void handleUpdateTimeEvent() override;
 
         void onFinished();
 
       public:
-        BGSoundsProgressPresenter(settings::Settings *settings, AbstractBGSoundsPlayer &player);
+        BGSoundsProgressPresenter(settings::Settings *settings,
+                                  AbstractBGSoundsPlayer &player,
+                                  std::unique_ptr<AbstractTimeModel> timeModel);
+        ~BGSoundsProgressPresenter();
     };
 } // namespace app::bgSounds

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsProgressWindow.cpp
@@ -9,7 +9,7 @@
 #include <apps-common/widgets/ProgressTimer.hpp>
 #include <apps-common/GuiTimer.hpp>
 #include <TextFixedSize.hpp>
-
+#include <time/dateCommon.hpp>
 namespace
 {
     inline constexpr auto bgSoundsTimerName     = "BGSoundsProgressTimer";
@@ -54,6 +54,13 @@ namespace
         decorateProgressItem(timer, gui::Alignment::Vertical::Top);
         return timer;
     }
+    gui::BellStatusClock *createClock(gui::Item *parent)
+    {
+        auto time = new gui::BellStatusClock(parent);
+        time->setMaximumSize(parent->getWidth(), parent->getHeight());
+        time->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
+        return time;
+    }
 } // namespace
 
 namespace gui
@@ -89,6 +96,7 @@ namespace gui
     }
     void BGSoundsProgressWindow::buildLayout()
     {
+        statusBar->setVisible(false);
         auto body = new gui::BellBaseLayout(this, 0, 0, style::bell_base_layout::w, style::bell_base_layout::h, false);
         auto vBox =
             new VBox(body->getCenterBox(), 0, 0, style::bell_base_layout::w, style::bell_base_layout::center_layout_h);
@@ -96,6 +104,8 @@ namespace gui
         title       = createTitle(vBox);
         progressBar = createProgress(vBox);
         timerText   = createTimer(body->lastBox);
+        time        = createClock(body->firstBox);
+        body->firstBox->resizeItems();
         vBox->resizeItems();
 
         dimensionChangedCallback = [&](Item &, const BoundingBox &newDim) -> bool {
@@ -141,5 +151,23 @@ namespace gui
     void BGSoundsProgressWindow::onPaused()
     {
         application->switchWindow(gui::window::name::bgSoundsPaused);
+    }
+    void BGSoundsProgressWindow::setTime(std::time_t newTime)
+    {
+        time->setTime(newTime);
+        time->setTimeFormatSpinnerVisibility(true);
+    }
+
+    void BGSoundsProgressWindow::setTimeFormat(utils::time::Locale::TimeFormat fmt)
+    {
+        time->setTimeFormat(fmt);
+    }
+
+    bool BGSoundsProgressWindow::updateTime()
+    {
+        if (presenter) {
+            presenter->handleUpdateTimeEvent();
+        }
+        return true;
     }
 } // namespace gui

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsProgressWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsProgressWindow.hpp
@@ -6,6 +6,7 @@
 #include "presenter/BGSoundsProgressPresenter.hpp"
 #include "data/BGSoundsAudioData.hpp"
 #include <AppWindow.hpp>
+#include <common/widgets/BellStatusClock.hpp>
 
 namespace gui
 {
@@ -17,11 +18,16 @@ namespace gui
         gui::Text *title            = nullptr;
         gui::HBarGraph *progressBar = nullptr;
         gui::Text *timerText        = nullptr;
+        gui::BellStatusClock *time  = nullptr;
         std::unique_ptr<BGSoundsAudioContext> audioContext;
 
         void buildInterface() override;
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
         auto onInput(const InputEvent &inputEvent) -> bool override;
+
+        void setTime(std::time_t newTime) override;
+        void setTimeFormat(utils::time::Locale::TimeFormat fmt) override;
+        bool updateTime() override;
 
         void buildLayout();
         void configureTimer();


### PR DESCRIPTION
The following commit uses recent BellClock widget
to match current time display to UI design