### PR TITLE
[BH-1073] Assets division minor fixes

### DIFF
--- a/image/assets/lang/Polski.json
+++ b/image/assets/lang/Polski.json
@@ -604,7 +604,7 @@
   "app_bellmain_background_sounds": "Biblioteka",
   "app_bellmain_settings": "Ustawienia",
   "app_bellmain_main_window_title": "Bell Hybrid+",
-  "app_bell_onboarding_finalize": "<text>Dobra robota!<br />Obudź się z radością</text>",
+  "app_bell_onboarding_finalize": "Dobra robota!",
   "app_bell_settings_advanced": "Zaawansowane",
   "app_bell_settings_advanced_time_units": "Czas i jednostki",
   "app_bell_settings_advanced_temp_scale": "Skala temperatury",

--- a/module-gui/gui/core/FontManager.cpp
+++ b/module-gui/gui/core/FontManager.cpp
@@ -142,7 +142,9 @@ namespace gui
         auto font = find(name);
         // default return first font
         if (font == nullptr && fonts.size() > 0) {
+#if DEBUG_MISSING_ASSETS == 1
             LOG_ERROR("=> font not found: %s using default", name.data());
+#endif
             return fonts[0];
         }
         return font;

--- a/module-gui/gui/core/ImageManager.cpp
+++ b/module-gui/gui/core/ImageManager.cpp
@@ -240,7 +240,9 @@ namespace gui
     ImageMap *ImageManager::getImageMap(uint32_t id)
     {
         if (id >= imageMaps.size()) {
+#if DEBUG_MISSING_ASSETS == 1
             LOG_ERROR("Unable to find an image by id: %" PRIu32, id);
+#endif
             return imageMaps[fallbackImageId];
         }
         return imageMaps[id];
@@ -254,7 +256,9 @@ namespace gui
                 return i;
             }
         }
+#if DEBUG_MISSING_ASSETS == 1
         LOG_ERROR("Unable to find an image: %s , using deafult fallback image instead.", name.c_str());
+#endif
         return fallbackImageId;
     }
 

--- a/module-utils/log/api/log/debug.hpp
+++ b/module-utils/log/api/log/debug.hpp
@@ -18,3 +18,4 @@
 #define DEBUG_TIMER                  0 /// debug timers system utility
 #define DEBUG_SETTINGS_DB            0 /// show extensive settings logs for all applications
 #define DEBUG_SERVICE_CELLULAR       0 /// show various logs in cellular service
+#define DEBUG_MISSING_ASSETS         1 /// show debug concerning missing assets

--- a/products/BellHybrid/apps/application-bell-onboarding/windows/OnBoardingFinalizeWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-onboarding/windows/OnBoardingFinalizeWindow.cpp
@@ -39,6 +39,7 @@ namespace gui
         BellFinishedWindow::onBeforeShow(mode, data);
 
         icon->image->set("bell_big_logo", ImageTypeSpecifier::W_G);
-        icon->text->setRichText(utils::translate("app_bell_onboarding_finalize"));
+        icon->text->setFont(style::window::font::verybiglight);
+        icon->text->setText(utils::translate("app_bell_onboarding_finalize"));
     }
 } // namespace gui

--- a/products/BellHybrid/apps/common/src/windows/BellWelcomeWindow.cpp
+++ b/products/BellHybrid/apps/common/src/windows/BellWelcomeWindow.cpp
@@ -53,7 +53,6 @@ namespace gui
 
         auto instructionText = new TextFixedSize(informationBody);
         instructionText->setMargins(Margins(0, sun_logo_margin_top, 0, 0));
-        instructionText->setFont(style::window::font::largelight);
         instructionText->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Center));
         instructionText->drawUnderline(false);
         instructionText->setFont(style::window::font::verybiglight);


### PR DESCRIPTION
This PR adds new debug flag to hide debug informations concerning missing assets.
It is needed for release as Bell needs some Pure related assets even though those are not used. It is side effect of using same application window base implementation.

Minor:
- minor font/copy fixes were introduced.