### PR TITLE
[EGD-7822] Fix clang_check script

### DIFF
--- a/config/clang_check.sh
+++ b/config/clang_check.sh
@@ -49,7 +49,7 @@ get_compile_commands()
 
 main()
 {
-    if [[ $# -ne 0 ]]; then
+    if [[ $# -ne 1 ]]; then
         help
         exit 0
     fi


### PR DESCRIPTION
Due to third-person enabled auto-merge one line was missing in
the previous PR