### PR TITLE
[EGD-8127] Add FreeRTOS return to main when scheduler exits

### DIFF
--- a/module-os/board/rt1051/fsl_tickless_gpt.c
+++ b/module-os/board/rt1051/fsl_tickless_gpt.c
@@ -34,6 +34,8 @@
 
 #if configUSE_TICKLESS_IDLE == 1
 #include "fsl_gpt.h"
+#else
+#include "fsl_common.h"
 #endif
 
 extern uint32_t SystemCoreClock; /* in Kinetis SDK, this contains the system core clock speed */
@@ -260,7 +262,6 @@ void vPortSetupTimerInterrupt( void )
         ulLPTimerCountsForOneTick = configGPT_CLOCK_HZ / configTICK_RATE_HZ;
         xMaximumPossibleSuppressedTicks = portMAX_32_BIT_NUMBER / ulLPTimerCountsForOneTick;
         NVIC_EnableIRQ(vPortGetGptIrqn());
-        
         GPC_EnableIRQ(GPC, vPortGetGptIrqn());
 
     #endif /* configUSE_TICKLESS_IDLE */
@@ -270,3 +271,17 @@ void vPortSetupTimerInterrupt( void )
     portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
     portNVIC_SYSTICK_CTRL_REG = ( portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT | portNVIC_SYSTICK_ENABLE_BIT );
 }
+
+void vPortStopTimerInterrupt( void )
+{
+    #if configUSE_TICKLESS_IDLE == 1
+        NVIC_DisableIRQ(vPortGetGptIrqn());
+        NVIC_ClearPendingIRQ(vPortGetGptIrqn());
+        GPC_DisableIRQ(GPC, vPortGetGptIrqn());
+        GPC_Deinit(vPortGetGptBase());
+    #endif
+    portNVIC_SYSTICK_CTRL_REG = 0;
+    NVIC_DisableIRQ(SysTick_IRQn);
+    NVIC_ClearPendingIRQ(SysTick_IRQn);
+}
+

--- a/module-os/board/rt1051/port.c
+++ b/module-os/board/rt1051/port.c
@@ -33,50 +33,52 @@
 #include "FreeRTOS.h"
 #include "task.h"
 #include "fsl_tickless_generic.h"
+#include <setjmp.h>
 
 extern uint32_t SystemCoreClock; /* in Kinetis SDK, this contains the system core clock speed */
-
+static jmp_buf xJumpBuf;
+extern void vPortStopTimerInterrupt(void);
 #ifndef __VFP_FP__
-	#error This port can only be used when the project options are configured to enable hardware floating point support.
+    #error This port can only be used when the project options are configured to enable hardware floating point support.
 #endif
 
 
 
 /* Constants used to detect a Cortex-M7 r0p1 core, which should use the ARM_CM7
 r0p1 port. */
-#define portCPUID							( * ( ( volatile uint32_t * ) 0xE000ed00 ) )
-#define portCORTEX_M7_r0p1_ID				( 0x410FC271UL )
-#define portCORTEX_M7_r0p0_ID				( 0x410FC270UL )
+#define portCPUID                           ( * ( ( volatile uint32_t * ) 0xE000ed00 ) )
+#define portCORTEX_M7_r0p1_ID               ( 0x410FC271UL )
+#define portCORTEX_M7_r0p0_ID               ( 0x410FC270UL )
 
-#define portNVIC_PENDSV_PRI					( ( ( uint32_t ) configKERNEL_INTERRUPT_PRIORITY ) << 16UL )
-#define portNVIC_SYSTICK_PRI				( ( ( uint32_t ) configKERNEL_INTERRUPT_PRIORITY ) << 24UL )
+#define portNVIC_PENDSV_PRI                 ( ( ( uint32_t ) configKERNEL_INTERRUPT_PRIORITY ) << 16UL )
+#define portNVIC_SYSTICK_PRI                ( ( ( uint32_t ) configKERNEL_INTERRUPT_PRIORITY ) << 24UL )
 
 /* Constants required to check the validity of an interrupt priority. */
-#define portFIRST_USER_INTERRUPT_NUMBER		( 16 )
-#define portNVIC_IP_REGISTERS_OFFSET_16 	( 0xE000E3F0 )
-#define portAIRCR_REG						( * ( ( volatile uint32_t * ) 0xE000ED0C ) )
-#define portMAX_8_BIT_VALUE					( ( uint8_t ) 0xff )
-#define portTOP_BIT_OF_BYTE					( ( uint8_t ) 0x80 )
-#define portMAX_PRIGROUP_BITS				( ( uint8_t ) 7 )
-#define portPRIORITY_GROUP_MASK				( 0x07UL << 8UL )
-#define portPRIGROUP_SHIFT					( 8UL )
+#define portFIRST_USER_INTERRUPT_NUMBER     ( 16 )
+#define portNVIC_IP_REGISTERS_OFFSET_16     ( 0xE000E3F0 )
+#define portAIRCR_REG                       ( * ( ( volatile uint32_t * ) 0xE000ED0C ) )
+#define portMAX_8_BIT_VALUE                 ( ( uint8_t ) 0xff )
+#define portTOP_BIT_OF_BYTE                 ( ( uint8_t ) 0x80 )
+#define portMAX_PRIGROUP_BITS               ( ( uint8_t ) 7 )
+#define portPRIORITY_GROUP_MASK             ( 0x07UL << 8UL )
+#define portPRIGROUP_SHIFT                  ( 8UL )
 
 /* Masks off all bits but the VECTACTIVE bits in the ICSR register. */
-#define portVECTACTIVE_MASK					( 0xFFUL )
+#define portVECTACTIVE_MASK                 ( 0xFFUL )
 
 /* Constants required to manipulate the VFP. */
-#define portFPCCR							( ( volatile uint32_t * ) 0xe000ef34 ) /* Floating point context control register. */
-#define portASPEN_AND_LSPEN_BITS			( 0x3UL << 30UL )
+#define portFPCCR                           ( ( volatile uint32_t * ) 0xe000ef34 ) /* Floating point context control register. */
+#define portASPEN_AND_LSPEN_BITS            ( 0x3UL << 30UL )
 
 /* Constants required to set up the initial stack. */
-#define portINITIAL_XPSR					( 0x01000000 )
-#define portINITIAL_EXC_RETURN				( 0xfffffffd )
+#define portINITIAL_XPSR                    ( 0x01000000 )
+#define portINITIAL_EXC_RETURN              ( 0xfffffffd )
 
 
 
 /* For strict compliance with the Cortex-M spec the task start address should
 have bit-0 clear, as it is loaded into the PC on exit from an ISR. */
-#define portSTART_ADDRESS_MASK		( ( StackType_t ) 0xfffffffeUL )
+#define portSTART_ADDRESS_MASK      ( ( StackType_t ) 0xfffffffeUL )
 
 
 
@@ -84,11 +86,12 @@ have bit-0 clear, as it is loaded into the PC on exit from an ISR. */
 prvTaskExitError() in case it messes up unwinding of the stack in the
 debugger. */
 #ifdef configTASK_RETURN_ADDRESS
-	#define portTASK_RETURN_ADDRESS	configTASK_RETURN_ADDRESS
+    #define portTASK_RETURN_ADDRESS configTASK_RETURN_ADDRESS
 #else
-	#define portTASK_RETURN_ADDRESS	prvTaskExitError
+    #define portTASK_RETURN_ADDRESS prvTaskExitError
 #endif
 
+#define portNESTING_START_VALUE 0xaaaaaaaa
 
 /*
  * Exception handlers.
@@ -116,7 +119,7 @@ static void prvTaskExitError( void );
 
 /* Each task maintains its own interrupt status in the critical nesting
 variable. */
-static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
+static UBaseType_t uxCriticalNesting = portNESTING_START_VALUE;
 
 /*
  * Used by the portASSERT_IF_INTERRUPT_PRIORITY_INVALID() macro to ensure
@@ -124,9 +127,9 @@ static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
  * a priority above configMAX_SYSCALL_INTERRUPT_PRIORITY.
  */
 #if( configASSERT_DEFINED == 1 )
-	 static uint8_t ucMaxSysCallPriority = 0;
-	 static uint32_t ulMaxPRIGROUPValue = 0;
-	 static const volatile uint8_t * const pcInterruptPriorityRegisters = ( const volatile uint8_t * const ) portNVIC_IP_REGISTERS_OFFSET_16;
+     static uint8_t ucMaxSysCallPriority = 0;
+     static uint32_t ulMaxPRIGROUPValue = 0;
+     static const volatile uint8_t * const pcInterruptPriorityRegisters = ( const volatile uint8_t * const ) portNVIC_IP_REGISTERS_OFFSET_16;
 #endif /* configASSERT_DEFINED */
 
 /*-----------------------------------------------------------*/
@@ -136,31 +139,31 @@ static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
  */
 StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
 {
-	/* Simulate the stack frame as it would be created by a context switch
-	interrupt. */
+    /* Simulate the stack frame as it would be created by a context switch
+    interrupt. */
 
-	/* Offset added to account for the way the MCU uses the stack on entry/exit
-	of interrupts, and to ensure alignment. */
-	pxTopOfStack--;
+    /* Offset added to account for the way the MCU uses the stack on entry/exit
+    of interrupts, and to ensure alignment. */
+    pxTopOfStack--;
 
-	*pxTopOfStack = portINITIAL_XPSR;	/* xPSR */
-	pxTopOfStack--;
-	*pxTopOfStack = ( ( StackType_t ) pxCode ) & portSTART_ADDRESS_MASK;	/* PC */
-	pxTopOfStack--;
-	*pxTopOfStack = ( StackType_t ) portTASK_RETURN_ADDRESS;	/* LR */
+    *pxTopOfStack = portINITIAL_XPSR;   /* xPSR */
+    pxTopOfStack--;
+    *pxTopOfStack = ( ( StackType_t ) pxCode ) & portSTART_ADDRESS_MASK;    /* PC */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) portTASK_RETURN_ADDRESS;    /* LR */
 
