### PR TITLE
[EGD-8034] Switch elements order on date and time screen

### DIFF
--- a/module-apps/application-settings/windows/system/DateAndTimeMainWindow.cpp
+++ b/module-apps/application-settings/windows/system/DateAndTimeMainWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DateAndTimeMainWindow.hpp"
@@ -58,14 +58,14 @@ namespace gui
             automaticDateAndTimeIsOn ? option::SettingRightItem::On : option::SettingRightItem::Off);
 
         if (!automaticDateAndTimeIsOn) {
-            addOption(utils::translate("app_settings_date_and_time_change_date_and_time"), [=](Item &item) {
-                LOG_INFO("switching to %s page", changeDateAndTimeWindow.c_str());
-                application->switchWindow(changeDateAndTimeWindow, nullptr);
-                return true;
-            });
             addOption(utils::translate("app_settings_date_and_time_change_time_zone"), [=](Item &item) {
                 LOG_INFO("switching to %s page", window::name::change_time_zone);
                 application->switchWindow(window::name::change_time_zone, nullptr);
+                return true;
+            });
+            addOption(utils::translate("app_settings_date_and_time_change_date_and_time"), [=](Item &item) {
+                LOG_INFO("switching to %s page", changeDateAndTimeWindow.c_str());
+                application->switchWindow(changeDateAndTimeWindow, nullptr);
                 return true;
             });
         }


### PR DESCRIPTION
Elements in the date and time screen were in the wrong order.
Now they are aligned with design.