### PR TITLE
[BH-1089] Fix onbarding info screens text

### DIFF
--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -634,7 +634,7 @@
   "app_bell_settings_alarm_settings_snooze_finished": "Snooze is set",
   "app_bell_settings_alarm_settings_snooze_length": "Snooze length",
   "app_bell_settings_alarm_settings_snooze_chime_interval": "Snooze chime interval",
-  "app_bell_settings_alarm_settings_snooze_chime_interval_bot_desc": "<text>recurring during<br />snooze</text>",
+  "app_bell_settings_alarm_settings_snooze_chime_interval_bot_desc": "recurring during snooze",
   "app_bell_settings_alarm_settings_snooze_chime_tone": "Snooze chime tone",
   "app_bell_settings_alarm_settings_snooze_chime_volume": "Snooze chime volume",
   "app_bellmain_home_screen_bottom_desc": "Next alarm will ring",

--- a/products/BellHybrid/apps/application-bell-onboarding/ApplicationBellOnBoarding.cpp
+++ b/products/BellHybrid/apps/application-bell-onboarding/ApplicationBellOnBoarding.cpp
@@ -135,7 +135,7 @@ namespace app
     {
         auto [icon, text] = getDisplayDataFromState();
         switchWindow(gui::window::name::informationOnBoardingWindow,
-                     gui::BellFinishedWindowData::Factory::create(icon, windowToReturn));
+                     gui::BellFinishedWindowData::Factory::create(icon, windowToReturn, utils::translate(text)));
     }
 
     OnBoarding::InformationDisplay ApplicationBellOnBoarding::getDisplayDataFromState()

--- a/products/BellHybrid/apps/common/include/common/data/BellFinishedWindowSwitchData.hpp
+++ b/products/BellHybrid/apps/common/include/common/data/BellFinishedWindowSwitchData.hpp
@@ -14,20 +14,22 @@ namespace gui
         struct Factory
         {
             static std::unique_ptr<BellFinishedWindowData> create(const UTF8 &icon,
-                                                                  const std::string &windowToReturn)
+                                                                  const std::string &windowToReturn,
+                                                                  const UTF8 &text = "")
             {
-                return std::unique_ptr<BellFinishedWindowData>(new BellFinishedWindowData(icon, windowToReturn));
+                return std::unique_ptr<BellFinishedWindowData>(new BellFinishedWindowData(icon, windowToReturn, text));
             }
         };
 
         UTF8 icon{};
         std::string windowToReturn;
+        UTF8 text{};
 
       private:
         BellFinishedWindowData() = default;
 
-        BellFinishedWindowData(const UTF8 &icon, const std::string &windowToReturn)
-            : icon{icon}, windowToReturn{windowToReturn}
+        BellFinishedWindowData(const UTF8 &icon, const std::string &windowToReturn, const UTF8 &text = "")
+            : icon{icon}, windowToReturn{windowToReturn}, text{text}
         {}
     };
 } // namespace gui

--- a/products/BellHybrid/apps/common/src/windows/BellFinishedWindow.cpp
+++ b/products/BellHybrid/apps/common/src/windows/BellFinishedWindow.cpp
@@ -30,6 +30,7 @@ namespace gui
         if (icon == nullptr) {
             icon = new Icon(this, 0, 0, style::window_width, style::window_height, {}, {});
             icon->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
+            icon->text->setFont(style::window::font::verybiglight);
         }
     }
 
@@ -48,6 +49,7 @@ namespace gui
 
         if (auto metadata = dynamic_cast<BellFinishedWindowData *>(data)) {
             icon->image->set(metadata->icon);
+            icon->text->setRichText(metadata->text);
             icon->resizeItems();
             windowToReturn = metadata->windowToReturn;
         }


### PR DESCRIPTION
Info screens texts are visible now on onboarding idle

Regression from: https://github.com/mudita/MuditaOS/pull/3036