### PR TITLE
[MOS-97] Fix of wrong label for missed call notification

### DIFF
--- a/module-apps/application-calllog/ApplicationCallLog.cpp
+++ b/module-apps/application-calllog/ApplicationCallLog.cpp
@@ -133,7 +133,9 @@ namespace app
         DBServiceAPI::GetQuery(this,
                                db::Interface::Name::Notifications,
                                std::make_unique<db::query::notifications::Clear>(NotificationsRecord::Key::Calls));
-        return true;
+        const auto [succeed, _] = DBServiceAPI::GetQuery(
+            this, db::Interface::Name::Calllog, std::make_unique<db::query::calllog::SetAllRead>());
+        return succeed;
     }
 
 } /* namespace app */

--- a/module-apps/application-calllog/windows/CallLogMainWindow.cpp
+++ b/module-apps/application-calllog/windows/CallLogMainWindow.cpp
@@ -164,7 +164,8 @@ namespace gui
     {
         auto notification = dynamic_cast<db::NotificationMessage *>(msg);
         if (notification != nullptr) {
-            if (notification->interface == db::Interface::Name::Calllog && notification->dataModified()) {
+            if (notification->interface == db::Interface::Name::Calllog &&
+                notification->type == db::Query::Type::Create) {
                 rebuild();
                 return true;
             }

--- a/module-apps/apps-common/notifications/NotificationsListPresenter.cpp
+++ b/module-apps/apps-common/notifications/NotificationsListPresenter.cpp
@@ -12,7 +12,7 @@ namespace
                              const notifications::NotificationWithContact *notification,
                              const std::string &text)
     {
-        if (notification->hasRecord()) {
+        if (notification->hasRecord() && !notification->getRecord().getFormattedName().empty()) {
             const auto &record = notification->getRecord();
             item->setName(record.getFormattedName());
         }


### PR DESCRIPTION
There was no label on missed call notification from private number.
After fix it is diplaying "Missed calls" info.

Original fix from 60bdca524338025dc0117edcc5c5579376441b0b [MOS-104]
was also modifed as it previously introduced regression on menu window.

[MOS-104]: https://appnroll.atlassian.net/browse/MOS-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