### PR TITLE
[CP-1048] Database instance mix-up in predefinedQuotesDB backup code

### DIFF
--- a/products/PurePhone/services/db/ServiceDB.cpp
+++ b/products/PurePhone/services/db/ServiceDB.cpp
@@ -292,8 +292,8 @@ bool ServiceDB::StoreIntoBackup(const std::filesystem::path &backupPath)
         return false;
     }
 
-    if (customQuotesDB->storeIntoFile(backupPath / std::filesystem::path(predefinedQuotesDB->getName()).filename()) ==
-        false) {
+    if (predefinedQuotesDB->storeIntoFile(backupPath /
+                                          std::filesystem::path(predefinedQuotesDB->getName()).filename()) == false) {
         LOG_ERROR("predefinedQuotesDB backup failed");
         return false;
     }


### PR DESCRIPTION
Used proper instance of quotes DB to backup.