### PR TITLE
[MOS-269] Fix lock audio subsystem during voice call

### DIFF
--- a/module-services/service-cellular/call/CallAudio.cpp
+++ b/module-services/service-cellular/call/CallAudio.cpp
@@ -37,5 +37,5 @@ void CallRingAudio::stop()
         return;
     }
     owner.sync(meta->async);
-    AudioServiceAPI::Stop(&owner, meta->async.getResult().token);
+    AudioServiceAPI::StopAll(&owner);
 }


### PR DESCRIPTION
Audio service is deadlocked on sentinel because IsBussy() method returns
that it's all the time bussy. Even though there is no ongoing audio
requested from either GSM or apps.