### PR TITLE
[BH-928] Fix alarm ring home screen issue.

### DIFF
--- a/products/BellHybrid/apps/application-bell-main/presenters/StateController.cpp
+++ b/products/BellHybrid/apps/application-bell-main/presenters/StateController.cpp
@@ -216,6 +216,8 @@ namespace app::home_screen
             auto entry = [](AbstractView &view, AbstractAlarmModel &alarmModel, AbstractPresenter &presenter) {
                 presenter.spawnTimer();
                 alarmModel.turnOff();
+                alarmModel.activate(false);
+                view.setAlarmTimeVisible(false);
                 view.setBottomDescription(Helpers::getGreeting());
                 view.setAlarmActive(false);
             };


### PR DESCRIPTION
Fix issue when switching off the alarm ring,
the home screen is not coherent with figma.