### PR TITLE
[CP-845] Allow saving contact without a phone number via MC

### DIFF
--- a/products/PurePhone/services/desktop/endpoints/contacts/ContactHelper.cpp
+++ b/products/PurePhone/services/desktop/endpoints/contacts/ContactHelper.cpp
@@ -156,14 +156,7 @@ namespace sdesktop::endpoints
     auto ContactHelper::createDBEntry(Context &context) -> sys::ReturnCodes
     {
         auto newRecord = from_json(context.getBody());
-        if (newRecord.numbers.empty()) {
-            LOG_ERROR("Empty number, not added!");
-            context.setResponseStatus(http::Code::NotAcceptable);
-            putToSendQueue(context.createSimpleResponse());
-            return sys::ReturnCodes::Failure;
-        }
-
-        auto query = std::make_unique<db::query::ContactAdd>(newRecord);
+        auto query     = std::make_unique<db::query::ContactAdd>(newRecord);
 
         auto listener = std::make_unique<db::EndpointListener>(
             [](db::QueryResult *result, Context context) {


### PR DESCRIPTION
Removed redundant check for empty number, while adding
a new contact through service-desktop.