### PR TITLE
[BH-1271] Icons on summary screens align vertical

### DIFF
--- a/products/BellHybrid/apps/application-bell-onboarding/windows/OnBoardingFinalizeWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-onboarding/windows/OnBoardingFinalizeWindow.cpp
@@ -5,6 +5,7 @@
 
 #include <gui/widgets/Icon.hpp>
 #include <i18n/i18n.hpp>
+#include <common/data/StyleCommon.hpp>
 
 namespace gui
 {
@@ -39,6 +40,6 @@ namespace gui
         BellFinishedWindow::onBeforeShow(mode, data);
 
         icon->image->set("circle_success_big");
-        icon->setY(0);
+        icon->setY(gui::bell_style::popup_icon_y_alignment);
     }
 } // namespace gui

--- a/products/BellHybrid/apps/common/include/common/data/StyleCommon.hpp
+++ b/products/BellHybrid/apps/common/include/common/data/StyleCommon.hpp
@@ -15,5 +15,6 @@ namespace gui::bell_style
 
     inline constexpr auto popup_icon_top_margin    = 120;
     inline constexpr auto popup_icon_bottom_margin = 30;
+    inline constexpr auto popup_icon_y_alignment   = 22;
 
 } // namespace gui::bell_style

--- a/products/BellHybrid/apps/common/src/windows/BellFactoryReset.cpp
+++ b/products/BellHybrid/apps/common/src/windows/BellFactoryReset.cpp
@@ -4,6 +4,7 @@
 #include "windows/BellFactoryReset.hpp"
 #include <gui/input/InputEvent.hpp>
 #include <gui/widgets/Icon.hpp>
+#include <common/data/StyleCommon.hpp>
 #include <i18n/i18n.hpp>
 #include <Application.hpp>
 
@@ -32,6 +33,7 @@ namespace gui
         if (icon == nullptr) {
             icon = new Icon(this, 0, 0, style::window_width, style::window_height, "circle_success_big", {});
             icon->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
+            icon->setY(bell_style::popup_icon_y_alignment);
         }
     }
     bool BellFactoryReset::onInput(const InputEvent &)

--- a/products/BellHybrid/apps/common/src/windows/BellFinishedWindow.cpp
+++ b/products/BellHybrid/apps/common/src/windows/BellFinishedWindow.cpp
@@ -5,6 +5,7 @@
 #include <apps-common/ApplicationCommon.hpp>
 #include <gui/input/InputEvent.hpp>
 #include <gui/widgets/Icon.hpp>
+#include <common/data/StyleCommon.hpp>
 #include "service-appmgr/Controller.hpp"
 
 namespace gui
@@ -41,6 +42,7 @@ namespace gui
             icon = new Icon(this, 0, 0, style::window_width, style::window_height, {}, {});
             icon->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
             icon->text->setFont(style::window::font::verybiglight);
+            icon->setY(bell_style::popup_icon_y_alignment);
         }
     }
 


### PR DESCRIPTION
Summary screens icons are aligned vertically