### PR TITLE
[BH-1060] Avoid seconds to milliseconds cast

### DIFF
--- a/module-apps/apps-common/popups/WindowWithTimer.hpp
+++ b/module-apps/apps-common/popups/WindowWithTimer.hpp
@@ -8,7 +8,7 @@
 
 namespace gui
 {
-    inline constexpr auto defautTimeout = std::chrono::seconds{3};
+    inline constexpr auto defautTimeout = std::chrono::milliseconds{3000};
     class WindowWithTimer : public gui::AppWindow
     {
       private:

--- a/products/BellHybrid/apps/application-bell-alarm/windows/BellAlarmSetWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-alarm/windows/BellAlarmSetWindow.hpp
@@ -24,7 +24,7 @@ namespace gui
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
 
       private:
-        constexpr static auto alarmSummaryDisplayDuration = std::chrono::seconds{5};
+        constexpr static auto alarmSummaryDisplayDuration = std::chrono::milliseconds{5000};
         std::shared_ptr<app::bell_alarm::BellAlarmSetContract::Presenter> presenter;
         Icon *icon{};
     };


### PR DESCRIPTION
Arm chrono implementation does not deal with
seconds to milliseconds conversion