### PR TITLE
[EGD-8258] Fix directory name in config scripts

### DIFF
--- a/config/bootstrap.sh
+++ b/config/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #####################################################################
@@ -16,7 +16,7 @@ SCRIPT=$(readlink -f $0)
 SCRIPT_DIR="$(dirname ${SCRIPT})"
 
 . ${SCRIPT_DIR}/bootstrap_config
-. ${SCRIPT_DIR}/common_scripsts_lib
+. ${SCRIPT_DIR}/common_scripts_lib
 
 function test_if_run_as_root() {
     echo -e "\e[32m${FUNCNAME[0]}\e[0m"

--- a/config/run_runner_docker
+++ b/config/run_runner_docker
@@ -4,7 +4,7 @@ SCRIPT=$(readlink -f $0)
 SCRIPT_DIR="$(dirname ${SCRIPT})"
 SRC_ROOT=$(readlink -f ${SCRIPT_DIR}/..)
 
-. ${SRC_ROOT}/config/common_scripsts_lib
+. ${SRC_ROOT}/config/common_scripts_lib
 . ${SRC_ROOT}/config/bootstrap_config
 . ${SRC_ROOT}/config/runner_settings
 


### PR DESCRIPTION
For the `bootscript.sh` and `run_runner_docker` script to run, the directory name for "common_scripts_lib" must be spelled correctly.