### PR TITLE
[MOS-234] Add Abc input mode to contact search

### DIFF
--- a/module-apps/application-phonebook/windows/PhonebookSearch.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookSearch.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhonebookSearch.hpp"
@@ -21,7 +21,7 @@ namespace gui
 
         inputField = inputBox(this, utils::translate("common_search_uc"), "search_32px_W_G");
         inputField->setInputMode(new InputMode(
-            {InputMode::ABC, InputMode::abc, InputMode::digit},
+            {InputMode::Abc, InputMode::ABC, InputMode::abc, InputMode::digit},
             [=](const UTF8 &Text) { application->getCurrentWindow()->navBarTemporaryMode(Text); },
             [=]() { application->getCurrentWindow()->navBarRestoreFromTemporaryMode(); },
             [=]() { application->getCurrentWindow()->selectSpecialCharacter(); }));

--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -74,7 +74,7 @@ auto ServiceDesktop::getDeviceToken() -> std::string
         tokenSeed = getDeviceUniqueId();
     }
 
-    return (tokenSeed);
+    return tokenSeed;
 }
 
 auto ServiceDesktop::getDeviceUniqueId() const -> std::string

--- a/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
@@ -41,7 +41,7 @@ namespace sdesktop
     inline constexpr auto SEND_QUEUE_BUFFER_NAME    = "sendQueueBuffer";
     inline constexpr auto IRQ_QUEUE_BUFFER_NAME     = "irqQueueBuffer";
     inline constexpr auto DeviceUniqueIdLength      = 32;
-    constexpr auto DeviceUniqueIdName               = "sd_device_unique_id";
+    inline constexpr auto DeviceUniqueIdName        = "sd_device_unique_id";
 
 }; // namespace sdesktop
 


### PR DESCRIPTION
Abc mode was not selected as a default,
because it was not added in this input field.