### PR TITLE
[EGD-7873] Fix call ended screen during BT connecting

### DIFF
--- a/module-bluetooth/Bluetooth/interface/profiles/PhoneInterface.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/PhoneInterface.cpp
@@ -9,12 +9,17 @@ namespace bluetooth
 {
     bool CellularInterfaceImpl::answerIncomingCall(sys::Service *service)
     {
+        callActive = true;
         return CellularServiceAPI::AnswerIncomingCall(service);
     }
 
     bool CellularInterfaceImpl::hangupCall(sys::Service *service)
     {
-        return CellularServiceAPI::HangupCall(service);
+        if (callActive) {
+            callActive = false;
+            return CellularServiceAPI::HangupCall(service);
+        }
+        return true;
     }
 
     bool AudioInterfaceImpl::startAudioRouting(sys::Service *service)

--- a/module-bluetooth/Bluetooth/interface/profiles/PhoneInterface.hpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/PhoneInterface.hpp
@@ -20,6 +20,9 @@ namespace bluetooth
       public:
         bool answerIncomingCall(sys::Service *service) override;
         bool hangupCall(sys::Service *service) override;
+
+      private:
+        bool callActive = false;
     };
 
     class AudioInterface


### PR DESCRIPTION
Some devices were sending hangup message during connecting, which caused
call ended screen - now it's disabled unless a call has been picked up