### PR TITLE
[EGD-7927] Long track attributes/names drawing

### DIFF
--- a/image/assets/lang/Deutsch.json
+++ b/image/assets/lang/Deutsch.json
@@ -190,7 +190,7 @@
   "app_music_player_uknown_title": "Unbekannter Titel",
   "app_music_player_uknown_artist": "Unbekannter Künstler",
   "app_music_player_music_library_window_name": "Musikbibliothek",
-  "app_music_player_empty_track_notification": "<text color='5'>Bitte wählen Sie einen Song aus der Bibliothek</text>",
+  "app_music_player_empty_track_notification": "Bitte wählen Sie einen Song aus der Bibliothek",
   "app_music_player_start_window_notification": "<text color='5'>Drücken Sie <b>nach unten</b>, um<br></br>einen Song auszuwählen</text>",
   "app_calllog_no_calls": "Noch keine Anrufe.",
   "app_desktop_unlock": "ENTSPERREN",

--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -546,7 +546,7 @@
   "app_music_player_music_library_window_name": "Music Library",
   "app_music_player_music_library": "MUSIC LIBRARY",
   "app_music_player_quit": "QUIT",
-  "app_music_player_empty_track_notification": "<text color='5'>Please choose a song from library</text>",
+  "app_music_player_empty_track_notification": "Please choose a song from library",
   "app_music_player_start_window_notification": "<text color='5'>Press <b>down arrow</b> to choose<br></br> a song from the library</text>",
   "app_music_player_music_empty_window_notification": "<text color='5'>No songs yet</text>",
   "app_special_input_window": "Special characters",

--- a/image/assets/lang/Espanol.json
+++ b/image/assets/lang/Espanol.json
@@ -190,7 +190,7 @@
   "app_music_player_uknown_title": "Título desconocido",
   "app_music_player_uknown_artist": "Artista desconocido",
   "app_music_player_music_library_window_name": "Biblioteca de música",
-  "app_music_player_empty_track_notification": "<text color = '5'> Elige una canción de la biblioteca </text>",
+  "app_music_player_empty_track_notification": "Elige una canción de la biblioteca",
   "app_music_player_start_window_notification": "<text color = '5'> Presiona la <b>abajo</b> para elegir <br> </br> una canción </text>",
   "app_desktop_unlock": "DESBLOQUEAR",
   "app_desktop_menu": "MENÚ",

--- a/image/assets/lang/Francais.json
+++ b/image/assets/lang/Francais.json
@@ -159,7 +159,7 @@
   "app_music_player_uknown_title": "Titre inconnu",
   "app_music_player_uknown_artist": "Artiste inconnu",
   "app_music_player_music_library_window_name": "Bibliothèque musicale",
-  "app_music_player_empty_track_notification": "<text color='5'>Veuillez choisir une chanson dans la bibliothèque</text>",
+  "app_music_player_empty_track_notification": "Veuillez choisir une chanson dans la bibliothèque",
   "app_music_player_start_window_notification": "<text color='5'>Appuyez sur <b>le bas</b> pour choisir<br></br> une chanson</text>",
   "app_desktop_unlock": "DÉVÉROUILLER",
   "app_desktop_menu": "MENU",

--- a/image/assets/lang/Polski.json
+++ b/image/assets/lang/Polski.json
@@ -191,7 +191,7 @@
   "app_music_player_uknown_title": "Nieznany tytuł",
   "app_music_player_uknown_artist": "Nieznany artysta",
   "app_music_player_music_library_window_name": "Biblioteka muzyki",
-  "app_music_player_empty_track_notification": "<text color='5'>Proszę wybrać utwór z biblioteki</text>",
+  "app_music_player_empty_track_notification": "Proszę wybrać utwór z biblioteki",
   "app_music_player_start_window_notification": "<text color='5'>Naciśnij <b>strzałkę w dół</b>, aby wybrać<br></br> utwór z biblioteki</text>",
   "app_desktop_unlock": "ODBLOKUJ",
   "app_desktop_menu": "MENU",

--- a/image/assets/lang/Svenska.json
+++ b/image/assets/lang/Svenska.json
@@ -144,7 +144,7 @@
   "app_music_player_uknown_title": "Okänd titel",
   "app_music_player_uknown_artist": "Okänd artist",
   "app_music_player_music_library_window_name": "Musikbibliotek",
