### PR TITLE
[CP-670] crashdumps on exit

### DIFF
--- a/board/rt1051/crashdump/crashcatcher_impl.cpp
+++ b/board/rt1051/crashdump/crashcatcher_impl.cpp
@@ -7,6 +7,7 @@
 
 #include <log/log.hpp>
 #include <date/date.h>
+#include <exit_backtrace.h>
 #include "crashdumpwriter_vfs.hpp"
 #include "consoledump.hpp"
 
@@ -23,9 +24,11 @@ const CrashCatcherMemoryRegion *CrashCatcher_GetMemoryRegions(void)
      */
     static const CrashCatcherMemoryRegion regions[] = {
         // SRAM_OC
-        {0x20200000, 0x20210000, CRASH_CATCHER_BYTE},
+        {0x20200000, 0x20210000, CRASH_CATCHER_WORD},
         // SRAM_DTC
-        {0x20000000, 0x20070000, CRASH_CATCHER_BYTE},
+        {0x20000000, 0x20070000, CRASH_CATCHER_WORD},
+        // intentionally skip text section
+        // intentionally skip the heap section
         // end tag
         {0xFFFFFFFF, 0xFFFFFFFF, CRASH_CATCHER_BYTE},
     };
@@ -57,6 +60,6 @@ void CrashCatcher_DumpMemory(const void *pvMemory, CrashCatcherElementSizes elem
 CrashCatcherReturnCodes CrashCatcher_DumpEnd(void)
 {
     cwrite.saveDump();
-    abort();
+    _exit_backtrace(-1, false);
     return CRASH_CATCHER_EXIT;
 }

--- a/board/rt1051/crashdump/crashdumpwriter_vfs.cpp
+++ b/board/rt1051/crashdump/crashdumpwriter_vfs.cpp
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include "purefs/vfs_subsystem.hpp"
 #include <purefs/filesystem_paths.hpp>
+#include <exit_backtrace.h>
 
 #include <filesystem>
 #include <stdint.h>
@@ -23,12 +24,12 @@ namespace crashdump
         LOG_INFO("Crash dump %s preparing ...", crashDumpFilePath.c_str());
         if (!rotator.rotateFile(crashDumpFilePath)) {
             LOG_FATAL("Failed to rotate crash dumps errno: %i", errno);
-            std::abort();
+            _exit_backtrace(-1, false);
         }
         file = std::fopen(crashDumpFilePath.c_str(), "w");
         if (!file) {
             LOG_FATAL("Failed to open crash dump file errno %i", errno);
-            std::abort();
+            _exit_backtrace(-1, false);
         }
     }
 
@@ -44,23 +45,23 @@ namespace crashdump
     {
         if (std::fwrite(buff, sizeof(*buff), size, file) != size) {
             LOG_FATAL("Unable to write crash dump errno: %i", errno);
-            std::abort();
+            _exit_backtrace(-1, false);
         }
     }
 
     void CrashDumpWriterVFS::writeHalfWords(const uint16_t *buff, std::size_t size)
     {
         if (std::fwrite(buff, sizeof(*buff), size, file) != size) {
-            LOG_FATAL("Unable to write crash dump");
-            std::abort();
+            LOG_FATAL("Unable to write crash dump errno: %i", errno);
+            _exit_backtrace(-1, false);
         }
     }
 
     void CrashDumpWriterVFS::writeWords(const uint32_t *buff, std::size_t size)
     {
         if (std::fwrite(buff, sizeof(*buff), size, file) != size) {
-            LOG_FATAL("Unable to write crash dump");
-            std::abort();
+            LOG_FATAL("Unable to write crash dump errno: %i", errno);
+            _exit_backtrace(-1, false);
         }
     }
 

--- a/module-bsp/board/rt1051/bsp/eMMC/fsl_mmc.c
+++ b/module-bsp/board/rt1051/bsp/eMMC/fsl_mmc.c
@@ -1865,11 +1865,7 @@ static status_t MMC_Write(
     }
 
     /* Wait for the card's buffer to be not full to write to improve the write performance. */
