### PR TITLE
[BH-1406] Low battery turnon

### DIFF
--- a/module-apps/apps-common/popups/Popups.cpp
+++ b/module-apps/apps-common/popups/Popups.cpp
@@ -44,6 +44,8 @@ namespace gui::popup
             return gui::popup::window::reboot_window;
         case ID::BedtimeNotification:
             return gui::popup::window::bedtime_notification_window;
+        case ID::DeadBatteryWindow:
+            return gui::popup::window::dead_battery_window;
         }
 
         return {};

--- a/module-apps/apps-common/popups/Popups.hpp
+++ b/module-apps/apps-common/popups/Popups.hpp
@@ -29,6 +29,7 @@ namespace gui
             PowerOff,
             Reboot,
             BedtimeNotification,
+            DeadBatteryWindow,
         };
 
         namespace window
@@ -52,6 +53,7 @@ namespace gui
             inline constexpr auto alarm_window                      = "AlarmPopup";
             inline constexpr auto reboot_window                     = "RebootPopup";
             inline constexpr auto bedtime_notification_window       = "BedtimeNotificationPopup";
+            inline constexpr auto dead_battery_window               = "DeadBatteryPopup";
         } // namespace window
 
         std::string resolveWindowName(ID id);

--- a/module-services/service-appmgr/include/service-appmgr/model/ActionsRegistry.hpp
+++ b/module-services/service-appmgr/include/service-appmgr/model/ActionsRegistry.hpp
@@ -54,6 +54,7 @@ namespace app::manager
 
         void enqueue(ActionEntry &&action);
         void finished();
+        void process();
 
         [[nodiscard]] auto hasPendingAction() const noexcept -> bool;
         [[nodiscard]] auto getPendingAction() noexcept -> ActionEntry *;

--- a/module-services/service-appmgr/model/ActionsRegistry.cpp
+++ b/module-services/service-appmgr/model/ActionsRegistry.cpp
@@ -58,6 +58,13 @@ namespace app::manager
         }
     }
 
+    void ActionsRegistry::process()
+    {
+        if (!isCurrentlyProcessing()) {
+            notifyAboutNextAction();
+        }
+    }
+
     void ActionsRegistry::addAction(ActionEntry &&action)
     {
         actions.push_back(std::move(action));

--- a/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
+++ b/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
@@ -717,7 +717,6 @@ namespace app::manager
             setState(State::Running);
             EventManagerCommon::messageSetApplication(this, app.name());
             onLaunchFinished(app);
-            actionsRegistry.process();
             return true;
         }
         if (getState() == State::AwaitingLostFocusConfirmation) {
@@ -738,8 +737,8 @@ namespace app::manager
     {
         // reset startupReason to default Launch
         app.startupReason = StartupReason::Launch;
-
         if (!actionsRegistry.hasPendingAction()) {
+            actionsRegistry.process();
             return;
         }
 
@@ -755,8 +754,9 @@ namespace app::manager
             actionsRegistry.finished();
             break;
         default: {
-            auto &params = action->params;
-            app::ApplicationCommon::requestAction(this, app.name(), action->actionId, std::move(params));
+            // IMO this is not neccessary! Commenting for now:
+            // auto &params = action->params;
+            // app::ApplicationCommon::requestAction(this, app.name(), action->actionId, std::move(params));
             break;
         }
         }

--- a/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
+++ b/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
@@ -367,6 +367,10 @@ namespace app::manager
 
         auto currentlyFocusedApp = getFocusedApplication();
         if (currentlyFocusedApp == nullptr) {
+            if (app->state() != ApplicationCommon::State::NONE) {
+                LOG_INFO("No focused application at the moment, but requested app is starting already...");
+                return false;
+            }
             LOG_INFO("No focused application at the moment. Starting new application...");
             onApplicationSwitch(*app, std::move(msg->getData()), msg->getWindow());
             startApplication(*app);
@@ -713,6 +717,7 @@ namespace app::manager
             setState(State::Running);
             EventManagerCommon::messageSetApplication(this, app.name());
             onLaunchFinished(app);
+            actionsRegistry.process();
             return true;
         }
         if (getState() == State::AwaitingLostFocusConfirmation) {

--- a/products/BellHybrid/apps/Application.cpp
+++ b/products/BellHybrid/apps/Application.cpp
@@ -13,6 +13,7 @@
 #include <common/popups/AlarmDeactivatedWindow.hpp>
 #include <common/popups/BellTurnOffOptionWindow.hpp>
 #include <common/popups/BellRebootWindow.hpp>
+#include <common/popups/DeadBatteryWindow.hpp>
 #include <common/windows/BellTurnOffWindow.hpp>
 #include <common/windows/BellWelcomeWindow.hpp>
 #include <service-appmgr/Constants.hpp>
@@ -65,6 +66,12 @@ namespace app
                 windowsFactory.attach(window::bedtime_notification_window,
                                       [](app::ApplicationCommon *app, const std::string &name) {
                                           return std::make_unique<gui::BedtimeNotificationWindow>(app);
+                                      });
+                break;
+            case ID::DeadBatteryWindow:
+                windowsFactory.attach(window::dead_battery_window,
+                                      [](app::ApplicationCommon *app, const std::string &name) {
+                                          return std::make_unique<gui::DeadBatteryWindow>(app);
                                       });
                 break;
             default:

--- a/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
+++ b/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
@@ -5,7 +5,6 @@
 #include "models/BatteryModel.hpp"
 #include "models/TemperatureModel.hpp"
 
-#include "windows/BellBatteryShutdownWindow.hpp"
 #include "windows/BellHomeScreenWindow.hpp"
 #include "windows/BellMainMenuWindow.hpp"
 #include "windows/BellBatteryStatusWindow.hpp"
@@ -49,7 +48,7 @@ namespace app
         });
 
         addActionReceiver(app::manager::actions::SystemBrownout, [this](auto &&data) {
-            requestShutdownWindow(gui::window::name::bell_battery_shutdown);
+            requestShutdownWindow(gui::popup::window::dead_battery_window);
             return actionHandled();
         });
 
