### PR TITLE
[MOS-337] Fix no audio for incoming calls/messages

### DIFF
--- a/module-services/service-cellular/call/CallAudio.cpp
+++ b/module-services/service-cellular/call/CallAudio.cpp
@@ -9,6 +9,7 @@
 #include "service-audio/AudioServiceName.hpp"
 #include <service-audio/AudioServiceAPI.hpp>
 #include <Timers/TimerFactory.hpp>
+#include <gsl/util>
 
 struct CallRingAudio::CallMeta
 {
@@ -33,11 +34,13 @@ void CallRingAudio::play()
 
 void CallRingAudio::stop()
 {
+    auto _ = gsl::finally([this] { AudioServiceAPI::StopAll(&owner); });
+
     if (not started) {
         return;
     }
+    started = false;
     owner.sync(meta->async);
-    AudioServiceAPI::StopAll(&owner);
 }
 
 void CallRingAudio::muteCall()


### PR DESCRIPTION
After the outgoing call was terminated,
the audio was terminated incorrectly,
therefore the next call did not ring.

**Your checklist for this pull request**

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

Thanks for your work ♥