-    error = MMC_PollingCardStatusBusy(card);
-    if(kStatus_Success != error)
-    {
-        return error;
-    }
+    while ((GET_SDMMCHOST_STATUS(card->host.base) & CARD_DATA0_STATUS_MASK) != CARD_DATA0_NOT_BUSY) {}
 
     /* Wait for the card write process complete */
     if (kStatus_Success != MMC_WaitWriteComplete(card)) {
@@ -2268,11 +2264,7 @@ status_t MMC_EraseGroups(mmc_card_t *card, uint32_t startGroup, uint32_t endGrou
     }
 
     /* Wait for the card's buffer to be not full to write to improve the write performance. */
-    status_t error = MMC_PollingCardStatusBusy(card);
-    if(kStatus_Success != error)
-    {
-        return error;
-    }
+    while ((GET_SDMMCHOST_STATUS(card->host.base) & CARD_DATA0_STATUS_MASK) != CARD_DATA0_NOT_BUSY) {}
 
     if (kStatus_Success != MMC_WaitWriteComplete(card)) {
         return kStatus_SDMMC_WaitWriteCompleteFailed;
@@ -2638,19 +2630,4 @@ status_t MMC_StopBoot(mmc_card_t *card, uint32_t bootMode)
     SDMMCHOST_ENABLE_MMC_BOOT(card->host.base, false);
 
     return kStatus_Success;
-}
-
-status_t MMC_PollingCardStatusBusy(mmc_card_t *card)
-{
-    int retries = 0;
-    const int maxRetries = 10000;
-    do {
-        if ((GET_SDMMCHOST_STATUS(card->host.base) & CARD_DATA0_STATUS_MASK) == CARD_DATA0_NOT_BUSY) {
-            return kStatus_Success;
-        }
-        // yeld 
-        SDMMCHOST_Delay(0);
-    } while (retries++ < maxRetries);
-    
-    return kStatus_SDMMC_PollingCardIdleFailed;
 }

--- a/module-bsp/board/rt1051/bsp/eMMC/fsl_mmc.h
+++ b/module-bsp/board/rt1051/bsp/eMMC/fsl_mmc.h
@@ -356,18 +356,6 @@ extern "C"
      */
     status_t MMC_SetMaxEraseUnitSize(mmc_card_t *card);
 
-    /*!
-     * @brief Polling card idle status.
-     *
-     * This function can be used to poll the status from busy to idle.
-     *
-     * @param card Card descriptor.
-     *
-     * @retval kStatus_SDMMC_TransferFailed Command tranfer failed.
-     * @retval kStatus_Success Operate successfully.
-     */
-    status_t MMC_PollingCardStatusBusy(mmc_card_t *card);
-
 /* @} */
 #if defined(__cplusplus)
 }

--- a/module-bsp/board/rt1051/bsp/eMMC/fsl_sdmmc_common.h
+++ b/module-bsp/board/rt1051/bsp/eMMC/fsl_sdmmc_common.h
@@ -124,7 +124,6 @@ enum _sdmmc_status
     kStatus_SDMMC_CardDetectFailed         = MAKE_STATUS(kStatusGroup_SDMMC, 39U), /*!<  card detect failed */
     kStatus_SDMMC_PartitioningFailed       = MAKE_STATUS(kStatusGroup_SDMMC, 40U), /*!<  Partitioning failed */
     kStatus_SDMMC_PartitioningNotSupported = MAKE_STATUS(kStatusGroup_SDMMC, 41U), /*!<  Partitioning not supported */
-    kStatus_SDMMC_PollingCardIdleFailed    = MAKE_STATUS(kStatusGroup_SDMMC, 42U), /*!< polling card idle status failed */
 };
 
 /*! @brief card operation voltage */

--- a/module-os/board/rt1051/_exit.c
+++ b/module-os/board/rt1051/_exit.c
@@ -35,10 +35,13 @@
 #include <log/log.hpp>
 #include <task.h>
 #include <macros.h>
+#include <stdbool.h>
+#include <string.h>
+#include <exit_backtrace.h>
 
-void __attribute__((noreturn, used)) _exit(int code)
+
+static void __attribute__((noreturn)) stop_system(void)
 {
-    LOG_INFO("_exit %d", code);
     haltIfDebugging();
     vTaskEndScheduler();
     NVIC_SystemReset();
@@ -48,4 +51,19 @@ void __attribute__((noreturn, used)) _exit(int code)
         __asm volatile("wfi\n");
 #endif
     };
+}
+
+void __attribute__((noreturn, used)) _exit_backtrace(int code, bool bt_dump)
+{
+    LOG_INFO("_exit %d", code);
+    if( bt_dump ) {
+        _StackTrace_Dump_And_Abort();
+    }
+    stop_system();
+};
+
+
+void __attribute__((noreturn, used)) _exit(int code)
+{
+     _exit_backtrace(code, code!=0);
 }

--- a/module-os/board/rt1051/include/exit_backtrace.h
+++ b/module-os/board/rt1051/include/exit_backtrace.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/** This is a extension for standard function @see exit which stop the system
+ * and optionaly takes a backtrace
+ * @param[in] code Standard terminate exit code
+ * @param[in] bt_dump If true backtrace will be created
+ * @note Function never returns
+ */
+void __attribute__((noreturn, used)) _exit_backtrace(int code, bool bt_dump);
+
+
+/** This is internal backtrce function
+ * @note In never shouldn't to be called directly in the user code
+ */
+static inline void __attribute__((always_inline)) _StackTrace_Dump_stage_1(void)
+{
+    // Redirect to the save stacktrace syscall (1)
+    __asm volatile("svc #1\n");
+}
+
+/** This is internal backtrce function
+ * @note In never shouldn't to be called directly in the user code
+ */
+extern void _StackTrace_Dump_stage_2(void);
+
+
+/** This function save a backtrace on the disk and stop the system by abort
+ */
+static inline void __attribute__((always_inline)) _StackTrace_Dump_And_Abort(void)
+{
+    _StackTrace_Dump_stage_1();
+    _StackTrace_Dump_stage_2();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+

--- a/module-platform/rt1051/src/disk_emmc.cpp
+++ b/module-platform/rt1051/src/disk_emmc.cpp
@@ -105,9 +105,8 @@ namespace purefs::blkdev
             return statusBlkDevFail;
         }
         // Wait for the card's buffer to become empty
