### PR TITLE
[EGD-8027] Disable USB device task

### DIFF
--- a/products/PurePhone/config.cmake
+++ b/products/PurePhone/config.cmake
@@ -2,4 +2,4 @@ set(CONFIG_SIMULATOR_DISPLAY_RES_X 480)
 set(CONFIG_SIMULATOR_DISPLAY_RES_Y 600)
 
 # Enable/disable USB MTP
-option(ENABLE_USB_TASK "Enables usage of USB Task" ON)
+option(ENABLE_USB_TASK "Enables usage of USB Task" OFF)


### PR DESCRIPTION
Disabling USB task to prevent BUSY errors during USB_DeviceCdcAcmSend().