-	/* Save code space by skipping register initialisation. */
-	pxTopOfStack -= 5;	/* R12, R3, R2 and R1. */
-	*pxTopOfStack = ( StackType_t ) pvParameters;	/* R0 */
+    /* Save code space by skipping register initialisation. */
+    pxTopOfStack -= 5;  /* R12, R3, R2 and R1. */
+    *pxTopOfStack = ( StackType_t ) pvParameters;   /* R0 */
 
-	/* A save method is being used that requires each task to maintain its
-	own exec return value. */
-	pxTopOfStack--;
-	*pxTopOfStack = portINITIAL_EXC_RETURN;
+    /* A save method is being used that requires each task to maintain its
+    own exec return value. */
+    pxTopOfStack--;
+    *pxTopOfStack = portINITIAL_EXC_RETURN;
 
-	pxTopOfStack -= 8;	/* R11, R10, R9, R8, R7, R6, R5 and R4. */
+    pxTopOfStack -= 8;  /* R11, R10, R9, R8, R7, R6, R5 and R4. */
 
-	return pxTopOfStack;
+    return pxTopOfStack;
 }
 /*-----------------------------------------------------------*/
 
@@ -168,30 +171,30 @@ static void prvTaskExitError( void )
 {
 volatile uint32_t ulDummy = 0;
 
-	/* A function that implements a task must not exit or attempt to return to
-	its caller as there is nothing to return to.  If a task wants to exit it
-	should instead call vTaskDelete( NULL ).
+    /* A function that implements a task must not exit or attempt to return to
+    its caller as there is nothing to return to.  If a task wants to exit it
+    should instead call vTaskDelete( NULL ).
 
-	Artificially force an assert() to be triggered if configASSERT() is
-	defined, then stop here so application writers can catch the error. */
-	configASSERT( uxCriticalNesting == ~0UL );
-	portDISABLE_INTERRUPTS();
-	while( ulDummy == 0 )
-	{
-		/* This file calls prvTaskExitError() after the scheduler has been
-		started to remove a compiler warning about the function being defined
-		but never called.  ulDummy is used purely to quieten other warnings
-		about code appearing after this function is called - making ulDummy
-		volatile makes the compiler think the function could return and
-		therefore not output an 'unreachable code' warning for code that appears
-		after it. */
-	}
+    Artificially force an assert() to be triggered if configASSERT() is
+    defined, then stop here so application writers can catch the error. */
+    configASSERT( uxCriticalNesting == ~0UL );
+    portDISABLE_INTERRUPTS();
+    while( ulDummy == 0 )
+    {
+        /* This file calls prvTaskExitError() after the scheduler has been
+        started to remove a compiler warning about the function being defined
+        but never called.  ulDummy is used purely to quieten other warnings
+        about code appearing after this function is called - making ulDummy
+        volatile makes the compiler think the function could return and
+        therefore not output an 'unreachable code' warning for code that appears
+        after it. */
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vPortSVCHandler( void )
 {
-	__asm volatile (
+    __asm volatile (
                     "   tst lr, #0x04                   \n" /* Extract SVC number from the opcode */
                     "   ite eq                          \n"
                     "   mrseq r0, MSP                   \n"
@@ -201,42 +204,37 @@ void vPortSVCHandler( void )
                     "   ldrb r0, [r0]                   \n"
                     "   cmp r0, #0                      \n" /* Check if SVC #0 */
                     "   bne _StackTrace_Dump_svc_1       \n" /* Nono zero value go to the dump backtrace */
-					"	ldr	r3, pxCurrentTCBConst2		\n" /* On SVC #0 Restore the context and start OS. */
-					"	ldr r1, [r3]					\n" /* Use pxCurrentTCBConst to get the pxCurrentTCB address. */
-					"	ldr r0, [r1]					\n" /* The first item in pxCurrentTCB is the task top of stack. */
-					"	ldmia r0!, {r4-r11, r14}		\n" /* Pop the registers that are not automatically saved on exception entry and the critical nesting count. */
-					"	msr psp, r0						\n" /* Restore the task stack pointer. */
-					"	isb								\n"
-					"	mov r0, #0 						\n"
-					"	msr	basepri, r0					\n"
-					"	bx r14							\n"
-					"									\n"
-					"	.align 4						\n"
-					"pxCurrentTCBConst2: .word pxCurrentTCB				\n"
-				);
+                    "   ldr r3, pxCurrentTCBConst2      \n" /* On SVC #0 Restore the context and start OS. */
+                    "   ldr r1, [r3]                    \n" /* Use pxCurrentTCBConst to get the pxCurrentTCB address. */
+                    "   ldr r0, [r1]                    \n" /* The first item in pxCurrentTCB is the task top of stack. */
+                    "   ldmia r0!, {r4-r11, r14}        \n" /* Pop the registers that are not automatically saved on exception entry and the critical nesting count. */
+                    "   msr psp, r0                     \n" /* Restore the task stack pointer. */
+                    "   isb                             \n"
+                    "   mov r0, #0                      \n"
+                    "   msr basepri, r0                 \n"
+                    "   bx r14                          \n"
+                    "                                   \n"
+                    "   .align 4                        \n"
+                    "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
+                );
 }
 /*-----------------------------------------------------------*/
-
 static void prvPortStartFirstTask( void )
 {
-	/* Start the first task.  This also clears the bit that indicates the FPU is
-	in use in case the FPU was used before the scheduler was started - which
-	would otherwise result in the unnecessary leaving of space in the SVC stack
-	for lazy saving of FPU registers. */
-	__asm volatile(
-					" ldr r0, =0xE000ED08 	\n" /* Use the NVIC offset register to locate the stack. */
-					" ldr r0, [r0] 			\n"
-					" ldr r0, [r0] 			\n"
-					" msr msp, r0			\n" /* Set the msp back to the start of the stack. */
-					" mov r0, #0			\n" /* Clear the bit that indicates the FPU is in use, see comment above. */
-					" msr control, r0		\n"
-					" cpsie i				\n" /* Globally enable interrupts. */
-					" cpsie f				\n"
-					" dsb					\n"
-					" isb					\n"
-					" svc 0					\n" /* System call to start first task. */
-					" nop					\n"
-				);
+    /* Start the first task.  This also clears the bit that indicates the FPU is
+    in use in case the FPU was used before the scheduler was started - which
+    would otherwise result in the unnecessary leaving of space in the SVC stack
+    for lazy saving of FPU registers. */
+    __asm volatile(
+                    " mov r0, #0            \n"
+                    " msr control, r0       \n"
+                    " cpsie i               \n" /* Globally enable interrupts. */
+                    " cpsie f               \n"
+                    " dsb                   \n"
+                    " isb                   \n"
+                    " svc 0                 \n" /* System call to start first task. */
+                    " nop                   \n"
+                );
 }
 /*-----------------------------------------------------------*/
 
@@ -245,297 +243,297 @@ static void prvPortStartFirstTask( void )
  */
 BaseType_t xPortStartScheduler( void )
 {
-	/* configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to 0.
-	See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
-	configASSERT( configMAX_SYSCALL_INTERRUPT_PRIORITY );
+    /* configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to 0.
+    See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
+    configASSERT( configMAX_SYSCALL_INTERRUPT_PRIORITY );
 
-	/* This port can be used on all revisions of the Cortex-M7 core other than
-	the r0p1 parts.  r0p1 parts should use the port from the
-	/source/portable/GCC/ARM_CM7/r0p1 directory. */
-	configASSERT( portCPUID != portCORTEX_M7_r0p1_ID );
-	configASSERT( portCPUID != portCORTEX_M7_r0p0_ID );
+    /* This port can be used on all revisions of the Cortex-M7 core other than
+    the r0p1 parts.  r0p1 parts should use the port from the
+    /source/portable/GCC/ARM_CM7/r0p1 directory. */
+    configASSERT( portCPUID != portCORTEX_M7_r0p1_ID );
+    configASSERT( portCPUID != portCORTEX_M7_r0p0_ID );
 
-	#if( configASSERT_DEFINED == 1 )
-	{
-		volatile uint32_t ulOriginalPriority;
-		volatile uint8_t * const pucFirstUserPriorityRegister = ( volatile uint8_t * const ) ( portNVIC_IP_REGISTERS_OFFSET_16 + portFIRST_USER_INTERRUPT_NUMBER );
-		volatile uint8_t ucMaxPriorityValue;
+    #if( configASSERT_DEFINED == 1 )
+    {
+        volatile uint32_t ulOriginalPriority;
+        volatile uint8_t * const pucFirstUserPriorityRegister = ( volatile uint8_t * const ) ( portNVIC_IP_REGISTERS_OFFSET_16 + portFIRST_USER_INTERRUPT_NUMBER );
+        volatile uint8_t ucMaxPriorityValue;
 
-		/* Determine the maximum priority from which ISR safe FreeRTOS API
-		functions can be called.  ISR safe functions are those that end in
-		"FromISR".  FreeRTOS maintains separate thread and ISR API functions to
-		ensure interrupt entry is as fast and simple as possible.
+        /* Determine the maximum priority from which ISR safe FreeRTOS API
+        functions can be called.  ISR safe functions are those that end in
+        "FromISR".  FreeRTOS maintains separate thread and ISR API functions to
+        ensure interrupt entry is as fast and simple as possible.
 
-		Save the interrupt priority value that is about to be clobbered. */
-		ulOriginalPriority = *pucFirstUserPriorityRegister;
+        Save the interrupt priority value that is about to be clobbered. */
+        ulOriginalPriority = *pucFirstUserPriorityRegister;
 
-		/* Determine the number of priority bits available.  First write to all
-		possible bits. */
-		*pucFirstUserPriorityRegister = portMAX_8_BIT_VALUE;
+        /* Determine the number of priority bits available.  First write to all
+        possible bits. */
+        *pucFirstUserPriorityRegister = portMAX_8_BIT_VALUE;
 
-		/* Read the value back to see how many bits stuck. */
-		ucMaxPriorityValue = *pucFirstUserPriorityRegister;
+        /* Read the value back to see how many bits stuck. */
+        ucMaxPriorityValue = *pucFirstUserPriorityRegister;
 
-		/* Use the same mask on the maximum system call priority. */
-		ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
+        /* Use the same mask on the maximum system call priority. */
+        ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
 
-		/* Calculate the maximum acceptable priority group value for the number
-		of bits read back. */
-		ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS;
-		while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
-		{
-			ulMaxPRIGROUPValue--;
-			ucMaxPriorityValue <<= ( uint8_t ) 0x01;
-		}
+        /* Calculate the maximum acceptable priority group value for the number
+        of bits read back. */
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS;
+        while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
+        {
+            ulMaxPRIGROUPValue--;
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+        }
 
-		#ifdef __NVIC_PRIO_BITS
-		{
-			/* Check the CMSIS configuration that defines the number of
-			priority bits matches the number of priority bits actually queried
-			from the hardware. */
-			configASSERT( ( portMAX_PRIGROUP_BITS - ulMaxPRIGROUPValue ) == __NVIC_PRIO_BITS );
-		}
-		#endif
+        #ifdef __NVIC_PRIO_BITS
+        {
+            /* Check the CMSIS configuration that defines the number of
+            priority bits matches the number of priority bits actually queried
+            from the hardware. */
+            configASSERT( ( portMAX_PRIGROUP_BITS - ulMaxPRIGROUPValue ) == __NVIC_PRIO_BITS );
+        }
+        #endif
 
-		#ifdef configPRIO_BITS
-		{
-			/* Check the FreeRTOS configuration that defines the number of
-			priority bits matches the number of priority bits actually queried
-			from the hardware. */
-			configASSERT( ( portMAX_PRIGROUP_BITS - ulMaxPRIGROUPValue ) == configPRIO_BITS );
-		}
-		#endif
+        #ifdef configPRIO_BITS
+        {
+            /* Check the FreeRTOS configuration that defines the number of
+            priority bits matches the number of priority bits actually queried
+            from the hardware. */
+            configASSERT( ( portMAX_PRIGROUP_BITS - ulMaxPRIGROUPValue ) == configPRIO_BITS );
+        }
+        #endif
 
-		/* Shift the priority group value back to its position within the AIRCR
-		register. */
-		ulMaxPRIGROUPValue <<= portPRIGROUP_SHIFT;
-		ulMaxPRIGROUPValue &= portPRIORITY_GROUP_MASK;
+        /* Shift the priority group value back to its position within the AIRCR
+        register. */
+        ulMaxPRIGROUPValue <<= portPRIGROUP_SHIFT;
+        ulMaxPRIGROUPValue &= portPRIORITY_GROUP_MASK;
 
-		/* Restore the clobbered interrupt priority register to its original
-		value. */
-		*pucFirstUserPriorityRegister = ulOriginalPriority;
-	}
-	#endif /* conifgASSERT_DEFINED */
+        /* Restore the clobbered interrupt priority register to its original
+        value. */
+        *pucFirstUserPriorityRegister = ulOriginalPriority;
+    }
+    #endif /* conifgASSERT_DEFINED */
 
-	/* Make PendSV and SysTick the lowest priority interrupts. */
-	portNVIC_SYSPRI2_REG |= portNVIC_PENDSV_PRI;
-	portNVIC_SYSPRI2_REG |= portNVIC_SYSTICK_PRI;
+    /* Make PendSV and SysTick the lowest priority interrupts. */
+    portNVIC_SYSPRI2_REG |= portNVIC_PENDSV_PRI;
+    portNVIC_SYSPRI2_REG |= portNVIC_SYSTICK_PRI;
 
-	/* Start the timer that generates the tick ISR.  Interrupts are disabled
-	here already. */
-	vPortSetupTimerInterrupt();
+    /* Start the timer that generates the tick ISR.  Interrupts are disabled
+    here already. */
+    vPortSetupTimerInterrupt();
 
-	/* Initialise the critical nesting count ready for the first task. */
-	uxCriticalNesting = 0;
+    /* Initialise the critical nesting count ready for the first task. */
+    uxCriticalNesting = 0;
 
-	/* Ensure the VFP is enabled - it should be anyway. */
-	vPortEnableVFP();
+    /* Ensure the VFP is enabled - it should be anyway. */
+    vPortEnableVFP();
 
-	/* Lazy save always. */
-	*( portFPCCR ) |= portASPEN_AND_LSPEN_BITS;
+    /* Lazy save always. */
+    *( portFPCCR ) |= portASPEN_AND_LSPEN_BITS;
 
-	/* Start the first task. */
-	prvPortStartFirstTask();
+    if(setjmp(xJumpBuf) != 0 ) {
+        /* When back while the scheduler ends */
+        return 1;
+    }
 
-	/* Should never get here as the tasks will now be executing!  Call the task
-	exit error function to prevent compiler warnings about a static function
-	not being called in the case that the application writer overrides this
-	functionality by defining configTASK_RETURN_ADDRESS.  Call
-	vTaskSwitchContext() so link time optimisation does not remove the
-	symbol. */
-	vTaskSwitchContext();
-	prvTaskExitError();
+    /* Start the first task. */
+    prvPortStartFirstTask();
 
-	/* Should not get here! */
-	return 0;
+    /* Should not get here! */
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 void vPortEndScheduler( void )
 {
-	/* Not implemented in ports where there is nothing to return to.
-	Artificially force an assert. */
-	//configASSERT( uxCriticalNesting == 1000UL );
+    /* Not implemented in ports where there is nothing to return to.
+    Artificially force an assert. */
+    //configASSERT( uxCriticalNesting == 1000UL );
+    vPortStopTimerInterrupt();
+    uxCriticalNesting = portNESTING_START_VALUE;
+    portENABLE_INTERRUPTS();
+    longjmp(xJumpBuf, 1);
 }
 /*-----------------------------------------------------------*/
 
 void vPortEnterCritical( void )
 {
-	portDISABLE_INTERRUPTS();
-	uxCriticalNesting++;
+    portDISABLE_INTERRUPTS();
+    uxCriticalNesting++;
 
-	/* This is not the interrupt safe version of the enter critical function so
-	assert() if it is being called from an interrupt context.  Only API
-	functions that end in "FromISR" can be used in an interrupt.  Only assert if
-	the critical nesting count is 1 to protect against recursive calls if the
-	assert function also uses a critical section. */
-	if( uxCriticalNesting == 1 )
-	{
-		configASSERT( ( portNVIC_INT_CTRL_REG & portVECTACTIVE_MASK ) == 0 );
-	}
+    /* This is not the interrupt safe version of the enter critical function so
+    assert() if it is being called from an interrupt context.  Only API
+    functions that end in "FromISR" can be used in an interrupt.  Only assert if
+    the critical nesting count is 1 to protect against recursive calls if the
+    assert function also uses a critical section. */
+    if( uxCriticalNesting == 1 )
+    {
+        configASSERT( ( portNVIC_INT_CTRL_REG & portVECTACTIVE_MASK ) == 0 );
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vPortExitCritical( void )
 {
-	configASSERT( uxCriticalNesting );
-	uxCriticalNesting--;
-	if( uxCriticalNesting == 0 )
-	{
-		portENABLE_INTERRUPTS();
-	}
+    configASSERT( uxCriticalNesting );
+    uxCriticalNesting--;
+    if( uxCriticalNesting == 0 )
+    {
+        portENABLE_INTERRUPTS();
+    }
 }
 /*-----------------------------------------------------------*/
 
 void xPortPendSVHandler( void )
 {
-	/* This is a naked function. */
+    /* This is a naked function. */
 
-	__asm volatile
-	(
-	"	mrs r0, psp							\n"
-	"	isb									\n"
-	"										\n"
-	"	ldr	r3, pxCurrentTCBConst			\n" /* Get the location of the current TCB. */
-	"	ldr	r2, [r3]						\n"
-	"										\n"
-	"	tst r14, #0x10						\n" /* Is the task using the FPU context?  If so, push high vfp registers. */
-	"	it eq								\n"
-	"	vstmdbeq r0!, {s16-s31}				\n"
-	"										\n"
-	"	stmdb r0!, {r4-r11, r14}			\n" /* Save the core registers. */
-	"	str r0, [r2]						\n" /* Save the new top of stack into the first member of the TCB. */
-	"										\n"
-	"	stmdb sp!, {r0, r3}					\n"
-	"	mov r0, %0 							\n"
-	"	msr basepri, r0						\n"
-	"	dsb									\n"
-	"	isb									\n"
-	"	bl vTaskSwitchContext				\n"
-	"	mov r0, #0							\n"
-	"	msr basepri, r0						\n"
-	"	ldmia sp!, {r0, r3}					\n"
-	"										\n"
-	"	ldr r1, [r3]						\n" /* The first item in pxCurrentTCB is the task top of stack. */
-	"	ldr r0, [r1]						\n"
-	"										\n"
-	"	ldmia r0!, {r4-r11, r14}			\n" /* Pop the core registers. */
-	"										\n"
-	"	tst r14, #0x10						\n" /* Is the task using the FPU context?  If so, pop the high vfp registers too. */
-	"	it eq								\n"
-	"	vldmiaeq r0!, {s16-s31}				\n"
-	"										\n"
-	"	msr psp, r0							\n"
-	"	isb									\n"
-	"										\n"
-	#ifdef WORKAROUND_PMU_CM001 /* XMC4000 specific errata workaround. */
-		#if WORKAROUND_PMU_CM001 == 1
-	"			push { r14 }				\n"
-	"			pop { pc }					\n"
-		#endif
-	#endif
-	"										\n"
-	"	bx r14								\n"
-	"										\n"
-	"	.align 4							\n"
-	"pxCurrentTCBConst: .word pxCurrentTCB	\n"
-	::"i"(configMAX_SYSCALL_INTERRUPT_PRIORITY)
-	);
+    __asm volatile
+    (
+    "   mrs r0, psp                         \n"
+    "   isb                                 \n"
+    "                                       \n"
+    "   ldr r3, pxCurrentTCBConst           \n" /* Get the location of the current TCB. */
+    "   ldr r2, [r3]                        \n"
+    "                                       \n"
+    "   tst r14, #0x10                      \n" /* Is the task using the FPU context?  If so, push high vfp registers. */
+    "   it eq                               \n"
+    "   vstmdbeq r0!, {s16-s31}             \n"
+    "                                       \n"
+    "   stmdb r0!, {r4-r11, r14}            \n" /* Save the core registers. */
+    "   str r0, [r2]                        \n" /* Save the new top of stack into the first member of the TCB. */
+    "                                       \n"
+    "   stmdb sp!, {r0, r3}                 \n"
+    "   mov r0, %0                          \n"
+    "   msr basepri, r0                     \n"
+    "   dsb                                 \n"
+    "   isb                                 \n"
+    "   bl vTaskSwitchContext               \n"
+    "   mov r0, #0                          \n"
+    "   msr basepri, r0                     \n"
+    "   ldmia sp!, {r0, r3}                 \n"
+    "                                       \n"
+    "   ldr r1, [r3]                        \n" /* The first item in pxCurrentTCB is the task top of stack. */
+    "   ldr r0, [r1]                        \n"
+    "                                       \n"
+    "   ldmia r0!, {r4-r11, r14}            \n" /* Pop the core registers. */
+    "                                       \n"
+    "   tst r14, #0x10                      \n" /* Is the task using the FPU context?  If so, pop the high vfp registers too. */
+    "   it eq                               \n"
+    "   vldmiaeq r0!, {s16-s31}             \n"
+    "                                       \n"
+    "   msr psp, r0                         \n"
+    "   isb                                 \n"
+    "                                       \n"
+    #ifdef WORKAROUND_PMU_CM001 /* XMC4000 specific errata workaround. */
+        #if WORKAROUND_PMU_CM001 == 1
+    "           push { r14 }                \n"
+    "           pop { pc }                  \n"
+        #endif
+    #endif
+    "                                       \n"
+    "   bx r14                              \n"
+    "                                       \n"
+    "   .align 4                            \n"
+    "pxCurrentTCBConst: .word pxCurrentTCB  \n"
+    ::"i"(configMAX_SYSCALL_INTERRUPT_PRIORITY)
+    );
 }
 /*-----------------------------------------------------------*/
 
 void xPortSysTickHandler( void )
 {
-	/* The SysTick runs at the lowest interrupt priority, so when this interrupt
-	executes all interrupts must be unmasked.  There is therefore no need to
-	save and then restore the interrupt mask value as its value is already
-	known. */
-	portDISABLE_INTERRUPTS();
-	{
-		/* Increment the RTOS tick. */
-		if( xTaskIncrementTick() != pdFALSE )
-		{
-			/* A context switch is required.  Context switching is performed in
-			the PendSV interrupt.  Pend the PendSV interrupt. */
-			portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
-		}
-	}
-	portENABLE_INTERRUPTS();
+    /* The SysTick runs at the lowest interrupt priority, so when this interrupt
+    executes all interrupts must be unmasked.  There is therefore no need to
+    save and then restore the interrupt mask value as its value is already
+    known. */
+    portDISABLE_INTERRUPTS();
+    {
+        /* Increment the RTOS tick. */
+        if( xTaskIncrementTick() != pdFALSE )
+        {
+            /* A context switch is required.  Context switching is performed in
+            the PendSV interrupt.  Pend the PendSV interrupt. */
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+    }
+    portENABLE_INTERRUPTS();
 }
 
 
 /* This is a naked function. */
 static void vPortEnableVFP( void )
 {
-	__asm volatile
-	(
-		"	ldr.w r0, =0xE000ED88		\n" /* The FPU enable bits are in the CPACR. */
-		"	ldr r1, [r0]				\n"
-		"								\n"
-		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
-		"	str r1, [r0]				\n"
-		"	bx r14						"
-	);
+    __asm volatile
+    (
+        "   ldr.w r0, =0xE000ED88       \n" /* The FPU enable bits are in the CPACR. */
+        "   ldr r1, [r0]                \n"
+        "                               \n"
+        "   orr r1, r1, #( 0xf << 20 )  \n" /* Enable CP10 and CP11 coprocessors, then save back. */
+        "   str r1, [r0]                \n"
+        "   bx r14                      "
+    );
 }
 /*-----------------------------------------------------------*/
 
 #if( configASSERT_DEFINED == 1 )
 
-	void vPortValidateInterruptPriority( void )
-	{
-	uint32_t ulCurrentInterrupt;
-	uint8_t ucCurrentPriority;
+    void vPortValidateInterruptPriority( void )
+    {
+    uint32_t ulCurrentInterrupt;
+    uint8_t ucCurrentPriority;
 
-		/* Obtain the number of the currently executing interrupt. */
-		__asm volatile( "mrs %0, ipsr" : "=r"( ulCurrentInterrupt ) :: "memory" );
+        /* Obtain the number of the currently executing interrupt. */
+        __asm volatile( "mrs %0, ipsr" : "=r"( ulCurrentInterrupt ) :: "memory" );
 
-		/* Is the interrupt number a user defined interrupt? */
-		if( ulCurrentInterrupt >= portFIRST_USER_INTERRUPT_NUMBER )
-		{
-			/* Look up the interrupt's priority. */
-			ucCurrentPriority = pcInterruptPriorityRegisters[ ulCurrentInterrupt ];
+        /* Is the interrupt number a user defined interrupt? */
+        if( ulCurrentInterrupt >= portFIRST_USER_INTERRUPT_NUMBER )
+        {
+            /* Look up the interrupt's priority. */
+            ucCurrentPriority = pcInterruptPriorityRegisters[ ulCurrentInterrupt ];
 
-			/* The following assertion will fail if a service routine (ISR) for
-			an interrupt that has been assigned a priority above
-			configMAX_SYSCALL_INTERRUPT_PRIORITY calls an ISR safe FreeRTOS API
-			function.  ISR safe FreeRTOS API functions must *only* be called
-			from interrupts that have been assigned a priority at or below
-			configMAX_SYSCALL_INTERRUPT_PRIORITY.
+            /* The following assertion will fail if a service routine (ISR) for
+            an interrupt that has been assigned a priority above
+            configMAX_SYSCALL_INTERRUPT_PRIORITY calls an ISR safe FreeRTOS API
+            function.  ISR safe FreeRTOS API functions must *only* be called
+            from interrupts that have been assigned a priority at or below
+            configMAX_SYSCALL_INTERRUPT_PRIORITY.
 
-			Numerically low interrupt priority numbers represent logically high
-			interrupt priorities, therefore the priority of the interrupt must
-			be set to a value equal to or numerically *higher* than
-			configMAX_SYSCALL_INTERRUPT_PRIORITY.
+            Numerically low interrupt priority numbers represent logically high
+            interrupt priorities, therefore the priority of the interrupt must
+            be set to a value equal to or numerically *higher* than
+            configMAX_SYSCALL_INTERRUPT_PRIORITY.
 
-			Interrupts that	use the FreeRTOS API must not be left at their
-			default priority of	zero as that is the highest possible priority,
-			which is guaranteed to be above configMAX_SYSCALL_INTERRUPT_PRIORITY,
-			and	therefore also guaranteed to be invalid.
+            Interrupts that use the FreeRTOS API must not be left at their
+            default priority of zero as that is the highest possible priority,
+            which is guaranteed to be above configMAX_SYSCALL_INTERRUPT_PRIORITY,
+            and therefore also guaranteed to be invalid.
 
-			FreeRTOS maintains separate thread and ISR API functions to ensure
-			interrupt entry is as fast and simple as possible.
+            FreeRTOS maintains separate thread and ISR API functions to ensure
+            interrupt entry is as fast and simple as possible.
 
-			The following links provide detailed information:
-			http://www.freertos.org/RTOS-Cortex-M3-M4.html
-			http://www.freertos.org/FAQHelp.html */
-			configASSERT( ucCurrentPriority >= ucMaxSysCallPriority );
-		}
+            The following links provide detailed information:
+            http://www.freertos.org/RTOS-Cortex-M3-M4.html
+            http://www.freertos.org/FAQHelp.html */
+            configASSERT( ucCurrentPriority >= ucMaxSysCallPriority );
+        }
 
-		/* Priority grouping:  The interrupt controller (NVIC) allows the bits
-		that define each interrupt's priority to be split between bits that
-		define the interrupt's pre-emption priority bits and bits that define
-		the interrupt's sub-priority.  For simplicity all bits must be defined
-		to be pre-emption priority bits.  The following assertion will fail if
-		this is not the case (if some bits represent a sub-priority).
+        /* Priority grouping:  The interrupt controller (NVIC) allows the bits
+        that define each interrupt's priority to be split between bits that
+        define the interrupt's pre-emption priority bits and bits that define
+        the interrupt's sub-priority.  For simplicity all bits must be defined
+        to be pre-emption priority bits.  The following assertion will fail if
+        this is not the case (if some bits represent a sub-priority).
 
-		If the application only uses CMSIS libraries for interrupt
-		configuration then the correct setting can be achieved on all Cortex-M
-		devices by calling NVIC_SetPriorityGrouping( 0 ); before starting the
-		scheduler.  Note however that some vendor specific peripheral libraries
-		assume a non-zero priority group setting, in which cases using a value
-		of zero will result in unpredictable behaviour. */
-		configASSERT( ( portAIRCR_REG & portPRIORITY_GROUP_MASK ) <= ulMaxPRIGROUPValue );
-	}
+        If the application only uses CMSIS libraries for interrupt
+        configuration then the correct setting can be achieved on all Cortex-M
+        devices by calling NVIC_SetPriorityGrouping( 0 ); before starting the
+        scheduler.  Note however that some vendor specific peripheral libraries
+        assume a non-zero priority group setting, in which cases using a value
+        of zero will result in unpredictable behaviour. */
+        configASSERT( ( portAIRCR_REG & portPRIORITY_GROUP_MASK ) <= ulMaxPRIGROUPValue );
+    }
 
 #endif /* configASSERT_DEFINED */
 

--- a/module-os/board/rt1051/systemview/port.c
+++ b/module-os/board/rt1051/systemview/port.c
@@ -34,49 +34,52 @@
 #include "task.h"
 #include "fsl_tickless_generic.h"
 
-extern uint32_t SystemCoreClock; /* in Kinetis SDK, this contains the system core clock speed */
+#include <setjmp.h>
 
+extern uint32_t SystemCoreClock; /* in Kinetis SDK, this contains the system core clock speed */
+static jmp_buf xJumpBuf;
+extern void vPortStopTimerInterrupt(void);
 #ifndef __VFP_FP__
-	#error This port can only be used when the project options are configured to enable hardware floating point support.
+    #error This port can only be used when the project options are configured to enable hardware floating point support.
 #endif
 
 
 
 /* Constants used to detect a Cortex-M7 r0p1 core, which should use the ARM_CM7
 r0p1 port. */
-#define portCPUID							( * ( ( volatile uint32_t * ) 0xE000ed00 ) )
-#define portCORTEX_M7_r0p1_ID				( 0x410FC271UL )
-#define portCORTEX_M7_r0p0_ID				( 0x410FC270UL )
+#define portCPUID                           ( * ( ( volatile uint32_t * ) 0xE000ed00 ) )
+#define portCORTEX_M7_r0p1_ID               ( 0x410FC271UL )
+#define portCORTEX_M7_r0p0_ID               ( 0x410FC270UL )
 
-#define portNVIC_PENDSV_PRI					( ( ( uint32_t ) configKERNEL_INTERRUPT_PRIORITY ) << 16UL )
-#define portNVIC_SYSTICK_PRI				( ( ( uint32_t ) configKERNEL_INTERRUPT_PRIORITY ) << 24UL )
+#define portNVIC_PENDSV_PRI                 ( ( ( uint32_t ) configKERNEL_INTERRUPT_PRIORITY ) << 16UL )
+#define portNVIC_SYSTICK_PRI                ( ( ( uint32_t ) configKERNEL_INTERRUPT_PRIORITY ) << 24UL )
 
 /* Constants required to check the validity of an interrupt priority. */
-#define portFIRST_USER_INTERRUPT_NUMBER		( 16 )
-#define portNVIC_IP_REGISTERS_OFFSET_16 	( 0xE000E3F0 )
-#define portAIRCR_REG						( * ( ( volatile uint32_t * ) 0xE000ED0C ) )
-#define portMAX_8_BIT_VALUE					( ( uint8_t ) 0xff )
-#define portTOP_BIT_OF_BYTE					( ( uint8_t ) 0x80 )
-#define portMAX_PRIGROUP_BITS				( ( uint8_t ) 7 )
-#define portPRIORITY_GROUP_MASK				( 0x07UL << 8UL )
-#define portPRIGROUP_SHIFT					( 8UL )
+#define portFIRST_USER_INTERRUPT_NUMBER     ( 16 )
+#define portNVIC_IP_REGISTERS_OFFSET_16     ( 0xE000E3F0 )
+#define portAIRCR_REG                       ( * ( ( volatile uint32_t * ) 0xE000ED0C ) )
+#define portMAX_8_BIT_VALUE                 ( ( uint8_t ) 0xff )
+#define portTOP_BIT_OF_BYTE                 ( ( uint8_t ) 0x80 )
+#define portMAX_PRIGROUP_BITS               ( ( uint8_t ) 7 )
+#define portPRIORITY_GROUP_MASK             ( 0x07UL << 8UL )
+#define portPRIGROUP_SHIFT                  ( 8UL )
 
 /* Masks off all bits but the VECTACTIVE bits in the ICSR register. */
-#define portVECTACTIVE_MASK					( 0xFFUL )
+#define portVECTACTIVE_MASK                 ( 0xFFUL )
 
 /* Constants required to manipulate the VFP. */
-#define portFPCCR							( ( volatile uint32_t * ) 0xe000ef34 ) /* Floating point context control register. */
-#define portASPEN_AND_LSPEN_BITS			( 0x3UL << 30UL )
+#define portFPCCR                           ( ( volatile uint32_t * ) 0xe000ef34 ) /* Floating point context control register. */
+#define portASPEN_AND_LSPEN_BITS            ( 0x3UL << 30UL )
 
 /* Constants required to set up the initial stack. */
-#define portINITIAL_XPSR					( 0x01000000 )
-#define portINITIAL_EXC_RETURN				( 0xfffffffd )
+#define portINITIAL_XPSR                    ( 0x01000000 )
+#define portINITIAL_EXC_RETURN              ( 0xfffffffd )
 
 
 
 /* For strict compliance with the Cortex-M spec the task start address should
 have bit-0 clear, as it is loaded into the PC on exit from an ISR. */
-#define portSTART_ADDRESS_MASK		( ( StackType_t ) 0xfffffffeUL )
+#define portSTART_ADDRESS_MASK      ( ( StackType_t ) 0xfffffffeUL )
 
 
 
@@ -84,11 +87,12 @@ have bit-0 clear, as it is loaded into the PC on exit from an ISR. */
 prvTaskExitError() in case it messes up unwinding of the stack in the
 debugger. */
 #ifdef configTASK_RETURN_ADDRESS
-	#define portTASK_RETURN_ADDRESS	configTASK_RETURN_ADDRESS
+    #define portTASK_RETURN_ADDRESS configTASK_RETURN_ADDRESS
 #else
-	#define portTASK_RETURN_ADDRESS	prvTaskExitError
+    #define portTASK_RETURN_ADDRESS prvTaskExitError
 #endif
 
+#define portNESTING_START_VALUE 0xaaaaaaaa
 
 /*
  * Exception handlers.
@@ -116,7 +120,7 @@ static void prvTaskExitError( void );
 
 /* Each task maintains its own interrupt status in the critical nesting
 variable. */
-static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
+static UBaseType_t uxCriticalNesting = portNESTING_START_VALUE;
 
 /*
  * Used by the portASSERT_IF_INTERRUPT_PRIORITY_INVALID() macro to ensure
@@ -124,9 +128,9 @@ static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
  * a priority above configMAX_SYSCALL_INTERRUPT_PRIORITY.
  */
 #if( configASSERT_DEFINED == 1 )
-	 static uint8_t ucMaxSysCallPriority = 0;
-	 static uint32_t ulMaxPRIGROUPValue = 0;
-	 static const volatile uint8_t * const pcInterruptPriorityRegisters = ( const volatile uint8_t * const ) portNVIC_IP_REGISTERS_OFFSET_16;
+     static uint8_t ucMaxSysCallPriority = 0;
+     static uint32_t ulMaxPRIGROUPValue = 0;
+     static const volatile uint8_t * const pcInterruptPriorityRegisters = ( const volatile uint8_t * const ) portNVIC_IP_REGISTERS_OFFSET_16;
 #endif /* configASSERT_DEFINED */
 
 /*-----------------------------------------------------------*/
@@ -136,31 +140,31 @@ static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
  */
 StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
 {
-	/* Simulate the stack frame as it would be created by a context switch
-	interrupt. */
+    /* Simulate the stack frame as it would be created by a context switch
+    interrupt. */
 
-	/* Offset added to account for the way the MCU uses the stack on entry/exit
-	of interrupts, and to ensure alignment. */
-	pxTopOfStack--;
+    /* Offset added to account for the way the MCU uses the stack on entry/exit
+    of interrupts, and to ensure alignment. */
+    pxTopOfStack--;
 
-	*pxTopOfStack = portINITIAL_XPSR;	/* xPSR */
-	pxTopOfStack--;
-	*pxTopOfStack = ( ( StackType_t ) pxCode ) & portSTART_ADDRESS_MASK;	/* PC */
-	pxTopOfStack--;
-	*pxTopOfStack = ( StackType_t ) portTASK_RETURN_ADDRESS;	/* LR */
+    *pxTopOfStack = portINITIAL_XPSR;   /* xPSR */
+    pxTopOfStack--;
+    *pxTopOfStack = ( ( StackType_t ) pxCode ) & portSTART_ADDRESS_MASK;    /* PC */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) portTASK_RETURN_ADDRESS;    /* LR */
 
-	/* Save code space by skipping register initialisation. */
-	pxTopOfStack -= 5;	/* R12, R3, R2 and R1. */
-	*pxTopOfStack = ( StackType_t ) pvParameters;	/* R0 */
+    /* Save code space by skipping register initialisation. */
+    pxTopOfStack -= 5;  /* R12, R3, R2 and R1. */
+    *pxTopOfStack = ( StackType_t ) pvParameters;   /* R0 */
 
-	/* A save method is being used that requires each task to maintain its
-	own exec return value. */
-	pxTopOfStack--;
-	*pxTopOfStack = portINITIAL_EXC_RETURN;
+    /* A save method is being used that requires each task to maintain its
+    own exec return value. */
+    pxTopOfStack--;
+    *pxTopOfStack = portINITIAL_EXC_RETURN;
 
-	pxTopOfStack -= 8;	/* R11, R10, R9, R8, R7, R6, R5 and R4. */
+    pxTopOfStack -= 8;  /* R11, R10, R9, R8, R7, R6, R5 and R4. */
 
-	return pxTopOfStack;
+    return pxTopOfStack;
 }
 /*-----------------------------------------------------------*/
 
@@ -168,66 +172,71 @@ static void prvTaskExitError( void )
 {
 volatile uint32_t ulDummy = 0;
 
-	/* A function that implements a task must not exit or attempt to return to
-	its caller as there is nothing to return to.  If a task wants to exit it
-	should instead call vTaskDelete( NULL ).
+    /* A function that implements a task must not exit or attempt to return to
+    its caller as there is nothing to return to.  If a task wants to exit it
+    should instead call vTaskDelete( NULL ).
 
-	Artificially force an assert() to be triggered if configASSERT() is
-	defined, then stop here so application writers can catch the error. */
-	configASSERT( uxCriticalNesting == ~0UL );
-	portDISABLE_INTERRUPTS();
-	while( ulDummy == 0 )
-	{
-		/* This file calls prvTaskExitError() after the scheduler has been
-		started to remove a compiler warning about the function being defined
-		but never called.  ulDummy is used purely to quieten other warnings
-		about code appearing after this function is called - making ulDummy
-		volatile makes the compiler think the function could return and
-		therefore not output an 'unreachable code' warning for code that appears
-		after it. */
-	}
+    Artificially force an assert() to be triggered if configASSERT() is
+    defined, then stop here so application writers can catch the error. */
+    configASSERT( uxCriticalNesting == ~0UL );
+    portDISABLE_INTERRUPTS();
+    while( ulDummy == 0 )
+    {
+        /* This file calls prvTaskExitError() after the scheduler has been
+        started to remove a compiler warning about the function being defined
+        but never called.  ulDummy is used purely to quieten other warnings
+        about code appearing after this function is called - making ulDummy
+        volatile makes the compiler think the function could return and
+        therefore not output an 'unreachable code' warning for code that appears
+        after it. */
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vPortSVCHandler( void )
 {
-	__asm volatile (
-					"	ldr	r3, pxCurrentTCBConst2		\n" /* Restore the context. */
-					"	ldr r1, [r3]					\n" /* Use pxCurrentTCBConst to get the pxCurrentTCB address. */
-					"	ldr r0, [r1]					\n" /* The first item in pxCurrentTCB is the task top of stack. */
-					"	ldmia r0!, {r4-r11, r14}		\n" /* Pop the registers that are not automatically saved on exception entry and the critical nesting count. */
-					"	msr psp, r0						\n" /* Restore the task stack pointer. */
-					"	isb								\n"
-					"	mov r0, #0 						\n"
-					"	msr	basepri, r0					\n"
-					"	bx r14							\n"
-					"									\n"
-					"	.align 4						\n"
-					"pxCurrentTCBConst2: .word pxCurrentTCB				\n"
-				);
+    __asm volatile (
+                    "   tst lr, #0x04                   \n" /* Extract SVC number from the opcode */
+                    "   ite eq                          \n"
+                    "   mrseq r0, MSP                   \n"
+                    "   mrsne r0, PSP                   \n"
+                    "   ldr r0, [r0, #24]               \n"
+                    "   sub r0, r0, #2                  \n"
+                    "   ldrb r0, [r0]                   \n"
+                    "   cmp r0, #0                      \n" /* Check if SVC #0 */
+                    "   bne _StackTrace_Dump_svc_1       \n" /* Nono zero value go to the dump backtrace */
+                    "   ldr r3, pxCurrentTCBConst2      \n" /* On SVC #0 Restore the context and start OS. */
+                    "   ldr r1, [r3]                    \n" /* Use pxCurrentTCBConst to get the pxCurrentTCB address. */
+                    "   ldr r0, [r1]                    \n" /* The first item in pxCurrentTCB is the task top of stack. */
+                    "   ldmia r0!, {r4-r11, r14}        \n" /* Pop the registers that are not automatically saved on exception entry and the critical nesting count. */
+                    "   msr psp, r0                     \n" /* Restore the task stack pointer. */
+                    "   isb                             \n"
+                    "   mov r0, #0                      \n"
+                    "   msr basepri, r0                 \n"
+                    "   bx r14                          \n"
+                    "                                   \n"
+                    "   .align 4                        \n"
+                    "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
+                );
 }
 /*-----------------------------------------------------------*/
 
 static void prvPortStartFirstTask( void )
 {
-	/* Start the first task.  This also clears the bit that indicates the FPU is
-	in use in case the FPU was used before the scheduler was started - which
-	would otherwise result in the unnecessary leaving of space in the SVC stack
-	for lazy saving of FPU registers. */
-	__asm volatile(
-					" ldr r0, =0xE000ED08 	\n" /* Use the NVIC offset register to locate the stack. */
-					" ldr r0, [r0] 			\n"
-					" ldr r0, [r0] 			\n"
-					" msr msp, r0			\n" /* Set the msp back to the start of the stack. */
-					" mov r0, #0			\n" /* Clear the bit that indicates the FPU is in use, see comment above. */
-					" msr control, r0		\n"
-					" cpsie i				\n" /* Globally enable interrupts. */
-					" cpsie f				\n"
-					" dsb					\n"
-					" isb					\n"
-					" svc 0					\n" /* System call to start first task. */
-					" nop					\n"
-				);
+    /* Start the first task.  This also clears the bit that indicates the FPU is
+    in use in case the FPU was used before the scheduler was started - which
+    would otherwise result in the unnecessary leaving of space in the SVC stack
+    for lazy saving of FPU registers. */
+    __asm volatile(
+                    " mov r0, #0            \n"
+                    " msr control, r0       \n"
+                    " cpsie i               \n" /* Globally enable interrupts. */
+                    " cpsie f               \n"
+                    " dsb                   \n"
+                    " isb                   \n"
+                    " svc 0                 \n" /* System call to start first task. */
+                    " nop                   \n"
+                );
 }
 /*-----------------------------------------------------------*/
 
@@ -236,303 +245,304 @@ static void prvPortStartFirstTask( void )
  */
 BaseType_t xPortStartScheduler( void )
 {
-	/* configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to 0.
-	See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
-	configASSERT( configMAX_SYSCALL_INTERRUPT_PRIORITY );
+    /* configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to 0.
+    See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
+    configASSERT( configMAX_SYSCALL_INTERRUPT_PRIORITY );
 
-	/* This port can be used on all revisions of the Cortex-M7 core other than
-	the r0p1 parts.  r0p1 parts should use the port from the
-	/source/portable/GCC/ARM_CM7/r0p1 directory. */
-	configASSERT( portCPUID != portCORTEX_M7_r0p1_ID );
-	configASSERT( portCPUID != portCORTEX_M7_r0p0_ID );
+    /* This port can be used on all revisions of the Cortex-M7 core other than
+    the r0p1 parts.  r0p1 parts should use the port from the
+    /source/portable/GCC/ARM_CM7/r0p1 directory. */
+    configASSERT( portCPUID != portCORTEX_M7_r0p1_ID );
+    configASSERT( portCPUID != portCORTEX_M7_r0p0_ID );
 
-	#if( configASSERT_DEFINED == 1 )
-	{
-		volatile uint32_t ulOriginalPriority;
-		volatile uint8_t * const pucFirstUserPriorityRegister = ( volatile uint8_t * const ) ( portNVIC_IP_REGISTERS_OFFSET_16 + portFIRST_USER_INTERRUPT_NUMBER );
-		volatile uint8_t ucMaxPriorityValue;
+    #if( configASSERT_DEFINED == 1 )
+    {
+        volatile uint32_t ulOriginalPriority;
+        volatile uint8_t * const pucFirstUserPriorityRegister = ( volatile uint8_t * const ) ( portNVIC_IP_REGISTERS_OFFSET_16 + portFIRST_USER_INTERRUPT_NUMBER );
+        volatile uint8_t ucMaxPriorityValue;
 
-		/* Determine the maximum priority from which ISR safe FreeRTOS API
-		functions can be called.  ISR safe functions are those that end in
-		"FromISR".  FreeRTOS maintains separate thread and ISR API functions to
-		ensure interrupt entry is as fast and simple as possible.
+        /* Determine the maximum priority from which ISR safe FreeRTOS API
+        functions can be called.  ISR safe functions are those that end in
+        "FromISR".  FreeRTOS maintains separate thread and ISR API functions to
+        ensure interrupt entry is as fast and simple as possible.
 
-		Save the interrupt priority value that is about to be clobbered. */
-		ulOriginalPriority = *pucFirstUserPriorityRegister;
+        Save the interrupt priority value that is about to be clobbered. */
+        ulOriginalPriority = *pucFirstUserPriorityRegister;
 
-		/* Determine the number of priority bits available.  First write to all
-		possible bits. */
-		*pucFirstUserPriorityRegister = portMAX_8_BIT_VALUE;
+        /* Determine the number of priority bits available.  First write to all
+        possible bits. */
+        *pucFirstUserPriorityRegister = portMAX_8_BIT_VALUE;
 
-		/* Read the value back to see how many bits stuck. */
-		ucMaxPriorityValue = *pucFirstUserPriorityRegister;
+        /* Read the value back to see how many bits stuck. */
+        ucMaxPriorityValue = *pucFirstUserPriorityRegister;
 
-		/* Use the same mask on the maximum system call priority. */
-		ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
+        /* Use the same mask on the maximum system call priority. */
+        ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
 
-		/* Calculate the maximum acceptable priority group value for the number
-		of bits read back. */
-		ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS;
-		while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
-		{
-			ulMaxPRIGROUPValue--;
-			ucMaxPriorityValue <<= ( uint8_t ) 0x01;
-		}
+        /* Calculate the maximum acceptable priority group value for the number
+        of bits read back. */
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS;
+        while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
+        {
+            ulMaxPRIGROUPValue--;
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+        }
 
-		#ifdef __NVIC_PRIO_BITS
-		{
-			/* Check the CMSIS configuration that defines the number of
-			priority bits matches the number of priority bits actually queried
-			from the hardware. */
-			configASSERT( ( portMAX_PRIGROUP_BITS - ulMaxPRIGROUPValue ) == __NVIC_PRIO_BITS );
-		}
-		#endif
+        #ifdef __NVIC_PRIO_BITS
+        {
+            /* Check the CMSIS configuration that defines the number of
+            priority bits matches the number of priority bits actually queried
+            from the hardware. */
+            configASSERT( ( portMAX_PRIGROUP_BITS - ulMaxPRIGROUPValue ) == __NVIC_PRIO_BITS );
+        }
+        #endif
 
-		#ifdef configPRIO_BITS
-		{
-			/* Check the FreeRTOS configuration that defines the number of
-			priority bits matches the number of priority bits actually queried
-			from the hardware. */
-			configASSERT( ( portMAX_PRIGROUP_BITS - ulMaxPRIGROUPValue ) == configPRIO_BITS );
-		}
-		#endif
+        #ifdef configPRIO_BITS
+        {
+            /* Check the FreeRTOS configuration that defines the number of
+            priority bits matches the number of priority bits actually queried
+            from the hardware. */
+            configASSERT( ( portMAX_PRIGROUP_BITS - ulMaxPRIGROUPValue ) == configPRIO_BITS );
+        }
+        #endif
 
-		/* Shift the priority group value back to its position within the AIRCR
-		register. */
-		ulMaxPRIGROUPValue <<= portPRIGROUP_SHIFT;
-		ulMaxPRIGROUPValue &= portPRIORITY_GROUP_MASK;
+        /* Shift the priority group value back to its position within the AIRCR
+        register. */
+        ulMaxPRIGROUPValue <<= portPRIGROUP_SHIFT;
+        ulMaxPRIGROUPValue &= portPRIORITY_GROUP_MASK;
 
-		/* Restore the clobbered interrupt priority register to its original
-		value. */
-		*pucFirstUserPriorityRegister = ulOriginalPriority;
-	}
-	#endif /* conifgASSERT_DEFINED */
+        /* Restore the clobbered interrupt priority register to its original
+        value. */
+        *pucFirstUserPriorityRegister = ulOriginalPriority;
+    }
+    #endif /* conifgASSERT_DEFINED */
 
-	/* Make PendSV and SysTick the lowest priority interrupts. */
-	portNVIC_SYSPRI2_REG |= portNVIC_PENDSV_PRI;
-	portNVIC_SYSPRI2_REG |= portNVIC_SYSTICK_PRI;
+    /* Make PendSV and SysTick the lowest priority interrupts. */
+    portNVIC_SYSPRI2_REG |= portNVIC_PENDSV_PRI;
+    portNVIC_SYSPRI2_REG |= portNVIC_SYSTICK_PRI;
 
-	/* Start the timer that generates the tick ISR.  Interrupts are disabled
-	here already. */
-	vPortSetupTimerInterrupt();
+    /* Start the timer that generates the tick ISR.  Interrupts are disabled
+    here already. */
+    vPortSetupTimerInterrupt();
 
-	/* Initialise the critical nesting count ready for the first task. */
-	uxCriticalNesting = 0;
+    /* Initialise the critical nesting count ready for the first task. */
+    uxCriticalNesting = 0;
 
-	/* Ensure the VFP is enabled - it should be anyway. */
-	vPortEnableVFP();
+    /* Ensure the VFP is enabled - it should be anyway. */
+    vPortEnableVFP();
 
-	/* Lazy save always. */
-	*( portFPCCR ) |= portASPEN_AND_LSPEN_BITS;
+    /* Lazy save always. */
+    *( portFPCCR ) |= portASPEN_AND_LSPEN_BITS;
 
-	/* Start the first task. */
-	prvPortStartFirstTask();
+    if(setjmp(xJumpBuf) != 0 ) {
+        /* When back while the scheduler ends */
+        return 1;
+    }
 
-	/* Should never get here as the tasks will now be executing!  Call the task
-	exit error function to prevent compiler warnings about a static function
-	not being called in the case that the application writer overrides this
-	functionality by defining configTASK_RETURN_ADDRESS.  Call
-	vTaskSwitchContext() so link time optimisation does not remove the
-	symbol. */
-	vTaskSwitchContext();
-	prvTaskExitError();
 
-	/* Should not get here! */
-	return 0;
+    /* Start the first task. */
+    prvPortStartFirstTask();
+
+    /* Should not get here! */
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 void vPortEndScheduler( void )
 {
-	/* Not implemented in ports where there is nothing to return to.
-	Artificially force an assert. */
-	//configASSERT( uxCriticalNesting == 1000UL );
+    /* Not implemented in ports where there is nothing to return to.
+    Artificially force an assert. */
+    //configASSERT( uxCriticalNesting == 1000UL );
+    vPortStopTimerInterrupt();
+    uxCriticalNesting = portNESTING_START_VALUE;
+    portENABLE_INTERRUPTS();
+    longjmp(xJumpBuf, 1);
 }
 /*-----------------------------------------------------------*/
 
 void vPortEnterCritical( void )
 {
-	portDISABLE_INTERRUPTS();
-	uxCriticalNesting++;
+    portDISABLE_INTERRUPTS();
+    uxCriticalNesting++;
 
-	/* This is not the interrupt safe version of the enter critical function so
-	assert() if it is being called from an interrupt context.  Only API
-	functions that end in "FromISR" can be used in an interrupt.  Only assert if
-	the critical nesting count is 1 to protect against recursive calls if the
-	assert function also uses a critical section. */
-	if( uxCriticalNesting == 1 )
-	{
-		configASSERT( ( portNVIC_INT_CTRL_REG & portVECTACTIVE_MASK ) == 0 );
-	}
+    /* This is not the interrupt safe version of the enter critical function so
+    assert() if it is being called from an interrupt context.  Only API
+    functions that end in "FromISR" can be used in an interrupt.  Only assert if
+    the critical nesting count is 1 to protect against recursive calls if the
+    assert function also uses a critical section. */
+    if( uxCriticalNesting == 1 )
+    {
+        configASSERT( ( portNVIC_INT_CTRL_REG & portVECTACTIVE_MASK ) == 0 );
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vPortExitCritical( void )
 {
-	configASSERT( uxCriticalNesting );
-	uxCriticalNesting--;
-	if( uxCriticalNesting == 0 )
-	{
-		portENABLE_INTERRUPTS();
-	}
+    configASSERT( uxCriticalNesting );
+    uxCriticalNesting--;
+    if( uxCriticalNesting == 0 )
+    {
+        portENABLE_INTERRUPTS();
+    }
 }
 /*-----------------------------------------------------------*/
 
 void xPortPendSVHandler( void )
 {
-	/* This is a naked function. */
+    /* This is a naked function. */
 
-	__asm volatile
-	(
-	"	mrs r0, psp							\n"
-	"	isb									\n"
-	"										\n"
-	"	ldr	r3, pxCurrentTCBConst			\n" /* Get the location of the current TCB. */
-	"	ldr	r2, [r3]						\n"
-	"										\n"
-	"	tst r14, #0x10						\n" /* Is the task using the FPU context?  If so, push high vfp registers. */
-	"	it eq								\n"
-	"	vstmdbeq r0!, {s16-s31}				\n"
-	"										\n"
-	"	stmdb r0!, {r4-r11, r14}			\n" /* Save the core registers. */
-	"	str r0, [r2]						\n" /* Save the new top of stack into the first member of the TCB. */
-	"										\n"
-	"	stmdb sp!, {r0, r3}					\n"
-	"	mov r0, %0 							\n"
-	"	msr basepri, r0						\n"
-	"	dsb									\n"
-	"	isb									\n"
-	"	bl vTaskSwitchContext				\n"
-	"	mov r0, #0							\n"
-	"	msr basepri, r0						\n"
-	"	ldmia sp!, {r0, r3}					\n"
-	"										\n"
-	"	ldr r1, [r3]						\n" /* The first item in pxCurrentTCB is the task top of stack. */
-	"	ldr r0, [r1]						\n"
-	"										\n"
-	"	ldmia r0!, {r4-r11, r14}			\n" /* Pop the core registers. */
-	"										\n"
-	"	tst r14, #0x10						\n" /* Is the task using the FPU context?  If so, pop the high vfp registers too. */
-	"	it eq								\n"
-	"	vldmiaeq r0!, {s16-s31}				\n"
-	"										\n"
-	"	msr psp, r0							\n"
-	"	isb									\n"
-	"										\n"
-	#ifdef WORKAROUND_PMU_CM001 /* XMC4000 specific errata workaround. */
-		#if WORKAROUND_PMU_CM001 == 1
-	"			push { r14 }				\n"
-	"			pop { pc }					\n"
-		#endif
-	#endif
-	"										\n"
-	"	bx r14								\n"
-	"										\n"
-	"	.align 4							\n"
-	"pxCurrentTCBConst: .word pxCurrentTCB	\n"
-	::"i"(configMAX_SYSCALL_INTERRUPT_PRIORITY)
-	);
+    __asm volatile
+    (
+    "   mrs r0, psp                         \n"
+    "   isb                                 \n"
+    "                                       \n"
+    "   ldr r3, pxCurrentTCBConst           \n" /* Get the location of the current TCB. */
+    "   ldr r2, [r3]                        \n"
+    "                                       \n"
+    "   tst r14, #0x10                      \n" /* Is the task using the FPU context?  If so, push high vfp registers. */
+    "   it eq                               \n"
+    "   vstmdbeq r0!, {s16-s31}             \n"
+    "                                       \n"
+    "   stmdb r0!, {r4-r11, r14}            \n" /* Save the core registers. */
+    "   str r0, [r2]                        \n" /* Save the new top of stack into the first member of the TCB. */
+    "                                       \n"
+    "   stmdb sp!, {r0, r3}                 \n"
+    "   mov r0, %0                          \n"
+    "   msr basepri, r0                     \n"
+    "   dsb                                 \n"
+    "   isb                                 \n"
+    "   bl vTaskSwitchContext               \n"
+    "   mov r0, #0                          \n"
+    "   msr basepri, r0                     \n"
+    "   ldmia sp!, {r0, r3}                 \n"
+    "                                       \n"
+    "   ldr r1, [r3]                        \n" /* The first item in pxCurrentTCB is the task top of stack. */
+    "   ldr r0, [r1]                        \n"
+    "                                       \n"
+    "   ldmia r0!, {r4-r11, r14}            \n" /* Pop the core registers. */
+    "                                       \n"
+    "   tst r14, #0x10                      \n" /* Is the task using the FPU context?  If so, pop the high vfp registers too. */
+    "   it eq                               \n"
+    "   vldmiaeq r0!, {s16-s31}             \n"
+    "                                       \n"
+    "   msr psp, r0                         \n"
+    "   isb                                 \n"
+    "                                       \n"
+    #ifdef WORKAROUND_PMU_CM001 /* XMC4000 specific errata workaround. */
+        #if WORKAROUND_PMU_CM001 == 1
+    "           push { r14 }                \n"
+    "           pop { pc }                  \n"
+        #endif
+    #endif
+    "                                       \n"
+    "   bx r14                              \n"
+    "                                       \n"
+    "   .align 4                            \n"
+    "pxCurrentTCBConst: .word pxCurrentTCB  \n"
+    ::"i"(configMAX_SYSCALL_INTERRUPT_PRIORITY)
+    );
 }
 /*-----------------------------------------------------------*/
 
 void xPortSysTickHandler( void )
 {
-	/* The SysTick runs at the lowest interrupt priority, so when this interrupt
-	executes all interrupts must be unmasked.  There is therefore no need to
-	save and then restore the interrupt mask value as its value is already
-	known. */
-	portDISABLE_INTERRUPTS();
-	if (traceSYSTEM_TIMER) traceISR_ENTER();
-	{
-		/* Increment the RTOS tick. */
-		if( xTaskIncrementTick() != pdFALSE )
-		{
-			if (traceSYSTEM_TIMER) traceISR_EXIT_TO_SCHEDULER();
-			/* A context switch is required.  Context switching is performed in
-			the PendSV interrupt.  Pend the PendSV interrupt. */
-			portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
-		}
-		else
-		{
-			if (traceSYSTEM_TIMER) traceISR_EXIT();
-		}
-	}
-	portENABLE_INTERRUPTS();
+    /* The SysTick runs at the lowest interrupt priority, so when this interrupt
+    executes all interrupts must be unmasked.  There is therefore no need to
+    save and then restore the interrupt mask value as its value is already
+    known. */
+    portDISABLE_INTERRUPTS();
+    if (traceSYSTEM_TIMER) traceISR_ENTER();
+    {
+        /* Increment the RTOS tick. */
+        if( xTaskIncrementTick() != pdFALSE )
+        {
+            if (traceSYSTEM_TIMER) traceISR_EXIT_TO_SCHEDULER();
+            /* A context switch is required.  Context switching is performed in
+            the PendSV interrupt.  Pend the PendSV interrupt. */
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            if (traceSYSTEM_TIMER) traceISR_EXIT();
+        }
+    }
+    portENABLE_INTERRUPTS();
 }
 
 
 /* This is a naked function. */
 static void vPortEnableVFP( void )
 {
-	__asm volatile
-	(
-		"	ldr.w r0, =0xE000ED88		\n" /* The FPU enable bits are in the CPACR. */
-		"	ldr r1, [r0]				\n"
-		"								\n"
-		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
-		"	str r1, [r0]				\n"
-		"	bx r14						"
-	);
+    __asm volatile
+    (
+        "   ldr.w r0, =0xE000ED88       \n" /* The FPU enable bits are in the CPACR. */
+        "   ldr r1, [r0]                \n"
+        "                               \n"
+        "   orr r1, r1, #( 0xf << 20 )  \n" /* Enable CP10 and CP11 coprocessors, then save back. */
+        "   str r1, [r0]                \n"
+        "   bx r14                      "
+    );
 }
 /*-----------------------------------------------------------*/
 
 #if( configASSERT_DEFINED == 1 )
 
-	void vPortValidateInterruptPriority( void )
-	{
-	uint32_t ulCurrentInterrupt;
-	uint8_t ucCurrentPriority;
+    void vPortValidateInterruptPriority( void )
+    {
+    uint32_t ulCurrentInterrupt;
+    uint8_t ucCurrentPriority;
 
-		/* Obtain the number of the currently executing interrupt. */
-		__asm volatile( "mrs %0, ipsr" : "=r"( ulCurrentInterrupt ) :: "memory" );
+        /* Obtain the number of the currently executing interrupt. */
+        __asm volatile( "mrs %0, ipsr" : "=r"( ulCurrentInterrupt ) :: "memory" );
 
-		/* Is the interrupt number a user defined interrupt? */
-		if( ulCurrentInterrupt >= portFIRST_USER_INTERRUPT_NUMBER )
-		{
-			/* Look up the interrupt's priority. */
-			ucCurrentPriority = pcInterruptPriorityRegisters[ ulCurrentInterrupt ];
+        /* Is the interrupt number a user defined interrupt? */
+        if( ulCurrentInterrupt >= portFIRST_USER_INTERRUPT_NUMBER )
+        {
+            /* Look up the interrupt's priority. */
+            ucCurrentPriority = pcInterruptPriorityRegisters[ ulCurrentInterrupt ];
 
-			/* The following assertion will fail if a service routine (ISR) for
-			an interrupt that has been assigned a priority above
-			configMAX_SYSCALL_INTERRUPT_PRIORITY calls an ISR safe FreeRTOS API
-			function.  ISR safe FreeRTOS API functions must *only* be called
-			from interrupts that have been assigned a priority at or below
-			configMAX_SYSCALL_INTERRUPT_PRIORITY.
+            /* The following assertion will fail if a service routine (ISR) for
+            an interrupt that has been assigned a priority above
+            configMAX_SYSCALL_INTERRUPT_PRIORITY calls an ISR safe FreeRTOS API
+            function.  ISR safe FreeRTOS API functions must *only* be called
+            from interrupts that have been assigned a priority at or below
+            configMAX_SYSCALL_INTERRUPT_PRIORITY.
 
-			Numerically low interrupt priority numbers represent logically high
-			interrupt priorities, therefore the priority of the interrupt must
-			be set to a value equal to or numerically *higher* than
-			configMAX_SYSCALL_INTERRUPT_PRIORITY.
+            Numerically low interrupt priority numbers represent logically high
+            interrupt priorities, therefore the priority of the interrupt must
+            be set to a value equal to or numerically *higher* than
+            configMAX_SYSCALL_INTERRUPT_PRIORITY.
 
-			Interrupts that	use the FreeRTOS API must not be left at their
-			default priority of	zero as that is the highest possible priority,
-			which is guaranteed to be above configMAX_SYSCALL_INTERRUPT_PRIORITY,
-			and	therefore also guaranteed to be invalid.
+            Interrupts that use the FreeRTOS API must not be left at their
+            default priority of zero as that is the highest possible priority,
+            which is guaranteed to be above configMAX_SYSCALL_INTERRUPT_PRIORITY,
+            and therefore also guaranteed to be invalid.
 
-			FreeRTOS maintains separate thread and ISR API functions to ensure
-			interrupt entry is as fast and simple as possible.
+            FreeRTOS maintains separate thread and ISR API functions to ensure
+            interrupt entry is as fast and simple as possible.
 
-			The following links provide detailed information:
-			http://www.freertos.org/RTOS-Cortex-M3-M4.html
-			http://www.freertos.org/FAQHelp.html */
-			configASSERT( ucCurrentPriority >= ucMaxSysCallPriority );
-		}
+            The following links provide detailed information:
+            http://www.freertos.org/RTOS-Cortex-M3-M4.html
+            http://www.freertos.org/FAQHelp.html */
+            configASSERT( ucCurrentPriority >= ucMaxSysCallPriority );
+        }
 
-		/* Priority grouping:  The interrupt controller (NVIC) allows the bits
-		that define each interrupt's priority to be split between bits that
-		define the interrupt's pre-emption priority bits and bits that define
-		the interrupt's sub-priority.  For simplicity all bits must be defined
-		to be pre-emption priority bits.  The following assertion will fail if
-		this is not the case (if some bits represent a sub-priority).
+        /* Priority grouping:  The interrupt controller (NVIC) allows the bits
+        that define each interrupt's priority to be split between bits that
+        define the interrupt's pre-emption priority bits and bits that define
+        the interrupt's sub-priority.  For simplicity all bits must be defined
+        to be pre-emption priority bits.  The following assertion will fail if
+        this is not the case (if some bits represent a sub-priority).
 
-		If the application only uses CMSIS libraries for interrupt
-		configuration then the correct setting can be achieved on all Cortex-M
-		devices by calling NVIC_SetPriorityGrouping( 0 ); before starting the
-		scheduler.  Note however that some vendor specific peripheral libraries
-		assume a non-zero priority group setting, in which cases using a value
-		of zero will result in unpredictable behaviour. */
-		configASSERT( ( portAIRCR_REG & portPRIORITY_GROUP_MASK ) <= ulMaxPRIGROUPValue );
-	}
+        If the application only uses CMSIS libraries for interrupt
+        configuration then the correct setting can be achieved on all Cortex-M
+        devices by calling NVIC_SetPriorityGrouping( 0 ); before starting the
+        scheduler.  Note however that some vendor specific peripheral libraries
+        assume a non-zero priority group setting, in which cases using a value
+        of zero will result in unpredictable behaviour. */
+        configASSERT( ( portAIRCR_REG & portPRIORITY_GROUP_MASK ) <= ulMaxPRIGROUPValue );
+    }
 
 #endif /* configASSERT_DEFINED */
 

--- a/products/PurePhone/PurePhoneMain.cpp
+++ b/products/PurePhone/PurePhoneMain.cpp
@@ -207,6 +207,6 @@ int main()
     LOG_PRINTF("Launching %s \n", ApplicationName);
     LOG_PRINTF("commit: %s version: %s branch: %s\n", GIT_REV, VERSION, GIT_BRANCH);
     cpp_freertos::Thread::StartScheduler();
-
+    LOG_PRINTF("Scheduler is terminated properly\n");
     return 0;
 }


### PR DESCRIPTION
Add support to the FreeRTOS to be able to back to main
functon when the scheduler is terminated.

Signed-off-by: Lucjan Bryndza <lucjan.bryndza@mudita.com>