### PR TITLE
[BH-947] Snooze Chime Volume Default Setting

### DIFF
--- a/image/user/db/settings_bell_002.sql
+++ b/image/user/db/settings_bell_002.sql
@@ -35,7 +35,7 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('snooze_length','10'),
     ('snooze_interval','1'),
     ('snooze_tone','Gentle Chime'),
-    ('snooze_volume','10'),
+    ('snooze_volume','5'),
     ('prewake_up_duration', '10'),
     ('prewake_up_tone','Joyful Awakening'),
     ('prewake_up_volume','5'),


### PR DESCRIPTION
Default value of Snooze Chime Volume set to "5"