### PR TITLE
[EGD-8168] Fix Fixed lock screen in Calendar and Meditation

### DIFF
--- a/module-apps/application-calendar/ApplicationCalendar.cpp
+++ b/module-apps/application-calendar/ApplicationCalendar.cpp
@@ -22,7 +22,7 @@ namespace app
         if (retMsg && (dynamic_cast<sys::ResponseMessage *>(retMsg.get())->retCode == sys::ReturnCodes::Success)) {
             return retMsg;
         }
-        return std::make_shared<sys::ResponseMessage>();
+        return handleAsyncResponse(resp);
     }
 
     sys::ReturnCodes ApplicationCalendar::InitHandler()

--- a/module-apps/application-meditation/ApplicationMeditation.cpp
+++ b/module-apps/application-meditation/ApplicationMeditation.cpp
@@ -30,7 +30,13 @@ namespace app
     auto ApplicationMeditation::DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp)
         -> sys::MessagePointer
     {
-        return Application::DataReceivedHandler(msgl);
+        auto retMsg = Application::DataReceivedHandler(msgl);
+        // if message was handled by application's template there is no need to process further.
+        if (retMsg && (dynamic_cast<sys::ResponseMessage *>(retMsg.get())->retCode == sys::ReturnCodes::Success)) {
+            return retMsg;
+        }
+
+        return handleAsyncResponse(resp);
     }
 
     auto ApplicationMeditation::SwitchPowerModeHandler(sys::ServicePowerMode mode) -> sys::ReturnCodes


### PR DESCRIPTION
Fixed empty Lock screen in applications Caledar and Meditation.
Error was caused by not handled messages response at all.