### PR TITLE
[EGD-7697] Change deafult bt device name to Mudita Pure

### DIFF
--- a/image/user/db/settings_v2_002.sql
+++ b/image/user/db/settings_v2_002.sql
@@ -28,7 +28,7 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('gs_os_current_version', '0.00.0'),
     ('\ServiceBluetooth\\bt_state', '0'),
     ('\ServiceBluetooth\\bt_device_visibility', '0'),
-    ('\ServiceBluetooth\\bt_device_name', 'PurePhone'),
+    ('\ServiceBluetooth\\bt_device_name', 'Mudita Pure'),
     ('\ServiceBluetooth\\bt_bonded_devices', ''),
     ('battery_critical_level', '10'),
     ('cl_offline_mode', '1'),


### PR DESCRIPTION
Mudita Pure is official name of the product,
and its default BT name required a change.