### PR TITLE
[MOS-245] Fix errant spaces

### DIFF
--- a/module-apps/application-music-player/data/MusicPlayerStyle.hpp
+++ b/module-apps/application-music-player/data/MusicPlayerStyle.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -10,7 +10,7 @@ namespace musicPlayerStyle
 {
     namespace common
     {
-        constexpr gui::ImageTypeSpecifier imageType = gui::ImageTypeSpecifier ::W_G;
+        constexpr gui::ImageTypeSpecifier imageType = gui::ImageTypeSpecifier::W_G;
     }
 
     namespace mainWindow

--- a/module-audio/Audio/Audio.cpp
+++ b/module-audio/Audio/Audio.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Audio.hpp"
@@ -86,7 +86,7 @@ namespace audio
             LOG_ERROR(
                 "Failed to create operation type %s, error message:\n%s", Operation::c_str(op), audioException.what());
             currentOperation = Operation::Create(Operation::Type::Idle);
-            currentState     = State ::Idle;
+            currentState     = State::Idle;
             return audioException.getErrorCode();
         }
 

--- a/module-audio/board/rt1051/puretx/RT1051CellularAudio.cpp
+++ b/module-audio/board/rt1051/puretx/RT1051CellularAudio.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "RT1051CellularAudio.hpp"
@@ -105,8 +105,8 @@ namespace audio
         memset(&config, 0, sizeof config);
         SAI_Deinit(BOARD_CELLULAR_AUDIO_SAIx);
         if (dmamux) {
-            dmamux->Disable(static_cast<uint32_t>(BoardDefinitions ::CELLULAR_AUDIO_TX_DMA_CHANNEL));
-            dmamux->Disable(static_cast<uint32_t>(BoardDefinitions ::CELLULAR_AUDIO_RX_DMA_CHANNEL));
+            dmamux->Disable(static_cast<uint32_t>(BoardDefinitions::CELLULAR_AUDIO_TX_DMA_CHANNEL));
+            dmamux->Disable(static_cast<uint32_t>(BoardDefinitions::CELLULAR_AUDIO_RX_DMA_CHANNEL));
         }
     }
 

