### PR TITLE
[MOS-303] GCC11 build fix

### DIFF
--- a/module-bsp/board/rt1051/bsp/audio/CodecMAX98090.hpp
+++ b/module-bsp/board/rt1051/bsp/audio/CodecMAX98090.hpp
@@ -6,6 +6,7 @@
 
 #include "Codec.hpp"
 #include "drivers/i2c/DriverI2C.hpp"
+#include <cstdint>
 
 class CodecParamsMAX98090 : public CodecParams
 {


### PR DESCRIPTION
Added missing header
