### PR TITLE
[EGD-8156] Fix cellular on system close whitelists

### DIFF
--- a/module-services/service-cellular/service-cellular/Constans.hpp
+++ b/module-services/service-cellular/service-cellular/Constans.hpp
@@ -1,0 +1,11 @@
+// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <service-cellular/api/common.hpp>
+
+namespace service::name
+{
+    inline constexpr auto cellular = cellular::service::name;
+};

--- a/module-sys/SystemManager/SystemManagerCommon.cpp
+++ b/module-sys/SystemManager/SystemManagerCommon.cpp
@@ -20,6 +20,7 @@
 #include <service-desktop/Constants.hpp>
 #include <service-appmgr/Constants.hpp>
 #include <service-appmgr/Controller.hpp>
+#include <service-cellular/Constans.hpp>
 #include <system/messages/DeviceRegistrationMessage.hpp>
 #include <system/messages/SentinelRegistrationMessage.hpp>
 #include <system/messages/RequestCpuFrequencyMessage.hpp>
@@ -51,7 +52,8 @@ namespace sys
                                                      service::name::gui,
                                                      service::name::db,
                                                      service::name::eink,
-                                                     service::name::appmgr};
+                                                     service::name::appmgr,
+                                                     service::name::cellular};
         }
 
         namespace restore
@@ -60,12 +62,13 @@ namespace sys
                                                      service::name::evt_manager,
                                                      service::name::gui,
                                                      service::name::eink,
-                                                     service::name::appmgr};
+                                                     service::name::appmgr,
+                                                     service::name::cellular};
         }
 
         namespace regularClose
         {
-            static constexpr std::array whitelist = {service::name::evt_manager};
+            static constexpr std::array whitelist = {service::name::evt_manager, service::name::cellular};
         }
 
         template <typename T> static bool isOnWhitelist(const T &list, const std::string &serviceName)


### PR DESCRIPTION
Service cellular is added to system close whitelists.
It prevents hard fault when cellular is blocked
on long command handler.