### PR TITLE
[BH-1434] Fix Bedtime Tone Return

### DIFF
--- a/products/BellHybrid/apps/application-bell-settings/presenter/BedtimeSettingsPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/presenter/BedtimeSettingsPresenter.cpp
@@ -22,7 +22,6 @@ namespace app::bell_settings
         this->provider->onExit = [this]() { getView()->exit(); };
 
         this->provider->onToneEnter  = playSound;
-        this->provider->onToneExit   = [this](const auto &) { stopSound(); };
         this->provider->onToneChange = playSound;
 
         this->provider->onVolumeEnter  = playSound;
@@ -65,6 +64,7 @@ namespace app::bell_settings
     }
     void SettingsPresenter::exitWithoutSave()
     {
+        this->stopSound();
         model->getBedtimeVolume().restoreDefault();
     }
 } // namespace app::bell_settings

--- a/products/BellHybrid/apps/application-bell-settings/presenter/alarm_settings/AlarmSettingsPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/presenter/alarm_settings/AlarmSettingsPresenter.cpp
@@ -22,7 +22,6 @@ namespace app::bell_settings
         this->provider->onExit = [this]() { getView()->exit(); };
 
         this->provider->onToneEnter  = playSound;
-        this->provider->onToneExit   = [this](const auto &) { stopSound(); };
         this->provider->onToneChange = playSound;
 
         this->provider->onVolumeEnter  = playSound;
@@ -67,6 +66,7 @@ namespace app::bell_settings
 
     void AlarmSettingsPresenter::exitWithRollback()
     {
+        this->stopSound();
         model->getAlarmVolume().restoreDefault();
         eraseProviderData();
     }

--- a/products/BellHybrid/apps/application-bell-settings/windows/alarm_settings/BellSettingsAlarmSettingsWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/windows/alarm_settings/BellSettingsAlarmSettingsWindow.cpp
@@ -55,6 +55,9 @@ namespace gui
             exit();
             return true;
         }
+        if (inputEvent.isShortRelease(KeyCode::KEY_RF)) {
+            presenter->exitWithRollback();
+        }
 
         return AppWindow::onInput(inputEvent);
     }


### PR DESCRIPTION
Fix audio playback on return

**Description**

Audio playback did not properly stop on return without save from Bedtime Tone Settings and Alarm Settings. Furthermore a crash due to segmentation fault was observed upon re-entering into those settings. This PR fixes those issues