-        auto error = MMC_PollingCardStatusBusy(mmcCard.get());
-        if (kStatus_Success != error) {
-            return error;
+        while ((GET_SDMMCHOST_STATUS(mmcCard->host.base) & CARD_DATA0_STATUS_MASK) != CARD_DATA0_NOT_BUSY) {
+            taskYIELD();
         }
         if (pmState == pm_state::suspend) {
             driverUSDHC->Enable();

--- a/products/BellHybrid/CMakeLists.txt
+++ b/products/BellHybrid/CMakeLists.txt
@@ -17,6 +17,7 @@ target_compile_options(BellHybrid
 
 target_sources(BellHybrid
     PRIVATE
+        ${TARGET_SOURCES}
         BellHybridMain.cpp
         PlatformFactory.cpp
         EinkSentinelBell.cpp

--- a/third-party/CrashDebug/CrashCatcher/CrashCatcherPriv.h
+++ b/third-party/CrashDebug/CrashCatcher/CrashCatcherPriv.h
@@ -18,7 +18,7 @@
 
 
 /* Definitions used by assembly language and C code. */
-#define CRASH_CATCHER_STACK_WORD_COUNT 125
+#define CRASH_CATCHER_STACK_WORD_COUNT  8192
 
 /* Does this device support THUMB instructions for FPU access? */
 #ifdef __ARM_ARCH_7EM__

--- a/third-party/CrashDebug/CrashCatcher/CrashCatcher_armv7m.S
+++ b/third-party/CrashDebug/CrashCatcher/CrashCatcher_armv7m.S
@@ -42,7 +42,7 @@ HardFault_Handler:
         r11
         exceptionLR */
     // Prevent double fault
-    ldr r0, = crash_orig_stack
+    ldr r0, =crash_orig_stack
     ldr r0, [r0]
     cmp r0, #0
     bne .
@@ -53,7 +53,6 @@ HardFault_Handler:
     mrs     r1, msp
     ldr     sp, =(g_crashCatcherStack + 4 * CRASH_CATCHER_STACK_WORD_COUNT)
     push.w  {r1-r11,lr}
-
     // Call original console dump
     ldr r0,=crash_orig_stack
     str sp, [r0]
@@ -127,6 +126,52 @@ CrashCatcher_CopyUpperFloatingPointRegisters:
     .size   CrashCatcher_CopyUpperFloatingPointRegisters, .-CrashCatcher_CopyUpperFloatingPointRegisters
 
 
+	/*
+		This function is called by the SVC #1 syscall
+		and then collect stack data for the crash dump
+		which will be run in the second stage
+		It also changes stack to the static internal
+		due to possibility of corruption of the oryginal
+		stack frame
+		extern "C" void _StackTrace_Dump_svc_1(void);
+    */
+    .global _StackTrace_Dump_svc_1
+    .type _StackTrace_Dump_svc_1 , %function
+    .thumb_func
+_StackTrace_Dump_svc_1:
+    mrs     r3, xpsr
+    mrs     r2, psp
+    mrs     r1, msp
+    ldr     sp, =(g_crashCatcherStack + 4 * CRASH_CATCHER_STACK_WORD_COUNT)
+    push.w  {r1-r11,lr}
+
+	ldr     r0, =crash_orig_stack
+    str    	sp, [r0]
+
+    mov     sp, r1
+    bx      lr
+    .pool
+    .size   _StackTrace_Dump_svc_1, .-_StackTrace_Dump_svc_1
+
+
+	/* This function is the second stage of the crash dump
+	   crash orig stack should contain valid stack from
+	   the exception and now crash catcher should be able
+	   to read stack frame pointer and dump data in the
+	   user mode from the second part of the exit function
+	   In our model crash newer return to the caller so
+	   we can use simply branch without care about unstacking
+      extern "C" void _StackTrace_Dump_stage_2(void);
+	*/
+    .global _StackTrace_Dump_stage_2
+    .type _StackTrace_Dump_stage_2 , %function
+    .thumb_func
+_StackTrace_Dump_stage_2:
+	 ldr	 r0, =crash_orig_stack
+	 ldr     r0, [r0]
+     b      CrashCatcher_Entry
+    .pool
+    .size   _StackTrace_Dump_stage_2, .-_StackTrace_Dump_stage_2
 
     .data
     crash_orig_stack: .long 0


### PR DESCRIPTION
Fix saving crash dump. 
Reduce crash dump size 
Add backtrace crashdump on exit abort or exceptions
