### PR TITLE
[BH-1248] Battery charger events handling

### DIFF
--- a/module-apps/apps-common/windows/AppWindow.hpp
+++ b/module-apps/apps-common/windows/AppWindow.hpp
@@ -76,7 +76,7 @@ namespace gui
         bool updateBluetooth(sys::bluetooth::BluetoothMode mode);
         bool updateAlarmClock(bool status);
         bool updateSim();
-        bool updateBatteryStatus();
+        virtual bool updateBatteryStatus();
         bool updateSignalStrength();
         bool updateNetworkAccessTechnology();
         void updatePhoneMode(sys::phone_modes::PhoneMode mode);

--- a/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
+++ b/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
@@ -165,10 +165,7 @@ namespace app
 
     bool ApplicationBellMain::isPopupPermitted([[maybe_unused]] gui::popup::ID popupId) const
     {
-        if (blockAllPopups) {
-            return false;
-        }
-        return true;
+        return !blockAllPopups;
     }
 
     void ApplicationBellMain::handleLowBatteryNotification(manager::actions::ActionParamsPtr &&data)

--- a/products/BellHybrid/apps/application-bell-main/presenters/HomeScreenPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-main/presenters/HomeScreenPresenter.hpp
@@ -93,13 +93,14 @@ namespace app::home_screen
         virtual void detachTimer()                                                               = 0;
         virtual void handleAlarmRingingEvent()                                                   = 0;
         virtual void handleAlarmModelReady()                                                     = 0;
+        virtual void handleBatteryStatus()                                                       = 0;
         virtual void setSnoozeTimer(std::unique_ptr<app::ProgressTimerWithSnoozeTimer> &&_timer) = 0;
         virtual void startSnoozeTimer(std::chrono::seconds snoozeDuration)                       = 0;
         virtual void stopSnoozeTimer()                                                           = 0;
         virtual void restartSnoozeTimer(std::chrono::seconds snoozeDuration)                     = 0;
         virtual std::uint32_t getBatteryLvl() const                                              = 0;
         virtual bool isBatteryCharging() const                                                   = 0;
-        virtual bool isStartupDeepPress()                                                        = 0;
+        virtual bool isAlarmActivatedByLatch() const                                             = 0;
 
         static constexpr auto defaultTimeout = std::chrono::milliseconds{5000};
     };
@@ -130,14 +131,15 @@ namespace app::home_screen
         void detachTimer() override;
         void handleAlarmRingingEvent() override;
         void handleAlarmModelReady() override;
+        void handleBatteryStatus() override;
 
         void setSnoozeTimer(std::unique_ptr<app::ProgressTimerWithSnoozeTimer> &&_timer) override;
-        void startSnoozeTimer(std::chrono::seconds snoozeDuration);
-        void stopSnoozeTimer();
-        void restartSnoozeTimer(std::chrono::seconds snoozeDuration);
+        void startSnoozeTimer(std::chrono::seconds snoozeDuration) override;
+        void stopSnoozeTimer() override;
+        void restartSnoozeTimer(std::chrono::seconds snoozeDuration) override;
         std::uint32_t getBatteryLvl() const override;
         bool isBatteryCharging() const override;
-        bool isStartupDeepPress() override;
+        bool isAlarmActivatedByLatch() const override;
 
       private:
         ApplicationCommon *app;
@@ -148,9 +150,6 @@ namespace app::home_screen
         std::unique_ptr<AbstractTimeModel> timeModel;
         std::shared_ptr<AbstractController> stateController;
         std::unique_ptr<ProgressTimerWithSnoozeTimer> snoozeTimer;
-        bool latchPressed = false;
-
-        void setStartupAlarmState();
 
         void handleCyclicDeepRefresh();
 

--- a/products/BellHybrid/apps/application-bell-main/presenters/StateController.hpp
+++ b/products/BellHybrid/apps/application-bell-main/presenters/StateController.hpp
@@ -35,6 +35,7 @@ namespace app::home_screen
         virtual bool handleTimeUpdateEvent()                             = 0;
         virtual bool handleAlarmRingingEvent()                           = 0;
         virtual bool handleAlarmModelReady()                             = 0;
+        virtual bool handleBatteryStatus()                               = 0;
         virtual bool isSnoozeAllowed()                                   = 0;
         virtual void snooze(bool ctrl)                                   = 0;
     };
@@ -56,6 +57,7 @@ namespace app::home_screen
         bool handleTimeUpdateEvent() override;
         bool handleAlarmRingingEvent() override;
         bool handleAlarmModelReady() override;
+        bool handleBatteryStatus() override;
         bool isSnoozeAllowed() override;
         void snooze(bool ctrl) override;
 

--- a/products/BellHybrid/apps/application-bell-main/widgets/BellBattery.cpp
+++ b/products/BellHybrid/apps/application-bell-main/widgets/BellBattery.cpp
@@ -53,12 +53,7 @@ namespace gui
                 setVisible(false);
             }
             else {
-                if (level > 10) {
-                    img->set(battery::battery_low, gui::ImageTypeSpecifier::W_M);
-                }
-                else {
-                    img->set(battery::battery_critical, gui::ImageTypeSpecifier::W_M);
-                }
+                img->set(result->image, gui::ImageTypeSpecifier::W_M);
                 percentText->setText(std::to_string(level) + "%");
                 setVisible(true);
             }

