### PR TITLE
[CP-1080] Collect contact notifications in outbox endpoint

### DIFF
--- a/module-services/service-db/ServiceDBCommon.cpp
+++ b/module-services/service-db/ServiceDBCommon.cpp
@@ -99,8 +99,8 @@ sys::ReturnCodes ServiceDBCommon::SwitchPowerModeHandler(const sys::ServicePower
     return sys::ReturnCodes::Success;
 }
 
-void ServiceDBCommon::sendUpdateNotification(db::Interface::Name interface, db::Query::Type type)
+void ServiceDBCommon::sendUpdateNotification(db::Interface::Name interface, db::Query::Type type, uint32_t recordId)
 {
-    auto notificationMessage = std::make_shared<db::NotificationMessage>(interface, type);
+    auto notificationMessage = std::make_shared<db::NotificationMessage>(interface, type, recordId);
     bus.sendMulticast(notificationMessage, sys::BusChannel::ServiceDBNotifications);
 }

--- a/module-services/service-db/include/service-db/DBNotificationMessage.hpp
+++ b/module-services/service-db/include/service-db/DBNotificationMessage.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -15,9 +15,10 @@ namespace db
     class NotificationMessage : public sys::DataMessage
     {
       public:
-        NotificationMessage(db::Interface::Name interface, Query::Type type);
+        NotificationMessage(db::Interface::Name interface, Query::Type type, uint32_t recordId);
         const db::Interface::Name interface;
         const Query::Type type;
+        const uint32_t recordId;
 
         bool dataModified();
     };

--- a/module-services/service-db/include/service-db/ServiceDBCommon.hpp
+++ b/module-services/service-db/include/service-db/ServiceDBCommon.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -31,5 +31,5 @@ class ServiceDBCommon : public sys::Service
 
     sys::ReturnCodes SwitchPowerModeHandler(const sys::ServicePowerMode mode) final;
 
-    void sendUpdateNotification(db::Interface::Name interface, db::Query::Type type);
+    void sendUpdateNotification(db::Interface::Name interface, db::Query::Type type, uint32_t recordId = 0);
 };

--- a/module-services/service-db/messages/DBNotificationMessage.cpp
+++ b/module-services/service-db/messages/DBNotificationMessage.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <service-db/DBNotificationMessage.hpp>
@@ -9,8 +9,8 @@
 
 namespace db
 {
-    NotificationMessage::NotificationMessage(db::Interface::Name interface, Query::Type type)
-        : sys::DataMessage(MessageType::DBServiceNotification), interface(interface), type(type)
+    NotificationMessage::NotificationMessage(db::Interface::Name interface, Query::Type type, uint32_t recordId)
+        : sys::DataMessage(MessageType::DBServiceNotification), interface(interface), type(type), recordId(recordId)
     {}
 
     bool NotificationMessage::dataModified()

--- a/module-services/service-desktop/CMakeLists.txt
+++ b/module-services/service-desktop/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
         DesktopEvent.cpp
         DeveloperModeMessage.cpp
         DesktopMessages.cpp
+        OutboxNotifications.cpp
         ServiceDesktop.cpp
         WorkerDesktop.cpp
         USBSecurityModel.cpp
@@ -27,6 +28,7 @@ target_sources(
         include/service-desktop/DesktopMessages.hpp
         include/service-desktop/DeveloperModeMessage.hpp
         include/service-desktop/Outbox.hpp
+        include/service-desktop/OutboxNotifications.hpp
         include/service-desktop/ServiceDesktop.hpp
         include/service-desktop/USBSecurityModel.hpp
 )

--- a/module-services/service-desktop/OutboxNotifications.cpp
+++ b/module-services/service-desktop/OutboxNotifications.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <service-desktop/OutboxNotifications.hpp>
+
+auto OutboxNotifications::getNotificationEntries() const -> std::vector<Outbox::NotificationEntry>
+{
+    return notificationEntries;
+}
+
+void OutboxNotifications::removeNotificationEntries(const std::vector<uint32_t> &uidsOfNotificationsToBeRemoved)
+{
+    for (auto const &entryUid : uidsOfNotificationsToBeRemoved) {
+        notificationEntries.erase(
+            std::remove_if(notificationEntries.begin(),
+                           notificationEntries.end(),
+                           [&](const Outbox::NotificationEntry &entry) { return entry.uid == entryUid; }),
+            notificationEntries.end());
+    }
+}
+
+void OutboxNotifications::clearNotifications()
+{
+    notificationEntries.clear();
+    notificationCurrentUid = 0;
+}
+
+void OutboxNotifications::newNotificationHandler(db::NotificationMessage *notificationMessage)
+{
+    auto entryType = Outbox::EntryType::INVALID;
+    switch (notificationMessage->interface) {
+    case db::Interface::Name::Contact:
+        entryType = Outbox::EntryType::CONTACT;
+        break;
+    case db::Interface::Name::SMS:
+        entryType = Outbox::EntryType::MESSAGE;
+        break;
+    case db::Interface::Name::SMSThread:
+        entryType = Outbox::EntryType::THREAD;
+        break;
+    default:
+        break;
+    }
+
+    auto entryChange = Outbox::EntryChange::INVALID;
+    switch (notificationMessage->type) {
+    case db::Query::Type::Create:
+        entryChange = Outbox::EntryChange::CREATED;
+        break;
+    case db::Query::Type::Update:
+        entryChange = Outbox::EntryChange::UPDATED;
+        break;
+    case db::Query::Type::Delete:
+        entryChange = Outbox::EntryChange::DELETED;
+        break;
+    default:
+        break;
+    }
+
+    if (entryType != Outbox::EntryType::INVALID && entryChange != Outbox::EntryChange::INVALID &&
+        notificationMessage->recordId != 0) {
+        Outbox::NotificationEntry newNotificationEntry = {
+            notificationCurrentUid++, entryType, entryChange, notificationMessage->recordId};
+        notificationEntries.emplace_back(newNotificationEntry);
+    }
+}

--- a/module-services/service-desktop/include/service-desktop/Outbox.hpp
+++ b/module-services/service-desktop/include/service-desktop/Outbox.hpp
@@ -23,9 +23,9 @@ struct Outbox
 
     struct NotificationEntry
     {
-        int uid                 = 0;
+        uint32_t uid            = 0;
         EntryType entryType     = EntryType::INVALID;
         EntryChange entryChange = EntryChange::INVALID;
-        int recordId            = 0;
+        uint32_t recordId       = 0;
     };
 };

