### PR TITLE
[BH-1109] Fix library audio playback stop

### DIFF
--- a/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsProgressPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/presenter/BGSoundsProgressPresenter.cpp
@@ -55,11 +55,6 @@ namespace app::bgSounds
     }
     void BGSoundsProgressPresenter::onFinished()
     {
-        if (player.getCurrentMode() == AbstractBGSoundsPlayer::PlaybackMode::SingleShot) {
-            getView()->onFinished();
-            return;
-        }
-
         auto onStopCallback = [this](audio::RetCode retCode) {
             if (retCode == audio::RetCode::Success) {
                 getView()->onFinished();


### PR DESCRIPTION
Make library audio playback to stop on _return_
input event even in SingleShot playback mode