### PR TITLE
[EGD-7822] Fix clang-check product entry (cherry-pick)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,7 +164,7 @@ pipeline {
                 /* requires compilation database - must be run after configuration */
                 sh '''#!/bin/bash -e
                 pushd ${WORKSPACE}
-                ./config/clang_check.sh
+                ./config/clang_check.sh PurePhone
                 popd'''
 
                 echo "Build"
@@ -249,7 +249,7 @@ pipeline {
                 /* requires compilation database - must be run after configuration */
                 sh '''#!/bin/bash -e
                 pushd ${WORKSPACE}
-                ./config/clang_check.sh
+                ./config/clang_check.sh BellHybrid
                 popd'''
 
                 echo "Build"

--- a/config/clang_check.sh
+++ b/config/clang_check.sh
@@ -49,7 +49,7 @@ get_compile_commands()
 
 main()
 {
-    if [[ $# -ne 0 ]]; then
+    if [[ $# -ne 1 ]]; then
         help
         exit 0
     fi
@@ -71,9 +71,9 @@ main()
 
     # get the stage
     verify_clang_format_version
-    get_compile_commands purephone
+    get_compile_commands "$1"
     # run tidy
     git diff -U0 --no-color remotes/origin/${CHANGE_TARGET}...HEAD $files_to_check | ${tool[*]} -p 1 -path=/tmp/
 }
 
-main
+main "$1"


### PR DESCRIPTION
As for now, all clang checks were performed only for PurePhone,
so we had to prepare it to work with bell builds