### PR TITLE
[BH-1328] Remove "Units" Literal

### DIFF
--- a/image/assets/lang/Deutsch.json
+++ b/image/assets/lang/Deutsch.json
@@ -638,7 +638,7 @@
   "app_bell_settings_bedtime_settings_volume": "<text>Lautstärke</text>",
   "app_bell_settings_advanced": "Erweitert",
   "app_bell_settings_turn_off": "Ausschalten",
-  "app_bell_settings_time_units": "Zeit und Einheiten",
+  "app_bell_settings_time_units": "Zeit",
   "app_bell_settings_language": "Sprache",
   "app_bell_settings_about": "Information",
   "app_bell_settings_about_product": "Mudita Harmony",

--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -609,7 +609,7 @@
   "app_bell_onboarding_info_deep_click_correction": "<text font='gt_pressura' weight='light' size='38'>Be more gentle,<br></br>try </text><text font='gt_pressura' weight='regular' size='38'>light click </text><text font='gt_pressura' weight='light' size='38'>this time</text>",
   "app_bell_onboarding_welcome": "Welcome",
   "app_bell_settings_advanced": "Advanced",
-  "app_bell_settings_time_units": "Time & units",
+  "app_bell_settings_time_units": "Time",
   "app_bell_settings_temp_scale": "Temperature scale",
   "app_bell_settings_language": "Language",
   "app_bell_settings_about": "About",

--- a/image/assets/lang/Espanol.json
+++ b/image/assets/lang/Espanol.json
@@ -638,7 +638,7 @@
   "app_bell_settings_bedtime_settings_volume": "Volumen",
   "app_bell_settings_advanced": "Avanzados",
   "app_bell_settings_turn_off": "Apagar",
-  "app_bell_settings_time_units": "Hora y unidades",
+  "app_bell_settings_time_units": "Hora",
   "app_bell_settings_language": "Idioma",
   "app_bell_settings_about": "Información",
   "app_bell_settings_about_product": "Mudita Harmony",

--- a/image/assets/lang/Francais.json
+++ b/image/assets/lang/Francais.json
@@ -608,7 +608,7 @@
   "app_bell_settings_bedtime_settings_volume": "Volume",
   "app_bell_settings_advanced": "Avancé",
   "app_bell_settings_turn_off": "Éteindre",
-  "app_bell_settings_time_units": "Temps et unités",
+  "app_bell_settings_time_units": "Temps",
   "app_bell_settings_language": "Langue",
   "app_bell_settings_about": "À propos",
   "app_bell_settings_about_product": "Mudita Harmony",

--- a/image/assets/lang/Polski.json
+++ b/image/assets/lang/Polski.json
@@ -629,7 +629,7 @@
   "app_bell_onboarding_info_deep_click_correction": "<text font='gt_pressura' weight='light' size='38'>Bądź bardziej delikatny,<br></br>spróbuj </text><text font='gt_pressura' weight='regular' size='38'>tym razem<br></br></text><text font='gt_pressura' weight='light' size='38'>lekko kliknąć</text>",
   "app_bell_onboarding_welcome": "Witamy",
   "app_bell_settings_advanced": "Zaawansowane",
-  "app_bell_settings_time_units": "Czas i jednostki",
+  "app_bell_settings_time_units": "Czas",
   "app_bell_settings_temp_scale": "Skala temperatury",
   "app_bell_settings_alarm_settings": "Alarm",
   "app_bell_settings_alarm_settings_title": "Ustawienia alarmu",


### PR DESCRIPTION
"Units" is removed from Time&Units app name