### PR TITLE
[EGD-7794] Show meditation timer by default

### DIFF
--- a/module-apps/application-meditation/include/application-meditation/OptionsData.hpp
+++ b/module-apps/application-meditation/include/application-meditation/OptionsData.hpp
@@ -18,6 +18,6 @@ namespace gui
         {}
 
         std::chrono::seconds preparationTime{5};
-        bool showCounter = false;
+        bool showCounter = true;
     };
 } // namespace gui


### PR DESCRIPTION
Show meditation timer counter is now ON by
default in meditation app options.