### PR TITLE
[MOS-104] Fix calllog responsivness with large number of contacts

### DIFF
--- a/module-apps/application-calllog/ApplicationCallLog.cpp
+++ b/module-apps/application-calllog/ApplicationCallLog.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationCallLog.hpp"
@@ -133,9 +133,7 @@ namespace app
         DBServiceAPI::GetQuery(this,
                                db::Interface::Name::Notifications,
                                std::make_unique<db::query::notifications::Clear>(NotificationsRecord::Key::Calls));
-        const auto [succeed, _] = DBServiceAPI::GetQuery(
-            this, db::Interface::Name::Calllog, std::make_unique<db::query::calllog::SetAllRead>());
-        return succeed;
+        return true;
     }
 
 } /* namespace app */

--- a/module-utils/phonenumber/NumberHolderMatcher.hpp
+++ b/module-utils/phonenumber/NumberHolderMatcher.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -63,6 +63,11 @@ namespace utils
                                          PhoneNumber::Match level = PhoneNumber::Match::EXACT)
         {
             utils::time::Scoped t{"bestMatch()"};
+            // if empty string, do not try to match, simply return
+            if (phoneNumber.get().empty()) {
+                return std::nullopt;
+            }
+
             restartFor(phoneNumber);
             do {
                 const auto it =

--- a/products/PurePhone/services/db/ServiceDB.cpp
+++ b/products/PurePhone/services/db/ServiceDB.cpp
@@ -128,13 +128,13 @@ sys::MessagePointer ServiceDB::DataReceivedHandler(sys::DataMessage *msgl, sys::
                 sys::ReturnCodes::Success, std::make_unique<ContactRecord>(std::move(ret->contact)));
         }
         else {
-            responseMsg = std::make_shared<DBContactNumberResponseMessage>(sys::ReturnCodes::Failure,
+            responseMsg = std::make_shared<DBContactNumberResponseMessage>(sys::ReturnCodes::Success,
                                                                            std::unique_ptr<ContactRecord>());
         }
     } break;
 
     case MessageType::DBContactMatchByNumberID: {
-        auto time = utils::time::Scoped("DBContactMatchByNumber");
+        auto time = utils::time::Scoped("DBContactMatchByNumberID");
         auto *msg = dynamic_cast<DBMatchContactByNumberIDMessage *>(msgl);
         auto ret  = contactRecordInterface->GetByNumberID(msg->numberID);
         if (ret.has_value()) {
@@ -142,7 +142,7 @@ sys::MessagePointer ServiceDB::DataReceivedHandler(sys::DataMessage *msgl, sys::
                 sys::ReturnCodes::Success, std::make_unique<ContactRecord>(std::move(*ret)));
         }
         else {
-            responseMsg = std::make_shared<DBContactNumberResponseMessage>(sys::ReturnCodes::Failure, nullptr);
+            responseMsg = std::make_shared<DBContactNumberResponseMessage>(sys::ReturnCodes::Success, nullptr);
         }
     } break;
 


### PR DESCRIPTION
Determined 3 reasons of lag
1. each calllog app opening is sending db::query::calllog::SetAllRead
which marks all calllog database entries as read and send CRUD
notification to application and hence the list view is rebuilt at least
twice for each app opening.
After deeper investigation it seems like dead feature (at least not
covered in GUI) and I am going to disable it.

2. DBServiceAPI::MatchContactByPhoneNumber requested for empty string
(private number) take really long time (above 1s).

3. DBServiceAPI::MatchContactByPhoneNumber took about time 150-200ms

This patch fixes only issues 1. and 2. Number 3. requires further
investigation and is consider as separate issue.

After mentioned fixes calllog is pretty responsive but requires ~2s
for each app start or page change.