### PR TITLE
[MOS-218] Fix broken documentation links

### DIFF
--- a/doc/adding_unittests.md
+++ b/doc/adding_unittests.md
@@ -2,7 +2,7 @@
 
 ## Unit test framework
 
-For writing test we are using (catch2)[https://github.com/catchorg/Catch2/blob/devel/docs/tutorial.md].
+For writing test we are using [catch2](https://github.com/catchorg/Catch2/blob/devel/docs/tutorial.md).
 There are few test written in `gtest` but we focus on using `catch2`
 
 ## adding unit test

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -183,7 +183,7 @@ git config commit.template .gitmessage
 ```
 
 This way each time you add a new commit you will see the template that will help
-you with the proper message format. More about that in (Development Workflow)[./doc/development_workflow.md#commit-changes]
+you with the proper message format. More about that in [Development Workflow](./doc/development_workflow.md#commit-changes)
 
 ### Commit message hook
 This hooks automatically converts your branch name to commit title
@@ -270,7 +270,7 @@ Please be aware that when building custom image you'll have to give it some tag 
 
 ## Preparing packages
 
-If you need a package, containing everything needed to run the application, please check (build_targests.md)[./doc/build_targests.md] document.
+If you need a package, containing everything needed to run the application, please check [build_targests.md](./doc/build_targests.md) document.
 
 ## Generating code coverage reports
 

--- a/doc/setup_ide.md
+++ b/doc/setup_ide.md
@@ -2,7 +2,7 @@
 
 ## Table of contents
 - [Setting up in Eclipse](#setting-up-in-eclipse)
-- [Setting up in CLion](#setting-up-in -clion)
+- [Setting up in CLion](#setting-up-in-clion)
 - [Additional info](#additional-info)
     + [Prevent Git from suggesting commits](#prevent-git-from-suggesting-commits)
     + [Seperate build folders](#separate-build-folders)


### PR DESCRIPTION
There are few broken links in the documentation that have been
corrected.  The cause is either errant whitespace in the link
or by confusing (link)[url] for [link](url).

Errors like this can be found with these regex grep statements:
```
grep -rnE "\([^\)]+\)\[[^]]+\]" doc/*
grep -rnE "[^\!]\[[^]]+\]\([^\)]*\s[^\)]*\)" doc/*
```