@@ -92,7 +91,7 @@ namespace app
     void ApplicationBellMain::createUserInterface()
     {
         windowsFactory.attach(gui::name::window::main_window, [this](ApplicationCommon *app, const std::string &name) {
-            auto layoutModel      = std::make_unique<bell_settings::LayoutModel>(app);
+            auto layoutModel    = std::make_unique<bell_settings::LayoutModel>(app);
             auto window         = std::make_unique<gui::BellHomeScreenWindow>(app, homeScreenPresenter);
             auto selectedLayout = layoutModel->getValue();
             setHomeScreenLayout(selectedLayout);
@@ -102,11 +101,6 @@ namespace app
         windowsFactory.attach(gui::window::name::bell_main_menu, [](ApplicationCommon *app, const std::string &name) {
             return std::make_unique<gui::BellMainMenuWindow>(app);
         });
-
-        windowsFactory.attach(gui::window::name::bell_battery_shutdown,
-                              [](ApplicationCommon *app, const std::string &name) {
-                                  return std::make_unique<gui::BellBatteryShutdownWindow>(app);
-                              });
 
         windowsFactory.attach(gui::BellFactoryReset::name, [](ApplicationCommon *app, const std::string &name) {
             return std::make_unique<gui::BellFactoryReset>(app, std::make_unique<gui::BellPowerOffPresenter>(app));
@@ -120,11 +114,14 @@ namespace app
             gui::window::name::bell_main_menu_dialog,
             [](ApplicationCommon *app, const std::string &name) { return std::make_unique<gui::Dialog>(app, name); });
 
-        attachPopups({gui::popup::ID::AlarmActivated,
-                      gui::popup::ID::AlarmDeactivated,
-                      gui::popup::ID::PowerOff,
-                      gui::popup::ID::Reboot,
-                      gui::popup::ID::BedtimeNotification});
+        attachPopups({
+            gui::popup::ID::AlarmActivated,
+            gui::popup::ID::AlarmDeactivated,
+            gui::popup::ID::PowerOff,
+            gui::popup::ID::Reboot,
+            gui::popup::ID::BedtimeNotification,
+            gui::popup::ID::DeadBatteryWindow,
+        });
     }
 
     sys::MessagePointer ApplicationBellMain::DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp)

--- a/products/BellHybrid/apps/application-bell-main/CMakeLists.txt
+++ b/products/BellHybrid/apps/application-bell-main/CMakeLists.txt
@@ -5,7 +5,6 @@ target_sources(application-bell-main
     PRIVATE
         ApplicationBellMain.cpp
 
-        windows/BellBatteryShutdownWindow.cpp
         windows/BellHomeScreenWindow.cpp
         windows/BellMainMenuWindow.cpp
         windows/BellBatteryStatusWindow.cpp
@@ -16,7 +15,6 @@ target_sources(application-bell-main
         presenters/HomeScreenPresenter.cpp
         presenters/StateController.cpp
 
-        windows/BellBatteryShutdownWindow.hpp
         windows/BellHomeScreenWindow.hpp
         windows/BellMainMenuWindow.hpp
         windows/BellBatteryStatusWindow.hpp

--- a/products/BellHybrid/apps/application-bell-onboarding/ApplicationBellOnBoarding.cpp
+++ b/products/BellHybrid/apps/application-bell-onboarding/ApplicationBellOnBoarding.cpp
@@ -50,6 +50,11 @@ namespace app
             return sys::msgNotHandled();
         });
 
+        addActionReceiver(app::manager::actions::SystemBrownout, [this](auto &&data) {
+            requestShutdownWindow(gui::popup::window::dead_battery_window);
+            return actionHandled();
+        });
+
         informationPromptTimer = sys::TimerFactory::createSingleShotTimer(
             this,
             OnBoarding::informationTimerName,
@@ -97,6 +102,10 @@ namespace app
                               [](ApplicationCommon *app, const std::string &name) {
                                   return std::make_unique<gui::OnBoardingInstructionPromptWindow>(app, name);
                               });
+
+        attachPopups({
+            gui::popup::ID::DeadBatteryWindow,
+        });
     }
 
     void ApplicationBellOnBoarding::destroyUserInterface()

--- a/products/BellHybrid/apps/common/CMakeLists.txt
+++ b/products/BellHybrid/apps/common/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(application-bell-common
         src/popups/AlarmDeactivatedWindow.cpp
         src/popups/BellTurnOffOptionWindow.cpp
         src/popups/BellRebootWindow.cpp
+        src/popups/DeadBatteryWindow.cpp
         src/popups/presenter/AlarmActivatedPresenter.cpp
         src/widgets/ListItems.cpp
         src/widgets/BellBattery.cpp
@@ -83,6 +84,7 @@ target_sources(application-bell-common
         include/common/popups/BedtimeNotificationWindow.hpp
         include/common/popups/BellTurnOffOptionWindow.hpp
         include/common/popups/BellRebootWindow.hpp
+        include/common/popups/DeadBatteryWindow.hpp
         include/common/widgets/BellBattery.hpp
         include/common/widgets/BellSideListItemWithCallbacks.hpp
         include/common/widgets/BellStatusClock.hpp

--- a/products/BellHybrid/apps/common/include/common/popups/DeadBatteryWindow.hpp
+++ b/products/BellHybrid/apps/common/include/common/popups/DeadBatteryWindow.hpp
@@ -9,12 +9,12 @@ namespace gui
 {
     class Icon;
 
-    class BellBatteryShutdownWindow : public gui::AppWindow
+    class DeadBatteryWindow : public gui::AppWindow
     {
       public:
-        static constexpr auto defaultName = "BellBatteryShutdown";
+        static constexpr auto defaultName = "DeadBatteryWindow";
 
-        BellBatteryShutdownWindow(app::ApplicationCommon *app, const std::string &name = defaultName);
+        DeadBatteryWindow(app::ApplicationCommon *app, const std::string &name = defaultName);
 
       private:
         void buildInterface() override;

--- a/products/BellHybrid/apps/common/src/popups/DeadBatteryWindow.cpp
+++ b/products/BellHybrid/apps/common/src/popups/DeadBatteryWindow.cpp
@@ -1,7 +1,8 @@
 // Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include "windows/BellBatteryShutdownWindow.hpp"
+#include "popups/DeadBatteryWindow.hpp"
+
 #include <gui/input/InputEvent.hpp>
 #include <gui/widgets/Icon.hpp>
 #include <i18n/i18n.hpp>
@@ -9,13 +10,13 @@
 
 namespace gui
 {
-    BellBatteryShutdownWindow::BellBatteryShutdownWindow(app::ApplicationCommon *app, const std::string &name)
+    DeadBatteryWindow::DeadBatteryWindow(app::ApplicationCommon *app, const std::string &name)
         : gui::AppWindow(app, name)
     {
         buildInterface();
     }
 
-    void gui::BellBatteryShutdownWindow::buildInterface()
+    void gui::DeadBatteryWindow::buildInterface()
     {
         AppWindow::buildInterface();
         statusBar->setVisible(false);
@@ -26,7 +27,7 @@ namespace gui
             new Icon(this, 0, 0, style::window_width, style::window_height, "bell_battery_status_empty_W_M", {});
         icon->text->setFont(style::window::font::verybiglight);
     }
-    bool BellBatteryShutdownWindow::onInput(const InputEvent &)
+    bool DeadBatteryWindow::onInput(const InputEvent &)
     {
         return false;
     }


### PR DESCRIPTION
Actions changes explaination:
Present state:
When an action is going to an application that is not turned on, system is launching the app and skipping the action. The action **will not be** processed until another action arrives.
Implemented change:
After application launch and switch confirmation, ApplicationManager processes all actions that are queued (skipped before) in the actionsRegistry