### PR TITLE
[BH-1178] Fix onboarding guidelines

### DIFF
--- a/image/assets/lang/Polski.json
+++ b/image/assets/lang/Polski.json
@@ -624,7 +624,7 @@
   "app_bell_onboarding_info_rotate": "<text font='gt_pressura' weight='regular' size='38'>Obróć, </text><text font='gt_pressura' weight='light' size='38'>aby wybrać</text>",
   "app_bell_onboarding_info_light_click": "<text font='gt_pressura' weight='regular' size='38'>Kliknij lekko, </text><text font='gt_pressura' weight='light' size='38'>aby kontynuować</text>",
   "app_bell_onboarding_info_deep_click_warning": "<text font='gt_pressura' weight='light' size='38'>Głęboko </text><text font='gt_pressura' weight='regular' size='38'>wciśnięty</text>",
-  "app_bell_onboarding_info_deep_click_correction": "<text font='gt_pressura' weight='light' size='38'>Bądź bardziej delikatny, <br></br>spróbuj </text><text font='gt_pressura' weight='regular' size='38'>tym razem </text><text font='gt_pressura' weight='light' size='38'>lekko kliknąć</text>",
+  "app_bell_onboarding_info_deep_click_correction": "<text font='gt_pressura' weight='light' size='38'>Bądź bardziej delikatny,<br></br>spróbuj </text><text font='gt_pressura' weight='regular' size='38'>tym razem<br></br></text><text font='gt_pressura' weight='light' size='38'>lekko kliknąć</text>",
   "app_bell_settings_advanced": "Zaawansowane",
   "app_bell_settings_time_units": "Czas i jednostki",
   "app_bell_settings_advanced_temp_scale": "Skala temperatury",

--- a/products/BellHybrid/apps/application-bell-onboarding/windows/OnBoardingInstructionPromptWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-onboarding/windows/OnBoardingInstructionPromptWindow.cpp
@@ -27,10 +27,7 @@ namespace gui
 
     bool OnBoardingInstructionPromptWindow::onInput(const InputEvent &inputEvent)
     {
-        if (inputEvent.isShortRelease(KeyCode::KEY_ENTER)) {
-            application->switchWindow(windowToReturn);
-            return true;
-        }
+        // Inputs are handled on Application level
         return false;
     }
 } // namespace gui


### PR DESCRIPTION
Fix onboarding guidelines:
- exiting info screen only on specific keypresses
- deep press up also activatess info screen
- deep press info screen also works on other info screens