### PR TITLE
[CP-813] Fix issues with adding contacts via Mudita Center

### DIFF
--- a/module-db/Interface/ContactRecord.cpp
+++ b/module-db/Interface/ContactRecord.cpp
@@ -579,11 +579,7 @@ auto ContactRecordInterface::addQuery(const std::shared_ptr<db::Query> &query) -
     auto result = false;
 
     auto duplicateCheckResult = verifyDuplicate(addQuery->rec);
-    if (auto temporaryCheckResult = verifyTemporary(addQuery->rec); temporaryCheckResult) {
-        addQuery->rec.removeFromGroup(ContactsDB::temporaryGroupId());
-        result = ContactRecordInterface::Update(addQuery->rec);
-    }
-    else if (!duplicateCheckResult) {
+    if (!duplicateCheckResult) {
         result = ContactRecordInterface::Add(addQuery->rec);
     }
 


### PR DESCRIPTION
There was an issue, when contact with a specific number was added,
then removed and added again via Mudita Center. Then
it was displayed without a name. This issue was caused by
another known issue with temporary contacts handling (EGD-79473).
This fix is a workaround to make adding contacts via MC work,
without the need to refactor temporary contacts handling.