### PR TITLE
[CP-755] Audio assets missing after restoring user data

### DIFF
--- a/products/PurePhone/services/db/ServiceDB.cpp
+++ b/products/PurePhone/services/db/ServiceDB.cpp
@@ -288,11 +288,6 @@ bool ServiceDB::StoreIntoBackup(const std::filesystem::path &backupPath)
         return false;
     }
 
-    if (quotesDB->storeIntoFile(backupPath / std::filesystem::path(multimediaFilesDB->getName()).filename()) == false) {
-        LOG_ERROR("multimediaFilesDB backup failed");
-        return false;
-    }
-
     if (notificationsDB->storeIntoFile(backupPath / std::filesystem::path(notificationsDB->getName()).filename()) ==
         false) {
         LOG_ERROR("notificationsDB backup failed");


### PR DESCRIPTION
Incorrectly populated multimedia.db backup with quotes.db contents
was restored causing audio assets not available.

Additionally, multimedia.db is not needed as part of backup,
so it's now removed from backed up user data.