### PR TITLE
[MOS-325] AudioServiceAPI removed from Call app

### DIFF
--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -16,7 +16,6 @@
 #include <PhoneNumber.hpp>
 #include <service-appmgr/Controller.hpp>
 #include <service-appmgr/data/MmiActionsParams.hpp>
-#include <service-audio/AudioServiceAPI.hpp>
 #include <service-cellular/CellularServiceAPI.hpp>
 #include <time/time_conversion.hpp>
 #include <WindowsPopupFilter.hpp>
@@ -264,25 +263,20 @@ namespace app
         }
     }
 
-    void ApplicationCall::startAudioRouting()
-    {
-        AudioServiceAPI::RoutingStart(this);
-    }
-
     void ApplicationCall::sendAudioEvent(AudioEvent audioEvent)
     {
         switch (audioEvent) {
         case AudioEvent::Mute:
-            AudioServiceAPI::SendEvent(this, audio::EventType::CallMute);
+            CellularServiceAPI::CallAudioMuteEvent(this);
             break;
         case AudioEvent::Unmute:
-            AudioServiceAPI::SendEvent(this, audio::EventType::CallUnmute);
+            CellularServiceAPI::CallAudioUnmuteEvent(this);
             break;
         case AudioEvent::LoudspeakerOn:
-            AudioServiceAPI::SendEvent(this, audio::EventType::CallLoudspeakerOn);
+            CellularServiceAPI::CallAudioLoudspeakerOnEvent(this);
             break;
         case AudioEvent::LoudspeakerOff:
-            AudioServiceAPI::SendEvent(this, audio::EventType::CallLoudspeakerOff);
+            CellularServiceAPI::CallAudioLoudspeakerOffEvent(this);
             break;
         }
     }

--- a/module-apps/application-call/include/application-call/ApplicationCall.hpp
+++ b/module-apps/application-call/include/application-call/ApplicationCall.hpp
@@ -45,7 +45,6 @@ namespace app
             LoudspeakerOff
         };
 
-        virtual void startAudioRouting()                   = 0;
         virtual void sendAudioEvent(AudioEvent audioEvent) = 0;
 
         virtual void transmitDtmfTone(uint32_t digit) = 0;
@@ -119,7 +118,6 @@ namespace app
             this->callState = state;
         }
 
-        void startAudioRouting() override;
         void sendAudioEvent(AudioEvent audioEvent) override;
 
         void transmitDtmfTone(uint32_t digit) override;

--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -189,9 +189,6 @@ namespace gui
             connectTimerOnExit();
         } break;
         case State::CALL_IN_PROGRESS: {
-            if (prevState == State::INCOMING_CALL) { // otherwise it is already started
-                interface->startAudioRouting();
-            }
             runCallTimer();
             navBar->setActive(gui::nav_bar::Side::Left, false);
             navBar->setActive(gui::nav_bar::Side::Center, false);
@@ -204,7 +201,6 @@ namespace gui
             setFocusItem(microphoneIcon);
         } break;
         case State::OUTGOING_CALL: {
-            interface->startAudioRouting();
             navBar->setActive(gui::nav_bar::Side::Left, false);
             navBar->setActive(gui::nav_bar::Side::Center, false);
             navBar->setText(gui::nav_bar::Side::Right, utils::translate(strings::endcall), true);

--- a/module-services/service-cellular/CellularRequestHandler.cpp
+++ b/module-services/service-cellular/CellularRequestHandler.cpp
@@ -24,6 +24,8 @@
 
 #include <service-appmgr/Constants.hpp>
 
+#include <service-audio/AudioServiceAPI.hpp>
+
 #include <module-cellular/at/response.hpp>
 
 void CellularRequestHandler::handle(cellular::ImeiRequest &request, at::Result &result)
@@ -71,6 +73,7 @@ void CellularRequestHandler::handle(cellular::CallRequest &request, at::Result &
     // Propagate "Ringing" notification into system
     cellular.bus.sendMulticast(std::make_shared<CellularRingingMessage>(request.getNumber()),
                                sys::BusChannel::ServiceCellularNotifications);
+    AudioServiceAPI::RoutingStart(&cellular);
     request.setHandled(true);
 }
 

--- a/module-services/service-cellular/CellularServiceAPI.cpp
+++ b/module-services/service-cellular/CellularServiceAPI.cpp
@@ -336,3 +336,31 @@ bool CellularServiceAPI::SetConnectionFrequency(sys::Service *serv, uint8_t conn
     return serv->bus.sendUnicast(std::make_shared<CellularSetConnectionFrequencyMessage>(connectionFrequency),
                                  ServiceCellular::serviceName);
 }
+
+bool CellularServiceAPI::CallAudioMuteEvent(sys::Service *serv)
+{
+    return serv->bus.sendUnicast(
+        std::make_shared<cellular::CallAudioEventRequest>(cellular::CallAudioEventRequest::EventType::Mute),
+        ServiceCellular::serviceName);
+}
+
+bool CellularServiceAPI::CallAudioUnmuteEvent(sys::Service *serv)
+{
+    return serv->bus.sendUnicast(
+        std::make_shared<cellular::CallAudioEventRequest>(cellular::CallAudioEventRequest::EventType::Unmute),
+        ServiceCellular::serviceName);
+}
+
+bool CellularServiceAPI::CallAudioLoudspeakerOnEvent(sys::Service *serv)
+{
+    return serv->bus.sendUnicast(
+        std::make_shared<cellular::CallAudioEventRequest>(cellular::CallAudioEventRequest::EventType::LoudspeakerOn),
+        ServiceCellular::serviceName);
+}
+
+bool CellularServiceAPI::CallAudioLoudspeakerOffEvent(sys::Service *serv)
+{
+    return serv->bus.sendUnicast(
+        std::make_shared<cellular::CallAudioEventRequest>(cellular::CallAudioEventRequest::EventType::LoudspeakerOff),
+        ServiceCellular::serviceName);
+}

--- a/module-services/service-cellular/call/CallAudio.cpp
+++ b/module-services/service-cellular/call/CallAudio.cpp
@@ -39,3 +39,23 @@ void CallRingAudio::stop()
     owner.sync(meta->async);
     AudioServiceAPI::StopAll(&owner);
 }
