### PR TITLE
[MOS-316] Fix compile lfs fuse with GCC11 host

### DIFF
--- a/host-tools/littlefs-fuse/CMakeLists.txt
+++ b/host-tools/littlefs-fuse/CMakeLists.txt
@@ -9,7 +9,7 @@ file(GLOB_RECURSE LFSFUSE_SRCS *.c)
 add_executable(${PROJECT_NAME} ${LFSFUSE_SRCS})
 
 
-target_compile_options(${PROJECT_NAME} PRIVATE -Wall -pedantic -Wno-missing-field-initializers)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -pedantic -Wno-missing-field-initializers -Wno-array-bounds -Wno-maybe-uninitialized)
 target_compile_definitions( ${PROJECT_NAME}
         PRIVATE
         _FILE_OFFSET_BITS=64


### PR DESCRIPTION
Fix compilation for the LFS fuse tools with GCC11

Signed-off-by: Lucjan Bryndza <lucjan.bryndza@mudita.com>

**Description**

Please describe your pull request

**Your checklist for this pull request**

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible.
- [ ] Has documentation updated

Thanks for your work ♥
