### PR TITLE
[EGD-7852] Fix charging/dead battery screens switch

### DIFF
--- a/module-apps/application-desktop/include/application-desktop/ApplicationDesktop.hpp
+++ b/module-apps/application-desktop/include/application-desktop/ApplicationDesktop.hpp
@@ -39,6 +39,8 @@ namespace app
         // done
         void handleNotificationsChanged(std::unique_ptr<gui::SwitchData> notificationsParams) override;
 
+        bool isPopupPermitted(gui::popup::ID popupId) const override;
+
         void setOsUpdateVersion(const std::string &value);
 
       private:
@@ -46,6 +48,7 @@ namespace app
         void handleLowBatteryNotification(manager::actions::ActionParamsPtr &&data);
         DBNotificationsHandler dbNotificationHandler;
         sys::MessagePointer handleAsyncResponse(sys::ResponseMessage *resp) override;
+        bool blockAllPopups = false;
     };
 
     template <> struct ManifestTraits<ApplicationDesktop>

--- a/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
+++ b/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
@@ -449,7 +449,8 @@ namespace app::manager
     {
         action.setTargetApplication(resolveHomeApplication());
 
-        SwitchRequest switchRequest(service::name::appmgr, resolveHomeApplication(), resolveHomeWindow(), nullptr);
+        SwitchRequest switchRequest(
+            service::name::appmgr, resolveHomeApplication(), resolveHomeWindow(), std::move(action.params));
         return handleSwitchApplication(&switchRequest) ? ActionProcessStatus::Accepted : ActionProcessStatus::Dropped;
     }
 


### PR DESCRIPTION
1. Deleting of charging/dead battery screens from windows stack after transition to normal battery state
2. Preventing any popups on top of charging/dead battery screens
