### PR TITLE
[EGD-7727] Fix userrealloc to ANSI standard capable

### DIFF
--- a/module-os/memory/usermem.c
+++ b/module-os/memory/usermem.c
@@ -387,9 +387,8 @@ void *userrealloc(void *pv, size_t xWantedSize) {
         }
         return NULL;
     }
-    else
-    {
-    	mtCOVERAGE_TEST_MARKER();
+    else {
+        return usermalloc(xWantedSize);
     }
     return NULL;
 }


### PR DESCRIPTION
Fix userrealloc() function to the ANSI to comply
ANSI C standard

Signed-off-by: Lucjan Bryndza <lucjan.bryndza@mudita.com>