### PR TITLE
[EGD-7528] Fix for removing SMS drafts

### DIFF
--- a/module-apps/application-messages/include/application-messages/ApplicationMessages.hpp
+++ b/module-apps/application-messages/include/application-messages/ApplicationMessages.hpp
@@ -55,7 +55,9 @@ namespace app
                               bool ignoreCurrentWindowOnStack = false);
         bool handleSendSmsFromThread(const utils::PhoneNumber::View &number, const UTF8 &body);
 
-        std::pair<SMSRecord, bool> createDraft(const utils::PhoneNumber::View &number, const UTF8 &body);
+        void createDraft(const utils::PhoneNumber::View &number,
+                         const UTF8 &body,
+                         std::function<void(const SMSRecord &)> onSuccess = {});
         bool updateDraft(SMSRecord &record, const UTF8 &body);
         bool removeDraft(const SMSRecord &record);
 

--- a/module-apps/application-messages/models/SMSThreadModel.cpp
+++ b/module-apps/application-messages/models/SMSThreadModel.cpp
@@ -103,10 +103,9 @@ void SMSThreadModel::addReturnNumber()
         auto app = dynamic_cast<app::ApplicationMessages *>(application);
         assert(app != nullptr);
         assert(smsInput->number != nullptr);
-        if (app->handleSendSmsFromThread(*smsInput->number, smsInput->inputText->getText())) {
+        if (!app->handleSendSmsFromThread(*smsInput->number, smsInput->inputText->getText())) {
             LOG_ERROR("handleSendSmsFromThread failed");
         }
-        smsInput->inputText->clear();
         smsInput->clearDraftMessage();
         return true;
     };

--- a/module-apps/application-messages/widgets/SMSInputWidget.cpp
+++ b/module-apps/application-messages/widgets/SMSInputWidget.cpp
@@ -161,10 +161,7 @@ namespace gui
             app->updateDraft(draft.value(), inputText);
         }
         else {
-            const auto &[draft, success] = app->createDraft(*number, inputText);
-            if (success) {
-                this->draft = draft;
-            }
+            app->createDraft(*number, inputText, [this](const SMSRecord &record) { draft = record; });
         }
     }
 

--- a/module-db/queries/messages/sms/QuerySMSAdd.cpp
+++ b/module-db/queries/messages/sms/QuerySMSAdd.cpp
@@ -22,4 +22,9 @@ namespace db::query
     {
         return "SMSAddResult"s;
     }
+
+    bool SMSAddResult::succeed() const noexcept
+    {
+        return result;
+    }
 } // namespace db::query

--- a/module-db/queries/messages/sms/QuerySMSAdd.hpp
+++ b/module-db/queries/messages/sms/QuerySMSAdd.hpp
@@ -25,6 +25,9 @@ namespace db::query
         explicit SMSAddResult(const SMSRecord &_record, bool _result);
 
         [[nodiscard]] std::string debugInfo() const override;
+
+        [[nodiscard]] bool succeed() const noexcept;
+
         SMSRecord record;
         bool result;
     };


### PR DESCRIPTION
SMS drafts are now properly removed.
They will not be displayed anymore once the SMS is sent from the thread.