### PR TITLE
[MOS-233] Fix no chime interval in med timer

### DIFF
--- a/module-apps/application-meditation/widgets/IntervalBox.cpp
+++ b/module-apps/application-meditation/widgets/IntervalBox.cpp
@@ -53,9 +53,6 @@ void IntervalBox::updateIntervals()
         if (chime < setTime) {
             chimeOptions.push_back(intervalToString(chime));
         }
-        else {
-            break;
-        }
     }
 
     auto currentInterval = chimeSpinner->getCurrentValue();


### PR DESCRIPTION
[Meditation] There is no None interval chime
for meditation time < 31min

Signed-off-by: Lucjan Bryndza <lucjan.bryndza@mudita.com>