### PR TITLE
[EGD-7498] Disable message SEND button when recipient empty

### DIFF
--- a/module-apps/application-messages/windows/NewMessage.cpp
+++ b/module-apps/application-messages/windows/NewMessage.cpp
@@ -258,13 +258,21 @@ namespace gui
         message->setFont(style::window::font::medium);
         message->setAlignment(Alignment(gui::Alignment::Horizontal::Left, gui::Alignment::Vertical::Center));
         message->activatedCallback = [=](Item &) -> bool {
+            if (recipient->getText().empty() || message->getText().empty()) {
+                return false;
+            }
             if (!sendSms()) {
                 LOG_ERROR("sendSms failed");
             }
             return true;
         };
         message->focusChangedCallback = [=](Item &) -> bool {
-            navBar->setText(nav_bar::Side::Center, utils::translate(style::strings::common::send));
+            if (recipient->getText().empty()) {
+                navBar->setActive(nav_bar::Side::Center, false);
+            }
+            else {
+                navBar->setText(nav_bar::Side::Center, utils::translate(style::strings::common::send));
+            }
             navBar->setActive(nav_bar::Side::Left, true);
             return true;
         };


### PR DESCRIPTION
SEND message button is now visible and active only
when the recipient field is not empty.

![recipient_empty](https://user-images.githubusercontent.com/58421550/140547154-37523eed-f637-4c77-84f0-6fab69449caf.png)

![recipient_not_empty](https://user-images.githubusercontent.com/58421550/140547164-17e04b97-7127-404e-9fb8-b878f5d5baab.png)

