### PR TITLE
Egd 8193 proper system shutdown during update 2

### DIFF
--- a/module-sys/SystemManager/include/SystemManager/SystemManagerCommon.hpp
+++ b/module-sys/SystemManager/include/SystemManager/SystemManagerCommon.hpp
@@ -39,7 +39,6 @@ namespace sys
     enum class Code
     {
         CloseSystem,
-        Update,
         Restore,
         Reboot,
         RebootToUpdate,
@@ -179,11 +178,11 @@ namespace sys
 
         void readyToCloseHandler(Message *msg);
 
-        void UpdateSystemHandler();
-
         void RestoreSystemHandler();
 
-        void RebootHandler(State state, std::optional<UpdateReason> updateReason = std::nullopt);
+        void RebootHandler();
+
+        void RebootToUpdateHandler(UpdateReason updateReason);
 
         void RebootToUsbMscModeHandler(State newState);
 
@@ -194,6 +193,7 @@ namespace sys
 
         bool cpuStatisticsTimerInit{false};
 
+        CloseReason closeReason{CloseReason::RegularPowerDown};
         UpdateReason updateReason{UpdateReason::Update};
         std::vector<std::unique_ptr<BaseServiceCreator>> systemServiceCreators;
         sys::TimerHandle freqTimer;

--- a/module-sys/common/include/system/Common.hpp
+++ b/module-sys/common/include/system/Common.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once


### PR DESCRIPTION
There are some issues with service eink and service desktop during update from mudita center and hence deinitializing both services during system update is temporarily disabled.