### PR TITLE
[EGD-8254] Fix Default interval is set to None

### DIFF
--- a/module-apps/application-meditation/widgets/IntervalBox.cpp
+++ b/module-apps/application-meditation/widgets/IntervalBox.cpp
@@ -16,7 +16,7 @@ namespace
 {
     using minutes = std::chrono::minutes;
     const std::vector<minutes> chimeIntervals{
-        minutes{0}, minutes{2}, minutes{5}, minutes{10}, minutes{15}, minutes{30}};
+        minutes{2}, minutes{5}, minutes{10}, minutes{15}, minutes{30}, minutes{0}};
 } // namespace
 
 IntervalBox::IntervalBox(Item *parent, uint32_t x, uint32_t y, uint32_t w, uint32_t h, TimerProperty *timerSetter)


### PR DESCRIPTION
Fix meditation timer default interval is set to none

Signed-off-by: Lucjan Bryndza <lucjan.bryndza@mudita.com>