### PR TITLE
[BH-1158] Fix alarm duration

### DIFF
--- a/products/BellHybrid/apps/application-bell-main/presenters/StateController.hpp
+++ b/products/BellHybrid/apps/application-bell-main/presenters/StateController.hpp
@@ -17,7 +17,7 @@ namespace app
 namespace app::home_screen
 {
 
-    inline constexpr auto defaultAlarmRingingTime = std::chrono::seconds(30);
+    inline constexpr auto defaultAlarmRingingTime = std::chrono::minutes(5);
 
     class AbstractView;
     class AbstractPresenter;


### PR DESCRIPTION
Set default alarm ring duration at 5 minutes