### PR TITLE
[EGD-7851] Remove redundant Service Desktop deinitialization

### DIFF
--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -228,6 +228,7 @@ sys::ReturnCodes ServiceDesktop::DeinitHandler()
     if (initialized) {
         settings->deinit();
         desktopWorker->deinit();
+        initialized = false;
     }
     return sys::ReturnCodes::Success;
 }


### PR DESCRIPTION
Service Desktop initialization flag was never cleaned, which caused double deinitialization of Service Desktop.