### PR TITLE
[EGD-7359] Remove 0 connection frequency for message only mode

### DIFF
--- a/image/user/db/settings_bell_002.sql
+++ b/image/user/db/settings_bell_002.sql
@@ -1,4 +1,4 @@
--- Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+-- Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 -- For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 -- ----------- insert default values ----------------------
@@ -20,7 +20,7 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('battery_critical_level', '10'),
     ('cl_offline_mode', '0'),
     ('cl_current_uid', '0'),
-    ('off_connection_frequency', '0'),
+    ('off_connection_frequency', '15'),
     ('off_notifications_when_locked', '0'),
     ('off_calls_from_favorites', '0'),
     ('\EventManager\\br_state', '0'),

--- a/image/user/db/settings_v2_002-devel.sql
+++ b/image/user/db/settings_v2_002-devel.sql
@@ -1,4 +1,4 @@
--- Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+-- Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 -- For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 -- ----------- insert default values ----------------------
@@ -32,7 +32,7 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('\ServiceBluetooth\\bt_bonded_devices', ''),
     ('battery_critical_level', '10'),
     ('cl_offline_mode', '1'),
-    ('off_connection_frequency', '0'),
+    ('off_connection_frequency', '15'),
     ('off_notifications_when_locked', '0'),
     ('off_calls_from_favorites', '0'),
     ('\EventManager\\br_state', '0'),

--- a/image/user/db/settings_v2_002.sql
+++ b/image/user/db/settings_v2_002.sql
@@ -1,4 +1,4 @@
--- Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+-- Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 -- For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 -- ----------- insert default values ----------------------
@@ -33,7 +33,7 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('battery_critical_level', '10'),
     ('cl_offline_mode', '1'),
     ('cl_current_uid', '0'),
-    ('off_connection_frequency', '0'),
+    ('off_connection_frequency', '15'),
     ('off_notifications_when_locked', '0'),
     ('off_calls_from_favorites', '0'),
     ('\EventManager\\br_state', '0'),

--- a/module-apps/application-settings/windows/phone-modes/ConnectionFrequencyWindow.cpp
+++ b/module-apps/application-settings/windows/phone-modes/ConnectionFrequencyWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ConnectionFrequencyWindow.hpp"
@@ -28,9 +28,6 @@ namespace gui
         std::list<gui::Option> optList;
 
         auto intervalText = [](uint8_t value) {
-            if (value == 0) {
-                return utils::translate("app_alarm_clock_repeat_never");
-            }
             const std::string toReplace = "%0";
             std::string temp            = utils::translate("app_meditation_interval_every_x_minutes");
             temp.replace(temp.find(toReplace), toReplace.size(), std::to_string(value));

--- a/module-apps/application-settings/windows/phone-modes/ConnectionFrequencyWindow.hpp
+++ b/module-apps/application-settings/windows/phone-modes/ConnectionFrequencyWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -19,7 +19,7 @@ namespace gui
         void rebuild() override;
         app::settingsInterface::ConnectionSettings *connectionSettings;
         void updateInterval(uint8_t value);
-        std::vector<uint8_t> frequency{0, 15, 30, 45, 60};
+        std::vector<uint8_t> frequency{15, 30, 45, 60};
 
       public:
         ConnectionFrequencyWindow(app::ApplicationCommon *app,


### PR DESCRIPTION
When Offline/Message only mode is set, Pure should log into
the network to send and download messages based on
connection frequency. The default option was set to 0, which
meant that the message-only mode was not working at all.

![image](https://user-images.githubusercontent.com/58421550/149385937-52db4938-0ff6-4bcf-8354-43bddbc084e6.png)
