### PR TITLE
[CP-1007] Add API for rebooting to USB MSC mode

### DIFF
--- a/module-bsp/board/rt1051/bsp/lpm/RT1051LPM.cpp
+++ b/module-bsp/board/rt1051/bsp/lpm/RT1051LPM.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "RT1051LPM.hpp"
@@ -60,6 +60,9 @@ namespace bsp
             break;
         case RebootType::GoToUpdaterFactoryReset:
             SNVS->LPGPR[0] = bsp::rebootCode::rebootToFactoryRstCode;
+            break;
+        case RebootType::GoToUsbMscMode:
+            SNVS->LPGPR[0] = bsp::rebootCode::rebootToUsbMscModeCode;
             break;
         case RebootType::NormalRestart:
             SNVS->LPGPR[0] = bsp::rebootCode::rebootNormalCode;

--- a/module-bsp/board/rt1051/common/reboot_codes.hpp
+++ b/module-bsp/board/rt1051/common/reboot_codes.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 // Copyright (c) 2021, Mudita Sp. z.o.o. All rights reserved.
@@ -16,6 +16,8 @@ namespace bsp
         rebootToUpdateCode     = std::uint32_t{0xdead0000},
         rebootToRecoveryCode   = std::uint32_t{0xdead0001},
         rebootToFactoryRstCode = std::uint32_t{0xdead0002},
+        // 0xdead0003 is reserved for eco_factory_pgm_keys
+        rebootToUsbMscModeCode = std::uint32_t{0x00000004},
         rebootFailedToBoot     = std::uint32_t{0xdeadFFFF}
     };
 } // namespace bsp

--- a/module-bsp/bsp/lpm/bsp_lpm.hpp
+++ b/module-bsp/bsp/lpm/bsp_lpm.hpp
@@ -21,6 +21,7 @@ namespace bsp
         enum class RebootType
         {
             NormalRestart,
+            GoToUsbMscMode,             // Reboot into USB MSC mode
             GoToUpdaterUpdate,       //! Goto updater into the update mode
             GoToUpdaterFactoryReset, //! GOto updater into the factory reset mode
             GoToUpdaterRecovery      //! Goto to updater into recovery mode

--- a/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
+++ b/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
@@ -157,14 +157,13 @@ namespace app::manager
         ActionRequest act = ActionRequest{this->GetName(), app::manager::actions::DisplayLogoAtExit, nullptr};
         switch (closeReason) {
         case sys::CloseReason::SystemBrownout:
-            [[fallthrough]];
         case sys::CloseReason::LowBattery:
             act = ActionRequest{this->GetName(), app::manager::actions::SystemBrownout, nullptr};
             break;
         case sys::CloseReason::RegularPowerDown:
-            [[fallthrough]];
         case sys::CloseReason::Reboot:
-            [[fallthrough]];
+        case sys::CloseReason::RebootToUpdate:
+        case sys::CloseReason::RebootToUsbMscMode:
         case sys::CloseReason::FactoryReset:
             break;
         }

--- a/module-services/service-desktop/endpoints/developerMode/DeveloperModeHelper.cpp
+++ b/module-services/service-desktop/endpoints/developerMode/DeveloperModeHelper.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <endpoints/developerMode/DeveloperModeHelper.hpp>
@@ -143,7 +143,6 @@ namespace sdesktop::endpoints
                        ? http::Code::NoContent
                        : http::Code::InternalServerError;
         }
