### PR TITLE
[BH-1078] Fix BGSounds bugs

### DIFF
--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -646,7 +646,7 @@
   "app_bell_settings_frontlight_mode_auto": "auto",
   "app_bell_settings_frontlight_mode_on_demand": "on demand",
   "app_bell_powernap_session_ended_message": "<text>Hello!<br />Rise & shine</text>",
-  "app_bell_background_sounds_timer_title": "Timer",
+  "app_bell_background_sounds_timer_title": "Auto turn off",
   "app_bell_turn_off_question": "Turn off the device?",
   "app_bell_goodbye": "Goodbye",
   "app_bell_reset_message": "<text>Resetting Mudita<br />Harmony</text>",

--- a/products/BellHybrid/apps/application-bell-background-sounds/ApplicationBellBackgroundSounds.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/ApplicationBellBackgroundSounds.cpp
@@ -13,6 +13,7 @@
 #include "windows/BGSoundsTimerSelectWindow.hpp"
 #include "windows/BGSoundsVolumeWindow.hpp"
 #include "widgets/BGSoundsPlayer.hpp"
+#include <apps-common/messages/AppMessage.hpp>
 #include <common/models/TimeModel.hpp>
 #include <service-audio/AudioMessage.hpp>
 
@@ -92,5 +93,20 @@ namespace app
         }
 
         return handleAsyncResponse(resp);
+    }
+
+    sys::MessagePointer ApplicationBellBackgroundSounds::handleSwitchWindow(sys::Message *msgl)
+    {
+        if (auto msg = dynamic_cast<AppSwitchWindowMessage *>(msgl); msg) {
+            const auto newWindowName = msg->getWindowName();
+            if (newWindowName == gui::window::name::bgSoundsProgress ||
+                newWindowName == gui::window::name::bgSoundsPaused) {
+                stopIdleTimer();
+            }
+            else {
+                startIdleTimer();
+            }
+        }
+        return ApplicationCommon::handleSwitchWindow(msgl);
     }
 } // namespace app

--- a/products/BellHybrid/apps/application-bell-background-sounds/include/application-bell-background-sounds/ApplicationBellBackgroundSounds.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/include/application-bell-background-sounds/ApplicationBellBackgroundSounds.hpp
@@ -23,6 +23,8 @@ namespace app
     {
         std::unique_ptr<bgSounds::BGSoundsPlayer> player;
 
+        sys::MessagePointer handleSwitchWindow(sys::Message *msgl) override;
+
       public:
         ApplicationBellBackgroundSounds(std::string name                    = applicationBellBackgroundSoundsName,
                                         std::string parent                  = "",

--- a/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsVolumePresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsVolumePresenter.hpp
@@ -8,6 +8,7 @@
 
 namespace app::bgSounds
 {
+    constexpr audio::Volume minVolume = 1u;
     using VolumeData = struct VolumeData
     {
         audio::Volume min;
@@ -35,7 +36,7 @@ namespace app::bgSounds
     {
         constexpr static struct VolumeData volumeData
         {
-            audio::minVolume, audio::maxVolume, audio::defaultVolumeStep
+            bgSounds::minVolume, audio::maxVolume, audio::defaultVolumeStep
         };
 
         VolumeData getVolumeData() override;

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsVolumeWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsVolumeWindow.hpp
@@ -16,7 +16,7 @@ namespace gui
     class BGSoundsVolumeWindow : public WindowWithTimer, public app::bgSounds::BGSoundsVolumeContract::View
     {
         std::unique_ptr<app::bgSounds::BGSoundsVolumeContract::Presenter> presenter;
-        audio::Volume volume = 0;
+        audio::Volume volume = 1;
         audio::Context audioContext;
 
         BellBaseLayout *body{};


### PR DESCRIPTION
The following commit fixes:
 * BH-1078 and BH-1082 issues that were caused by
the 30s-auto-main-screen return. The solution
is made in consistency with BellMain application
(auto-return is turned off for selected windows).
 * BH-1080 wrong title issue: title for timer select
screen was updated in English.json.
 * BH-1079 minimal value for the background sounds'
audio was changed from 0 to 1.