### PR TITLE
[EGD-7939] Fix wrong battery status after restarting the phone

### DIFF
--- a/module-bsp/board/rt1051/puretx/bsp/battery_charger/battery_charger.cpp
+++ b/module-bsp/board/rt1051/puretx/bsp/battery_charger/battery_charger.cpp
@@ -573,6 +573,9 @@ namespace bsp::battery_charger
         configureTemperatureMeasurement();
 
         checkTemperatureRange();
+
+        // Short time to synchronize after configuration
+        vTaskDelay(pdMS_TO_TICKS(100));
         StateOfCharge level = getBatteryLevel();
         bool charging       = getChargeStatus();
         LOG_INFO("Phone battery start state: %d %d", level, charging);


### PR DESCRIPTION
Adding the necessary, short delay for synchronization
after configuration.