### PR TITLE
[EGD-8225] Fix incorrect logs of Power Manager Efficiency

### DIFF
--- a/module-sys/SystemManager/include/SystemManager/PowerManager.hpp
+++ b/module-sys/SystemManager/include/SystemManager/PowerManager.hpp
@@ -25,7 +25,7 @@ namespace sys
 
       private:
         std::string levelName;
-        TickType_t totalTicksCount{0};
+        std::uint64_t totalTicksCount{0};
     };
 
     class PowerManager


### PR DESCRIPTION
After a longer time (~ 14 hours), the Power Manager
Efficiency logs showed incorrect values.