### PR TITLE
[MOS-135] Proper system shutdown during restore

### DIFF
--- a/module-sys/SystemManager/SystemManagerCommon.cpp
+++ b/module-sys/SystemManager/SystemManagerCommon.cpp
@@ -49,8 +49,6 @@ namespace sys
         {
             static constexpr std::array whitelist = {service::name::service_desktop,
                                                      service::name::evt_manager,
-                                                     service::name::gui,
-                                                     service::name::eink,
                                                      service::name::appmgr,
                                                      service::name::cellular};
         }


### PR DESCRIPTION
After the restore process is complete, the system shuts down
properly without any unexpected events.