### PR TITLE
[MOS-144] Fix Increased CPU usage

### DIFF
--- a/module-services/service-evtmgr/service-evtmgr/EventManagerCommon.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/EventManagerCommon.hpp
@@ -23,16 +23,6 @@
 
 class WorkerEventCommon;
 
-class EventManagerSentinel
-{
-  public:
-    explicit EventManagerSentinel(std::shared_ptr<sys::CpuSentinel> cpuSentinel, bsp::CpuFrequencyMHz frequencyToHold);
-    ~EventManagerSentinel();
-
-  private:
-    std::shared_ptr<sys::CpuSentinel> cpuSentinel;
-};
-
 class EventManagerCommon : public sys::Service
 {
   public:
@@ -83,7 +73,7 @@ class EventManagerCommon : public sys::Service
 
     std::shared_ptr<settings::Settings> settings;
     std::unique_ptr<WorkerEventCommon> EventWorker;
-    std::shared_ptr<sys::CpuSentinel> cpuSentinel;
+    std::shared_ptr<sys::TimedCpuSentinel> cpuSentinel;
     // application where key events are sent. This is also only application that is allowed to change keyboard long
     // press settings.
     std::string targetApplication;

--- a/module-sys/SystemManager/include/SystemManager/CpuSentinel.hpp
+++ b/module-sys/SystemManager/include/SystemManager/CpuSentinel.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -9,6 +9,7 @@
 #include <string>
 #include <functional>
 #include <atomic>
+#include <Timers/TimerHandle.hpp>
 
 namespace sys
 {
@@ -59,6 +60,18 @@ namespace sys
         std::function<void(bsp::CpuFrequencyMHz)> callback;
 
         TaskHandle_t taskHandle = nullptr;
+    };
+
+    /// Sentinel releases the frequency lock automatically after the time specified in the parameter - timeout
+    class TimedCpuSentinel : public CpuSentinel
+    {
+      public:
+        TimedCpuSentinel(std::string name, sys::Service *service);
+        ~TimedCpuSentinel();
+        void HoldMinimumFrequencyForTime(bsp::CpuFrequencyMHz frequencyToHold, std::chrono::milliseconds timeout);
+
+      private:
+        sys::TimerHandle timerHandle;
     };
 
 } // namespace sys

--- a/module-sys/SystemManager/tests/unittest_CpuSentinelsGovernor.cpp
+++ b/module-sys/SystemManager/tests/unittest_CpuSentinelsGovernor.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #define CATCH_CONFIG_MAIN
@@ -7,13 +7,42 @@
 #include <SystemManager/CpuGovernor.hpp>
 #include <SystemManager/CpuSentinel.hpp>
 
+namespace sys
+{
+    class MockedService : public sys::Service
+    {
+      public:
+        MockedService(const std::string &name) : sys::Service(name)
+        {}
+
+        sys::ReturnCodes InitHandler() override
+        {
+            return sys::ReturnCodes::Success;
+        }
+        sys::ReturnCodes DeinitHandler() override
+        {
+            return sys::ReturnCodes::Success;
+        }
+        sys::ReturnCodes SwitchPowerModeHandler(const sys::ServicePowerMode mode) override
+        {
+            return sys::ReturnCodes::Success;
+        }
+        sys::MessagePointer DataReceivedHandler(sys::DataMessage *req, sys::ResponseMessage *resp) override
+        {
+            return std::make_shared<sys::ResponseMessage>();
+        };
+    };
+
+} // namespace sys
+
 TEST_CASE("Power Manager CPU sentinels governor test")
 {
     using namespace sys;
+    auto mockedService                          = std::make_shared<MockedService>("TestService");
     std::shared_ptr<CpuSentinel> testSentinel_0 = nullptr;
-    auto testSentinel_1                         = std::make_shared<CpuSentinel>("testSentinel_1", nullptr);
-    auto testSentinel_2                         = std::make_shared<CpuSentinel>("testSentinel_2", nullptr);
-    auto testSentinel_3                         = std::make_shared<CpuSentinel>("testSentinel_1", nullptr);
+    auto testSentinel_1                         = std::make_shared<CpuSentinel>("testSentinel_1", mockedService.get());
+    auto testSentinel_2                         = std::make_shared<CpuSentinel>("testSentinel_2", mockedService.get());
+    auto testSentinel_3                         = std::make_shared<CpuSentinel>("testSentinel_1", mockedService.get());
 
     SECTION("Sentinel registration")
     {


### PR DESCRIPTION
On the locked screen, while refreshing the screen,
the CPU woke up to the maximum frequency,
which resulted in an increased power consumption.