-
         else {
             context.setResponseStatus(http::Code::BadRequest);
             putToSendQueue(context.createSimpleResponse());

--- a/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -25,30 +25,33 @@ namespace sdesktop::endpoints::json
     inline constexpr auto networkOperatorName = "networkOperatorName";
     inline constexpr auto accessTechnology    = "accessTechnology";
 
-    inline constexpr auto update              = "update";
-    inline constexpr auto updateInfo          = "updateInfo";
-    inline constexpr auto updateError         = "updateError";
-    inline constexpr auto errorCode           = "errorCode";
-    inline constexpr auto statusCode          = "statusCode";
-    inline constexpr auto updateHistory       = "updateHistory";
-    inline constexpr auto versionString       = "string";
-    inline constexpr auto fileExists          = "fileExists";
-    inline constexpr auto boot                = "boot";
-    inline constexpr auto version             = "version";
-    inline constexpr auto taskId              = "id";
-    inline constexpr auto state               = "state";
-    inline constexpr auto success             = "success";
-    inline constexpr auto request             = "request";
-    inline constexpr auto restore             = "restore";
-    inline constexpr auto finished            = "finished";
-    inline constexpr auto pending             = "pending";
-    inline constexpr auto location            = "location";
-    inline constexpr auto reason              = "reason";
-    inline constexpr auto serialNumber        = "serialNumber";
-    inline constexpr auto caseColour          = "caseColour";
-    inline constexpr auto fileList            = "fileList";
-    inline constexpr auto files               = "files";
-    inline constexpr auto backupLocation      = "backupLocation";
+    inline constexpr auto update         = "update";
+    inline constexpr auto updateInfo     = "updateInfo";
+    inline constexpr auto updateError    = "updateError";
+    inline constexpr auto errorCode      = "errorCode";
+    inline constexpr auto statusCode     = "statusCode";
+    inline constexpr auto updateHistory  = "updateHistory";
+    inline constexpr auto usbMscMode     = "usbMscMode";
+    inline constexpr auto versionString  = "string";
+    inline constexpr auto fileExists     = "fileExists";
+    inline constexpr auto boot           = "boot";
+    inline constexpr auto version        = "version";
+    inline constexpr auto taskId         = "id";
+    inline constexpr auto state          = "state";
+    inline constexpr auto success        = "success";
+    inline constexpr auto reboot         = "reboot";
+    inline constexpr auto rebootMode     = "rebootMode";
+    inline constexpr auto request        = "request";
+    inline constexpr auto restore        = "restore";
+    inline constexpr auto finished       = "finished";
+    inline constexpr auto pending        = "pending";
+    inline constexpr auto location       = "location";
+    inline constexpr auto reason         = "reason";
+    inline constexpr auto serialNumber   = "serialNumber";
+    inline constexpr auto caseColour     = "caseColour";
+    inline constexpr auto fileList       = "fileList";
+    inline constexpr auto files          = "files";
+    inline constexpr auto backupLocation = "backupLocation";
 
     namespace updateprocess
     {

--- a/module-services/service-desktop/endpoints/include/endpoints/developerMode/DeveloperModeHelper.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/developerMode/DeveloperModeHelper.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/module-services/service-desktop/endpoints/include/endpoints/update/UpdateHelper.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/update/UpdateHelper.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -7,7 +7,6 @@
 
 namespace sdesktop::endpoints
 {
-
     class UpdateHelper : public BaseHelper
     {
       public:
@@ -15,7 +14,7 @@ namespace sdesktop::endpoints
         {}
 
         auto processPost(Context &context) -> ProcessResult final;
+        auto processPut(Context &context) -> ProcessResult final;
         void preProcess(http::Method method, Context &context) final;
     };
-
 } // namespace sdesktop::endpoints

--- a/module-services/service-desktop/endpoints/update/UpdateHelper.cpp
+++ b/module-services/service-desktop/endpoints/update/UpdateHelper.cpp
@@ -1,8 +1,9 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include <endpoints/update/UpdateHelper.hpp>
 #include <endpoints/Context.hpp>
+#include <endpoints/JsonKeyNames.hpp>
+#include <endpoints/update/UpdateHelper.hpp>
 #include <log/log.hpp>
 #include <SystemManager/SystemManagerCommon.hpp>
 #include <purefs/filesystem_paths.hpp>
@@ -23,7 +24,7 @@ namespace sdesktop::endpoints
     {
         const auto &body = context.getBody();
 
-        if (!(body["update"] == true && body["reboot"] == true)) {
+        if (!(body[json::update] == true && body[json::reboot] == true)) {
             return {sent::no, ResponseContext{.status = http::Code::BadRequest}};
         }
 
@@ -36,6 +37,18 @@ namespace sdesktop::endpoints
         }
 
         return {sent::no, ResponseContext{.status = http::Code::InternalServerError}};
+    }
+
+    auto UpdateHelper::processPut(Context &context) -> ProcessResult
+    {
+        const auto &body = context.getBody();
+        auto code        = http::Code::BadRequest;
+        if (body[json::rebootMode] == json::usbMscMode) {
+            code = sys::SystemManagerCommon::RebootToUsbMscMode(owner) ? http::Code::NoContent
+                                                                       : http::Code::InternalServerError;
+        }
+
+        return {sent::no, ResponseContext{.status = code}};
     }
 
 } // namespace sdesktop::endpoints

--- a/module-sys/SystemManager/PowerManager.cpp
+++ b/module-sys/SystemManager/PowerManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <log/log.hpp>
@@ -55,6 +55,11 @@ namespace sys
     int32_t PowerManager::Reboot()
     {
         return lowPowerControl->Reboot(bsp::LowPowerMode::RebootType::NormalRestart);
+    }
+
+    int32_t PowerManager::RebootToUsbMscMode()
+    {
+        return lowPowerControl->Reboot(bsp::LowPowerMode::RebootType::GoToUsbMscMode);
     }
 
     int32_t PowerManager::RebootToUpdate(UpdateReason reason)

--- a/module-sys/SystemManager/include/SystemManager/PowerManager.hpp
+++ b/module-sys/SystemManager/include/SystemManager/PowerManager.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #ifndef PUREPHONE_POWERMANAGER_HPP
@@ -37,6 +37,7 @@ namespace sys
 
         int32_t PowerOff();
         int32_t Reboot();
+        int32_t RebootToUsbMscMode();
         int32_t RebootToUpdate(UpdateReason reason);
 
         /// called periodically to calculate the CPU requirement

--- a/module-sys/SystemManager/include/SystemManager/SystemManagerCommon.hpp
+++ b/module-sys/SystemManager/include/SystemManager/SystemManagerCommon.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -43,6 +43,7 @@ namespace sys
         Restore,
         Reboot,
         RebootToUpdate,
+        RebootToUsbMscMode,
         FactoryReset,
         None,
     };
