### PR TITLE
[BH-1080] Fix Bgsounds timeout and volume

### DIFF
--- a/products/BellHybrid/apps/application-bell-background-sounds/ApplicationBellBackgroundSounds.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/ApplicationBellBackgroundSounds.cpp
@@ -72,7 +72,7 @@ namespace app
         });
 
         windowsFactory.attach(gui::popup::window::volume_window, [](ApplicationCommon *app, const std::string &name) {
-            auto presenter = std::make_unique<bgSounds::BGSoundsVolumePresenter>();
+            auto presenter = std::make_unique<bgSounds::BGSoundsVolumePresenter>(*app);
             return std::make_unique<gui::BGSoundsVolumeWindow>(app, std::move(presenter));
         });
 

--- a/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsProgressPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsProgressPresenter.cpp
@@ -55,6 +55,11 @@ namespace app::bgSounds
     }
     void BGSoundsProgressPresenter::onFinished()
     {
+        if (player.getCurrentMode() == AbstractBGSoundsPlayer::PlaybackMode::SingleShot) {
+            getView()->onFinished();
+            return;
+        }
+
         auto onStopCallback = [this](audio::RetCode retCode) {
             if (retCode == audio::RetCode::Success) {
                 getView()->onFinished();

--- a/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsVolumePresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsVolumePresenter.cpp
@@ -2,9 +2,13 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BGSoundsVolumePresenter.hpp"
+#include <Application.hpp>
 
 namespace app::bgSounds
 {
+    BGSoundsVolumePresenter::BGSoundsVolumePresenter(app::ApplicationCommon &app) : app{app}
+    {}
+
     VolumeData BGSoundsVolumePresenter::getVolumeData()
     {
         return volumeData;
@@ -15,4 +19,15 @@ namespace app::bgSounds
         return audio::defaultVolume;
     }
 
+    void BGSoundsVolumePresenter::increaseVolume()
+    {
+        app.increaseCurrentVolume();
+    }
+
+    void BGSoundsVolumePresenter::decreaseVolume()
+    {
+        if (getView()->getCurrentVolume() != minVolume) {
+            app.decreaseCurrentVolume();
+        }
+    }
 } // namespace app::bgSounds

--- a/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsVolumePresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsVolumePresenter.hpp
@@ -6,6 +6,10 @@
 #include <apps-common/BasePresenter.hpp>
 #include <module-audio/Audio/AudioCommon.hpp>
 
+namespace app
+{
+    class ApplicationCommon;
+}
 namespace app::bgSounds
 {
     constexpr audio::Volume minVolume = 1u;
@@ -23,17 +27,21 @@ namespace app::bgSounds
         {
           public:
             virtual ~View() = default;
+            virtual audio::Volume getCurrentVolume() const noexcept = 0;
         };
         class Presenter : public BasePresenter<BGSoundsVolumeContract::View>
         {
           public:
             virtual VolumeData getVolumeData()       = 0;
             virtual audio::Volume getDefaultVolume() = 0;
+            virtual void increaseVolume()            = 0;
+            virtual void decreaseVolume()            = 0;
         };
     };
 
     class BGSoundsVolumePresenter : public BGSoundsVolumeContract::Presenter
     {
+        app::ApplicationCommon &app;
         constexpr static struct VolumeData volumeData
         {
             bgSounds::minVolume, audio::maxVolume, audio::defaultVolumeStep
@@ -41,5 +49,10 @@ namespace app::bgSounds
 
         VolumeData getVolumeData() override;
         audio::Volume getDefaultVolume() override;
+        void increaseVolume() override;
+        void decreaseVolume() override;
+
+      public:
+        explicit BGSoundsVolumePresenter(app::ApplicationCommon &app);
     };
 } // namespace app::bgSounds

--- a/products/BellHybrid/apps/application-bell-background-sounds/widgets/BGSoundsPlayer.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/widgets/BGSoundsPlayer.cpp
@@ -98,4 +98,8 @@ namespace app::bgSounds
         }
         return sys::msgHandled();
     }
+    AbstractBGSoundsPlayer::PlaybackMode BGSoundsPlayer::getCurrentMode() const noexcept
+    {
+        return playbackMode;
+    }
 } // namespace app::bgSounds

--- a/products/BellHybrid/apps/application-bell-background-sounds/widgets/BGSoundsPlayer.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/widgets/BGSoundsPlayer.hpp
@@ -28,6 +28,7 @@ namespace app::bgSounds
         virtual void stop(OnStateChangeCallback callback)                                                  = 0;
         virtual void pause(OnStateChangeCallback callback)                                                 = 0;
         virtual void resume(OnStateChangeCallback callback)                                                = 0;
+        virtual PlaybackMode getCurrentMode() const noexcept                                               = 0;
     };
 
     class BGSoundsPlayer : public AbstractBGSoundsPlayer, public app::AsyncCallbackReceiver
@@ -41,6 +42,7 @@ namespace app::bgSounds
         void stop(OnStateChangeCallback callback) override;
         void pause(OnStateChangeCallback callback) override;
         void resume(OnStateChangeCallback callback) override;
+        PlaybackMode getCurrentMode() const noexcept override;
 
       public:
         explicit BGSoundsPlayer(app::ApplicationCommon *app);

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsVolumeWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsVolumeWindow.cpp
@@ -57,11 +57,11 @@ namespace gui
         resetTimer();
 
         if (inputEvent.isShortRelease(KeyCode::KEY_DOWN)) {
-            application->decreaseCurrentVolume();
+            presenter->decreaseVolume();
             return true;
         }
         else if (inputEvent.isShortRelease(KeyCode::KEY_UP)) {
-            application->increaseCurrentVolume();
+            presenter->increaseVolume();
             return true;
         }
         return WindowWithTimer::onInput(inputEvent);
@@ -82,5 +82,10 @@ namespace gui
             body->setArrowVisible(BellBaseLayout::Arrow::Left, not isMin);
             body->setArrowVisible(BellBaseLayout::Arrow::Right, not isMax);
         }
+    }
+
+    audio::Volume BGSoundsVolumeWindow::getCurrentVolume() const noexcept
+    {
+        return spinner->getCurrentValue();
     }
 } // namespace gui

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsVolumeWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsVolumeWindow.hpp
@@ -26,6 +26,8 @@ namespace gui
         bool onInput(const gui::InputEvent &inputEvent) override;
         void onBeforeShow(ShowMode mode, SwitchData *data);
 
+        audio::Volume getCurrentVolume() const noexcept override;
+
       public:
         BGSoundsVolumeWindow(app::ApplicationCommon *app,
                              std::unique_ptr<app::bgSounds::BGSoundsVolumeContract::Presenter> &&windowPresenter);


### PR DESCRIPTION
The following commit provides fixes for:
 * BH-1080: bug appears only in case off timer's
auto turn off set to off.  The OnStopCallback
passed to async stop request was not processed due
to receiving TokenNotFound RetCode, which is expected in
singleShot mode. Since there is no need for calling
BGSoundsPlayer::stop on timeout in singleShot mode,
the check was transfered to presenter's onFinished
method.
 * BH-1079: user could set Volume to 0. System-wide
min volume is 0 so there was presenter-level check added
to restrict minimal Volume value to 1.