-  "app_music_player_empty_track_notification": "<text color='5'>Välj en låt från biblioteket</text>",
+  "app_music_player_empty_track_notification": "Välj en låt från biblioteket",
   "app_music_player_start_window_notification": "<text color='5'>Tryck på <b>nedåtpil</b> för att välja<br></br> en låt från biblioteket</text>",
   "app_desktop_unlock": "LÅS UPP",
   "app_desktop_menu": "MENY",

--- a/module-apps/application-music-player/data/MusicPlayerStyle.hpp
+++ b/module-apps/application-music-player/data/MusicPlayerStyle.hpp
@@ -29,6 +29,7 @@ namespace musicPlayerStyle
         namespace trackInfoScreen
         {
             constexpr uint32_t topMargin      = 110;
+            constexpr uint32_t titleWidth     = 400;
             constexpr uint32_t titleHeight    = 40;
             constexpr uint32_t internalMargin = 16;
             constexpr uint32_t artistHeight   = 30;

--- a/module-apps/application-music-player/widgets/SongItem.cpp
+++ b/module-apps/application-music-player/widgets/SongItem.cpp
@@ -2,6 +2,7 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "module-apps/application-music-player/widgets/SongItem.hpp"
+#include <gui/widgets/Label.hpp>
 #include <i18n/i18n.hpp>
 
 namespace gui
@@ -45,30 +46,26 @@ namespace gui
         durationText->setEditMode(EditMode::Browse);
         durationText->setText(duration);
 
-        songText = new TextFixedSize(firstHBox, 0, 0, 0, 0);
+        songText = new Label(firstHBox, 0, 0, 0, 0);
         songText->setMinimumHeight(songItem::bold_text_h);
         songText->setMaximumWidth(songItem::w);
         songText->setMargins(Margins(songItem::leftMargin, 0, 0, 0));
         songText->setEdges(RectangleEdge::None);
-        songText->drawUnderline(false);
         songText->setFont(style::window::font::bigbold);
         songText->setAlignment(Alignment(gui::Alignment::Horizontal::Left, gui::Alignment::Vertical::Center));
-        songText->setEditMode(EditMode::Browse);
         songText->setText(songName);
 
         playedSong = new Image(secondHBox, 0, 0, "");
         playedSong->setAlignment(Alignment(gui::Alignment::Horizontal::Right, gui::Alignment::Vertical::Center));
         playedSong->setVisible(false);
 
-        authorText = new TextFixedSize(secondHBox, 0, 0, 0, 0);
+        authorText = new Label(secondHBox, 0, 0, 0, 0);
         authorText->setMinimumHeight(songItem::text_h);
         authorText->setMaximumWidth(songItem::w);
         authorText->setMargins(Margins(songItem::leftMargin, 0, 0, 0));
         authorText->setEdges(RectangleEdge::None);
-        authorText->drawUnderline(false);
         authorText->setFont(style::window::font::medium);
         authorText->setAlignment(Alignment(gui::Alignment::Horizontal::Left, gui::Alignment::Vertical::Center));
-        authorText->setEditMode(EditMode::Browse);
         authorText->setText(authorName);
 
         dimensionChangedCallback = [&]([[maybe_unused]] gui::Item &item, const BoundingBox &newDim) -> bool {

--- a/module-apps/application-music-player/widgets/SongItem.hpp
+++ b/module-apps/application-music-player/widgets/SongItem.hpp
@@ -34,8 +34,8 @@ namespace gui
         VBox *vBox                                                   = nullptr;
         HBox *firstHBox                                              = nullptr;
         HBox *secondHBox                                             = nullptr;
-        TextFixedSize *authorText                                    = nullptr;
-        TextFixedSize *songText                                      = nullptr;
+        Label *authorText                                            = nullptr;
+        Label *songText                                              = nullptr;
         TextFixedSize *durationText                                  = nullptr;
         Image *playedSong                                            = nullptr;
         ItemState itemState                                          = ItemState::None;

--- a/module-apps/application-music-player/windows/MusicPlayerMainWindow.cpp
+++ b/module-apps/application-music-player/windows/MusicPlayerMainWindow.cpp
@@ -95,21 +95,19 @@ namespace gui
         auto mainBox = new VBox(this, 0, 0, style::window_width, style::window_height);
         mainBox->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
 
-        titleText = new Text(mainBox, 0, 0, style::window_width, trackInfoScreen::titleHeight);
+        titleText = new Label(mainBox, 0, 0, trackInfoScreen::titleWidth, trackInfoScreen::titleHeight);
         titleText->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
-        titleText->setTextType(TextType::SingleLine);
-        titleText->setEditMode(EditMode::Browse);
         titleText->setFont(style::window::font::mediumbigbold);
-        titleText->setRichText(currentTitle);
+        titleText->setText(currentTitle);
         titleText->setMargins(Margins(0, trackInfoScreen::topMargin, 0, 0));
+        titleText->setEdges(RectangleEdge::None);
 
-        artistText = new Text(mainBox, 0, 0, style::window_width, trackInfoScreen::artistHeight);
+        artistText = new Label(mainBox, 0, 0, trackInfoScreen::titleWidth, trackInfoScreen::artistHeight);
         artistText->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
-        artistText->setTextType(TextType::SingleLine);
-        artistText->setEditMode(EditMode::Browse);
         artistText->setFont(style::window::font::medium);
-        artistText->setRichText(currentArtist);
+        artistText->setText(currentArtist);
         artistText->setMargins(Margins(0, trackInfoScreen::internalMargin, 0, 0));
+        artistText->setEdges(RectangleEdge::None);
 
         buildTrackProgressInterface(mainBox);
         buildPlayButtonsInterface(mainBox);
@@ -337,13 +335,12 @@ namespace gui
         textBox->setMinimumSize(trackInfo::width - trackInfo::internalMargin - trackInfo::height, trackInfo::height);
         textBox->setEdges(RectangleEdge::None);
         textBox->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Center));