@@ -80,7 +81,8 @@ namespace sys
             Shutdown,
             ShutdownReady,
             Reboot,
-            RebootToUpdate
+            RebootToUpdate,
+            RebootToUsbMscMode
         } state = State::Running;
 
         explicit SystemManagerCommon(std::vector<std::unique_ptr<BaseServiceCreator>> &&creators);
@@ -97,6 +99,8 @@ namespace sys
         static bool FactoryReset(Service *s);
 
         static bool Reboot(Service *s);
+
+        static bool RebootToUsbMscMode(Service *s);
 
         static bool RebootToUpdate(Service *s, UpdateReason updateReason);
 
@@ -179,6 +183,8 @@ namespace sys
 
         void RebootHandler(State state, std::optional<UpdateReason> updateReason = std::nullopt);
 
+        void RebootToUsbMscModeHandler(State newState);
+
         /// periodic update of cpu statistics
         void CpuStatisticsTimerHandler();
 
@@ -223,6 +229,9 @@ inline const char *c_str(sys::SystemManagerCommon::State state)
         return "Reboot";
     case sys::SystemManagerCommon::State::RebootToUpdate:
         return "RebootToUpdate";
+    case sys::SystemManagerCommon::State::RebootToUsbMscMode:
+        return "RebootToUsbMscModeUpdate";
+        break;
     case sys::SystemManagerCommon::State::ShutdownReady:
         return "ShutdownReady";
     }

--- a/module-sys/common/include/system/Common.hpp
+++ b/module-sys/common/include/system/Common.hpp
@@ -48,6 +48,8 @@ namespace sys
     {
         RegularPowerDown,
         Reboot,
+        RebootToUpdate,
+        RebootToUsbMscMode,
         FactoryReset,
         SystemBrownout,
         LowBattery


### PR DESCRIPTION
It will allow to reboot the device to USB MSC mode
without need to interact with a physical keyboard.