### PR TITLE
[EGD-7974] BTstack: fix typo in CMake

### DIFF
--- a/module-bluetooth/lib/btstack.cmake
+++ b/module-bluetooth/lib/btstack.cmake
@@ -126,7 +126,7 @@ set(TARGET_LIBRARIES_INCLUDES
 
 
 if(${PROJECT_TARGET} STREQUAL "TARGET_Linux")
-message("Linux specyfic includes")
+message("Linux specific includes")
 message("-----------------------")
     list(APPEND TARGET_LIBRARIES_INCLUDES
         ${BT_STACK_ROOT}/platform/posix/


### PR DESCRIPTION
I just noticed it while compiling the project, should have no functionality changes.