### PR TITLE
[BH-1143] Change no interaction time to 15 sec

### DIFF
--- a/products/BellHybrid/apps/application-bell-onboarding/include/application-bell-onboarding/ApplicationBellOnBoarding.hpp
+++ b/products/BellHybrid/apps/application-bell-onboarding/include/application-bell-onboarding/ApplicationBellOnBoarding.hpp
@@ -11,7 +11,7 @@ namespace app::OnBoarding
     /// Image name, Prompt info text
     using InformationDisplay = std::pair<std::string, std::string>;
 
-    constexpr auto informationPromptTimeout = std::chrono::seconds{5};
+    constexpr auto informationPromptTimeout = std::chrono::seconds{15};
     constexpr auto informationTimerName     = "OnBoardingInformationTimer";
 
     enum class InformationStates


### PR DESCRIPTION
Information prompt windows in Onboarding should be displayed after 15 sec. of no interaction