### PR TITLE
[EGD-7871] Fix refreshing calllog details after editing contact

### DIFF
--- a/module-apps/application-calllog/windows/CallLogDetailsWindow.hpp
+++ b/module-apps/application-calllog/windows/CallLogDetailsWindow.hpp
@@ -40,6 +40,7 @@ namespace gui
         // virtual methods
         bool onInput(const InputEvent &inputEvent) override;
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
+        bool onDatabaseMessage(sys::Message *msgl) override;
 
         void rebuild() override;
         void buildInterface() override;


### PR DESCRIPTION
After editing a contact from the calllog level,
the calllog details will be refreshed.