### PR TITLE
[MOS-339] Fixed frequency rippling when CPU is mostly idle

### DIFF
--- a/module-sys/SystemManager/cpu/algorithm/ImmediateUpscale.cpp
+++ b/module-sys/SystemManager/cpu/algorithm/ImmediateUpscale.cpp
@@ -12,6 +12,10 @@ namespace sys::cpu
         if (now > was) {
             return {algorithm::Change::UpScaled, now};
         }
+        else if (now == was) {
+            return {algorithm::Change::Hold, now};
+        }
+
         return {algorithm::Change::NoChange, was};
     }
 } // namespace sys::cpu


### PR DESCRIPTION
**Description**

This happened when:
* CPU was mostly idle and therefore FrequencyDown was affected
* Then ImmediateUpscale algorithm came in to upscale the cpu


**Your checklist for this pull request**

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible.
- [ ] Has documentation updated
