### PR TITLE
[MOS-361] Navbar fonts size fix

### DIFF
--- a/module-gui/gui/widgets/NavBar.cpp
+++ b/module-gui/gui/widgets/NavBar.cpp
@@ -43,7 +43,7 @@ namespace gui::nav_bar
         left->setAlignment(Alignment(Alignment::Horizontal::Left, gui::Alignment::Vertical::Bottom));
         left->setPadding({0, 0, 0, style::nav_bar::bottom_padding});
         left->setMinimumHeight(widgetArea.h);
-        left->setFont(style::nav_bar::font::medium);
+        left->setFont(style::window::font::smallbold);
         left->setTextEllipsisType(TextEllipsis::Right);
         left->setVisible(true);
         left->setEdges(RectangleEdge::None);
@@ -53,7 +53,7 @@ namespace gui::nav_bar
         center->setPadding({0, 0, 0, style::nav_bar::bottom_padding});
         center->setMinimumHeight(widgetArea.h);
         center->setMaximumWidth(widgetArea.w);
-        center->setFont(style::nav_bar::font::bold);
+        center->setFont(style::window::font::smallbold);
         center->setTextEllipsisType(TextEllipsis::Right);
         center->setVisible(true);
         center->setEdges(RectangleEdge::None);
@@ -62,7 +62,7 @@ namespace gui::nav_bar
         right->setAlignment(Alignment(Alignment::Horizontal::Right, gui::Alignment::Vertical::Bottom));
         right->setPadding({0, 0, 0, style::nav_bar::bottom_padding});
         right->setMinimumHeight(widgetArea.h);
-        right->setFont(style::nav_bar::font::medium);
+        right->setFont(style::window::font::smallbold);
         right->setTextEllipsisType(TextEllipsis::Right);
         right->setVisible(true);
         right->setEdges(RectangleEdge::None);

--- a/module-gui/gui/widgets/Style.hpp
+++ b/module-gui/gui/widgets/Style.hpp
@@ -113,13 +113,6 @@ namespace style
         inline constexpr auto bottom_padding = 16U;
         inline constexpr auto left_margin    = 30U;
         inline constexpr auto right_margin   = 30U;
-
-        namespace font
-        {
-            inline constexpr auto bold   = "mediumbold";
-            inline constexpr auto medium = "medium";
-        }; // namespace font
-
     } // namespace nav_bar
 
     namespace settings


### PR DESCRIPTION
![Selection_430](https://user-images.githubusercontent.com/79840715/160860613-157fd933-613b-4294-8653-0bc26ada86ee.png)
RED - new look
BLACK - look before regression took place (community build)
So basically 100% overlap except time

Unfortunatelly the screen does not match MIRO perfectly (main time and date are shifted), but since im not fluent with Pure workflow I will only fix the refression I created and make a bug for the rest in JIRA