### PR TITLE
[BH-1432] Split Language Display Handling

### DIFF
--- a/module-services/service-appmgr/include/service-appmgr/model/ApplicationManagerCommon.hpp
+++ b/module-services/service-appmgr/include/service-appmgr/model/ApplicationManagerCommon.hpp
@@ -106,6 +106,8 @@ namespace app::manager
         auto handleSwitchApplication(SwitchRequest *msg, bool closeCurrentlyFocusedApp = true) -> bool;
         virtual void handleStart(StartAllowedMessage *msg);
         virtual auto handleActionOnFocusedApp(ActionEntry &action) -> ActionProcessStatus;
+        virtual auto handleDisplayLanguageChange(DisplayLanguageChangeRequest *msg) -> bool;
+        void rebuildActiveApplications();
 
         ApplicationName rootApplicationName;
         ActionsRegistry actionsRegistry;
@@ -113,7 +115,6 @@ namespace app::manager
 
       private:
         void startPendingApplicationOnCurrentClose();
-        void rebuildActiveApplications();
         void suspendSystemServices();
         void closeNoLongerNeededApplications();
         auto closeApplications() -> bool;
@@ -131,7 +132,6 @@ namespace app::manager
         auto handleSwitchConfirmation(SwitchConfirmation *msg) -> bool;
         auto handleSwitchBack(SwitchBackRequest *msg) -> bool;
         auto handleInitApplication(ApplicationInitialised *msg) -> bool;
-        auto handleDisplayLanguageChange(DisplayLanguageChangeRequest *msg) -> bool;
         auto handleInputLanguageChange(InputLanguageChangeRequest *msg) -> bool;
         auto handlePowerSavingModeInit() -> bool;
         virtual auto handleDeveloperModeRequest(sys::Message *request) -> sys::MessagePointer;

--- a/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
+++ b/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
@@ -665,7 +665,6 @@ namespace app::manager
         settings->setValue(
             settings::SystemProperties::displayLanguage, requestedLanguage, settings::SettingsScope::Global);
         rebuildActiveApplications();
-        DBServiceAPI::InformLanguageChanged(this);
         return true;
     }
 

--- a/products/BellHybrid/services/appmgr/ApplicationManager.cpp
+++ b/products/BellHybrid/services/appmgr/ApplicationManager.cpp
@@ -9,6 +9,7 @@
 #include <application-bell-main/ApplicationBellMain.hpp>
 #include <application-bell-onboarding/BellOnBoardingNames.hpp>
 #include <service-appmgr/Constants.hpp>
+#include <service-db/agents/settings/SystemSettings.hpp>
 
 namespace app::manager
 {
@@ -43,6 +44,11 @@ namespace app::manager
         default:
             return ApplicationManagerCommon::handleAction(action);
         }
+    }
+
+    auto ApplicationManager::handleDisplayLanguageChange(app::manager::DisplayLanguageChangeRequest *msg) -> bool
+    {
+        return ApplicationManagerCommon::handleDisplayLanguageChange(msg);
     }
 
     void ApplicationManager::registerMessageHandlers()

--- a/products/BellHybrid/services/appmgr/include/appmgr/ApplicationManager.hpp
+++ b/products/BellHybrid/services/appmgr/include/appmgr/ApplicationManager.hpp
@@ -17,6 +17,7 @@ namespace app::manager
 
       protected:
         auto handleAction(ActionEntry &action) -> ActionProcessStatus override;
+        auto handleDisplayLanguageChange(DisplayLanguageChangeRequest *msg) -> bool override;
 
       private:
         sys::TimerHandle idleTimer;

--- a/products/PurePhone/services/appmgr/ApplicationManager.cpp
+++ b/products/PurePhone/services/appmgr/ApplicationManager.cpp
@@ -603,4 +603,19 @@ namespace app::manager
             break;
         }
     }
+
+    auto ApplicationManager::handleDisplayLanguageChange(app::manager::DisplayLanguageChangeRequest *msg) -> bool
+    {
+        const auto &requestedLanguage = msg->getLanguage();
+
+        if (not utils::setDisplayLanguage(requestedLanguage)) {
+            LOG_WARN("The selected language is already set. Ignore.");
+            return false;
+        }
+        settings->setValue(
+            settings::SystemProperties::displayLanguage, requestedLanguage, settings::SettingsScope::Global);
+        rebuildActiveApplications();
+        DBServiceAPI::InformLanguageChanged(this);
+        return true;
+    }
 } // namespace app::manager

--- a/products/PurePhone/services/appmgr/include/appmgr/ApplicationManager.hpp
+++ b/products/PurePhone/services/appmgr/include/appmgr/ApplicationManager.hpp
@@ -51,6 +51,7 @@ namespace app::manager
         auto handleAction(ActionEntry &action) -> ActionProcessStatus override;
         void handleStart(StartAllowedMessage *msg) override;
         void runAppsInBackground();
+        auto handleDisplayLanguageChange(DisplayLanguageChangeRequest *msg) -> bool override;
 
         std::shared_ptr<sys::phone_modes::Observer> phoneModeObserver;
         sys::bluetooth::BluetoothMode bluetoothMode = sys::bluetooth::BluetoothMode::Disabled;


### PR DESCRIPTION
Separate implementations of handleDisplayLanguageChanged()

**Description**
This PR fixes BellHybrid application assertion during language change. HandleDisplayLanguageChanged() needs to have different behaviour now between Bell and Pure