### PR TITLE
[BH-1181] Change Onboarding Default Time

### DIFF
--- a/products/BellHybrid/apps/application-bell-settings/include/application-bell-settings/models/TimeUnitsModel.hpp
+++ b/products/BellHybrid/apps/application-bell-settings/include/application-bell-settings/models/TimeUnitsModel.hpp
@@ -63,7 +63,7 @@ namespace app::bell_settings
         auto loadData() -> void override;
 
       private:
-        static constexpr int factoryResetTime    = 60 * 60 * 12; // noon
+        static constexpr int factoryResetTime    = 12; // noon
         static constexpr auto factoryRestTimeFmt = utils::time::Locale::TimeFormat::FormatTime12H;
     };
 } // namespace app::bell_settings


### PR DESCRIPTION
Default Time during Onboarding must be 12:00 AM (not PM)