-        descriptionText = new Text(textBox, 0, 0, 0, 0);
+        descriptionText = new Label(textBox, 0, 0, 0, 0);
         descriptionText->setMinimumSize(trackInfo::width - trackInfo::height - trackInfo::internalMargin,
                                         trackInfo::height);
         descriptionText->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Center));
-        descriptionText->setTextType(TextType::SingleLine);
-        descriptionText->setEditMode(EditMode::Browse);
         descriptionText->setFont(style::window::font::small);
+        descriptionText->setEdges(RectangleEdge::None);
     }
 
     void MusicPlayerMainWindow::destroyInterface()
@@ -451,9 +448,9 @@ namespace gui
         auto isPaused  = state == RecordState::Paused;
 
         if (titleText != nullptr)
-            titleText->setRichText(currentTitle);
+            titleText->setText(currentTitle);
         if (artistText != nullptr)
-            artistText->setRichText(currentArtist);
+            artistText->setText(currentArtist);
 
         if (totalTimeText != nullptr)
             totalTimeText->setRichText(currentTotalTimeString);
@@ -477,11 +474,13 @@ namespace gui
             std::string trackDescription;
             if (!isPaused && !isPlaying) {
                 trackDescription = utils::translate("app_music_player_empty_track_notification");
+                descriptionText->setTextColor(gui::ColorGrey);
             }
             else {
                 trackDescription = currentTitle + " - " + currentArtist;
+                descriptionText->setTextColor(gui::ColorFullBlack);
             }
-            descriptionText->setRichText(trackDescription);
+            descriptionText->setText(trackDescription);
         }
 
         if (myViewMode == ViewMode::TRACK) {

--- a/module-apps/application-music-player/windows/MusicPlayerMainWindow.hpp
+++ b/module-apps/application-music-player/windows/MusicPlayerMainWindow.hpp
@@ -70,15 +70,15 @@ namespace gui
         ViewMode myViewMode = ViewMode::START;
 
         std::shared_ptr<app::music_player::SongsContract::Presenter> presenter;
-        Text *titleText                          = nullptr;
-        Text *artistText                         = nullptr;
+        Label *titleText                         = nullptr;
+        Label *artistText                        = nullptr;
         Text *currentTimeText                    = nullptr;
         Text *totalTimeText                      = nullptr;
         ImageBox *rewImageBox                    = nullptr;
         ImageBox *pauseImageBox                  = nullptr;
         ImageBox *ffImageBox                     = nullptr;
         ImageBox *stateImageBox                  = nullptr;
-        Text *descriptionText                    = nullptr;
+        Label *descriptionText                   = nullptr;
         Image *progressBarItems[progressBarSize] = {nullptr};
 
         float currentProgress            = 0.f;


### PR DESCRIPTION
When playing tracks with long names they were incorrectly drawn in MP.
Now the beginning of string + elipsis is shown.