+
+void CallRingAudio::muteCall()
+{
+    AudioServiceAPI::SendEvent(&owner, audio::EventType::CallMute);
+}
+
+void CallRingAudio::unmuteCall()
+{
+    AudioServiceAPI::SendEvent(&owner, audio::EventType::CallUnmute);
+}
+
+void CallRingAudio::setLaudspeakerOn()
+{
+    AudioServiceAPI::SendEvent(&owner, audio::EventType::CallLoudspeakerOn);
+}
+
+void CallRingAudio::setLaudspeakerOff()
+{
+    AudioServiceAPI::SendEvent(&owner, audio::EventType::CallLoudspeakerOff);
+}

--- a/module-services/service-cellular/call/CallAudio.hpp
+++ b/module-services/service-cellular/call/CallAudio.hpp
@@ -21,4 +21,8 @@ class CallRingAudio
 
     void play();
     void stop();
+    void muteCall();
+    void unmuteCall();
+    void setLaudspeakerOn();
+    void setLaudspeakerOff();
 };

--- a/module-services/service-cellular/call/CellularCall.cpp
+++ b/module-services/service-cellular/call/CellularCall.cpp
@@ -186,6 +186,24 @@ namespace CellularCall
         cpuSentinel = std::move(sentinel);
     }
 
+    void Call::handleCallAudioEventRequest(cellular::CallAudioEventRequest::EventType event)
+    {
+        switch (event) {
+        case cellular::CallAudioEventRequest::EventType::Mute:
+            audio.muteCall();
+            break;
+        case cellular::CallAudioEventRequest::EventType::Unmute:
+            audio.unmuteCall();
+            break;
+        case cellular::CallAudioEventRequest::EventType::LoudspeakerOn:
+            audio.setLaudspeakerOn();
+            break;
+        case cellular::CallAudioEventRequest::EventType::LoudspeakerOff:
+            audio.setLaudspeakerOff();
+            break;
+        }
+    }
+
     bool Call::Operations::areCallsFromFavouritesEnabled()
     {
         return call.owner.areCallsFromFavouritesEnabled();

--- a/module-services/service-cellular/service-cellular/CellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/CellularMessage.hpp
@@ -1028,4 +1028,20 @@ namespace cellular
       public:
         RetryGetCSQ() : sys::DataMessage(MessageType::MessageTypeUninitialized){};
     };
+
+    class CallAudioEventRequest : public sys::DataMessage
+    {
+      public:
+        enum class EventType
+        {
+            Mute,
+            Unmute,
+            LoudspeakerOn,
+            LoudspeakerOff
+        };
+        explicit CallAudioEventRequest(EventType event)
+            : sys::DataMessage(MessageType::MessageTypeUninitialized), eventType(event){};
+
+        EventType eventType;
+    };
 } // namespace cellular

--- a/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
+++ b/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
@@ -141,4 +141,12 @@ namespace CellularServiceAPI
 
     bool SetConnectionFrequency(sys::Service *serv, uint8_t connectionFrequency);
 
+    bool CallAudioMuteEvent(sys::Service *serv);
+
+    bool CallAudioUnmuteEvent(sys::Service *serv);
+
+    bool CallAudioLoudspeakerOnEvent(sys::Service *serv);
+
+    bool CallAudioLoudspeakerOffEvent(sys::Service *serv);
+
 }; // namespace CellularServiceAPI

--- a/module-services/service-cellular/service-cellular/call/CellularCall.hpp
+++ b/module-services/service-cellular/service-cellular/call/CellularCall.hpp
@@ -7,6 +7,7 @@
 #include "call/CallGUI.hpp"
 #include "call/CallDB.hpp"
 #include "PhoneModes/PhoneMode.hpp"
+#include <service-cellular/CellularMessage.hpp>
 #include <Interface/CalllogRecord.hpp>
 #include <SystemManager/CpuSentinel.hpp>
 #include <PhoneNumber.hpp>
@@ -98,6 +99,8 @@ namespace CellularCall
         bool handleRING();
         bool handleCLIP(const utils::PhoneNumber::View &number);
         bool endCall(Forced forced = Forced::False);
+
+        void handleCallAudioEventRequest(cellular::CallAudioEventRequest::EventType event);
 
         bool isValid() const
         {


### PR DESCRIPTION
AudioServiceAPI is now removed from Call app.
Call audio routing is handled in service cellular.

**Description**

Please describe your pull request

**Your checklist for this pull request**

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

Thanks for your work ♥
