### PR TITLE
[MOS-291] Fix bluetooth auto turn off

### DIFF
--- a/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
@@ -73,6 +73,7 @@ class ServiceBluetooth : public sys::Service
     void ProcessCloseReason(sys::CloseReason closeReason) override;
     virtual sys::ReturnCodes SwitchPowerModeHandler(const sys::ServicePowerMode mode) override;
     void sendWorkerCommand(bluetooth::Command command);
+    void handleTurnOff();
     QueueHandle_t workerQueue = nullptr;
     std::shared_ptr<bluetooth::SettingsHolder> settingsHolder;
     bluetooth::ProfileManager *profileManagerPtr = nullptr;
@@ -85,6 +86,7 @@ class ServiceBluetooth : public sys::Service
 
     void startTimeoutTimer();
     void stopTimeoutTimer();
+    void resetTimeoutTimer();
 
     template <typename T> auto connectHandler() -> bool
     {


### PR DESCRIPTION
Fix bluetooth not auto turning off.
Changes in logic (consulted with PO):
Changed logic to properly turn off on idle state (with no device connected).
Changed turnoff timeout to 10 minutes. 