### PR TITLE
[EGD-7932] Added downloader for assets for Bell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
+set(MUDITA_CACHE_DIR "~/.mudita/" CACHE STRING "cache directory for our downloaded assets")
 project(PureOS)
 enable_language(C CXX ASM)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,11 @@ pipeline {
                 GITHUB_HEAD_REF="${pullRequest.headRef}"
             }
             steps {
+                withCredentials([string(credentialsId: 'f412733a-851c-4f87-ad24-7da2139a98ca', variable: 'TOKEN')]) {
+                    sh ''' #!/bin/bash -e
+                    git config --add --global user.apitoken ${TOKEN}
+                    '''
+                }
                 echo "install additional python dependencies"
                 sh '''#!/bin/bash -e
                 python3 -m pip install ghapi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,10 @@ pipeline {
                 GITHUB_HEAD_REF="${pullRequest.headRef}"
             }
             steps {
+                echo "install additional python dependencies"
+                sh '''#!/bin/bash -e
+                python3 -m pip install ghapi
+                '''
                 echo "Check if branch needs rebasing"
                 sh '''#!/bin/bash -e
                 pushd ${WORKSPACE}

--- a/cmake/modules/AddPackage.cmake
+++ b/cmake/modules/AddPackage.cmake
@@ -39,6 +39,7 @@ function(add_standalone_image SOURCE_TARGET)
         COMMAND tar -ScJf ${STANDALONE_PKG} ${SOURCE_TARGET}.img
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         DEPENDS ${BIN_FILE}
+        DEPENDS json-target
         DEPENDS ecoboot.bin-target
         DEPENDS updater.bin-target
         DEPENDS ${SOURCE_TARGET}-version.json-target
@@ -64,6 +65,7 @@ function(add_update_package SOURCE_TARGET)
 
     add_custom_command(
         OUTPUT ${UPDATE_PKG}
+        DEPENDS json-target
         DEPENDS ${SOURCE_TARGET}
         DEPENDS ${SOURCE_TARGET}-boot.bin
         DEPENDS ${SOURCE_TARGET}-version.json-target

--- a/cmake/modules/DiskImage.cmake
+++ b/cmake/modules/DiskImage.cmake
@@ -60,6 +60,7 @@ function(add_image)
     add_custom_command(
         OUTPUT ${DISK_IMAGE_NAME}
         DEPENDS ${COMMAND_DEPENDS}
+        DEPENDS json-target
         COMMAND
             ${SCRIPT_PATH}
             ${DISK_IMAGE_NAME}

--- a/cmake/modules/DownloadAsset2.cmake
+++ b/cmake/modules/DownloadAsset2.cmake
@@ -1,0 +1,10 @@
+function(download_asset2 json install_path cache_dir)
+    add_custom_target(json-target
+        COMMAND python3 ${CMAKE_SOURCE_DIR}/tools/download_asset2.py
+            --json ${json}
+            github
+            --install_dir ${install_path}
+            --cache_dir ${cache_dir}
+        COMMENT "Download binary assets listed in json file"
+        )
+endfunction()

--- a/products/BellHybrid/CMakeLists.txt
+++ b/products/BellHybrid/CMakeLists.txt
@@ -85,6 +85,8 @@ add_hex_target(BellHybrid)
 
 include(BinaryAssetsVersions.cmake)
 include(DownloadAsset)
+include(DownloadAsset2)
+download_asset2(${CMAKE_CURRENT_SOURCE_DIR}/assets.json ${PROJECT_SOURCE_DIR} ${MUDITA_CACHE_DIR})
 download_asset(PureUpdater_RT.bin updater.bin PureUpdater ${UPDATER_BIN_VERSION})
 download_asset(ecoboot.bin ecoboot.bin ecoboot ${ECOBOOT_BIN_VERSION})
 

--- a/products/BellHybrid/assets.json
+++ b/products/BellHybrid/assets.json
@@ -1,0 +1,59 @@
+{
+    "comment": "This is kiss structure - asset path & sha",
+    "assets": [
+        {
+            "name": "./fonts/bell/gt_pressura_regular_38.mpf",
+            "output": "assets/fonts/gt_pressura_regular_38.mpf",
+            "ref": "fd168040c5d1216d457e6cf223e8ea9bb76bf7b"
+        },
+        {
+            "name": "./fonts/bell/gt_pressura_light_38.mpf",
+            "output": "assets/fonts/gt_pressura_light_38.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a"
+        },
+        {
+            "name": "./fonts/bell/gt_pressura_regular_90.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_regular_90.mpf"
+        },
+        {
+            "name": "./fonts/bell/gt_pressura_regular_190.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_regular_190.mpf"
+        },
+        {
+            "name": "./fonts/common/gt_pressura_light_30.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_light_30.mpf"
+        },
+        {
+            "name": "./fonts/common/gt_pressura_regular_30.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_regular_30.mpf"
+        },
+        {
+            "name": "./fonts/common/gt_pressura_bold_30.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_bold_30.mpf"
+        },
+        {
+            "name": "./fonts/common/gt_pressura_regular_46.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_regular_46.mpf"
+        },
+        {
+            "name": "./fonts/common/gt_pressura_light_46.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_light_46.mpf"
+        },
+        {
+            "name": "./fonts/common/gt_pressura_light_90.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_light_90.mpf"
+        },
+        {
+            "name": "./image/Luts.bin",
+            "output": "Luts.bin"
+        }
+    ]
+}

--- a/products/PurePhone/CMakeLists.txt
+++ b/products/PurePhone/CMakeLists.txt
@@ -102,6 +102,8 @@ add_hex_target(PurePhone)
 
 include(BinaryAssetsVersions.cmake)
 include(DownloadAsset)
+include(DownloadAsset2)
+download_asset2(${CMAKE_CURRENT_SOURCE_DIR}/assets.json ${PROJECT_SOURCE_DIR} ${MUDITA_CACHE_DIR})
 download_asset(PureUpdater_RT.bin updater.bin PureUpdater ${UPDATER_BIN_VERSION})
 download_asset(ecoboot.bin ecoboot.bin ecoboot ${ECOBOOT_BIN_VERSION})
 

--- a/products/PurePhone/assets.json
+++ b/products/PurePhone/assets.json
@@ -1,0 +1,74 @@
+{
+    "assets": [
+        {
+            "name": "./fonts/pure/dejavu_sans_bold_27.mpf",
+            "output":"assets/fonts/dejavu_sans_bold_27.mpf"
+        },
+        {
+            "name": "./fonts/pure/gt_pressura_regular_20.mpf",
+            "output":"assets/fonts/gt_pressura_regular_20.mpf"
+        },
+        {
+            "name": "./fonts/pure/gt_pressura_bold_20.mpf",
+            "output":"assets/fonts/gt_pressura_bold_20.mpf"
+        },
+        {
+            "name": "./fonts/pure/gt_pressura_regular_24.mpf",
+            "output":"assets/fonts/gt_pressura_regular_24.mpf"
+        },
+        {
+            "name": "./fonts/pure/gt_pressura_bold_24.mpf",
+            "output":"assets/fonts/gt_pressura_bold_24.mpf"
+        },
+        {
+            "name": "./fonts/pure/gt_pressura_light_27.mpf",
+            "output":"assets/fonts/gt_pressura_light_27.mpf"
+        },
+        {
+            "name": "./fonts/pure/gt_pressura_regular_27.mpf",
+            "output":"assets/fonts/gt_pressura_regular_27.mpf"
+        },
+        {
+            "name": "./fonts/pure/gt_pressura_bold_27.mpf",
+            "output":"assets/fonts/gt_pressura_bold_27.mpf"
+        },
+        {
+            "name": "./fonts/pure/gt_pressura_bold_32.mpf",
+            "output":"assets/fonts/gt_pressura_bold_32.mpf"
+        },
+        {
+            "name": "./fonts/common/gt_pressura_light_30.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_light_30.mpf"
+        },
+        {
+            "name": "./fonts/common/gt_pressura_regular_30.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_regular_30.mpf"
+        },
+        {
+            "name": "./fonts/common/gt_pressura_bold_30.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_bold_30.mpf"
+        },
+        {
+            "name": "./fonts/common/gt_pressura_regular_46.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_regular_46.mpf"
+        },
+        {
+            "name": "./fonts/common/gt_pressura_light_46.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_light_46.mpf"
+        },
+        {
+            "name": "./fonts/common/gt_pressura_light_90.mpf",
+            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "output": "assets/fonts/gt_pressura_light_90.mpf"
+        },
+        {
+            "name": "./image/Luts.bin",
+            "output": "Luts.bin"
+        }
+    ]
+}

--- a/tools/download_asset2.py
+++ b/tools/download_asset2.py
@@ -172,7 +172,7 @@ class GitOps:
                 output.parent.mkdir(parents=True, exist_ok=True)
                 self.copy_file(cached, output)
             except HTTP404NotFoundError as ex:
-                raise RuntimeError(f'file not found with: {data} err: {ex}')
+                raise RuntimeError(f'file not found with: {data} err: {ex}  on path: {Path(".").absolute()} with cache dir: {self.cache.absolute()} for {val["name"]}')
             except HTTP403ForbiddenError as ex:
                 # gh is messed up - if you get persistent error on this file, try renaming
                 raise RuntimeError(f'something is wrong with: {data} err: {ex}')

--- a/tools/download_asset2.py
+++ b/tools/download_asset2.py
@@ -1,0 +1,216 @@
+#!/usr/bin/python3
+# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+'''
+class to download assets listed in json file
+additional classes can be added to i.e. just copy files from some other location
+which is super simple as it uses json file for description
+
+{
+    "comment": "This is kiss structure - asset path & sha",         <-- random comment in file if you wish
+    "assets": [
+        {
+            "name": "./fonts/bell/gt_pressura_regular_38.mpf",      <-- name of our file to download in repo
+            "output": "fonts/gt_pressura_regular_38.mpf",           <-- output: where should be and how shall be called the file
+            "ref": "fd168040c5d1216d457e6cf223e8ea9bb76bf7b"        <-- from what ref shall we download the file
+        },
+    ...
+}
+
+Github downloader essentially:
+-> connects to api -> loads json -> check if file for `sha` exists locally -> downloads file if not exists -> copy file from cache
+'''
+import subprocess
+import json
+from functools import lru_cache
+from tqdm import tqdm
+from ghapi.all import GhApi
+from pathlib import Path
+from fastcore.net import HTTP404NotFoundError, HTTP403ForbiddenError
+from base64 import b64decode
+import logging
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+class TqdmLoggingHandler(logging.Handler):
+    '''
+    required for pretty logs with tqdm
+    '''
+    def __init__(self, level=logging.NOTSET):
+        super().__init__(level)
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            tqdm.write(msg)
+            self.flush()
+        except Exception:
+            self.handleError(record)
+
+
+log.addHandler(TqdmLoggingHandler())
+
+
+def getToken():
+    '''
+    util to get github token for user from git config
+    '''
+    res = subprocess.Popen(["git", "config", "user.apitoken"], stdout=subprocess.PIPE).communicate()[0]
+    return res[:-1].decode()
+
+
+def get_assets_json(name):
+    with open(name) as f:
+        j = json.load(f)
+    return j
+
+
+def verify_config(j):
+    '''
+    checks for required fields for json description file
+    '''
+    required = ['assets']
+    for val in required:
+        if val not in j:
+            raise(RuntimeError(f"value '{val}' not found in config!"))
+
+
+class GitOps:
+    '''
+    Simplest github download wrapper based on ghapi (passed by api)
+    please see reference here: https://ghapi.fast.ai/fullapi.html
+    '''
+    def __init__(self, api: GhApi, cache_dir: str, install_dir, j: dict):
+        self.api = api
+        self.j = j
+        self.cache = Path(cache_dir)
+        self.cache.expanduser().mkdir(exist_ok=True)
+        self.install_dir = install_dir
+
+    def get_cached(self, file_name, git_sha):
+        '''
+        create catalog in downloads for file
+            file_name - file to download as
+            git_sha - git sha, `ref` by ghapi v3, if sha is not provided `master` is taken
+        '''
+        where = (self.cache / git_sha / file_name).expanduser()
+        if not where.parent.exists():
+            where.parent.mkdir(parents=True)
+        return where
+
+    def create_download_data(self, val, ref):
+        '''
+        generate 'data' required for github api to download via get_content
+        essentially:
+            val - file to take, remove `./` if required - http paths doesn't have ./
+            ref - git sha to use for download
+        '''
+        file_name = val['name']
+        if './' == file_name[0:2]:
+            file_name = file_name[2:]
+        data = {"path": file_name, "ref": ref}
+        return data
+
+    def download_file_from_git(self, where, data):
+        '''
+        use ghapi to download
+            where - where to download file to (please remember to download to cache)
+            data - what to download
+        '''
+        path = self.api.repos.get_content(**data)
+        with where.open("wb") as f:
+            # TODO in generall - content says what encoding is used, this is simplification
+            data = b64decode(path["content"])
+            f.write(data)
+
+    def copy_file(self, what: Path, where: Path):
+        '''
+        if there is no path to `where` create -> then copy `what`
+        '''
+        import shutil
+        where.parent.mkdir(exist_ok=True, parents=True)
+        log.debug(f'{what} -> {where}')
+        shutil.copy(what, where)
+
+    @lru_cache(maxsize=None)
+    def fallback_ref(self):
+        '''
+        get master sha, cached as asking api visible time and there is no need to do so
+        '''
+        for val in self.api.repos.list_branches():
+            if val['name'] == 'master':
+                log.debug(f"using {val['commit']['sha']} for master")
+                return val['commit']['sha']
+        raise RuntimeError('Master not found!')
+
+    def download_json(self):
+        '''
+        download function which uses our json to download all files required
+        -> check if file for sha exists -> if not: download -> copy where needed
+        '''
+        for idx, val in enumerate(tqdm(self.j['assets'])):
+            data = None
+            if 'name' not in val:
+                raise RuntimeError(f'there is no name in json->assets on position {idx}')
+            try:
+                git_sha = val['ref'] if 'ref' in val else self.fallback_ref()
+                data = self.create_download_data(val, git_sha)
+                cached = self.get_cached(data['path'], git_sha)
+                if not cached.exists():
+                    log.debug(f"downloading: {data} to: {str(cached)}")
+                    self.download_file_from_git(cached, data)
+                output = Path(val['output']) if 'output' in val else Path(val['name'])
+                if output.is_absolute() and self.install_dir is not None:
+                    raise RuntimeError("cant have absolute output with install dir...")
+                if not output.is_absolute() and self.install_dir is not None:
+                    log.debug("prepend install dir")
+                    output = Path(self.install_dir) / output
+                output.parent.mkdir(parents=True, exist_ok=True)
+                self.copy_file(cached, output)
+            except HTTP404NotFoundError as ex:
+                raise RuntimeError(f'file not found with: {data} err: {ex}')
+            except HTTP403ForbiddenError as ex:
+                # gh is messed up - if you get persistent error on this file, try renaming
+                raise RuntimeError(f'something is wrong with: {data} err: {ex}')
+
+
+def arguments():
+    import argparse
+    parser = argparse.ArgumentParser(description="download assets from repo, requires valid token in git config")
+    parser.add_argument('--json', help="json file with description what shall we load", required=True)
+    subparsers = parser.add_subparsers(title='cmd', description="command to run", required=True, dest='cmd')
+    git_args = subparsers.add_parser('github', description="download assets from github")
+    git_args.add_argument('--owner', help="owner to take data from, in our case Mudita", default="mudita")
+    git_args.add_argument('--repository', help='repository to take assets from', default='MuditaOSAssets')
+    git_args.add_argument('--cache_dir', help='cache dir to store downloaded files', default='~/.mudita/')
+    git_args.add_argument('--install_dir', help='optional install dir for path, default - relative to script', default=None)
+    git_args = subparsers.add_parser('local', description="just copy assets from local directory")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    try:
+        log.info('download_assets')
+        args = arguments()
+        if args.cmd == 'github':
+            log.info('get token...')
+            token = getToken()
+            log.info('get config...')
+            j = get_assets_json(args.json)
+            log.info('verify config...')
+            verify_config(j)
+            log.info('use GhApi...')
+            api = GhApi(owner=args.owner, token=token, repo=args.repository)
+            downloader = GitOps(api, args.cache_dir, args.install_dir, j)
+            downloader.download_json()
+            log.info('downloader success')
+        if args.cmd == 'local':
+            raise RuntimeError('Not implemented')
+    except RuntimeError as ex:
+        log.error(ex)
+        log.error('downloader exit with error!')
+        exit(1)

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -7,3 +7,4 @@ requests==2.26.0
 smmap==4.0.0
 tqdm==4.62.2
 urllib3==1.26.6
+ghapi


### PR DESCRIPTION
EGD-7932
With this, all fonts and Luts bin are downloaded for other repo which
Is closed to others. With minimum changes to our cmake and flow
Fonts are cached in `~/.mudita/`
![image](https://user-images.githubusercontent.com/6411862/141116404-d9b7e0b8-d346-4baf-955a-a470cae01325.png)
This is an quick enabler so that we can remove mpf and luts.bin from MuditaOS openourced

scripts with `2` will be merged into one with jira: EGD-7947