### PR TITLE
[EGD-7976] Umount all filesystems on failure

### DIFF
--- a/Target_RT1051.cmake
+++ b/Target_RT1051.cmake
@@ -59,7 +59,7 @@ add_compile_options(
 
 set(TARGET_SOURCES
 
-        ${CMAKE_CURRENT_LIST_DIR}/module-os/board/rt1051/_exit.c
+        ${CMAKE_CURRENT_LIST_DIR}/module-os/board/rt1051/_exit.cpp
         CACHE INTERNAL ""
 )
 

--- a/module-os/board/rt1051/_exit.cpp
+++ b/module-os/board/rt1051/_exit.cpp
@@ -38,10 +38,18 @@
 #include <stdbool.h>
 #include <string.h>
 #include <exit_backtrace.h>
+#include <purefs/vfs_subsystem.hpp>
 
 
 static void __attribute__((noreturn)) stop_system(void)
 {
+    const auto err = purefs::subsystem::unmount_all();
+    if(err) {
+        LOG_WARN("Unable unmount all filesystems with error: %i.", err);
+    } else {
+        LOG_INFO("Filesystems unmounted successfully...");
+    }
+    LOG_INFO("Restarting the system...");
     haltIfDebugging();
     vTaskEndScheduler();
     NVIC_SystemReset();

--- a/module-os/board/rt1051/include/exit_backtrace.h
+++ b/module-os/board/rt1051/include/exit_backtrace.h
@@ -18,6 +18,14 @@ extern "C" {
 void __attribute__((noreturn, used)) _exit_backtrace(int code, bool bt_dump);
 
 
+/** This is a standard function @see exit which stop the system
+ * and optionaly takes a backtrace
+ * @param[in] code Standard terminate exit code
+ * @note Function never returns and dump backtrace when code is not equal EXIT_SUCCESS
+ */
+void __attribute__((noreturn, used)) _exit(int code);
+
+
 /** This is internal backtrce function
  * @note In never shouldn't to be called directly in the user code
  */


### PR DESCRIPTION
Umount all mounted filesystems in case of fault like
Hardfault, abort, uncautched exception.

Signed-off-by: Lucjan Bryndza <lucjan.bryndza@mudita.com>