--- a/module-services/service-desktop/include/service-desktop/OutboxNotifications.hpp
+++ b/module-services/service-desktop/include/service-desktop/OutboxNotifications.hpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <service-db/DBNotificationMessage.hpp>
+#include <service-desktop/Outbox.hpp>
+
+class OutboxNotifications
+{
+  public:
+    void clearNotifications();
+    void newNotificationHandler(db::NotificationMessage *notificationMessage);
+    auto getNotificationEntries() const -> std::vector<Outbox::NotificationEntry>;
+    void removeNotificationEntries(const std::vector<uint32_t> &);
+
+  private:
+    uint32_t notificationCurrentUid = 0;
+    std::vector<Outbox::NotificationEntry> notificationEntries;
+};

--- a/products/PurePhone/services/db/ServiceDB.cpp
+++ b/products/PurePhone/services/db/ServiceDB.cpp
@@ -91,7 +91,7 @@ sys::MessagePointer ServiceDB::DataReceivedHandler(sys::DataMessage *msgl, sys::
         record->push_back(msg->record);
         LOG_DEBUG("Last ID %" PRIu32, msg->record.ID);
         responseMsg = std::make_shared<DBContactResponseMessage>(std::move(record), ret);
-        sendUpdateNotification(db::Interface::Name::Contact, db::Query::Type::Create);
+        sendUpdateNotification(db::Interface::Name::Contact, db::Query::Type::Create, msg->record.ID);
     } break;
 
     case MessageType::DBContactGetByID: {
@@ -151,7 +151,7 @@ sys::MessagePointer ServiceDB::DataReceivedHandler(sys::DataMessage *msgl, sys::
         DBContactMessage *msg = reinterpret_cast<DBContactMessage *>(msgl);
         auto ret              = contactRecordInterface->RemoveByID(msg->id);
         responseMsg           = std::make_shared<DBContactResponseMessage>(nullptr, ret);
-        sendUpdateNotification(db::Interface::Name::Contact, db::Query::Type::Delete);
+        sendUpdateNotification(db::Interface::Name::Contact, db::Query::Type::Delete, msg->id);
     } break;
 
     case MessageType::DBContactUpdate: {
@@ -159,7 +159,7 @@ sys::MessagePointer ServiceDB::DataReceivedHandler(sys::DataMessage *msgl, sys::
         DBContactMessage *msg = reinterpret_cast<DBContactMessage *>(msgl);
         auto ret              = contactRecordInterface->Update(msg->record);
         responseMsg           = std::make_shared<DBContactResponseMessage>(nullptr, ret);
-        sendUpdateNotification(db::Interface::Name::Contact, db::Query::Type::Update);
+        sendUpdateNotification(db::Interface::Name::Contact, db::Query::Type::Update, msg->record.ID);
     } break;
 
         /**
@@ -179,7 +179,7 @@ sys::MessagePointer ServiceDB::DataReceivedHandler(sys::DataMessage *msgl, sys::
         record->push_back(msg->record);
         LOG_INFO("Last ID %" PRIu32, msg->record.ID);
         responseMsg = std::make_shared<DBCalllogResponseMessage>(std::move(record), ret);
-        sendUpdateNotification(db::Interface::Name::Calllog, db::Query::Type::Create);
+        sendUpdateNotification(db::Interface::Name::Calllog, db::Query::Type::Create, msg->record.ID);
     } break;
 
     case MessageType::DBCalllogRemove: {
@@ -187,7 +187,7 @@ sys::MessagePointer ServiceDB::DataReceivedHandler(sys::DataMessage *msgl, sys::
         DBCalllogMessage *msg = reinterpret_cast<DBCalllogMessage *>(msgl);
         auto ret              = calllogRecordInterface->RemoveByID(msg->id);
         responseMsg           = std::make_shared<DBCalllogResponseMessage>(nullptr, ret);
-        sendUpdateNotification(db::Interface::Name::Calllog, db::Query::Type::Delete);
+        sendUpdateNotification(db::Interface::Name::Calllog, db::Query::Type::Delete, msg->id);
     } break;
 
     case MessageType::DBCalllogUpdate: {
@@ -195,7 +195,7 @@ sys::MessagePointer ServiceDB::DataReceivedHandler(sys::DataMessage *msgl, sys::
         DBCalllogMessage *msg = reinterpret_cast<DBCalllogMessage *>(msgl);
         auto ret              = calllogRecordInterface->Update(msg->record);
         responseMsg           = std::make_shared<DBCalllogResponseMessage>(nullptr, ret);
-        sendUpdateNotification(db::Interface::Name::Calllog, db::Query::Type::Update);
+        sendUpdateNotification(db::Interface::Name::Calllog, db::Query::Type::Update, msg->record.ID);
     } break;
 
     case MessageType::DBServiceBackup: {

--- a/products/PurePhone/services/desktop/endpoints/outbox/OutboxHelper.cpp
+++ b/products/PurePhone/services/desktop/endpoints/outbox/OutboxHelper.cpp
@@ -11,10 +11,10 @@ namespace sdesktop::endpoints
 {
     auto OutboxHelper::toJson(const Outbox::NotificationEntry &entry) -> json11::Json
     {
-        auto notificationEntry = json11::Json::object{{json::outbox::uid, entry.uid},
+        auto notificationEntry = json11::Json::object{{json::outbox::uid, static_cast<int>(entry.uid)},
                                                       {json::outbox::type, static_cast<int>(entry.entryType)},
                                                       {json::outbox::change, static_cast<int>(entry.entryChange)},
-                                                      {json::outbox::record_id, entry.recordId}};
+                                                      {json::outbox::record_id, static_cast<int>(entry.recordId)}};
         return notificationEntry;
     }
 
@@ -67,7 +67,7 @@ namespace sdesktop::endpoints
         }
 
         auto entriesToBeRemoved = context.getBody()[json::entries].array_items();
-        std::vector<int> uidsOfEntriesToBeRemoved;
+        std::vector<uint32_t> uidsOfEntriesToBeRemoved;
         uidsOfEntriesToBeRemoved.reserve(entriesToBeRemoved.size());
         for (const auto &entryUid : entriesToBeRemoved) {
             uidsOfEntriesToBeRemoved.emplace_back(entryUid.int_value());


### PR DESCRIPTION
**Description**

When contact record is created/updated/removed during 
connection with Mudita Center, notification of that             
action should be collected in outbox endpoint to
keep contacts data synchronized between MuditaOS
and Mudita Center. In upcoming PRs, SMS and SMSThread
records changes will be handled in a similar way.

**Your checklist for this pull request**

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible.
- [x] Has documentation updated
