### PR TITLE
[CP-1021] Add token field to Device Info API

### DIFF
--- a/module-services/service-appmgr/include/service-appmgr/model/ApplicationManagerCommon.hpp
+++ b/module-services/service-appmgr/include/service-appmgr/model/ApplicationManagerCommon.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -51,6 +51,36 @@ auto ServiceDesktop::getSerialNumber() const -> std::string
     return settings->getValue(std::string("factory_data/serial"), settings::SettingsScope::Global);
 }
 
+auto ServiceDesktop::generateDeviceUniqueId() -> void
+{
+    const auto deviceUniqueId = utils::generateRandomId(sdesktop::DeviceUniqueIdLength);
+    LOG_SENSITIVE(LOGINFO, "Device unique id: %s", deviceUniqueId.c_str());
+    setDeviceUniqueId(deviceUniqueId);
+}
+
+auto ServiceDesktop::setDeviceUniqueId(const std::string &token) -> void
+{
+    return settings->setValue(sdesktop::DeviceUniqueIdName, token);
+}
+
+auto ServiceDesktop::getDeviceToken() -> std::string
+{
+    std::string tokenSeed = getDeviceUniqueId();
+
+    if (tokenSeed.empty()) {
+        LOG_DEBUG("Device unique id is empty, generating one...");
+        generateDeviceUniqueId();
+        tokenSeed = getDeviceUniqueId();
+    }
+
+    return (tokenSeed);
+}
+
+auto ServiceDesktop::getDeviceUniqueId() const -> std::string
+{
+    return settings->getValue(sdesktop::DeviceUniqueIdName);
+}
+
 auto ServiceDesktop::getCaseColour() const -> std::string
 {
     return settings->getValue(std::string("factory_data/case_colour"), settings::SettingsScope::Global);

--- a/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
@@ -52,6 +52,7 @@ namespace sdesktop::endpoints::json
     inline constexpr auto fileList       = "fileList";
     inline constexpr auto files          = "files";
     inline constexpr auto backupLocation = "backupLocation";
+    inline constexpr auto deviceToken    = "deviceToken";
 
     namespace updateprocess
     {

--- a/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
@@ -40,6 +40,8 @@ namespace sdesktop
     inline constexpr auto RECEIVE_QUEUE_BUFFER_NAME = "receiveQueueBuffer";
     inline constexpr auto SEND_QUEUE_BUFFER_NAME    = "sendQueueBuffer";
     inline constexpr auto IRQ_QUEUE_BUFFER_NAME     = "irqQueueBuffer";
+    inline constexpr auto DeviceUniqueIdLength      = 32;
+    constexpr auto DeviceUniqueIdName               = "sd_device_unique_id";
 
 }; // namespace sdesktop
 
@@ -83,8 +85,14 @@ class ServiceDesktop : public sys::Service
     auto getNotificationEntries() const -> std::vector<Outbox::NotificationEntry>;
     void removeNotificationEntries(const std::vector<int> &);
     void restartNotificationsClearTimer();
+    auto getDeviceToken() -> std::string;
 
   private:
+    auto getDeviceUniqueId() const -> std::string;
+
+    void generateDeviceUniqueId();
+    void setDeviceUniqueId(const std::string &token);
+
     std::unique_ptr<sdesktop::USBSecurityModel> usbSecurityModel;
     std::unique_ptr<settings::Settings> settings;
     std::unique_ptr<sdesktop::bluetooth::BluetoothMessagesHandler> btMsgHandler;

--- a/products/PurePhone/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
+++ b/products/PurePhone/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
@@ -128,6 +128,11 @@ namespace sdesktop::endpoints
         return static_cast<ServiceDesktop *>(ownerServicePtr)->getCaseColour();
     }
 
+    auto DeviceInfoEndpoint::getDeviceToken() -> std::string
+    {
+        return static_cast<ServiceDesktop *>(ownerServicePtr)->getDeviceToken();
+    }
+
     auto DeviceInfoEndpoint::getStorageStats(const std::string &path) -> std::tuple<long, long>
     {
         std::unique_ptr<struct statvfs> vfstat = std::make_unique<struct statvfs>();
@@ -198,13 +203,14 @@ namespace sdesktop::endpoints
              {json::fsTotal, std::to_string(totalMbytes)},
              {json::fsFree, std::to_string(freeUserMbytes)},
              {json::fsFreePercent, std::to_string(freePercent)},
-             {json::gitRevision, (std::string)(GIT_REV)},
-             {json::gitBranch, (std::string)GIT_BRANCH},
+             {json::gitRevision, std::string(GIT_REV)},
+             {json::gitBranch, std::string(GIT_BRANCH)},
              {json::currentRTCTime, std::to_string(static_cast<uint32_t>(std::time(nullptr)))},
              {json::version, std::string(VERSION)},
              {json::serialNumber, getSerialNumber()},
              {json::caseColour, getCaseColour()},
-             {json::backupLocation, purefs::dir::getBackupOSPath().string()}}));
+             {json::backupLocation, purefs::dir::getBackupOSPath().string()},
+             {json::deviceToken, getDeviceToken()}}));
 
         context.setResponseStatus(http::Code::OK);
         return true;

--- a/products/PurePhone/services/desktop/endpoints/include/endpoints/deviceInfo/DeviceInfoEndpoint.hpp
+++ b/products/PurePhone/services/desktop/endpoints/include/endpoints/deviceInfo/DeviceInfoEndpoint.hpp
@@ -28,6 +28,7 @@ namespace sdesktop::endpoints
         auto fileListToJsonObject(const std::vector<std::string> &fileList) const -> json11::Json::object const;
         auto requestLogsFlush() const -> void;
         auto getStorageStats(const std::string &path) -> std::tuple<long, long>;
+        auto getDeviceToken() -> std::string;
 
         static constexpr auto OS_RESERVED_SPACE_IN_MB = (1024LU);
 

--- a/test/pytest/service-desktop/test_device_info.py
+++ b/test/pytest/service-desktop/test_device_info.py
@@ -28,6 +28,7 @@ def test_get_device_information(harness):
     assert re.match(r"^\d{3,14}$", ret.diag_info["serialNumber"])
     assert ret.diag_info["caseColour"] in ["gray", "black"]
     assert ret.diag_info["backupLocation"] == "/sys/user/backup"
+    assert re.match(r"^(\d|[a-zA-Z]){32}$", ret.diag_info["deviceToken"])
 
 
 @pytest.mark.service_desktop_test


### PR DESCRIPTION
Generating a device unique id during on-boarding
Returning device token generated from device unique id in DeviceInfo
Added test for device token in test_devic_info.py
