### PR TITLE
[EGD-8108] Bugfix typo fix

### DIFF
--- a/module-apps/apps-common/popups/presenter/AlarmPresenter.cpp
+++ b/module-apps/apps-common/popups/presenter/AlarmPresenter.cpp
@@ -167,7 +167,7 @@ namespace app::popup
 
     bool AlarmPopupPresenter::haveSnoozedSkip()
     {
-        return isSnoozed() && snoozedTill().empty();
+        return isSnoozed() && !snoozedTill().empty();
     }
 
     std::string AlarmPopupPresenter::snoozedTill()


### PR DESCRIPTION
There was typo in check (missin **!** ) when copied the test in if :face_exhaling: 

![image](https://user-images.githubusercontent.com/6411862/149358477-23ecf0c8-f2a6-4c92-99e8-850e46d86221.png)
for: 7127efa876eef0f593ba8358e911b606d06a14dc