### PR TITLE
[BH-979] Remove time spinner preceding zero

### DIFF
--- a/module-apps/apps-common/widgets/TimeSetSpinner.cpp
+++ b/module-apps/apps-common/widgets/TimeSetSpinner.cpp
@@ -30,6 +30,7 @@ namespace gui
         hour->setEdges(RectangleEdge::None);
         hour->setPenFocusWidth(style::time_set_spinner::focus::size);
         hour->setCurrentValue(0);
+        hour->setLeadingFillChar(' ');
 
         addWidget(hour);
 

--- a/module-gui/gui/widgets/Spinner.cpp
+++ b/module-gui/gui/widgets/Spinner.cpp
@@ -103,7 +103,7 @@ namespace gui
     {
         std::stringstream outStream;
         if (fixedFieldWidth > 0) {
-            outStream << std::setw(fixedFieldWidth) << std::setfill('0');
+            outStream << std::setw(fixedFieldWidth) << std::setfill(leadingFillChar);
         }
         outStream << currentValue;
         setText(outStream.str());
@@ -122,6 +122,11 @@ namespace gui
     void Spinner::setFocusEdges(RectangleEdge edges)
     {
         focusEdges = edges;
+    }
+
+    void Spinner::setLeadingFillChar(char fillChar)
+    {
+        leadingFillChar = fillChar;
     }
 
 } // namespace gui

--- a/module-gui/gui/widgets/Spinner.hpp
+++ b/module-gui/gui/widgets/Spinner.hpp
@@ -29,6 +29,7 @@ namespace gui
         // virtual methods from Item
         bool onInput(const InputEvent &inputEvent) override;
         bool onFocus(bool state) override;
+        void setLeadingFillChar(char fillChar);
 
       private:
         int minValue;
@@ -40,6 +41,7 @@ namespace gui
         ///< if current < fixedFieldWidth Label will be filled with 0
         ///< value of 0 means no fixed width.
         RectangleEdge focusEdges = RectangleEdge::Bottom;
+        char leadingFillChar     = '0';
         void updateSpinner();
 
         OnUpdateCallback onUpdate{nullptr};


### PR DESCRIPTION
Remove leading '0' from hour display in time spinners.