### PR TITLE
[CP-825] Interrupted transfer to FS endpoint may corrupt the filesystem

### DIFF
--- a/module-services/service-desktop/endpoints/include/endpoints/filesystem/FileContext.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/filesystem/FileContext.hpp
@@ -19,7 +19,6 @@ class FileContext
     explicit FileContext(const std::filesystem::path &path,
                          std::size_t size,
                          std::size_t chunkSize,
-                         const std::string &openMode,
                          std::size_t offset = 0);
 
     virtual ~FileContext();
@@ -40,8 +39,6 @@ class FileContext
 
   protected:
     std::filesystem::path path{};
-    std::FILE *file{};
-    std::unique_ptr<char[]> streamBuffer;
     std::size_t size{};
     std::size_t offset{};
     std::size_t chunkSize{};

--- a/module-services/service-desktop/endpoints/include/endpoints/filesystem/FileOperations.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/filesystem/FileOperations.hpp
@@ -23,7 +23,8 @@ class FileOperations
     std::map<transfer_id, std::unique_ptr<FileReadContext>> readTransfers;
     std::map<transfer_id, std::unique_ptr<FileWriteContext>> writeTransfers;
 
-    std::atomic<transfer_id> runningXfrId{0};
+    std::atomic<transfer_id> runningRxId{0};
+    std::atomic<transfer_id> runningTxId{0};
 
     auto createFileReadContextFor(const std::filesystem::path &file, std::size_t fileSize, transfer_id xfrId) -> void;
 

--- a/module-utils/log/Logger.cpp
+++ b/module-utils/log/Logger.cpp
@@ -136,7 +136,13 @@ namespace Log
     /// @return:   1 - log flush successflul
     auto Logger::dumpToFile(std::filesystem::path logPath) -> int
     {
-        auto firstDump = !std::filesystem::exists(logPath);
+        std::error_code errorCode;
+        auto firstDump = !std::filesystem::exists(logPath, errorCode);
+        if (errorCode) {
+            LOG_ERROR("Failed to check if file %s exists, error: %d", logPath.c_str(), errorCode.value());
+            return -EIO;
+        }
+
         if (const bool maxSizeExceeded = !firstDump && std::filesystem::file_size(logPath) > maxFileSize;
             maxSizeExceeded) {
             LOG_DEBUG("Max log file size exceeded. Rotating log files...");


### PR DESCRIPTION
Using std::fstream for file I/O at every file access in FileContext. Additionally, reworked file opening/closing to happen on each file chunk read/write, so that a file isn’t left open in case of error or transfer cancelation.