### PR TITLE
[BH-1039] Fixed frontlight fallback to default value

### DIFF
--- a/products/BellHybrid/services/evtmgr/screen-light-control/ScreenLightControl.cpp
+++ b/products/BellHybrid/services/evtmgr/screen-light-control/ScreenLightControl.cpp
@@ -43,6 +43,7 @@ namespace bell::screen_light_control
             break;
         case Action::disableAutomaticMode:
             disableAutomaticMode();
+            setManualBrightnessLevel(brightnessValue);
             break;
         case Action::setManualModeBrightness:
             if (params.hasManualModeParams()) {
@@ -162,7 +163,6 @@ namespace bell::screen_light_control
         disableTimers();
         automaticMode = ScreenLightMode::Manual;
         automaticModeFunctions.clear();
-        setManualBrightnessLevel(brightnessValue);
     }
 
     void ScreenLightController::turnOn(const std::optional<ManualModeParameters> &params)
@@ -191,5 +191,7 @@ namespace bell::screen_light_control
         bsp::eink_frontlight::turnOff();
         disableAutomaticMode();
         lightOn = false;
+
+        setManualBrightnessLevel(brightnessValue);
     }
 } // namespace screen_light_control


### PR DESCRIPTION
The frontlight should not fallback to its default value
once the ramp target is reached.