### PR TITLE
[EGD-8128] Baudrate change for cellular transmission

### DIFF
--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -2183,7 +2183,7 @@ auto ServiceCellular::handleNetworkStatusUpdateNotification(sys::Message *msg) -
 auto ServiceCellular::handleUrcIncomingNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
     // when handling URC, the CPU frequency does not go below a certain level
-    cpuSentinel->HoldMinimumFrequency(bsp::CpuFrequencyMHz::Level_4);
+    cpuSentinel->HoldMinimumFrequency(bsp::CpuFrequencyMHz::Level_2);
     cmux->exitSleepMode();
     return std::make_shared<CellularResponseMessage>(true);
 }

--- a/module-services/service-cellular/service-cellular/ServiceCellular.hpp
+++ b/module-services/service-cellular/service-cellular/ServiceCellular.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -105,7 +105,7 @@ class ServiceCellular : public sys::Service
 
   private:
     at::ATURCStream atURCStream;
-    std::unique_ptr<CellularMux> cmux = std::make_unique<CellularMux>(PortSpeed_e::PS460800, this);
+    std::unique_ptr<CellularMux> cmux = std::make_unique<CellularMux>(PortSpeed_e::PS115200, this);
     std::shared_ptr<sys::CpuSentinel> cpuSentinel;
 
     // used for polling for call state


### PR DESCRIPTION
UART baudrate changed from 460800 to 115200
* lower power consumption by modem
* CPU does not need to wake up to handle URC