### PR TITLE
[EGD-8141] Fix brownout handling while charging

### DIFF
--- a/module-bsp/board/rt1051/puretx/hal/battery_charger/BatteryCharger.hpp
+++ b/module-bsp/board/rt1051/puretx/hal/battery_charger/BatteryCharger.hpp
@@ -1,9 +1,10 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include <hal/battery_charger/AbstractBatteryCharger.hpp>
+#include <timers.h>
 
 namespace hal::battery
 {
@@ -21,6 +22,7 @@ namespace hal::battery
         void checkBatteryChargerInterrupts();
 
         AbstractBatteryCharger::BatteryChargerEvents &eventsHandler;
+        TimerHandle_t timerHandle;
     };
 
     BaseType_t INTBHandlerIRQ();


### PR DESCRIPTION
When the voltage dropped below the brownout threshold,
the system did not detect the battery charging
and displayed a window with the low battery icon all the time.