### PR TITLE
[EGD-8027] Disable USB device task - cherry-pick

### DIFF
--- a/module-audio/Audio/transcode/BasicInterpolator.hpp
+++ b/module-audio/Audio/transcode/BasicInterpolator.hpp
@@ -34,8 +34,9 @@ namespace audio::transcode
         /**
          * @brief Integer type to be used to read and write data from/to a buffer.
          */
-        using IntegerType = typename decltype(
-            utils::integer::getIntegerType<sizeof(SampleType) * utils::integer::BitsInByte * Channels>())::type;
+        using IntegerType =
+            typename decltype(utils::integer::getIntegerType<sizeof(SampleType) * utils::integer::BitsInByte *
+                                                             Channels>())::type;
 
       public:
         auto transformBlockSize(std::size_t blockSize) const noexcept -> std::size_t override

--- a/products/PurePhone/config.cmake
+++ b/products/PurePhone/config.cmake
@@ -2,4 +2,4 @@ set(CONFIG_SIMULATOR_DISPLAY_RES_X 480)
 set(CONFIG_SIMULATOR_DISPLAY_RES_Y 600)
 
 # Enable/disable USB MTP
-option(ENABLE_USB_TASK "Enables usage of USB Task" ON)
+option(ENABLE_USB_TASK "Enables usage of USB Task" OFF)


### PR DESCRIPTION
Disabling USB task to prevent BUSY errors during USB_DeviceCdcAcmSend().