### PR TITLE
[EGD-7440] Fix BT statusbar after BT disconnect

### DIFF
--- a/module-services/service-bluetooth/ServiceBluetooth.cpp
+++ b/module-services/service-bluetooth/ServiceBluetooth.cpp
@@ -334,8 +334,12 @@ auto ServiceBluetooth::handle(message::bluetooth::DisconnectResult *msg) -> std:
     }
     bluetoothDevicesModel->syncDevicesWithApp();
     settingsHolder->setValue(bluetooth::Settings::ConnectedDevice, std::string());
-    bus.sendMulticast(std::make_shared<sys::bluetooth::BluetoothModeChanged>(sys::bluetooth::BluetoothMode::Enabled),
-                      sys::BusChannel::BluetoothModeChanges);
+
+    if (auto btOn = std::visit(bluetooth::BoolVisitor(), settingsHolder->getValue(bluetooth::Settings::State)); btOn) {
+        bus.sendMulticast(
+            std::make_shared<sys::bluetooth::BluetoothModeChanged>(sys::bluetooth::BluetoothMode::Enabled),
+            sys::BusChannel::BluetoothModeChanges);
+    }
 
     bus.sendMulticast(std::make_shared<message::bluetooth::DisconnectResult>(msg->getDevice()),
                       sys::BusChannel::BluetoothNotifications);


### PR DESCRIPTION
BT statusbar was set by disconnect message, which was not
aware of BT on/off status, thus always after disconnect
the statusbar icon was set to idle/enabled