--- a/module-bsp/board/rt1051/bellpx/audio.cpp
+++ b/module-bsp/board/rt1051/bellpx/audio.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "audio.hpp"
@@ -18,23 +18,21 @@ AudioConfig audioConfig;
 
 void bsp::audio::init()
 {
-    audioConfig.pllAudio =
-        DriverPLL::Create(static_cast<PLLInstances>(BoardDefinitions ::AUDIO_PLL), DriverPLLParams{});
+    audioConfig.pllAudio = DriverPLL::Create(static_cast<PLLInstances>(BoardDefinitions::AUDIO_PLL), DriverPLLParams{});
     audioConfig.dmamux =
-        DriverDMAMux::Create(static_cast<DMAMuxInstances>(BoardDefinitions ::AUDIOCODEC_DMAMUX), DriverDMAMuxParams{});
-    audioConfig.dma =
-        DriverDMA::Create(static_cast<DMAInstances>(BoardDefinitions ::AUDIOCODEC_DMA), DriverDMAParams{});
+        DriverDMAMux::Create(static_cast<DMAMuxInstances>(BoardDefinitions::AUDIOCODEC_DMAMUX), DriverDMAMuxParams{});
+    audioConfig.dma = DriverDMA::Create(static_cast<DMAInstances>(BoardDefinitions::AUDIOCODEC_DMA), DriverDMAParams{});
 
     // Enable MCLK clock
     IOMUXC_GPR->GPR1 |= BELL_AUDIOCODEC_SAIx_MCLK_MASK;
 
     audioConfig.txDMAHandle =
-        audioConfig.dma->CreateHandle(static_cast<uint32_t>(BoardDefinitions ::AUDIOCODEC_TX_DMA_CHANNEL));
+        audioConfig.dma->CreateHandle(static_cast<uint32_t>(BoardDefinitions::AUDIOCODEC_TX_DMA_CHANNEL));
     audioConfig.rxDMAHandle =
-        audioConfig.dma->CreateHandle(static_cast<uint32_t>(BoardDefinitions ::AUDIOCODEC_RX_DMA_CHANNEL));
-    audioConfig.dmamux->Enable(static_cast<uint32_t>(BoardDefinitions ::AUDIOCODEC_TX_DMA_CHANNEL),
+        audioConfig.dma->CreateHandle(static_cast<uint32_t>(BoardDefinitions::AUDIOCODEC_RX_DMA_CHANNEL));
+    audioConfig.dmamux->Enable(static_cast<uint32_t>(BoardDefinitions::AUDIOCODEC_TX_DMA_CHANNEL),
                                BSP_AUDIOCODEC_SAIx_DMA_TX_SOURCE);
-    audioConfig.dmamux->Enable(static_cast<uint32_t>(BoardDefinitions ::AUDIOCODEC_RX_DMA_CHANNEL),
+    audioConfig.dmamux->Enable(static_cast<uint32_t>(BoardDefinitions::AUDIOCODEC_RX_DMA_CHANNEL),
                                BSP_AUDIOCODEC_SAIx_DMA_RX_SOURCE);
 
     audioConfig.mclkSourceClockHz = GetPerphSourceClock(PerphClock_SAI1);
@@ -56,8 +54,8 @@ void bsp::audio::deinit()
     memset(&audioConfig.config, 0, sizeof(audioConfig.config));
     SAI_Deinit(BELL_AUDIOCODEC_SAIx);
     if (audioConfig.dmamux) {
-        audioConfig.dmamux->Disable(static_cast<uint32_t>(BoardDefinitions ::AUDIOCODEC_TX_DMA_CHANNEL));
-        audioConfig.dmamux->Disable(static_cast<uint32_t>(BoardDefinitions ::AUDIOCODEC_RX_DMA_CHANNEL));
+        audioConfig.dmamux->Disable(static_cast<uint32_t>(BoardDefinitions::AUDIOCODEC_TX_DMA_CHANNEL));
+        audioConfig.dmamux->Disable(static_cast<uint32_t>(BoardDefinitions::AUDIOCODEC_RX_DMA_CHANNEL));
     }
 
     // force order of destruction

--- a/module-bsp/board/rt1051/bellpx/board/BoardDefinitions.hpp
+++ b/module-bsp/board/rt1051/bellpx/board/BoardDefinitions.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -15,7 +15,7 @@
 enum class BoardDefinitions
 {
 
-    POWER_SWITCH_HOLD_GPIO   = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    POWER_SWITCH_HOLD_GPIO   = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     POWER_SWITCH_HOLD_BUTTON = 7,
 
     USB_FUNCTION_MUX_SELECT = 25, // GPIO_AD_B1_09, USB_MUX_SEL0
@@ -23,15 +23,15 @@ enum class BoardDefinitions
     I2C_STD_BAUDRATE        = 100000,
 
     AUDIOCODEC_I2C_BAUDRATE   = I2C_STD_BAUDRATE,
-    AUDIOCODEC_I2C            = static_cast<int>(drivers::I2CInstances ::I2C2),
-    AUDIOCODEC_DMAMUX         = static_cast<int>(drivers::DMAMuxInstances ::DMAMUX0),
-    AUDIOCODEC_DMA            = static_cast<int>(drivers::DMAInstances ::DMA_0),
+    AUDIOCODEC_I2C            = static_cast<int>(drivers::I2CInstances::I2C2),
+    AUDIOCODEC_DMAMUX         = static_cast<int>(drivers::DMAMuxInstances::DMAMUX0),
+    AUDIOCODEC_DMA            = static_cast<int>(drivers::DMAInstances::DMA_0),
     AUDIOCODEC_TX_DMA_CHANNEL = 2,
     AUDIOCODEC_RX_DMA_CHANNEL = 3,
     AUDIOCODEC_IRQ            = 31, // GPIO_B1_15  requires pull-up 10kΩ
-    AUDIOCODEC_IRQ_GPIO       = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    AUDIOCODEC_IRQ_GPIO       = static_cast<int>(drivers::GPIOInstances::GPIO_2),
 
-    MIC_BIAS_DRIVER_GPIO = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    MIC_BIAS_DRIVER_GPIO = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     MIC_BIAS_DRIVER_EN   = 19, // GPIO_B1_03 MIC_LDO_EN
 
     CELLULAR_AUDIO_DMAMUX         = AUDIOCODEC_DMAMUX,
@@ -41,30 +41,30 @@ enum class BoardDefinitions
 
     KEYBOARD_I2C_BAUDRATE = AUDIOCODEC_I2C_BAUDRATE,
     KEYBOARD_I2C          = AUDIOCODEC_I2C,
-    KEYBOARD_GPIO         = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    KEYBOARD_GPIO         = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     KEYBOARD_RF_BUTTON    = 6,
     KEYBOARD_IRQ_PIN      = 28,
     KEYBOARD_RESET_PIN    = 29,
 
     HEADSET_I2C_BAUDRATE = AUDIOCODEC_I2C_BAUDRATE,
     HEADSET_I2C          = AUDIOCODEC_I2C,
-    HEADSET_GPIO         = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    HEADSET_GPIO         = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     HEADSET_IRQ_PIN      = 30,
 
     BATTERY_CHARGER_I2C_BAUDRATE = AUDIOCODEC_I2C_BAUDRATE,
     BATTERY_CHARGER_I2C          = AUDIOCODEC_I2C,
-    BATTERY_CHARGER_GPIO         = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    BATTERY_CHARGER_GPIO         = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     BATTERY_CHARGER_INOKB_PIN    = 12,
     BATTERY_CHARGER_WCINOKB      = 13, // UNUSABLE as WCIN is not connected to the charger !
     BATTERY_CHARGER_INTB_PIN     = 14, // interrupt on charger/fuel-gauge event
 
-    CELLULAR_DMA               = static_cast<int>(drivers::DMAInstances ::DMA_0),
-    CELLULAR_DMAMUX            = static_cast<int>(drivers::DMAMuxInstances ::DMAMUX0),
+    CELLULAR_DMA               = static_cast<int>(drivers::DMAInstances::DMA_0),
+    CELLULAR_DMAMUX            = static_cast<int>(drivers::DMAMuxInstances::DMAMUX0),
     CELLULAR_TX_DMA_CHANNEL    = 4,
     CELLULAR_RX_DMA_CHANNEL    = 5,
-    CELLULAR_GPIO_1            = static_cast<int>(drivers::GPIOInstances ::GPIO_1),
-    CELLULAR_GPIO_2            = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
-    CELLULAR_GPIO_3            = static_cast<int>(drivers::GPIOInstances ::GPIO_3),
+    CELLULAR_GPIO_1            = static_cast<int>(drivers::GPIOInstances::GPIO_1),
+    CELLULAR_GPIO_2            = static_cast<int>(drivers::GPIOInstances::GPIO_2),
+    CELLULAR_GPIO_3            = static_cast<int>(drivers::GPIOInstances::GPIO_3),
     CELLULAR_GPIO_1_CTS_PIN    = 14,
     CELLULAR_GPIO_1_RTS_PIN    = 15,
     CELLULAR_GPIO_3_DTR_PIN    = 27,
@@ -84,21 +84,21 @@ enum class BoardDefinitions
     CELLULAR_GPIO_2_USB_BOOT_PIN          = 24, // GPIO_B1_08, output
     CELLULAR_LPUART_INSTANCE              = static_cast<int>(drivers::LPUARTInstances::LPUART_1),
 
-    EINK_DMA            = static_cast<int>(drivers::DMAInstances ::DMA_0),
-    EINK_DMAMUX         = static_cast<int>(drivers::DMAMuxInstances ::DMAMUX0),
+    EINK_DMA            = static_cast<int>(drivers::DMAInstances::DMA_0),
+    EINK_DMAMUX         = static_cast<int>(drivers::DMAMuxInstances::DMAMUX0),
     EINK_TX_DMA_CHANNEL = 0,
     EINK_RX_DMA_CHANNEL = 1,
-    EINK_GPIO           = static_cast<int>(drivers::GPIOInstances ::GPIO_3),
+    EINK_GPIO           = static_cast<int>(drivers::GPIOInstances::GPIO_3),
     EINK_CS_PIN         = 13,
     EINK_RESET_PIN      = 16,
     EINK_BUSY_PIN       = 17,
     EINK_PLL            = static_cast<int>(drivers::PLLInstances::PLL2_PFD2),
     EINK_LPSPI_INSTANCE = static_cast<int>(drivers::LPSPIInstances::LPSPI_1),
-    EINK_BELL_PWR_GPIO  = static_cast<int>(drivers::GPIOInstances ::GPIO_1),
+    EINK_BELL_PWR_GPIO  = static_cast<int>(drivers::GPIOInstances::GPIO_1),
     EINK_BELL_PWR_PIN   = 19,
 
-    BLUETOOTH_DMA            = static_cast<int>(drivers::DMAInstances ::DMA_0),
-    BLUETOOTH_DMAMUX         = static_cast<int>(drivers::DMAMuxInstances ::DMAMUX0),
+    BLUETOOTH_DMA            = static_cast<int>(drivers::DMAInstances::DMA_0),
+    BLUETOOTH_DMAMUX         = static_cast<int>(drivers::DMAMuxInstances::DMAMUX0),
     BLUETOOTH_TX_DMA_CHANNEL = 8,
     BLUETOOTH_RX_DMA_CHANNEL = 9,
 
@@ -136,40 +136,40 @@ enum class BoardDefinitions
     LIGHT_SENSOR_IRQ_GPIO     = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     LIGHT_SENSOR_IRQ          = 15, // GPIO_B0_15
 
-    DCDC_INVERTER_MODE_GPIO = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    DCDC_INVERTER_MODE_GPIO = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     DCDC_INVERTER_MODE_PIN  = 26,
 
     EEPROM_I2C          = AUDIOCODEC_I2C,
     EEPROM_I2C_BAUDRATE = I2C_STD_BAUDRATE,
 
-    BELL_TEMP_SENSOR_I2C          = static_cast<int>(drivers::I2CInstances ::I2C4),
+    BELL_TEMP_SENSOR_I2C          = static_cast<int>(drivers::I2CInstances::I2C4),
     BELL_TEMP_SENSOR_I2C_BAUDRATE = I2C_STD_BAUDRATE,
 
-    BELL_SWITCHES_GPIO   = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    BELL_SWITCHES_GPIO   = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     BELL_SWITCHES_CENTER = 16, // GPIO_B1_00
     BELL_SWITCHES_RIGHT  = 24, // GPIO_B1_08
     BELL_SWITCHES_LEFT   = 25, // GPIO_B1_09
     BELL_SWITCHES_LATCH  = 26, // GPIO_B1_10
     BELL_SWITCHES_DOME   = 27, // GPIO_B1_11
 
-    BELL_WAKEUP_GPIO = static_cast<int>(drivers::GPIOInstances ::GPIO_5),
+    BELL_WAKEUP_GPIO = static_cast<int>(drivers::GPIOInstances::GPIO_5),
     BELL_WAKEUP      = 0, // SNVS_WAKEUP_GPIO5_IO00
 
-    BELL_BATTERY_CHARGER_GPIO       = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    BELL_BATTERY_CHARGER_GPIO       = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     BELL_BATTERY_CHARGER_CHGEN_PIN  = 23,
     BELL_BATTERY_CHARGER_ACOK_PIN   = 22,
-    BELL_BATTERY_CHARGER_CHGOK_GPIO = static_cast<int>(drivers::GPIOInstances ::GPIO_1),
+    BELL_BATTERY_CHARGER_CHGOK_GPIO = static_cast<int>(drivers::GPIOInstances::GPIO_1),
     BELL_BATTERY_CHARGER_CHGOK_PIN  = 0,
 
     BELL_FUELGAUGE_I2C_BAUDRATE = I2C_STD_BAUDRATE,
-    BELL_FUELGAUGE_I2C          = static_cast<int>(drivers::I2CInstances ::I2C4),
-    BELL_FUELGAUGE_ALRT_GPIO    = static_cast<int>(drivers::GPIOInstances ::GPIO_1),
+    BELL_FUELGAUGE_I2C          = static_cast<int>(drivers::I2CInstances::I2C4),
+    BELL_FUELGAUGE_ALRT_GPIO    = static_cast<int>(drivers::GPIOInstances::GPIO_1),
     BELL_FUELGAUGE_ALRT_PIN     = 3,
 
-    BELL_TEMP_SENSOR_PWR_GPIO = static_cast<int>(drivers::GPIOInstances ::GPIO_1),
+    BELL_TEMP_SENSOR_PWR_GPIO = static_cast<int>(drivers::GPIOInstances::GPIO_1),
     BELL_TEMP_SENSOR_PWR_PIN  = 27,
 
-    BELL_AUDIOCODEC_GPIO        = static_cast<int>(drivers::GPIOInstances ::GPIO_1),
+    BELL_AUDIOCODEC_GPIO        = static_cast<int>(drivers::GPIOInstances::GPIO_1),
     BELL_AUDIOCODEC_RSTN_PA_PIN = 14,
     BELL_AUDIOCODEC_INTN_PA_PIN = 24,
 

--- a/module-bsp/board/rt1051/bsp/audio/Codec.hpp
+++ b/module-bsp/board/rt1051/bsp/audio/Codec.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #ifndef PUREPHONE_CODEC_HPP
@@ -37,7 +37,7 @@ class CodecParams
     {
         switch (rate) {
         case 8000:
-            return SampleRate ::Rate8KHz;
+            return SampleRate::Rate8KHz;
         case 16000:
             return SampleRate::Rate16KHz;
         case 32000:
@@ -49,7 +49,7 @@ class CodecParams
         case 96000:
             return SampleRate::Rate96KHz;
         default:
-            return SampleRate ::Invalid;
+            return SampleRate::Invalid;
         }
     }
 
@@ -76,7 +76,7 @@ class CodecParams
     Cmd opCmd             = Cmd::None;
     float outVolume       = 0;
     float inGain          = 0;
-    SampleRate sampleRate = SampleRate ::Rate44K1Hz;
+    SampleRate sampleRate = SampleRate::Rate44K1Hz;
 };
 
 enum class CodecRetCode

--- a/module-bsp/board/rt1051/bsp/eink/bsp_eink.cpp
+++ b/module-bsp/board/rt1051/bsp/eink/bsp_eink.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "bsp_eink.h"
@@ -203,14 +203,14 @@ status_t BSP_EinkInit(bsp_eink_BusyEvent event)
     // fsl_lpspi doesn't support configuring autopcs feature
     BSP_EINK_LPSPI_BASE->CFGR1 |= LPSPI_CFGR1_AUTOPCS(0);
 
-    dmamux = DriverDMAMux::Create(static_cast<DMAMuxInstances>(BoardDefinitions ::EINK_DMAMUX), DriverDMAMuxParams{});
-    dma    = DriverDMA::Create(static_cast<DMAInstances>(BoardDefinitions ::EINK_DMA), DriverDMAParams{});
+    dmamux = DriverDMAMux::Create(static_cast<DMAMuxInstances>(BoardDefinitions::EINK_DMAMUX), DriverDMAMuxParams{});
+    dma    = DriverDMA::Create(static_cast<DMAInstances>(BoardDefinitions::EINK_DMA), DriverDMAParams{});
 
-    txDMAHandle = dma->CreateHandle(static_cast<uint32_t>(BoardDefinitions ::EINK_TX_DMA_CHANNEL));
-    rxDMAHandle = dma->CreateHandle(static_cast<uint32_t>(BoardDefinitions ::EINK_RX_DMA_CHANNEL));
-    dmamux->Enable(static_cast<uint32_t>(BoardDefinitions ::EINK_TX_DMA_CHANNEL),
+    txDMAHandle = dma->CreateHandle(static_cast<uint32_t>(BoardDefinitions::EINK_TX_DMA_CHANNEL));
+    rxDMAHandle = dma->CreateHandle(static_cast<uint32_t>(BoardDefinitions::EINK_RX_DMA_CHANNEL));
+    dmamux->Enable(static_cast<uint32_t>(BoardDefinitions::EINK_TX_DMA_CHANNEL),
                    BSP_EINK_LPSPI_DMA_TX_PERI_SEL); // TODO: M.P fix BSP_EINK_LPSPI_DMA_TX_PERI_SEL
-    dmamux->Enable(static_cast<uint32_t>(BoardDefinitions ::EINK_RX_DMA_CHANNEL),
+    dmamux->Enable(static_cast<uint32_t>(BoardDefinitions::EINK_RX_DMA_CHANNEL),
                    BSP_EINK_LPSPI_DMA_RX_PERI_SEL); // TODO: M.P fix BSP_EINK_LPSPI_DMA_RX_PERI_SEL
 
     BSP_EINK_LPSPI_EdmaDriverState.edmaTxDataToTxRegHandle =
@@ -263,8 +263,8 @@ void BSP_EinkDeinit(void)
 
     pll.reset();
 
-    dmamux->Disable(static_cast<uint32_t>(BoardDefinitions ::EINK_TX_DMA_CHANNEL));
-    dmamux->Disable(static_cast<uint32_t>(BoardDefinitions ::EINK_RX_DMA_CHANNEL));
+    dmamux->Disable(static_cast<uint32_t>(BoardDefinitions::EINK_TX_DMA_CHANNEL));
+    dmamux->Disable(static_cast<uint32_t>(BoardDefinitions::EINK_RX_DMA_CHANNEL));
 
     dma.reset();
     dmamux.reset();

--- a/module-bsp/board/rt1051/drivers/RT1051DriverI2C.cpp
+++ b/module-bsp/board/rt1051/drivers/RT1051DriverI2C.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "RT1051DriverI2C.hpp"
@@ -14,19 +14,19 @@ namespace drivers
         lpi2c_master_config_t lpi2cConfig = {};
 
         switch (instance) {
-        case I2CInstances ::I2C1:
+        case I2CInstances::I2C1:
             base = LPI2C1;
             LOG_DEBUG("Init: I2C1");
             break;
-        case I2CInstances ::I2C2:
+        case I2CInstances::I2C2:
             base = LPI2C2;
             LOG_DEBUG("Init: I2C2");
             break;
-        case I2CInstances ::I2C3:
+        case I2CInstances::I2C3:
             base = LPI2C3;
             LOG_DEBUG("Init: I2C3");
             break;
-        case I2CInstances ::I2C4:
+        case I2CInstances::I2C4:
             base = LPI2C4;
             LOG_DEBUG("Init: I2C4");
             break;
@@ -40,16 +40,16 @@ namespace drivers
     RT1051DriverI2C::~RT1051DriverI2C()
     {
         switch (instance) {
-        case I2CInstances ::I2C1:
+        case I2CInstances::I2C1:
             LOG_DEBUG("Deinit: I2C1");
             break;
-        case I2CInstances ::I2C2:
+        case I2CInstances::I2C2:
             LOG_DEBUG("Deinit: I2C2");
             break;
-        case I2CInstances ::I2C3:
+        case I2CInstances::I2C3:
             LOG_DEBUG("Deinit: I2C3");
             break;
-        case I2CInstances ::I2C4:
+        case I2CInstances::I2C4:
             LOG_DEBUG("Deinit: I2C4");
             break;
         default:

--- a/module-bsp/board/rt1051/drivers/RT1051DriverSAI.cpp
+++ b/module-bsp/board/rt1051/drivers/RT1051DriverSAI.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "RT1051DriverSAI.hpp"
@@ -18,19 +18,19 @@ namespace drivers
         : DriverSAI(params)
     {
         switch (instances) {
-        case SAIInstances ::SAI_1:
+        case SAIInstances::SAI_1:
             rxDMASource = kDmaRequestMuxSai1Rx;
             txDMASource = kDmaRequestMuxSai1Tx;
             base        = SAI1;
             IOMUXC_GPR->GPR1 |= IOMUXC_GPR_GPR1_SAI1_MCLK_DIR_MASK;
             break;
-        case SAIInstances ::SAI_2:
+        case SAIInstances::SAI_2:
             rxDMASource = kDmaRequestMuxSai2Rx;
             txDMASource = kDmaRequestMuxSai2Tx;
             base        = SAI2;
             IOMUXC_GPR->GPR1 |= IOMUXC_GPR_GPR1_SAI2_MCLK_DIR_MASK;
             break;
-        case SAIInstances ::SAI_3:
+        case SAIInstances::SAI_3:
             rxDMASource = kDmaRequestMuxSai3Rx;
             txDMASource = kDmaRequestMuxSai3Tx;
             base        = SAI3;
@@ -38,11 +38,11 @@ namespace drivers
             break;
         }
 
-        pll    = DriverInterface<DriverPLL>::Create(static_cast<PLLInstances>(BoardDefinitions ::AUDIO_PLL),
+        pll    = DriverInterface<DriverPLL>::Create(static_cast<PLLInstances>(BoardDefinitions::AUDIO_PLL),
                                                  DriverPLLParams{});
         dmamux = DriverInterface<DriverDMAMux>::Create(
-            static_cast<DMAMuxInstances>(BoardDefinitions ::AUDIOCODEC_DMAMUX), DriverDMAMuxParams{});
-        dma = DriverInterface<DriverDMA>::Create(static_cast<DMAInstances>(BoardDefinitions ::AUDIOCODEC_DMA),
+            static_cast<DMAMuxInstances>(BoardDefinitions::AUDIOCODEC_DMAMUX), DriverDMAMuxParams{});
+        dma = DriverInterface<DriverDMA>::Create(static_cast<DMAInstances>(BoardDefinitions::AUDIOCODEC_DMA),
                                                  DriverDMAParams{});
     }
 
@@ -63,8 +63,7 @@ namespace drivers
         // Initialize SAI Rx module
         SAI_RxGetDefaultConfig(&config);
 
-        config.masterSlave =
-            (parameters.masterslave == DriverSAIParams::MasterSlave ::Slave) ? kSAI_Slave : kSAI_Master;
+        config.masterSlave = (parameters.masterslave == DriverSAIParams::MasterSlave::Slave) ? kSAI_Slave : kSAI_Master;
         SAI_RxInit(base, &config);
 
         /* Configure the audio format */
@@ -118,8 +117,7 @@ namespace drivers
 
         // Initialize SAI Tx module
         SAI_TxGetDefaultConfig(&config);
-        config.masterSlave =
-            (parameters.masterslave == DriverSAIParams::MasterSlave ::Slave) ? kSAI_Slave : kSAI_Master;
+        config.masterSlave = (parameters.masterslave == DriverSAIParams::MasterSlave::Slave) ? kSAI_Slave : kSAI_Master;
         SAI_TxInit(base, &config);
 
         /* Configure the audio format */

--- a/module-bsp/board/rt1051/eMMC/eMMC.cpp
+++ b/module-bsp/board/rt1051/eMMC/eMMC.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "eMMC.hpp"
@@ -24,7 +24,7 @@ namespace bsp
             "EMMC", static_cast<drivers::USDHCInstances>(BoardDefinitions::EMMC_USDHC_INSTANCE));
 #if defined(TARGET_RT1051)
 
-        // pll = DriverPLL::Create(static_cast<PLLInstances >(BoardDefinitions ::EMMC_PLL),DriverPLLParams{});
+        // pll = DriverPLL::Create(static_cast<PLLInstances >(BoardDefinitions::EMMC_PLL),DriverPLLParams{});
 
         mmcCard.busWidth                   = kMMC_DataBusWidth8bit;
         mmcCard.busTiming                  = kMMC_HighSpeedTiming;

--- a/module-bsp/board/rt1051/puretx/audio.cpp
+++ b/module-bsp/board/rt1051/puretx/audio.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "audio.hpp"
@@ -18,23 +18,21 @@ bsp::audio::AudioConfig audioConfig;
 
 void bsp::audio::init()
 {
-    audioConfig.pllAudio =
-        DriverPLL::Create(static_cast<PLLInstances>(BoardDefinitions ::AUDIO_PLL), DriverPLLParams{});
+    audioConfig.pllAudio = DriverPLL::Create(static_cast<PLLInstances>(BoardDefinitions::AUDIO_PLL), DriverPLLParams{});
     audioConfig.dmamux =
-        DriverDMAMux::Create(static_cast<DMAMuxInstances>(BoardDefinitions ::AUDIOCODEC_DMAMUX), DriverDMAMuxParams{});
-    audioConfig.dma =
-        DriverDMA::Create(static_cast<DMAInstances>(BoardDefinitions ::AUDIOCODEC_DMA), DriverDMAParams{});
+        DriverDMAMux::Create(static_cast<DMAMuxInstances>(BoardDefinitions::AUDIOCODEC_DMAMUX), DriverDMAMuxParams{});
+    audioConfig.dma = DriverDMA::Create(static_cast<DMAInstances>(BoardDefinitions::AUDIOCODEC_DMA), DriverDMAParams{});
 
     // Enable MCLK clock
     IOMUXC_GPR->GPR1 |= BOARD_AUDIOCODEC_SAIx_MCLK_MASK;
 
     audioConfig.txDMAHandle =
-        audioConfig.dma->CreateHandle(static_cast<uint32_t>(BoardDefinitions ::AUDIOCODEC_TX_DMA_CHANNEL));
+        audioConfig.dma->CreateHandle(static_cast<uint32_t>(BoardDefinitions::AUDIOCODEC_TX_DMA_CHANNEL));
     audioConfig.rxDMAHandle =
-        audioConfig.dma->CreateHandle(static_cast<uint32_t>(BoardDefinitions ::AUDIOCODEC_RX_DMA_CHANNEL));
-    audioConfig.dmamux->Enable(static_cast<uint32_t>(BoardDefinitions ::AUDIOCODEC_TX_DMA_CHANNEL),
+        audioConfig.dma->CreateHandle(static_cast<uint32_t>(BoardDefinitions::AUDIOCODEC_RX_DMA_CHANNEL));
+    audioConfig.dmamux->Enable(static_cast<uint32_t>(BoardDefinitions::AUDIOCODEC_TX_DMA_CHANNEL),
                                BSP_AUDIOCODEC_SAIx_DMA_TX_SOURCE);
-    audioConfig.dmamux->Enable(static_cast<uint32_t>(BoardDefinitions ::AUDIOCODEC_RX_DMA_CHANNEL),
+    audioConfig.dmamux->Enable(static_cast<uint32_t>(BoardDefinitions::AUDIOCODEC_RX_DMA_CHANNEL),
                                BSP_AUDIOCODEC_SAIx_DMA_RX_SOURCE);
 
     audioConfig.mclkSourceClockHz = GetPerphSourceClock(PerphClock_SAI2);
@@ -56,8 +54,8 @@ void bsp::audio::deinit()
     memset(&audioConfig.config, 0, sizeof(audioConfig.config));
     SAI_Deinit(BOARD_AUDIOCODEC_SAIx);
     if (audioConfig.dmamux) {
-        audioConfig.dmamux->Disable(static_cast<uint32_t>(BoardDefinitions ::AUDIOCODEC_TX_DMA_CHANNEL));
-        audioConfig.dmamux->Disable(static_cast<uint32_t>(BoardDefinitions ::AUDIOCODEC_RX_DMA_CHANNEL));
+        audioConfig.dmamux->Disable(static_cast<uint32_t>(BoardDefinitions::AUDIOCODEC_TX_DMA_CHANNEL));
+        audioConfig.dmamux->Disable(static_cast<uint32_t>(BoardDefinitions::AUDIOCODEC_RX_DMA_CHANNEL));
     }
 
     // force order of destruction

--- a/module-bsp/board/rt1051/puretx/board/BoardDefinitions.hpp
+++ b/module-bsp/board/rt1051/puretx/board/BoardDefinitions.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -15,7 +15,7 @@
 enum class BoardDefinitions
 {
 
-    POWER_SWITCH_HOLD_GPIO   = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    POWER_SWITCH_HOLD_GPIO   = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     POWER_SWITCH_HOLD_BUTTON = 7,
 
     USB_FUNCTION_MUX_SELECT = 25, // GPIO_AD_B1_09, USB_MUX_SEL0
@@ -23,15 +23,15 @@ enum class BoardDefinitions
     I2C_STD_BAUDRATE        = 100000,
 
     AUDIOCODEC_I2C_BAUDRATE   = I2C_STD_BAUDRATE,
-    AUDIOCODEC_I2C            = static_cast<int>(drivers::I2CInstances ::I2C2),
-    AUDIOCODEC_DMAMUX         = static_cast<int>(drivers::DMAMuxInstances ::DMAMUX0),
-    AUDIOCODEC_DMA            = static_cast<int>(drivers::DMAInstances ::DMA_0),
+    AUDIOCODEC_I2C            = static_cast<int>(drivers::I2CInstances::I2C2),
+    AUDIOCODEC_DMAMUX         = static_cast<int>(drivers::DMAMuxInstances::DMAMUX0),
+    AUDIOCODEC_DMA            = static_cast<int>(drivers::DMAInstances::DMA_0),
     AUDIOCODEC_TX_DMA_CHANNEL = 6,
     AUDIOCODEC_RX_DMA_CHANNEL = 7,
     AUDIOCODEC_IRQ            = 31, // GPIO_B1_15  requires pull-up 10kΩ
-    AUDIOCODEC_IRQ_GPIO       = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    AUDIOCODEC_IRQ_GPIO       = static_cast<int>(drivers::GPIOInstances::GPIO_2),
 
-    MIC_BIAS_DRIVER_GPIO = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    MIC_BIAS_DRIVER_GPIO = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     MIC_BIAS_DRIVER_EN   = 19, // GPIO_B1_03 MIC_LDO_EN
 
     CELLULAR_AUDIO_DMAMUX         = AUDIOCODEC_DMAMUX,
@@ -41,30 +41,30 @@ enum class BoardDefinitions
 
     KEYBOARD_I2C_BAUDRATE = AUDIOCODEC_I2C_BAUDRATE,
     KEYBOARD_I2C          = AUDIOCODEC_I2C,
-    KEYBOARD_GPIO         = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    KEYBOARD_GPIO         = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     KEYBOARD_RF_BUTTON    = 6,
     KEYBOARD_IRQ_PIN      = 28,
     KEYBOARD_RESET_PIN    = 29,
 
     HEADSET_I2C_BAUDRATE = AUDIOCODEC_I2C_BAUDRATE,
     HEADSET_I2C          = AUDIOCODEC_I2C,
-    HEADSET_GPIO         = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    HEADSET_GPIO         = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     HEADSET_IRQ_PIN      = 30,
 
     BATTERY_CHARGER_I2C_BAUDRATE = AUDIOCODEC_I2C_BAUDRATE,
     BATTERY_CHARGER_I2C          = AUDIOCODEC_I2C,
-    BATTERY_CHARGER_GPIO         = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    BATTERY_CHARGER_GPIO         = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     BATTERY_CHARGER_INOKB_PIN    = 12,
     BATTERY_CHARGER_WCINOKB      = 13, // UNUSABLE as WCIN is not connected to the charger !
     BATTERY_CHARGER_INTB_PIN     = 14, // interrupt on charger/fuel-gauge event
 
-    CELLULAR_DMA               = static_cast<int>(drivers::DMAInstances ::DMA_0),
-    CELLULAR_DMAMUX            = static_cast<int>(drivers::DMAMuxInstances ::DMAMUX0),
+    CELLULAR_DMA               = static_cast<int>(drivers::DMAInstances::DMA_0),
+    CELLULAR_DMAMUX            = static_cast<int>(drivers::DMAMuxInstances::DMAMUX0),
     CELLULAR_TX_DMA_CHANNEL    = 4,
     CELLULAR_RX_DMA_CHANNEL    = 5,
-    CELLULAR_GPIO_1            = static_cast<int>(drivers::GPIOInstances ::GPIO_1),
-    CELLULAR_GPIO_2            = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
-    CELLULAR_GPIO_3            = static_cast<int>(drivers::GPIOInstances ::GPIO_3),
+    CELLULAR_GPIO_1            = static_cast<int>(drivers::GPIOInstances::GPIO_1),
+    CELLULAR_GPIO_2            = static_cast<int>(drivers::GPIOInstances::GPIO_2),
+    CELLULAR_GPIO_3            = static_cast<int>(drivers::GPIOInstances::GPIO_3),
     CELLULAR_GPIO_1_CTS_PIN    = 14,
     CELLULAR_GPIO_1_RTS_PIN    = 15,
     CELLULAR_GPIO_3_DTR_PIN    = 27,
@@ -84,19 +84,19 @@ enum class BoardDefinitions
     CELLULAR_GPIO_2_USB_BOOT_PIN          = 24, // GPIO_B1_08, output
     CELLULAR_LPUART_INSTANCE              = static_cast<int>(drivers::LPUARTInstances::LPUART_1),
 
-    EINK_DMA            = static_cast<int>(drivers::DMAInstances ::DMA_0),
-    EINK_DMAMUX         = static_cast<int>(drivers::DMAMuxInstances ::DMAMUX0),
+    EINK_DMA            = static_cast<int>(drivers::DMAInstances::DMA_0),
+    EINK_DMAMUX         = static_cast<int>(drivers::DMAMuxInstances::DMAMUX0),
     EINK_TX_DMA_CHANNEL = 0,
     EINK_RX_DMA_CHANNEL = 1,
-    EINK_GPIO           = static_cast<int>(drivers::GPIOInstances ::GPIO_3),
+    EINK_GPIO           = static_cast<int>(drivers::GPIOInstances::GPIO_3),
     EINK_CS_PIN         = 13,
     EINK_RESET_PIN      = 16,
     EINK_BUSY_PIN       = 17,
     EINK_PLL            = static_cast<int>(drivers::PLLInstances::PLL2_PFD2),
     EINK_LPSPI_INSTANCE = static_cast<int>(drivers::LPSPIInstances::LPSPI_1),
 
-    BLUETOOTH_DMA            = static_cast<int>(drivers::DMAInstances ::DMA_0),
-    BLUETOOTH_DMAMUX         = static_cast<int>(drivers::DMAMuxInstances ::DMAMUX0),
+    BLUETOOTH_DMA            = static_cast<int>(drivers::DMAInstances::DMA_0),
+    BLUETOOTH_DMAMUX         = static_cast<int>(drivers::DMAMuxInstances::DMAMUX0),
     BLUETOOTH_TX_DMA_CHANNEL = 8,
     BLUETOOTH_RX_DMA_CHANNEL = 9,
 
@@ -134,7 +134,7 @@ enum class BoardDefinitions
     LIGHT_SENSOR_IRQ_GPIO     = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     LIGHT_SENSOR_IRQ          = 15, // GPIO_B0_15
 
-    DCDC_INVERTER_MODE_GPIO = static_cast<int>(drivers::GPIOInstances ::GPIO_2),
+    DCDC_INVERTER_MODE_GPIO = static_cast<int>(drivers::GPIOInstances::GPIO_2),
     DCDC_INVERTER_MODE_PIN  = 26,
 
     EEPROM_I2C          = AUDIOCODEC_I2C,

--- a/module-bsp/drivers/dma/DriverDMA.cpp
+++ b/module-bsp/drivers/dma/DriverDMA.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DriverDMA.hpp"
@@ -16,7 +16,7 @@
 namespace drivers
 {
 
-    std::weak_ptr<DriverDMA> DriverDMA::singleton[static_cast<uint32_t>(DMAInstances ::COUNT)];
+    std::weak_ptr<DriverDMA> DriverDMA::singleton[static_cast<uint32_t>(DMAInstances::COUNT)];
 
     std::shared_ptr<DriverDMA> DriverDMA::Create(const drivers::DMAInstances instance,
                                                  const drivers::DriverDMAParams &params)

--- a/module-bsp/drivers/dma/DriverDMA.hpp
+++ b/module-bsp/drivers/dma/DriverDMA.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #ifndef PUREPHONE_DRIVERDMA_HPP
@@ -43,7 +43,7 @@ namespace drivers
         const DriverDMAParams parameters;
 
       private:
-        static std::weak_ptr<DriverDMA> singleton[static_cast<uint32_t>(DMAInstances ::COUNT)];
+        static std::weak_ptr<DriverDMA> singleton[static_cast<uint32_t>(DMAInstances::COUNT)];
     };
 
 } // namespace drivers

--- a/module-bsp/drivers/dmamux/DriverDMAMux.cpp
+++ b/module-bsp/drivers/dmamux/DriverDMAMux.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DriverDMAMux.hpp"
@@ -16,7 +16,7 @@
 namespace drivers
 {
 
-    std::weak_ptr<DriverDMAMux> DriverDMAMux::singleton[static_cast<uint32_t>(DMAMuxInstances ::COUNT)];
+    std::weak_ptr<DriverDMAMux> DriverDMAMux::singleton[static_cast<uint32_t>(DMAMuxInstances::COUNT)];
 
     std::shared_ptr<DriverDMAMux> DriverDMAMux::Create(const drivers::DMAMuxInstances instance,
                                                        const drivers::DriverDMAMuxParams &params)

--- a/module-bsp/drivers/dmamux/DriverDMAMux.hpp
+++ b/module-bsp/drivers/dmamux/DriverDMAMux.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #ifndef PUREPHONE_DRIVERDMAMUX_HPP
@@ -36,7 +36,7 @@ namespace drivers
         const DriverDMAMuxParams parameters;
 
       private:
-        static std::weak_ptr<DriverDMAMux> singleton[static_cast<uint32_t>(DMAMuxInstances ::COUNT)];
+        static std::weak_ptr<DriverDMAMux> singleton[static_cast<uint32_t>(DMAMuxInstances::COUNT)];
     };
 
 } // namespace drivers

--- a/module-bsp/drivers/gpio/DriverGPIO.cpp
+++ b/module-bsp/drivers/gpio/DriverGPIO.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DriverGPIO.hpp"
@@ -17,7 +17,7 @@
 namespace drivers
 {
 
-    std::weak_ptr<DriverGPIO> DriverGPIO::singleton[static_cast<uint32_t>(GPIOInstances ::COUNT)];
+    std::weak_ptr<DriverGPIO> DriverGPIO::singleton[static_cast<uint32_t>(GPIOInstances::COUNT)];
 
     std::shared_ptr<DriverGPIO> DriverGPIO::Create(const drivers::GPIOInstances instance,
                                                    const drivers::DriverGPIOParams &params)

--- a/module-bsp/drivers/gpio/DriverGPIO.hpp
+++ b/module-bsp/drivers/gpio/DriverGPIO.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #ifndef PUREPHONE_DRIVERGPIO_HPP
@@ -86,7 +86,7 @@ namespace drivers
         const DriverGPIOParams parameters;
 
       private:
-        static std::weak_ptr<DriverGPIO> singleton[static_cast<uint32_t>(GPIOInstances ::COUNT)];
+        static std::weak_ptr<DriverGPIO> singleton[static_cast<uint32_t>(GPIOInstances::COUNT)];
     };
 
 } // namespace drivers

--- a/module-bsp/drivers/i2c/DriverI2C.cpp
+++ b/module-bsp/drivers/i2c/DriverI2C.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DriverI2C.hpp"
@@ -17,7 +17,7 @@
 namespace drivers
 {
 
-    std::weak_ptr<DriverI2C> DriverI2C::singleton[static_cast<uint32_t>(I2CInstances ::COUNT)];
+    std::weak_ptr<DriverI2C> DriverI2C::singleton[static_cast<uint32_t>(I2CInstances::COUNT)];
 
     std::shared_ptr<DriverI2C> DriverI2C::Create(const drivers::I2CInstances instance,
                                                  const drivers::DriverI2CParams &params)

--- a/module-bsp/drivers/i2c/DriverI2C.hpp
+++ b/module-bsp/drivers/i2c/DriverI2C.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #ifndef PUREPHONE_DRIVERI2C_HPP
@@ -54,7 +54,7 @@ namespace drivers
         const DriverI2CParams parameters;
 
       private:
-        static std::weak_ptr<DriverI2C> singleton[static_cast<uint32_t>(I2CInstances ::COUNT)];
+        static std::weak_ptr<DriverI2C> singleton[static_cast<uint32_t>(I2CInstances::COUNT)];
     };
 
 } // namespace drivers

--- a/module-bsp/drivers/pll/DriverPLL.cpp
+++ b/module-bsp/drivers/pll/DriverPLL.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DriverPLL.hpp"
@@ -16,7 +16,7 @@
 namespace drivers
 {
 
-    std::weak_ptr<DriverPLL> DriverPLL::singleton[static_cast<uint32_t>(PLLInstances ::COUNT)];
+    std::weak_ptr<DriverPLL> DriverPLL::singleton[static_cast<uint32_t>(PLLInstances::COUNT)];
 
     std::shared_ptr<DriverPLL> DriverPLL::Create(const drivers::PLLInstances instance,
                                                  const drivers::DriverPLLParams &params)

--- a/module-bsp/drivers/pll/DriverPLL.hpp
+++ b/module-bsp/drivers/pll/DriverPLL.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #ifndef PUREPHONE_DRIVERPLL_HPP
@@ -40,7 +40,7 @@ namespace drivers
         const DriverPLLParams parameters;
 
       private:
-        static std::weak_ptr<DriverPLL> singleton[static_cast<uint32_t>(PLLInstances ::COUNT)];
+        static std::weak_ptr<DriverPLL> singleton[static_cast<uint32_t>(PLLInstances::COUNT)];
     };
 
 } // namespace drivers

--- a/module-cellular/modem/mux/CellularMux.cpp
+++ b/module-cellular/modem/mux/CellularMux.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CellularMux.h"
@@ -100,7 +100,7 @@ void CellularMux::setStartParams(PortSpeed_e portSpeed)
 CellularMuxFrame::frame_t createCMUXExitFrame()
 {
     CellularMuxFrame::frame_t frame;
-    frame.Address = 0 | static_cast<unsigned char>(MuxDefines ::GSM0710_CR);
+    frame.Address = 0 | static_cast<unsigned char>(MuxDefines::GSM0710_CR);
     frame.Control = TypeOfFrame_e::UIH;
     frame.data.push_back(static_cast<uint8_t>(MuxDefines::GSM0710_CONTROL_CLD) |
                          static_cast<uint8_t>(MuxDefines::GSM0710_EA) | static_cast<uint8_t>(MuxDefines::GSM0710_CR));
@@ -273,7 +273,7 @@ CellularMux::ConfState CellularMux::confProcedure()
         return ConfState::Failure;
     }
 
-    return ConfState ::Success;
+    return ConfState::Success;
 }
 
 CellularMux::ConfState CellularMux::audioConfProcedure()

--- a/module-db/Interface/ContactRecord.cpp
+++ b/module-db/Interface/ContactRecord.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ContactRecord.hpp"
@@ -827,7 +827,7 @@ auto ContactRecordInterface::GetLimitOffsetByField(uint32_t offset,
     auto records = std::make_unique<std::vector<ContactRecord>>();
 
     switch (field) {
-    case ContactRecordField ::PrimaryName: {
+    case ContactRecordField::PrimaryName: {
         auto ret = contactDB->name.getLimitOffsetByField(offset, limit, ContactNameTableFields::NamePrimary, str);
 
         for (const auto &record : ret) {
@@ -866,7 +866,7 @@ auto ContactRecordInterface::GetLimitOffsetByField(uint32_t offset,
     } break;
 
     case ContactRecordField::NumberUser: {
-        auto ret = contactDB->number.getLimitOffsetByField(offset, limit, ContactNumberTableFields ::NumberUser, str);
+        auto ret = contactDB->number.getLimitOffsetByField(offset, limit, ContactNumberTableFields::NumberUser, str);
 
         for (const auto &record : ret) {
 

--- a/module-db/Interface/SMSRecord.cpp
+++ b/module-db/Interface/SMSRecord.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SMSRecord.hpp"
@@ -170,7 +170,7 @@ bool SMSRecordInterface::Update(const SMSRecord &recUpdated)
 
     // update thread details with the latest sms from given thread
 
-    auto latest_vec = GetLimitOffsetByField(0, 1, SMSRecordField ::ThreadID, std::to_string(thread.ID).c_str());
+    auto latest_vec = GetLimitOffsetByField(0, 1, SMSRecordField::ThreadID, std::to_string(thread.ID).c_str());
 
     if (latest_vec->size() == 0) {
         return false;
@@ -217,7 +217,7 @@ bool SMSRecordInterface::RemoveByID(uint32_t id)
     else {
         // update thread details if deleted SMS is the latest sms from the thread
 
-        auto twoLatest = GetLimitOffsetByField(0, 2, SMSRecordField ::ThreadID, std::to_string(threadRec.ID).c_str());
+        auto twoLatest = GetLimitOffsetByField(0, 2, SMSRecordField::ThreadID, std::to_string(threadRec.ID).c_str());
 
         if (twoLatest->size() == 0) {
             LOG_ERROR("Cannot fetch no SMSes even though thread's msgCount says so (id %lu)",

--- a/module-db/Tables/ContactsAddressTable.cpp
+++ b/module-db/Tables/ContactsAddressTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ContactsAddressTable.hpp"
@@ -88,7 +88,7 @@ std::vector<ContactsAddressTableRow> ContactsAddressTable::getLimitOffsetByField
 
     std::string fieldName;
     switch (field) {
-    case ContactAddressTableFields ::Mail:
+    case ContactAddressTableFields::Mail:
         fieldName = "mail";
         break;
     default:

--- a/module-db/Tables/ContactsNameTable.cpp
+++ b/module-db/Tables/ContactsNameTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ContactsNameTable.hpp"
@@ -87,10 +87,10 @@ std::vector<ContactsNameTableRow> ContactsNameTable::getLimitOffsetByField(uint3
     std::string fieldName;
 
     switch (field) {
-    case ContactNameTableFields ::NamePrimary:
+    case ContactNameTableFields::NamePrimary:
         fieldName = "name_primary";
         break;
-    case ContactNameTableFields ::NameAlternative:
+    case ContactNameTableFields::NameAlternative:
         fieldName = "name_alternative";
         break;
     default:

--- a/module-db/Tables/ContactsNumberTable.cpp
+++ b/module-db/Tables/ContactsNumberTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ContactsNumberTable.hpp"
@@ -135,10 +135,10 @@ std::vector<ContactsNumberTableRow> ContactsNumberTable::getLimitOffsetByField(u
 {
     std::string fieldName;
     switch (field) {
-    case ContactNumberTableFields ::NumberUser:
+    case ContactNumberTableFields::NumberUser:
         fieldName = "number_user";
         break;
-    case ContactNumberTableFields ::NumberE164:
+    case ContactNumberTableFields::NumberE164:
         fieldName = "number_e164";
         break;
     default:

--- a/module-db/Tables/ContactsRingtonesTable.cpp
+++ b/module-db/Tables/ContactsRingtonesTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ContactsRingtonesTable.hpp"
@@ -78,7 +78,7 @@ std::vector<ContactsRingtonesTableRow> ContactsRingtonesTable::getLimitOffsetByF
 {
     std::string fieldName;
     switch (field) {
-    case ContactRingtonesTableFields ::AssetPath:
+    case ContactRingtonesTableFields::AssetPath:
         fieldName = "asset_path";
         break;
     default:

--- a/module-db/Tables/ContactsTable.cpp
+++ b/module-db/Tables/ContactsTable.cpp
@@ -394,7 +394,7 @@ std::vector<ContactsTableRow> ContactsTable::getLimitOffsetByField(uint32_t offs
 
     std::string fieldName;
     switch (field) {
-    case ContactTableFields ::SpeedDial:
+    case ContactTableFields::SpeedDial:
         fieldName = "speeddial";
         break;
     default:

--- a/module-db/Tables/NotesTable.cpp
+++ b/module-db/Tables/NotesTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "NotesTable.hpp"
@@ -92,7 +92,7 @@ std::vector<NotesTableRow> NotesTable::getLimitOffsetByField(std::uint32_t offse
     case NotesTableFields::Date:
         fieldName = "date";
         break;
-    case NotesTableFields ::Snippet:
+    case NotesTableFields::Snippet:
         fieldName = "snippet";
         break;
     default:

--- a/module-db/Tables/SMSTable.cpp
+++ b/module-db/Tables/SMSTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SMSTable.hpp"
@@ -33,15 +33,15 @@ bool SMSTable::removeByField(SMSTableFields field, const char *str)
     std::string fieldName;
 
     switch (field) {
-    case SMSTableFields ::ThreadID:
+    case SMSTableFields::ThreadID:
         fieldName = "thread_id";
         break;
 
-    case SMSTableFields ::ContactID:
+    case SMSTableFields::ContactID:
         fieldName = "contact_id";
         break;
 
-    case SMSTableFields ::Date:
+    case SMSTableFields::Date:
         fieldName = "date";
         break;
     default:
@@ -285,10 +285,10 @@ std::vector<SMSTableRow> SMSTable::getLimitOffsetByField(uint32_t offset,
     case SMSTableFields::Date:
         fieldName = "date";
         break;
-    case SMSTableFields ::ContactID:
+    case SMSTableFields::ContactID:
         fieldName = "contact_id";
         break;
-    case SMSTableFields ::ThreadID:
+    case SMSTableFields::ThreadID:
         fieldName = "thread_id";
         break;
     default:

--- a/module-db/Tables/ThreadsTable.cpp
+++ b/module-db/Tables/ThreadsTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ThreadsTable.hpp"
@@ -111,10 +111,10 @@ std::vector<ThreadsTableRow> ThreadsTable::getLimitOffsetByField(uint32_t offset
     case ThreadsTableFields::MsgCount:
         fieldName = "msg_count";
         break;
-    case ThreadsTableFields ::ContactID:
+    case ThreadsTableFields::ContactID:
         fieldName = "contact_id";
         break;
-    case ThreadsTableFields ::NumberID:
+    case ThreadsTableFields::NumberID:
         fieldName = "number_id";
         break;
     default:

--- a/module-db/queries/phonebook/QueryContactGet.cpp
+++ b/module-db/queries/phonebook/QueryContactGet.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "QueryContactGet.hpp"
@@ -60,7 +60,7 @@ ContactGetLetterMap::ContactGetLetterMap(std::size_t limit,
     : RecordQuery(limit, offset), TextFilter(filter), ContactGroupFilter(groupFilter), ContactDisplayMode(displayMode)
 {}
 
-ContactGetLetterMapResult ::ContactGetLetterMapResult(ContactsMapData &LetterMap) : LetterMapResult(LetterMap)
+ContactGetLetterMapResult::ContactGetLetterMapResult(ContactsMapData &LetterMap) : LetterMapResult(LetterMap)
 {}
 
 [[nodiscard]] auto ContactGet::debugInfo() const -> std::string

--- a/module-db/tests/ContactsRecord_tests.cpp
+++ b/module-db/tests/ContactsRecord_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "common.hpp"
@@ -27,7 +27,7 @@ TEST_CASE("Contact Record db tests")
     const char *mailTest                          = "TestMail";
     const char *assetPath                         = "/Test/Path/To/Asset";
     const char *speeddialTest                     = "100";
-    const ContactNumberType contactNumberTypeTest = ContactNumberType ::PAGER;
+    const ContactNumberType contactNumberTypeTest = ContactNumberType::PAGER;
 
     ContactRecordInterface contRecInterface(&contactDB);
 
@@ -614,7 +614,7 @@ TEST_CASE("Check if new contact record can be recognised as a duplicate in DB")
     testContactRecord.primaryName     = "PrimaryNameTest";
     testContactRecord.alternativeName = "AlternativeNameTest";
     testContactRecord.numbers         = std::vector<ContactRecord::Number>({
-        ContactRecord::Number("600123456", "+48600123456", ContactNumberType ::HOME),
+        ContactRecord::Number("600123456", "+48600123456", ContactNumberType::HOME),
     });
 
     REQUIRE(records.Add(testContactRecord));
@@ -625,7 +625,7 @@ TEST_CASE("Check if new contact record can be recognised as a duplicate in DB")
         noDuplicateContactRecord.primaryName     = "PrimaryNameTest2";
         noDuplicateContactRecord.alternativeName = "AlternativeNameTest2";
         noDuplicateContactRecord.numbers         = std::vector<ContactRecord::Number>({
-            ContactRecord::Number("600123451", "+48600123451", ContactNumberType ::HOME),
+            ContactRecord::Number("600123451", "+48600123451", ContactNumberType::HOME),
         });
 
         REQUIRE(records.verifyDuplicate(noDuplicateContactRecord) == false);
@@ -638,7 +638,7 @@ TEST_CASE("Check if new contact record can be recognised as a duplicate in DB")
         duplicateContactRecord.primaryName     = "PrimaryNameDuplicate";
         duplicateContactRecord.alternativeName = "AlternativeNameDuplicate";
         duplicateContactRecord.numbers         = std::vector<ContactRecord::Number>({
-            ContactRecord::Number("600123456", "+48600123456", ContactNumberType ::HOME),
+            ContactRecord::Number("600123456", "+48600123456", ContactNumberType::HOME),
         });
 
         REQUIRE(records.verifyDuplicate(duplicateContactRecord) == true);
@@ -663,7 +663,7 @@ TEST_CASE("Check if new contact record exists in DB as a temporary contact")
     testContactRecord.primaryName     = "PrimaryNameTest";
     testContactRecord.alternativeName = "AlternativeNameTest";
     testContactRecord.numbers         = std::vector<ContactRecord::Number>({
-        ContactRecord::Number("600123456", "+48600123456", ContactNumberType ::HOME),
+        ContactRecord::Number("600123456", "+48600123456", ContactNumberType::HOME),
     });
 
     REQUIRE(records.Add(testContactRecord));
@@ -674,7 +674,7 @@ TEST_CASE("Check if new contact record exists in DB as a temporary contact")
         anotherTestContactRecord.primaryName     = "PrimaryNameTest2";
         anotherTestContactRecord.alternativeName = "AlternativeNameTest2";
         anotherTestContactRecord.numbers         = std::vector<ContactRecord::Number>({
-            ContactRecord::Number("600123451", "+48600123451", ContactNumberType ::HOME),
+            ContactRecord::Number("600123451", "+48600123451", ContactNumberType::HOME),
         });
 
         REQUIRE(records.verifyTemporary(anotherTestContactRecord) == false);
@@ -684,7 +684,7 @@ TEST_CASE("Check if new contact record exists in DB as a temporary contact")
     {
         ContactRecord temporaryContactRecord;
         temporaryContactRecord.numbers = std::vector<ContactRecord::Number>({
-            ContactRecord::Number("600123452", "+48600123452", ContactNumberType ::HOME),
+            ContactRecord::Number("600123452", "+48600123452", ContactNumberType::HOME),
         });
         temporaryContactRecord.addToGroup(ContactsDB::temporaryGroupId());
 
@@ -694,7 +694,7 @@ TEST_CASE("Check if new contact record exists in DB as a temporary contact")
         noTemporaryContactRecord.primaryName     = "PrimaryNameNoTemporary";
         noTemporaryContactRecord.alternativeName = "AlternativeNameNoTemporary";
         noTemporaryContactRecord.numbers         = std::vector<ContactRecord::Number>({
-            ContactRecord::Number("600123452", "+48600123452", ContactNumberType ::HOME),
+            ContactRecord::Number("600123452", "+48600123452", ContactNumberType::HOME),
         });
 
         REQUIRE(records.verifyTemporary(noTemporaryContactRecord) == true);

--- a/module-db/tests/SMSRecord_tests.cpp
+++ b/module-db/tests/SMSRecord_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "common.hpp"
@@ -45,7 +45,7 @@ TEST_CASE("SMS Record tests")
     auto numberTest2             = utils::PhoneNumber("222333444", utils::country::Id::UNKNOWN).getView();
     const char *bodyTest         = "Test SMS Body";
     const char *bodyTest2        = "Test SMS Body2";
-    const SMSType typeTest       = SMSType ::DRAFT;
+    const SMSType typeTest       = SMSType::DRAFT;
 
     SMSRecordInterface smsRecInterface(&smsDB, &contactsDB);
 
@@ -208,7 +208,7 @@ TEST_CASE("SMS Record tests")
 
     SECTION("SMS Record Draft and Input test")
     {
-        recordIN.type = SMSType ::INBOX;
+        recordIN.type = SMSType::INBOX;
 
         // Add 3 INBOX Records
         REQUIRE(smsRecInterface.Add(recordIN));
@@ -216,7 +216,7 @@ TEST_CASE("SMS Record tests")
         REQUIRE(smsRecInterface.Add(recordIN));
 
         // Add 1 Draft Records
-        recordIN.type = SMSType ::DRAFT;
+        recordIN.type = SMSType::DRAFT;
         recordIN.body = "Draft Message";
         REQUIRE(smsRecInterface.Add(recordIN));
 

--- a/module-db/tests/SMSTable_tests.cpp
+++ b/module-db/tests/SMSTable_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -30,7 +30,7 @@ TEST_CASE("SMS Table tests")
                             .date      = 0,
                             .errorCode = 0,
                             .body      = "Test SMS message 1",
-                            .type      = SMSType ::INBOX
+                            .type      = SMSType::INBOX
 
     };
 
@@ -40,7 +40,7 @@ TEST_CASE("SMS Table tests")
                             .date      = 0,
                             .errorCode = 0,
                             .body      = "Test Draft SMS",
-                            .type      = SMSType ::DRAFT
+                            .type      = SMSType::DRAFT
 
     };
 
@@ -124,7 +124,7 @@ TEST_CASE("SMS Table tests")
         auto results = smsdb.sms.getByThreadIdWithoutDraftWithEmptyInput(0, 0, 10);
 
         REQUIRE(results.size() == 3);
-        REQUIRE(results.back().type == SMSType ::INPUT);
+        REQUIRE(results.back().type == SMSType::INPUT);
     }
 
     Database::deinitialize();

--- a/module-db/tests/ThreadRecord_tests.cpp
+++ b/module-db/tests/ThreadRecord_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "common.hpp"
@@ -42,7 +42,7 @@ TEST_CASE("Thread Record tests")
     const uint32_t dateTest      = 123456789;
     const char *snippetTest      = "Test snippet";
     const char *snippetTest2     = "Test snippet2";
-    const SMSType typeTest       = SMSType ::UNKNOWN;
+    const SMSType typeTest       = SMSType::UNKNOWN;
 
     ThreadRecordInterface threadRecordInterface1(&smsDB, &contactsDB);
 
@@ -193,7 +193,7 @@ TEST_CASE("Thread Record tests")
         recordIN.errorCode = 0;
         recordIN.number    = phoneNumber.getView();
         recordIN.body      = "Ala";
-        recordIN.type      = SMSType ::DRAFT;
+        recordIN.type      = SMSType::DRAFT;
 
         REQUIRE(smsRecInterface.Add(recordIN));
 
@@ -247,7 +247,7 @@ TEST_CASE("Thread Record tests")
         recordIN.date      = 123456789;
         recordIN.errorCode = 0;
         recordIN.number    = phoneNumber.getView();
-        recordIN.type      = SMSType ::DRAFT;
+        recordIN.type      = SMSType::DRAFT;
 
         UTF8 snippetIncluded = "Good 😁IS GOOD";
         UTF8 snippetExcluded = "\nthis part should not be included in snippet";

--- a/module-db/tests/ThreadsTable_tests.cpp
+++ b/module-db/tests/ThreadsTable_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -32,7 +32,7 @@ TEST_CASE("Threads Table tests")
                                 .unreadMsgCount = 0,
                                 .contactID      = 0,
                                 .snippet        = "Test snippet",
-                                .type           = SMSType ::DRAFT
+                                .type           = SMSType::DRAFT
 
     };
 

--- a/module-services/service-antenna/ServiceAntenna.cpp
+++ b/module-services/service-antenna/ServiceAntenna.cpp
@@ -155,11 +155,11 @@ sys::ReturnCodes ServiceAntenna::SwitchPowerModeHandler(const sys::ServicePowerM
     suspended = true;
 
     switch (mode) {
-    case sys::ServicePowerMode ::Active:
+    case sys::ServicePowerMode::Active:
         suspended = false;
         break;
-    case sys::ServicePowerMode ::SuspendToRAM:
-    case sys::ServicePowerMode ::SuspendToNVM:
+    case sys::ServicePowerMode::SuspendToRAM:
+    case sys::ServicePowerMode::SuspendToNVM:
         break;
     }
 

--- a/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
+++ b/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
@@ -281,13 +281,13 @@ namespace app::manager
         LOG_INFO("Power mode: %s", c_str(mode));
 
         switch (mode) {
-        case sys::ServicePowerMode ::Active:
+        case sys::ServicePowerMode::Active:
             sys::SystemManagerCommon::ResumeService(service::name::eink, this);
             sys::SystemManagerCommon::ResumeService(service::name::gui, this);
             break;
-        case sys::ServicePowerMode ::SuspendToRAM:
+        case sys::ServicePowerMode::SuspendToRAM:
             [[fallthrough]];
-        case sys::ServicePowerMode ::SuspendToNVM:
+        case sys::ServicePowerMode::SuspendToNVM:
             suspendSystemServices();
             break;
         }

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -280,11 +280,11 @@ sys::ReturnCodes ServiceCellular::SwitchPowerModeHandler(const sys::ServicePower
     LOG_INFO("[ServiceCellular] PowerModeHandler: %s", c_str(mode));
 
     switch (mode) {
-    case sys::ServicePowerMode ::Active:
+    case sys::ServicePowerMode::Active:
         cmux->exitSleepMode();
         break;
-    case sys::ServicePowerMode ::SuspendToRAM:
-    case sys::ServicePowerMode ::SuspendToNVM:
+    case sys::ServicePowerMode::SuspendToRAM:
+    case sys::ServicePowerMode::SuspendToNVM:
         cmux->enterSleepMode();
         break;
     }

--- a/module-services/service-db/messages/DBCalllogMessage.cpp
+++ b/module-services/service-db/messages/DBCalllogMessage.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <service-db/DBCalllogMessage.hpp>
@@ -10,12 +10,12 @@ DBCalllogMessage::DBCalllogMessage(MessageType messageType, const CalllogRecord 
     : DBMessage(messageType), record(rec)
 {}
 
-DBCalllogResponseMessage ::DBCalllogResponseMessage(std::unique_ptr<std::vector<CalllogRecord>> rec,
-                                                    uint32_t retCode,
-                                                    uint32_t limit,
-                                                    uint32_t offset,
-                                                    uint32_t count,
-                                                    MessageType respTo)
+DBCalllogResponseMessage::DBCalllogResponseMessage(std::unique_ptr<std::vector<CalllogRecord>> rec,
+                                                   uint32_t retCode,
+                                                   uint32_t limit,
+                                                   uint32_t offset,
+                                                   uint32_t count,
+                                                   MessageType respTo)
     : DBResponseMessage(retCode, count, respTo), records(std::move(rec)), limit(limit), offset(offset)
 {
     this->count = count;

--- a/module-services/service-db/messages/DBContactMessage.cpp
+++ b/module-services/service-db/messages/DBContactMessage.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <service-db/DBContactMessage.hpp>
@@ -10,17 +10,17 @@
 #include <memory>
 #include <utility>
 
-DBContactMessage ::DBContactMessage(MessageType messageType, const ContactRecord &rec, bool favourite)
+DBContactMessage::DBContactMessage(MessageType messageType, const ContactRecord &rec, bool favourite)
     : DBMessage(messageType), record(rec), favourite{favourite}
 {}
 
-DBContactResponseMessage ::DBContactResponseMessage(std::unique_ptr<std::vector<ContactRecord>> rec,
-                                                    uint32_t retCode,
-                                                    uint32_t limit,
-                                                    uint32_t offset,
-                                                    bool favourite,
-                                                    uint32_t count,
-                                                    MessageType respTo)
+DBContactResponseMessage::DBContactResponseMessage(std::unique_ptr<std::vector<ContactRecord>> rec,
+                                                   uint32_t retCode,
+                                                   uint32_t limit,
+                                                   uint32_t offset,
+                                                   bool favourite,
+                                                   uint32_t count,
+                                                   MessageType respTo)
     : DBResponseMessage(retCode, count, respTo),
       records(std::move(rec)), favourite{favourite}, limit{limit}, offset{offset}
 {}

--- a/module-services/service-desktop/tests/unittest.cpp
+++ b/module-services/service-desktop/tests/unittest.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <endpoints/Endpoint.hpp>
@@ -174,7 +174,7 @@ TEST_CASE("DB Helpers test - json encoding (contacts)")
     contact->primaryName = "Baatek";
 
     utils::PhoneNumber phoneNumber("724842187");
-    auto contactNum = ContactRecord::Number(phoneNumber.get(), phoneNumber.toE164(), ContactNumberType ::PAGER);
+    auto contactNum = ContactRecord::Number(phoneNumber.get(), phoneNumber.toE164(), ContactNumberType::PAGER);
 
     contact->numbers.emplace_back(contactNum);
 
@@ -194,7 +194,7 @@ TEST_CASE("DB Helpers test - json encoding (messages)")
     auto message = std::make_unique<SMSRecord>();
 
     utils::PhoneNumber phoneNumber("111222333");
-    auto contactNum = ContactRecord::Number(phoneNumber.get(), phoneNumber.toE164(), ContactNumberType ::PAGER);
+    auto contactNum = ContactRecord::Number(phoneNumber.get(), phoneNumber.toE164(), ContactNumberType::PAGER);
 
     message->body      = "test message";
     message->contactID = 1;

--- a/module-services/service-eink/ServiceEink.cpp
+++ b/module-services/service-eink/ServiceEink.cpp
@@ -180,17 +180,17 @@ namespace service::eink
         auto displayPowerOffTimerReload = gsl::finally([this]() { displayPowerOffTimer.start(); });
 
         if (const auto status = prepareDisplay(refreshMode, WaveformTemperature::KEEP_CURRENT);
-            status != EinkStatus_e ::EinkOK) {
+            status != EinkStatus_e::EinkOK) {
             LOG_FATAL("Failed to prepare frame");
             return;
         }
 
-        if (const auto status = updateDisplay(frameBuffer, refreshMode); status != EinkStatus_e ::EinkOK) {
+        if (const auto status = updateDisplay(frameBuffer, refreshMode); status != EinkStatus_e::EinkOK) {
             LOG_FATAL("Failed to update frame");
             return;
         }
 
-        if (const auto status = refreshDisplay(refreshMode); status != EinkStatus_e ::EinkOK) {
+        if (const auto status = refreshDisplay(refreshMode); status != EinkStatus_e::EinkOK) {
             LOG_FATAL("Failed to refresh frame");
             return;
         }

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -258,10 +258,10 @@ sys::ReturnCodes EventManagerCommon::SwitchPowerModeHandler(const sys::ServicePo
     LOG_FATAL("[ServiceEvtMgr] PowerModeHandler: %s", c_str(mode));
 
     switch (mode) {
-    case sys::ServicePowerMode ::Active:
+    case sys::ServicePowerMode::Active:
         break;
-    case sys::ServicePowerMode ::SuspendToRAM:
-    case sys::ServicePowerMode ::SuspendToNVM:
+    case sys::ServicePowerMode::SuspendToRAM:
+    case sys::ServicePowerMode::SuspendToNVM:
         break;
     }
 

--- a/module-sys/Service/details/bus/Bus.cpp
+++ b/module-sys/Service/details/bus/Bus.cpp
@@ -124,7 +124,7 @@ namespace sys
         }
 
         message->sender    = sender->GetName();
-        message->transType = Message::TransmissionType ::Unicast;
+        message->transType = Message::TransmissionType::Unicast;
 
         message->ValidateUnicastMessage();
 
@@ -201,7 +201,7 @@ namespace sys
             message->id = uniqueMsgId.getNext();
         }
 
-        message->transType = Message::TransmissionType ::Broadcast;
+        message->transType = Message::TransmissionType::Broadcast;
         message->sender    = sender->GetName();
 
         message->ValidateBroadcastMessage();

--- a/products/BellHybrid/apps/application-bell-alarm/presenter/BellAlarmSetPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-alarm/presenter/BellAlarmSetPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BellAlarmSetPresenter.hpp"
@@ -9,8 +9,8 @@
 
 namespace app::bell_alarm
 {
-    BellAlarmSetPresenter ::BellAlarmSetPresenter(app::ApplicationCommon *app,
-                                                  std::shared_ptr<AbstractAlarmModel> alarmModel)
+    BellAlarmSetPresenter::BellAlarmSetPresenter(app::ApplicationCommon *app,
+                                                 std::shared_ptr<AbstractAlarmModel> alarmModel)
         : app{app}, alarmModel{std::move(alarmModel)}
     {}
 

--- a/products/BellHybrid/apps/application-bell-meditation-timer/presenter/MeditationProgressPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/presenter/MeditationProgressPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationBellMeditationTimer.hpp"
@@ -17,9 +17,9 @@ namespace
 
 namespace app::meditation
 {
-    MeditationProgressPresenter ::MeditationProgressPresenter(app::ApplicationCommon *app,
-                                                              settings::Settings *settings,
-                                                              std::unique_ptr<AbstractTimeModel> timeModel)
+    MeditationProgressPresenter::MeditationProgressPresenter(app::ApplicationCommon *app,
+                                                             settings::Settings *settings,
+                                                             std::unique_ptr<AbstractTimeModel> timeModel)
         : app{app}, settings{settings}, timeModel{std::move(timeModel)}
     {
         duration = std::chrono::minutes{

--- a/products/BellHybrid/apps/application-bell-meditation-timer/presenter/MeditationTimerPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/presenter/MeditationTimerPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationBellMeditationTimer.hpp"
@@ -19,7 +19,7 @@ namespace
 
 namespace app::meditation
 {
-    MeditationTimerPresenter ::MeditationTimerPresenter(app::ApplicationCommon *app, settings::Settings *settings)
+    MeditationTimerPresenter::MeditationTimerPresenter(app::ApplicationCommon *app, settings::Settings *settings)
         : app{app}, settings{settings}
     {}
 

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationTimerWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationTimerWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationBellMeditationTimer.hpp"
@@ -36,7 +36,7 @@ namespace gui
         topMessage->drawUnderline(false);
 
         spinner = new UIntegerSpinner(
-            UIntegerSpinner ::Range{presenter->getMinValue(), presenter->getMaxValue(), presenter->getStepValue()},
+            UIntegerSpinner::Range{presenter->getMinValue(), presenter->getMaxValue(), presenter->getStepValue()},
             Boundaries::Fixed);
         spinner->onValueChanged = [this](const auto val) { this->onValueChanged(val); };
         spinner->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::h);

--- a/products/BellHybrid/apps/application-bell-powernap/data/PowerNapListItem.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/data/PowerNapListItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PowerNapListItem.hpp"
@@ -27,7 +27,7 @@ namespace gui
 
     void PowerNapListItem::createSpinner()
     {
-        spinner = new UIntegerSpinner(UIntegerSpinner ::Range{spinnerMin, spinnerMax, spinnerStep}, Boundaries::Fixed);
+        spinner = new UIntegerSpinner(UIntegerSpinner::Range{spinnerMin, spinnerMax, spinnerStep}, Boundaries::Fixed);
         spinner->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::h);
         spinner->setFont(powerNapStyle::napPeriodFont);
         spinner->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));

--- a/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapSessionEndedPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapSessionEndedPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PowerNapSessionEndedPresenter.hpp"
@@ -9,7 +9,7 @@
 
 namespace app::powernap
 {
-    PowerNapSessionEndPresenter ::PowerNapSessionEndPresenter(app::ApplicationCommon *app) : app{app}
+    PowerNapSessionEndPresenter::PowerNapSessionEndPresenter(app::ApplicationCommon *app) : app{app}
     {}
 
     void PowerNapSessionEndPresenter::activate()

--- a/products/BellHybrid/apps/common/src/popups/presenter/AlarmActivatedPresenter.cpp
+++ b/products/BellHybrid/apps/common/src/popups/presenter/AlarmActivatedPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <common/popups/presenter/AlarmActivatedPresenter.hpp>
@@ -8,7 +8,7 @@
 
 namespace app::popup
 {
-    AlarmActivatedPresenter ::AlarmActivatedPresenter(std::shared_ptr<AbstractAlarmModel> alarmModel)
+    AlarmActivatedPresenter::AlarmActivatedPresenter(std::shared_ptr<AbstractAlarmModel> alarmModel)
         : alarmModel{std::move(alarmModel)}
     {}
 

--- a/products/PurePhone/services/desktop/endpoints/contacts/ContactHelper.cpp
+++ b/products/PurePhone/services/desktop/endpoints/contacts/ContactHelper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <endpoints/contacts/ContactHelper.hpp>
@@ -66,7 +66,7 @@ namespace sdesktop::endpoints
 
         for (const auto &num : contactJSON[json::contacts::numbers].array_items()) {
             utils::PhoneNumber phoneNumber(num.string_value());
-            auto contactNum = ContactRecord::Number(phoneNumber.get(), phoneNumber.toE164(), ContactNumberType ::CELL);
+            auto contactNum = ContactRecord::Number(phoneNumber.get(), phoneNumber.toE164(), ContactNumberType::CELL);
             newRecord.numbers.push_back(contactNum);
         }
 


### PR DESCRIPTION
It appears in the past a major edit was made but had used a regex to
change some text which resulted in an errant space between the
enumuneration/struct/class name and the scope resolution operator.
These errant spaces have been removed.