### PR TITLE
[EGD-5371] Call log layout fix

### DIFF
--- a/module-apps/application-calllog/widgets/CalllogItem.cpp
+++ b/module-apps/application-calllog/widgets/CalllogItem.cpp
@@ -27,6 +27,7 @@ namespace gui
         auto newImg = [=](const UTF8 imageName) -> gui::Image * {
             auto img = new gui::Image(hBox, imageName, gui::ImageTypeSpecifier::W_M);
             img->setAlignment(gui::Alignment{gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center});
+            img->setMargins(Margins(0, 0, clItemStyle::internal_margin, 0));
             img->setVisible(false);
             return img;
         };

--- a/module-apps/application-calllog/widgets/CalllogItem.hpp
+++ b/module-apps/application-calllog/widgets/CalllogItem.hpp
@@ -17,6 +17,7 @@ namespace gui
     {
         inline constexpr auto w                 = style::window::default_body_width;
         inline constexpr auto h                 = style::window::label::big_h;
+        inline constexpr auto internal_margin   = 4;
         inline constexpr auto right_margin      = 10;
 
         namespace timestamp


### PR DESCRIPTION
Added missing margin between call icon and caller name.