### PR TITLE
[EGD-7882] Fixed operator name request

### DIFF
--- a/module-services/service-cellular/CellularUrcHandler.cpp
+++ b/module-services/service-cellular/CellularUrcHandler.cpp
@@ -43,7 +43,13 @@ void CellularUrcHandler::Handle(Creg &urc)
                  utils::enumToString(status).c_str(),
                  utils::enumToString(accessTechnology).c_str());
 
-        CellularServiceAPI::RequestCurrentOperatorName(&cellularService);
+        if (status == Store::Network::Status::RegisteredHomeNetwork ||
+            status == Store::Network::Status::RegisteredRoaming) {
+            CellularServiceAPI::RequestCurrentOperatorName(&cellularService);
+        }
+        else {
+            Store::GSM::get()->setNetworkOperatorName("");
+        }
 
         Store::Network network{status, accessTechnology};
         if (Store::GSM::get()->getNetwork() != network) {


### PR DESCRIPTION
Operator name request is sended only when modem is connected to
the network now. It was causing stucking in Onboarding sim
selecting window.