### PR TITLE
[MOS-117] Faster eInk sleep after screen redraw

### DIFF
--- a/module-services/service-eink/ServiceEink.cpp
+++ b/module-services/service-eink/ServiceEink.cpp
@@ -28,7 +28,7 @@ namespace service::eink
     namespace
     {
         constexpr auto ServceEinkStackDepth = 4096U;
-        constexpr std::chrono::milliseconds displayPowerOffTimeout{3800};
+        constexpr std::chrono::milliseconds displayPowerOffTimeout{2000};
 
         std::string toSettingString(EinkModeMessage::Mode mode)
         {

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -280,10 +280,6 @@ int EventManagerCommon::dumpLogsToFile()
 
 void EventManagerCommon::handleMinuteUpdate(time_t timestamp)
 {
-    // temporary frequency lock to handle time update event
-    if (cpuSentinel) {
-        cpuSentinel->HoldMinimumFrequencyForTime(bsp::CpuFrequencyMHz::Level_2, std::chrono::seconds(1));
-    }
     if (onMinuteTick) {
         onMinuteTick(timestamp);
     }

--- a/products/PurePhone/EinkSentinelPure.cpp
+++ b/products/PurePhone/EinkSentinelPure.cpp
@@ -10,7 +10,6 @@ namespace service::eink
 {
     namespace
     {
-        constexpr auto RedrawLockedEinkCpuFrequency   = bsp::CpuFrequencyMHz::Level_4;
         constexpr auto RedrawUnlockedEinkCpuFrequency = bsp::CpuFrequencyMHz::Level_6;
     } // namespace
 
@@ -27,10 +26,12 @@ namespace service::eink
 
     void EinkSentinel::HoldMinimumFrequency()
     {
-        currentReason = std::string("up: ") + owner->getCurrentProcessing() + std::string(" req: ") +
-                        std::to_string(static_cast<int>((GetFrequency())));
-        CpuSentinel::HoldMinimumFrequency(isScreenLocked ? RedrawLockedEinkCpuFrequency
-                                                         : RedrawUnlockedEinkCpuFrequency);
+        if (!isScreenLocked) {
+            currentReason = std::string("up: ") + owner->getCurrentProcessing() + std::string(" req: ") +
+                            std::to_string(static_cast<int>((GetFrequency())));
+
+            CpuSentinel::HoldMinimumFrequency(RedrawUnlockedEinkCpuFrequency);
+        }
     }
 
     sys::MessagePointer EinkSentinel::handleLockedPhone()


### PR DESCRIPTION
eInk is turned on for 2 sec to redraw the screen 
- so far it was 3.8 sec

**Your checklist for this pull request**

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible.
- [ ] Has documentation updated

Thanks for your work ♥
