### PR TITLE
[EGD-7658] Fix unsafe usage of std::filesystem::file_size

### DIFF
--- a/module-gui/gui/core/ImageManager.cpp
+++ b/module-gui/gui/core/ImageManager.cpp
@@ -120,6 +120,10 @@ namespace gui
     {
 
         auto file = std::fopen(filename.c_str(), "rb");
+        if (!file) {
+            LOG_ERROR(" Unable to open file %s", filename.c_str());
+            return nullptr;
+        }
 
         auto fileSize = std::filesystem::file_size(filename);
 


### PR DESCRIPTION
Find and fix unsafe usage of the file_size in the MuditaOS
filesystem.