### PR TITLE
[MOS-76] add missing space in the separator

### DIFF
--- a/module-apps/application-alarm-clock/models/NewEditAlarmModel.cpp
+++ b/module-apps/application-alarm-clock/models/NewEditAlarmModel.cpp
@@ -19,8 +19,8 @@ namespace app::alarmClock
                                          std::shared_ptr<SoundsPlayer> player,
                                          std::shared_ptr<alarmClock::AlarmRRulePresenter> rRulePresenter,
                                          std::shared_ptr<AbstractAlarmsRepository> alarmsRepository)
-        : application(app), alarmsRepository{std::move(alarmsRepository)}, soundsPlayer(player),
-          rRulePresenter(rRulePresenter)
+        : application(app), alarmsRepository{std::move(alarmsRepository)}, soundsPlayer(std::move(player)),
+          rRulePresenter(std::move(rRulePresenter))
     {}
 
     unsigned int NewEditAlarmModel::requestRecordsCount()

--- a/module-apps/application-alarm-clock/presenter/AlarmRRulePresenter.cpp
+++ b/module-apps/application-alarm-clock/presenter/AlarmRRulePresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlarmRRulePresenter.hpp"
@@ -6,7 +6,8 @@
 
 namespace app::alarmClock
 {
-    AlarmRRulePresenter::AlarmRRulePresenter(std::shared_ptr<AlarmEventRecord> recordToLoad) : alarm(recordToLoad)
+    AlarmRRulePresenter::AlarmRRulePresenter(std::shared_ptr<AlarmEventRecord> recordToLoad)
+        : alarm(std::move(recordToLoad))
     {}
 
     void AlarmRRulePresenter::loadRecord(std::shared_ptr<AlarmEventRecord> recordToLoad)
@@ -63,11 +64,11 @@ namespace app::alarmClock
             for (unsigned int i = 0; i < utl::num_days; ++i) {
                 if ((0x1 & (setDays >> i)) != 0) {
                     auto dayname = utils::time::Locale::get_short_day(i);
-                    retval += dayname + ",";
+                    retval += dayname + ", ";
                 }
             }
             if (retval.length() > 0) {
-                retval.removeChar(retval.length() - 1);
+                retval.removeChar(retval.length() - 2);
             }
         }
         return retval;


### PR DESCRIPTION
Days of the week should be separated by
a comma and a space in the alarm repeat widget.

![image](https://user-images.githubusercontent.com/58421550/154999310-466b0cfa-1e45-402d-9c70-94fc97dd4b16.png)
![image](https://user-images.githubusercontent.com/58421550/154999379-d9cfb9a7-668a-4406-901a-ad3d7f8903eb.png)

