### PR TITLE
[EGD-7800] Enable SDP register on BT startup

### DIFF
--- a/module-bluetooth/Bluetooth/CommandHandler.cpp
+++ b/module-bluetooth/Bluetooth/CommandHandler.cpp
@@ -35,7 +35,9 @@ namespace bluetooth
                                    std::shared_ptr<bluetooth::AbstractDriver> driver)
         : service{service}, settings{std::move(settings)}, profileManager{std::move(profileManager)}, driver{std::move(
                                                                                                           driver)}
-    {}
+    {
+        this->driver->registerPowerOnCallback([profilePtr = this->profileManager]() { profilePtr->init(); });
+    }
 
     Error::Code CommandHandler::handle(Command command)
     {
@@ -115,7 +117,6 @@ namespace bluetooth
 
     Error::Code CommandHandler::establishAudioConnection(const Devicei &device)
     {
-        profileManager->init();
         LOG_INFO("Connecting audio");
         profileManager->connect(device);
         return Error::Success;

--- a/module-bluetooth/Bluetooth/interface/BluetoothDriver.hpp
+++ b/module-bluetooth/Bluetooth/interface/BluetoothDriver.hpp
@@ -9,11 +9,13 @@
 
 namespace bluetooth
 {
+    using PowerOnCallback = std::function<void()>;
+
     class AbstractDriver
     {
       public:
-        using ErrorCallback                = std::function<void(uint8_t)>;
         virtual ~AbstractDriver() noexcept = default;
+        using ErrorCallback                = std::function<void(uint8_t)>;
 
         [[nodiscard]] virtual auto init() -> Error::Code                     = 0;
         [[nodiscard]] virtual auto run() -> Error::Code                      = 0;
@@ -24,6 +26,7 @@ namespace bluetooth
         [[nodiscard]] virtual auto pair(Devicei device, std::uint8_t protectionLevel = 0) -> bool = 0;
         [[nodiscard]] virtual auto unpair(Devicei device) -> bool                                 = 0;
 
-        virtual void registerErrorCallback(const ErrorCallback &newCallback) = 0;
+        virtual void registerErrorCallback(const ErrorCallback &newCallback)     = 0;
+        virtual void registerPowerOnCallback(const PowerOnCallback &newCallback) = 0;
     };
 } // namespace bluetooth

--- a/module-bluetooth/Bluetooth/interface/BluetoothDriverImpl.hpp
+++ b/module-bluetooth/Bluetooth/interface/BluetoothDriverImpl.hpp
@@ -22,6 +22,8 @@ namespace bluetooth
         const btstack_run_loop *runLoop;
         btstack_packet_callback_registration_t hci_event_callback_registration;
         std::unique_ptr<bluetooth::GAP> gap;
+        static PowerOnCallback powerOnCallback;
+
         static void hci_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size);
         static void local_version_information_handler(uint8_t *packet);
 #ifdef TARGET_RT1051
@@ -37,6 +39,8 @@ namespace bluetooth
         [[nodiscard]] auto run() -> Error::Code override;
         [[nodiscard]] auto stop() -> Error::Code override;
         void registerErrorCallback(const ErrorCallback &newCallback) override;
+        void registerPowerOnCallback(const PowerOnCallback &newCallback) override;
+
         auto scan() -> Error override;
         void stopScan() override;
         void setVisibility(bool visibility) override;

--- a/module-bluetooth/tests/tests-StatefulController.cpp
+++ b/module-bluetooth/tests/tests-StatefulController.cpp
@@ -40,6 +40,8 @@ class DriverMock : public AbstractDriver
     }
     void registerErrorCallback(const ErrorCallback &) override
     {}
+    void registerPowerOnCallback(const PowerOnCallback &) override
+    {}
 
     Error::Code initReturnCode = Error::Success;
     Error::Code runReturnCode  = Error::Success;


### PR DESCRIPTION
To be able to pair properly using SSP the BT device have to know
which services we're running, thus we need to register SDP entries
after startup of the BT stack