### PR TITLE
[EGD-7877] Call errors while MTP file transfer

### DIFF
--- a/products/BellHybrid/config.cmake
+++ b/products/BellHybrid/config.cmake
@@ -1,3 +1,5 @@
 set(CONFIG_SIMULATOR_DISPLAY_RES_X 600)
 set(CONFIG_SIMULATOR_DISPLAY_RES_Y 480)
 
+# Enable/disable USB MTP
+option(ENABLE_USB_TASK "Enables usage of USB Task" OFF)

--- a/products/PurePhone/config.cmake
+++ b/products/PurePhone/config.cmake
@@ -1,3 +1,5 @@
 set(CONFIG_SIMULATOR_DISPLAY_RES_X 480)
 set(CONFIG_SIMULATOR_DISPLAY_RES_Y 600)
 
+# Enable/disable USB MTP
+option(ENABLE_USB_TASK "Enables usage of USB Task" ON)


### PR DESCRIPTION
Enabled USB device task to handle USB requests outside IRQ handler