--- a/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.cpp
@@ -267,10 +267,12 @@ namespace gui
 
     void BellHomeScreenWindow::onBeforeShow(ShowMode, SwitchData *data)
     {
-        presenter->onBeforeShow();
         const auto alarmRingingSwitchData = dynamic_cast<app::actions::AlarmRingingData *>(data);
         if (alarmRingingSwitchData != nullptr) {
             presenter->handleAlarmRingingEvent();
+        }
+        else {
+            presenter->onBeforeShow();
         }
     }
 
@@ -330,6 +332,11 @@ namespace gui
     void BellHomeScreenWindow::setSnoozeTime(std::time_t newTime)
     {
         snoozeTimer->setTime(newTime);
+    }
+    bool BellHomeScreenWindow::updateBatteryStatus()
+    {
+        presenter->handleBatteryStatus();
+        return true;
     }
 
 } // namespace gui

--- a/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.hpp
@@ -65,6 +65,8 @@ namespace gui
         void switchToMenu() override;
         void switchToBatteryStatus() override;
 
+        bool updateBatteryStatus() override;
+
         BellBaseLayout *body{};
 
         TimeSetFmtSpinner *time{};

--- a/products/BellHybrid/services/evtmgr/EventManager.cpp
+++ b/products/BellHybrid/services/evtmgr/EventManager.cpp
@@ -20,7 +20,6 @@
 #include <service-evtmgr/ScreenLightControlMessage.hpp>
 #include <service-evtmgr/WorkerEventCommon.hpp>
 #include <sys/messages/AlarmActivationStatusChangeRequest.hpp>
-#include <switches/LatchStatusRequest.hpp>
 #include <switches/LatchState.hpp>
 
 namespace
@@ -41,6 +40,7 @@ EventManager::EventManager(LogDumpFunction logDumpFunction, const std::string &n
       temperatureSource{hal::temperature::AbstractTemperatureSource::Factory::create()},
       backlightHandler(settings, this), userActivityHandler(std::make_shared<sys::CpuSentinel>(name, this), this)
 {
+    latchStatus = bsp::bell_switches::isLatchPressed() ? sevm::LatchStatus::PRESSED : sevm::LatchStatus::RELEASED;
     buildKeySequences();
     updateTemperature(*temperatureSource);
 
@@ -116,9 +116,7 @@ void EventManager::initProductEvents()
     });
 
     connect(sevm::LatchStatusRequest(), [&](sys::Message *msgl) {
-        sevm::LatchStatus state =
-            bsp::bell_switches::isLatchPressed() ? sevm::LatchStatus::PRESSED : sevm::LatchStatus::RELEASED;
-        auto msg = std::make_shared<sevm::LatchStatusResponse>(state);
+        auto msg = std::make_shared<sevm::LatchStatusResponse>(latchStatus);
         return msg;
     });
 }
@@ -155,6 +153,7 @@ void EventManager::buildKeySequences()
 
     auto alarmActivateSeq      = std::make_unique<AlarmActivateSequence>();
     alarmActivateSeq->onAction = [this]() {
+        latchStatus = sevm::LatchStatus::RELEASED;
         bus.sendUnicast(
             std::make_shared<sys::AlarmActivationStatusChangeRequest>(sys::AlarmActivationStatus::ACTIVATED),
             service::name::system_manager);
@@ -163,6 +162,7 @@ void EventManager::buildKeySequences()
 
     auto alarmDeactivateSeq      = std::make_unique<AlarmDeactivateSequence>();
     alarmDeactivateSeq->onAction = [this]() {
+        latchStatus = sevm::LatchStatus::PRESSED;
         bus.sendUnicast(
             std::make_shared<sys::AlarmActivationStatusChangeRequest>(sys::AlarmActivationStatus::DEACTIVATED),
             service::name::system_manager);

--- a/products/BellHybrid/services/evtmgr/include/evtmgr/EventManager.hpp
+++ b/products/BellHybrid/services/evtmgr/include/evtmgr/EventManager.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <bsp/switches/LatchStatusRequest.hpp>
 #include <service-evtmgr/EventManagerCommon.hpp>
 
 #include "backlight-handler/BacklightHandler.hpp"
@@ -32,6 +33,8 @@ class EventManager : public EventManagerCommon
     evm::UserActivityHandler userActivityHandler;
 
     std::shared_ptr<KeySequenceMgr> keySequenceMgr;
+
+    sevm::LatchStatus latchStatus{};
 };
 
 namespace sys


### PR DESCRIPTION
[BH-1249][BH-1248] Added handling of battery charger async
events to the home screen.
[BH-1276] Enter battery status from snooze active window.
[BH-1278] Proper latch state handling when in battery critical state.
Fixed various minor bugs spotted along the way.

[BH-1249]: https://appnroll.atlassian.net/browse/BH-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BH-1248]: https://appnroll.atlassian.net/browse/BH-1248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BH-1276]: https://appnroll.atlassian.net/browse/BH-1276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BH-1278]: https://appnroll.atlassian.net/browse/BH-1278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