### PR TITLE
[EGD-8041] Quick fix for enable support 24-bit flac

### DIFF
--- a/module-audio/board/rt1051/puretx/PureTxAudioCodec.hpp
+++ b/module-audio/board/rt1051/puretx/PureTxAudioCodec.hpp
@@ -52,7 +52,7 @@ namespace audio
         constexpr static TickType_t codecSettleTime                               = 20 * portTICK_PERIOD_MS;
         constexpr static std::initializer_list<unsigned int> supportedSampleRates = {
             8000, 16000, 32000, 44100, 48000, 96000};
-        constexpr static std::initializer_list<unsigned int> supportedBitWidths    = {16};
+        constexpr static std::initializer_list<unsigned int> supportedBitWidths    = {16, 24};
         constexpr static std::initializer_list<unsigned int> supportedChannelModes = {1, 2};
 
         enum class State


### PR DESCRIPTION
It is a quick fix for enable support for the 24-bit
audio flac files. It fix only flac but for
24 bit wav support 3rd party library should be added
Audio system will be fixed for support all format
in the another jira case