### PR TITLE
[EGD-6857] Fix HSP audio quality

### DIFF
--- a/module-audio/Audio/StreamFactory.cpp
+++ b/module-audio/Audio/StreamFactory.cpp
@@ -84,7 +84,7 @@ auto StreamFactory::makeStream(Source &source, Sink &sink, AudioFormat streamFor
 auto StreamFactory::makeInputTranscodingStream(Source &source,
                                                Sink &sink,
                                                AudioFormat streamFormat,
-                                               std::shared_ptr<Transform>(transform))
+                                               std::shared_ptr<Transform> transform)
     -> std::unique_ptr<InputTranscodeProxy>
 {
     auto sourceTraits = source.getTraits();

--- a/module-audio/Audio/StreamFactory.hpp
+++ b/module-audio/Audio/StreamFactory.hpp
@@ -26,7 +26,7 @@ namespace audio
         auto makeInputTranscodingStream(Source &source,
                                         Sink &sink,
                                         AudioFormat streamFormat,
-                                        std::shared_ptr<transcode::Transform>(transform))
+                                        std::shared_ptr<transcode::Transform> transform)
             -> std::unique_ptr<transcode::InputTranscodeProxy>;
 
       private:

--- a/module-audio/Audio/test/unittest_transcode.cpp
+++ b/module-audio/Audio/test/unittest_transcode.cpp
@@ -347,9 +347,11 @@ TEST(Transform, BasicInterpolator)
 
     std::uint16_t inputBuffer[8]          = {1, 2, 3, 4, 0, 0, 0, 0};
     static const uint16_t expectBuffer[8] = {1, 2, 1, 2, 3, 4, 3, 4};
-    auto inputSpan  = ::audio::AbstractStream::Span{.data     = reinterpret_cast<uint8_t *>(inputBuffer),
+    auto inputSpan      = ::audio::AbstractStream::Span{.data     = reinterpret_cast<uint8_t *>(inputBuffer),
                                                    .dataSize = 4 * sizeof(std::uint16_t)};
-    auto outputSpan = interp2.transform(inputSpan, inputSpan);
+    auto transformSpace = ::audio::AbstractStream::Span{.data     = reinterpret_cast<uint8_t *>(inputBuffer),
+                                                        .dataSize = 8 * sizeof(std::uint16_t)};
+    auto outputSpan     = interp2.transform(inputSpan, transformSpace);
 
     EXPECT_EQ(outputSpan.dataSize, sizeof(uint16_t) * 8);
     EXPECT_EQ(memcmp(outputSpan.data, expectBuffer, outputSpan.dataSize), 0);

--- a/module-audio/Audio/transcode/BasicInterpolator.hpp
+++ b/module-audio/Audio/transcode/BasicInterpolator.hpp
@@ -9,6 +9,7 @@
 
 #include <type_traits>
 
+#include <cassert>
 #include <cstdint>
 
 namespace audio::transcode
@@ -33,8 +34,9 @@ namespace audio::transcode
         /**
          * @brief Integer type to be used to read and write data from/to a buffer.
          */
-        using IntegerType = typename decltype(
-            utils::integer::getIntegerType<sizeof(SampleType) * utils::integer::BitsInByte * Channels>())::type;
+        using IntegerType =
+            typename decltype(utils::integer::getIntegerType<sizeof(SampleType) * utils::integer::BitsInByte *
+                                                             Channels>())::type;
 
       public:
         auto transformBlockSize(std::size_t blockSize) const noexcept -> std::size_t override
@@ -63,6 +65,8 @@ namespace audio::transcode
             auto outputSpan     = Span{.data = transformSpace.data, .dataSize = transformBlockSize(inputSpan.dataSize)};
             IntegerType *input  = reinterpret_cast<IntegerType *>(inputSpan.data);
             IntegerType *output = reinterpret_cast<IntegerType *>(outputSpan.data);
+
+            assert(outputSpan.dataSize <= transformSpace.dataSize);
 
             for (unsigned i = inputSpan.dataSize / sizeof(IntegerType); i > 0; i--) {
                 for (unsigned j = 1; j <= Ratio; j++) {

--- a/module-bluetooth/Bluetooth/audio/BluetoothAudioDevice.cpp
+++ b/module-bluetooth/Bluetooth/audio/BluetoothAudioDevice.cpp
@@ -266,7 +266,7 @@ auto A2DPAudioDevice::getTraits() const -> ::audio::Endpoint::Traits
 
 auto CVSDAudioDevice::getTraits() const -> ::audio::Endpoint::Traits
 {
-    return Traits{.usesDMA = false, .blockSizeConstraint = 32U, .timeConstraint = 16ms};
+    return Traits{.usesDMA = false, .blockSizeConstraint = 128U, .timeConstraint = 16ms};
 }
 
 auto A2DPAudioDevice::getSourceFormat() -> ::audio::AudioFormat


### PR DESCRIPTION
    [EGD-6857] Fix HSP audio quality
    
    Fixed HSP sound quality issues:
     - fixed HF caused by invalid output block size during interpolation of
       the Bluetooth input,
     - increased Bluetooth stack priority to greatly reduce deviation in
       the interval between Bluetooth audio frames
     - increased block size to increase time send interval to 8ms
    
    Fixed issue with error handling when writing to the overflowed stream.


[EGD-6857]: https://appnroll.atlassian.net/browse/EGD-6857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