### PR TITLE
[EGD-7656] Return contact record after adding new contact

### DIFF
--- a/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
@@ -170,10 +170,12 @@ namespace gui
 
         // perform actual add/update operation
         if (contactAction == ContactAction::Add) {
-            if (!DBServiceAPI::ContactAdd(application, *contact)) {
+            auto returnedContact = DBServiceAPI::ContactAdd(application, *contact);
+            if (!returnedContact.has_value()) {
                 LOG_ERROR("verifyAndSave failed to ADD contact");
                 return false;
             }
+            *contact = returnedContact.value();
         }
         else if (contactAction == ContactAction::Edit || contactAction == ContactAction::EditTemporary) {
             contact->groups.erase(ContactsDB::temporaryGroupId());
@@ -193,8 +195,7 @@ namespace gui
     {
         auto matchedContact   = DBServiceAPI::MatchContactByPhoneNumber(application, duplicatedNumber);
         auto oldContactRecord = (matchedContact != nullptr) ? *matchedContact : ContactRecord{};
-
-        auto metaData = std::make_unique<gui::DialogMetadataMessage>(
+        auto metaData         = std::make_unique<gui::DialogMetadataMessage>(
             gui::DialogMetadata{duplicatedNumber.getFormatted(),
                                 "info_big_circle_W_G",
                                 text::RichTextParser()

--- a/module-apps/application-phonebook/windows/PhonebookNewContact.hpp
+++ b/module-apps/application-phonebook/windows/PhonebookNewContact.hpp
@@ -15,7 +15,7 @@ namespace gui
     class PhonebookNewContact : public AppWindow
     {
       public:
-        PhonebookNewContact(app::ApplicationCommon *app);
+        explicit PhonebookNewContact(app::ApplicationCommon *app);
 
         auto onInput(const InputEvent &inputEvent) -> bool override;
         void onBeforeShow(ShowMode mode, SwitchData *data) override;

--- a/module-services/service-db/DBServiceAPI.cpp
+++ b/module-services/service-db/DBServiceAPI.cpp
@@ -160,7 +160,7 @@ auto DBServiceAPI::verifyContact(sys::Service *serv, const ContactRecord &rec)
     return ContactVerificationResult::success;
 }
 
-auto DBServiceAPI::ContactAdd(sys::Service *serv, const ContactRecord &rec) -> bool
+auto DBServiceAPI::ContactAdd(sys::Service *serv, const ContactRecord &rec) -> std::optional<ContactRecord>
 {
     std::shared_ptr<DBContactMessage> msg = std::make_shared<DBContactMessage>(MessageType::DBContactAdd, rec);
 
@@ -168,12 +168,15 @@ auto DBServiceAPI::ContactAdd(sys::Service *serv, const ContactRecord &rec) -> b
     auto contactResponse = dynamic_cast<DBContactResponseMessage *>(ret.second.get());
     if (contactResponse == nullptr) {
         LOG_ERROR("DB response error, return code: %s", c_str(ret.first));
-        return false;
+        return std::nullopt;
     }
     if ((ret.first == sys::ReturnCodes::Success) && (contactResponse->retCode != 0)) {
-        return true;
+        auto records = *contactResponse->records;
+        if (!records.empty()) {
+            return records[0];
+        }
     }
-    return false;
+    return std::nullopt;
 }
 
 auto DBServiceAPI::ContactRemove(sys::Service *serv, uint32_t id) -> bool

--- a/module-services/service-db/include/service-db/DBServiceAPI.hpp
+++ b/module-services/service-db/include/service-db/DBServiceAPI.hpp
@@ -100,7 +100,7 @@ class DBServiceAPI
         -> std::unique_ptr<ContactRecord>;
     [[deprecated]] static auto NumberByID(sys::Service *serv, std::uint32_t numberID) -> utils::PhoneNumber::View;
 
-    [[deprecated]] static auto ContactAdd(sys::Service *serv, const ContactRecord &rec) -> bool;
+    [[deprecated]] static auto ContactAdd(sys::Service *serv, const ContactRecord &rec) -> std::optional<ContactRecord>;
     [[deprecated]] static auto ContactRemove(sys::Service *serv, uint32_t id) -> bool;
     [[deprecated]] static auto ContactUpdate(sys::Service *serv, const ContactRecord &rec) -> bool;
 

--- a/products/PurePhone/services/db/ServiceDB.cpp
+++ b/products/PurePhone/services/db/ServiceDB.cpp
@@ -86,7 +86,10 @@ sys::MessagePointer ServiceDB::DataReceivedHandler(sys::DataMessage *msgl, sys::
         auto time             = utils::time::Scoped("DBContactAdd");
         DBContactMessage *msg = reinterpret_cast<DBContactMessage *>(msgl);
         auto ret              = contactRecordInterface->Add(msg->record);
-        responseMsg           = std::make_shared<DBContactResponseMessage>(nullptr, ret);
+        auto record           = std::make_unique<std::vector<ContactRecord>>();
+        record->push_back(msg->record);
+        LOG_DEBUG("Last ID %" PRIu32, msg->record.ID);
+        responseMsg = std::make_shared<DBContactResponseMessage>(std::move(record), ret);
         sendUpdateNotification(db::Interface::Name::Contact, db::Query::Type::Create);
     } break;
 


### PR DESCRIPTION
Fixed issue that appeared when user switched to contact
edition via Contact details -> Contact Options just after
adding new contact. Contact record without correct ID
was passed through windows, which caused to open
Add new contact window instead of Edit.