### PR TITLE
[EGD-5371] Fix call log layout

### DIFF
--- a/module-apps/application-calllog/widgets/CalllogItem.cpp
+++ b/module-apps/application-calllog/widgets/CalllogItem.cpp
@@ -27,7 +27,6 @@ namespace gui
         auto newImg = [=](const UTF8 imageName) -> gui::Image * {
             auto img = new gui::Image(hBox, imageName, gui::ImageTypeSpecifier::W_M);
             img->setAlignment(gui::Alignment{gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center});
-            img->setMargins(Margins(clItemStyle::left_right_margin, 0, clItemStyle::left_right_margin, 0));
             img->setVisible(false);
             return img;
         };
@@ -44,7 +43,7 @@ namespace gui
         text->setEllipsis(Ellipsis::Right);
 
         timestamp = new gui::Label(hBox, 0, 0, 0, 0);
-        timestamp->setMargins(Margins(0, 0, clItemStyle::left_right_margin, 0));
+        timestamp->setMargins(Margins(0, 0, clItemStyle::right_margin, 0));
         timestamp->setMinimumHeight(clItemStyle::h);
         timestamp->setMinimumWidth(clItemStyle::timestamp::min_w);
         timestamp->setEdges(gui::RectangleEdge::None);

--- a/module-apps/application-calllog/widgets/CalllogItem.hpp
+++ b/module-apps/application-calllog/widgets/CalllogItem.hpp
@@ -17,7 +17,7 @@ namespace gui
     {
         inline constexpr auto w                 = style::window::default_body_width;
         inline constexpr auto h                 = style::window::label::big_h;
-        inline constexpr auto left_right_margin = 10;
+        inline constexpr auto right_margin      = 10;
 
         namespace timestamp
         {


### PR DESCRIPTION
Margins in call log are changed to look as in UX design.