### PR TITLE
[BH-1135] Fix meditation app double bell

### DIFF
--- a/module-apps/apps-common/widgets/ProgressTimer.cpp
+++ b/module-apps/apps-common/widgets/ProgressTimer.cpp
@@ -54,6 +54,7 @@ namespace app
 
     auto ProgressTimer::onTimerTimeout(sys::Timer &task) -> bool
     {
+        ++elapsed;
         if (isStopped() || isFinished()) {
             task.stop();
             if (isFinished() && onFinishedCallback != nullptr) {
@@ -62,7 +63,6 @@ namespace app
             return true;
         }
 
-        ++elapsed;
         if ((intervalReached() || isFinished()) && onIntervalCallback != nullptr) {
             onIntervalCallback();
         }


### PR DESCRIPTION
Prevent progress timer from triggering finish
and interval callbacks at once