### PR TITLE
[BH-1277] Fix critical battery flow

### DIFF
--- a/module-bsp/board/linux/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/linux/hal/battery_charger/BatteryCharger.cpp
@@ -110,6 +110,8 @@ namespace hal::battery
 
         xTaskCreate(batteryWorker, "battery", 512, nullptr, 0, &batteryWorkerHandle);
         Store::Battery::modify().level = batteryLevel;
+        Store::Battery::modify().state =
+            isPlugged ? Store::Battery::State::Charging : Store::Battery::State::Discharging;
     }
 
     void BatteryCharger::deinit()

--- a/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
+++ b/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
@@ -517,7 +517,7 @@ namespace app::manager
     {
         const auto actionHandlers = applications.findByAction(action.actionId);
         if (actionHandlers.empty()) {
-            LOG_ERROR("No applications handling action #%d.", action.actionId);
+            LOG_INFO("No applications handling action #%d.", action.actionId);
             return ActionProcessStatus::Dropped;
         }
         if (actionHandlers.size() > 1) {

--- a/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
+++ b/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
@@ -51,7 +51,12 @@ namespace app
         });
 
         addActionReceiver(app::manager::actions::DisplayLowBatteryScreen, [this](auto &&data) {
-            handleLowBatteryNotification(std::move(data));
+            /**
+             * Due to the way of handling shutdown sequence by GUI renderer and applications it is required to leave
+             * this handler defined but not implemented even if it's not used at all.
+             * Without it, the renderer won't render the last frame properly.
+             * This issue will be addressed in future PRs.
+             */
             return actionHandled();
         });
     }
@@ -161,30 +166,5 @@ namespace app
             }
         }
         return ApplicationCommon::handleSwitchWindow(msgl);
-    }
-
-    bool ApplicationBellMain::isPopupPermitted([[maybe_unused]] gui::popup::ID popupId) const
-    {
-        return !blockAllPopups;
-    }
-
-    void ApplicationBellMain::handleLowBatteryNotification(manager::actions::ActionParamsPtr &&data)
-    {
-        auto lowBatteryState = static_cast<manager::actions::LowBatteryNotificationParams *>(data.get());
-        auto currentWindow   = getCurrentWindow();
-        if (currentWindow->getName() == gui::window::name::bell_battery_shutdown) {
-            data->ignoreCurrentWindowOnStack = true;
-        }
-
-        if (lowBatteryState->isActive() && !lowBatteryState->isCharging()) {
-            blockAllPopups = true;
-            switchWindow(gui::window::name::bell_battery_shutdown, std::move(data));
-        }
-        else {
-            blockAllPopups = false;
-            if (currentWindow->getName() == gui::window::name::bell_battery_shutdown) {
-                app::manager::Controller::sendAction(this, app::manager::actions::Home, std::move(data));
-            }
-        }
     }
 } // namespace app

--- a/products/BellHybrid/apps/application-bell-main/include/application-bell-main/ApplicationBellMain.hpp
+++ b/products/BellHybrid/apps/application-bell-main/include/application-bell-main/ApplicationBellMain.hpp
@@ -40,14 +40,10 @@ namespace app
         }
 
       private:
-        bool blockAllPopups = false;
-
-        bool isPopupPermitted([[maybe_unused]] gui::popup::ID popupId) const;
         void showPopup(gui::popup::ID id, const gui::PopupRequestParams *params) override;
         auto isHomeScreenFocused() -> bool;
         void onStart() override;
         sys::MessagePointer handleSwitchWindow(sys::Message *msgl) override;
-        void handleLowBatteryNotification(manager::actions::ActionParamsPtr &&data);
     };
 
     template <> struct ManifestTraits<ApplicationBellMain>


### PR DESCRIPTION
Removed handling of critical battery level from bell's
home screen. From now on, battery SOC can drop to 1%
(battery notification will change from showing 1 bar to
crossed battery symbol upon reaching <5% SOC). If it drops
any further system shutdown procedure is invoked which results
in the device being turned off.