### PR TITLE
[MOS-264] Connect signal strength and operator name with HFP profile

### DIFF
--- a/module-bluetooth/Bluetooth/BluetoothWorker.cpp
+++ b/module-bluetooth/Bluetooth/BluetoothWorker.cpp
@@ -10,6 +10,7 @@
 #include "interface/profiles/HSP/HSP.hpp"
 #include "audio/BluetoothAudioDevice.hpp"
 #include "BtKeysStorage.hpp"
+#include "command/DeviceData.hpp"
 
 #if DEBUG_BLUETOOTH_HCI_COMS == 1
 #define logHciComs(...) LOG_DEBUG(__VA_ARGS__)
@@ -95,7 +96,7 @@ BluetoothWorker::BluetoothWorker(sys::Service *service)
 {
     init({
         {queues::io, sizeof(bluetooth::Message), queues::queueLength},
-        {queues::cmd, sizeof(bluetooth::Command), queues::queueLength},
+        {queues::cmd, sizeof(bluetooth::Command::CommandPack), queues::queueLength},
         {queues::btstack, sizeof(bool), queues::triggerQueueLength},
     });
     registerQueues();
@@ -140,11 +141,12 @@ auto BluetoothWorker::run() -> bool
 
 auto BluetoothWorker::handleCommand(QueueHandle_t queue) -> bool
 {
-    bluetooth::Command command(bluetooth::Command::None);
-    if (xQueueReceive(queue, static_cast<void *>(&command), 0) != pdTRUE) {
+    bluetooth::Command::CommandPack pack{};
+    if (xQueueReceive(queue, static_cast<void *>(&pack), 0) != pdTRUE) {
         LOG_ERROR("Queue receive failure!");
         return false;
     }
+    auto command = bluetooth::Command(std::move(pack));
 
     switch (command.getType()) {
     case bluetooth::Command::PowerOn:
@@ -154,11 +156,12 @@ auto BluetoothWorker::handleCommand(QueueHandle_t queue) -> bool
     case bluetooth::Command::PowerOff:
         controller->turnOff();
         break;
-    case bluetooth::Command::Unpair:
+    case bluetooth::Command::Unpair: {
         controller->processCommand(command);
-        removeFromBoundDevices(command.getDevice().address);
-        handleUnpairDisconnect(command.getDevice());
-        break;
+        auto device = std::get<Devicei>(command.getData());
+        removeFromBoundDevices(device.address);
+        handleUnpairDisconnect(device);
+    } break;
     case bluetooth::Command::None:
         break;
     default:
@@ -294,7 +297,9 @@ auto BluetoothWorker::isAddressConnected(const uint8_t *addr) -> bool
 void BluetoothWorker::handleUnpairDisconnect(const Devicei &device)
 {
     if (isAddressConnected(device.address)) {
-        auto disconnectCmd = bluetooth::Command(bluetooth::Command::DisconnectAudio, device);
+        auto commandData   = std::make_unique<bluetooth::DeviceData>(device);
+        auto disconnectCmd = bluetooth::Command(
+            bluetooth::Command::CommandPack{bluetooth::Command::DisconnectAudio, std::move(commandData)});
         controller->processCommand(disconnectCmd);
     }
 }

--- a/module-bluetooth/Bluetooth/CommandHandler.cpp
+++ b/module-bluetooth/Bluetooth/CommandHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CommandHandler.hpp"
@@ -39,7 +39,7 @@ namespace bluetooth
         this->driver->registerPowerOnCallback([profilePtr = this->profileManager]() { profilePtr->init(); });
     }
 
-    Error::Code CommandHandler::handle(Command command)
+    Error::Code CommandHandler::handle(Command &command)
     {
         switch (command.getType()) {
         case bluetooth::Command::PowerOn:
@@ -51,15 +51,15 @@ namespace bluetooth
         case bluetooth::Command::StopScan:
             return stopScan();
         case bluetooth::Command::Pair:
-            return pair(command.getDevice());
+            return pair(command.getData());
         case bluetooth::Command::Unpair:
-            return unpair(command.getDevice());
+            return unpair(command.getData());
         case bluetooth::Command::VisibilityOn:
             return setVisibility(true);
         case bluetooth::Command::VisibilityOff:
             return setVisibility(false);
         case bluetooth::Command::ConnectAudio:
-            return establishAudioConnection(command.getDevice());
+            return establishAudioConnection(command.getData());
         case bluetooth::Command::DisconnectAudio:
             return disconnectAudioConnection();
         case bluetooth::Command::PowerOff:
@@ -77,7 +77,11 @@ namespace bluetooth
         case Command::CallAnswered:
             return profileManager->callAnswered();
         case Command::IncomingCallNumber:
-            return profileManager->setIncomingCallNumber(command.getNumberString());
+            return profileManager->setIncomingCallNumber(command.getData());
+        case Command::SignalStrengthData:
+            return profileManager->setSignalStrengthData(command.getData());
+        case Command::OperatorNameData:
+            return profileManager->setOperatorNameData(command.getData());
         case Command::StartStream:
             profileManager->start();
             return Error::Success;
@@ -115,8 +119,9 @@ namespace bluetooth
         return Error::Success;
     }
 
-    Error::Code CommandHandler::establishAudioConnection(const Devicei &device)
+    Error::Code CommandHandler::establishAudioConnection(const DataVariant &data)
     {
+        auto device = std::get<Devicei>(data);
         LOG_INFO("Connecting audio");
         profileManager->connect(device);
         return Error::Success;
@@ -128,12 +133,13 @@ namespace bluetooth
         profileManager->disconnect();
         return Error::Success;
     }
-    Error::Code CommandHandler::pair(const Devicei &device)
+    Error::Code CommandHandler::pair(const DataVariant &data)
     {
+        auto device = std::get<Devicei>(data);
         LOG_INFO("Pairing...");
-        const auto error_code = driver->pair(device) ? Error::Success : Error::LibraryError;
-        LOG_INFO("Pairing result: %s", magic_enum::enum_name(error_code).data());
-        return error_code;
+        const auto errorCode = driver->pair(device) ? Error::Success : Error::LibraryError;
+        LOG_INFO("Pairing result: %s", magic_enum::enum_name(errorCode).data());
+        return errorCode;
     }
     Error::Code CommandHandler::switchAudioProfile()
     {
@@ -149,12 +155,13 @@ namespace bluetooth
         profileManager->switchProfile(profile);
         return Error::Success;
     }
-    Error::Code CommandHandler::unpair(const Devicei &device)
+    Error::Code CommandHandler::unpair(const DataVariant &data)
     {
+        auto device = std::get<Devicei>(data);
         LOG_INFO("Unpairing...");
-        const auto error_code = driver->unpair(device) ? Error::Success : Error::LibraryError;
-        LOG_INFO("Unpairing result: %s", magic_enum::enum_name(error_code).data());
-        return error_code;
+        const auto errorCode = driver->unpair(device) ? Error::Success : Error::LibraryError;
+        LOG_INFO("Unpairing result: %s", magic_enum::enum_name(errorCode).data());
+        return errorCode;
     }
 
     Error::Code CommandHandler::availableDevices()
@@ -164,4 +171,5 @@ namespace bluetooth
 
         return Error::Success;
     }
+
 } // namespace bluetooth

--- a/module-bluetooth/Bluetooth/CommandHandler.hpp
+++ b/module-bluetooth/Bluetooth/CommandHandler.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -9,6 +9,8 @@
 
 #include <cstdint>
 #include <PhoneNumber.hpp>
+#include <command/Command.hpp>
+#include <utility>
 
 namespace sys
 {
@@ -19,82 +21,13 @@ namespace sys
 namespace bluetooth
 {
     class SettingsHolder;
-    class Command
-    {
-      public:
-        enum Type
-        {
-            StartScan,
-            StopScan,
-            getDevicesAvailable,
-            VisibilityOn,
-            VisibilityOff,
-            ConnectAudio,
-            DisconnectAudio,
-            PowerOn,
-            PowerOff,
-            Pair,
-            Unpair,
-            StartRinging,
-            StopRinging,
-            StartRouting,
-            StartStream,
-            StopStream,
-            SwitchProfile,
-            CallAnswered,
-            IncomingCallNumber,
-            None,
-        };
-        Command(Command::Type type, std::optional<Devicei> dev) : type(type)
-        {
-            if (dev.has_value()) {
-                device = dev.value();
-            }
-        }
-        Command(Command::Type type, std::optional<utils::PhoneNumber::View> num) : type(type)
-        {
-            if (num.has_value()) {
-                numberStringPtr  = new std::string();
-                *numberStringPtr = num->getEntered();
-            }
-        }
-        explicit Command(Command::Type type) : type(type)
-        {}
-        auto getType() const noexcept -> Command::Type
-        {
-            return type;
-        }
-
-        auto getDevice() const noexcept -> Devicei
-        {
-            return device;
-        }
-
-        auto getNumberString() noexcept -> std::string
-        {
-            if (numberStringPtr != nullptr) {
-                return *numberStringPtr;
-            }
-            return std::string();
-        }
-
-        void destroy()
-        {
-            delete numberStringPtr;
-        }
-
-      private:
-        Devicei device{};
-        std::string *numberStringPtr = nullptr;
-        Type type;
-    };
 
     class AbstractCommandHandler
     {
       public:
         virtual ~AbstractCommandHandler() noexcept = default;
 
-        virtual auto handle(Command command) -> Error::Code = 0;
+        virtual auto handle(Command &command) -> Error::Code = 0;
     };
 
     class CommandHandler : public AbstractCommandHandler
@@ -105,16 +38,16 @@ namespace bluetooth
                                 std::shared_ptr<bluetooth::ProfileManager> profileManager,
                                 std::shared_ptr<bluetooth::AbstractDriver> driver);
 
-        auto handle(Command command) -> Error::Code override;
+        auto handle(Command &command) -> Error::Code override;
 
       private:
         Error::Code scan();
         Error::Code stopScan();
         Error::Code setVisibility(bool visibility);
-        Error::Code establishAudioConnection(const Devicei &device);
+        Error::Code establishAudioConnection(const DataVariant &data);
         Error::Code disconnectAudioConnection();
-        Error::Code pair(const Devicei &device);
-        Error::Code unpair(const Devicei &device);
+        Error::Code pair(const DataVariant &data);
+        Error::Code unpair(const DataVariant &data);
         Error::Code availableDevices();
         Error::Code switchAudioProfile();
         sys::Service *service;

--- a/module-bluetooth/Bluetooth/WorkerController.hpp
+++ b/module-bluetooth/Bluetooth/WorkerController.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -24,7 +24,7 @@ namespace bluetooth
         virtual auto isOn() const -> bool         = 0;
         virtual auto isTerminated() const -> bool = 0;
 
-        virtual void processCommand(Command command) = 0;
+        virtual void processCommand(Command &command) = 0;
     };
 
     class StatefulController : public AbstractController
@@ -41,7 +41,7 @@ namespace bluetooth
         [[nodiscard]] auto isOn() const -> bool override;
         [[nodiscard]] auto isTerminated() const -> bool override;
 
-        void processCommand(Command command) override;
+        void processCommand(Command &command) override;
 
       private:
         class Impl;

--- a/module-bluetooth/Bluetooth/command/Command.cpp
+++ b/module-bluetooth/Bluetooth/command/Command.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "Command.hpp"
+#include <log/log.hpp>
+
+namespace bluetooth
+{
+
+    Command::Command(CommandPack &&pack) : pack(std::move(pack))
+    {}
+
+    auto Command::getType() const noexcept -> Command::Type
+    {
+        return pack.commandType;
+    }
+
+    auto Command::getData() -> DataVariant
+    {
+        if (pack.data == nullptr) {
+            LOG_ERROR("Terrible,terrible damage!");
+            return DataVariant{};
+        }
+        return pack.data->getData();
+    }
+} // namespace bluetooth

--- a/module-bluetooth/Bluetooth/command/Command.hpp
+++ b/module-bluetooth/Bluetooth/command/Command.hpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+#include "CommandData.hpp"
+
+namespace bluetooth
+{
+
+    class Command
+    {
+      public:
+        enum Type
+        {
+            StartScan,
+            StopScan,
+            getDevicesAvailable,
+            VisibilityOn,
+            VisibilityOff,
+            ConnectAudio,
+            DisconnectAudio,
+            PowerOn,
+            PowerOff,
+            Pair,
+            Unpair,
+            StartRinging,
+            StopRinging,
+            StartRouting,
+            StartStream,
+            StopStream,
+            SwitchProfile,
+            CallAnswered,
+            IncomingCallNumber,
+            SignalStrengthData,
+            OperatorNameData,
+            None,
+        };
+
+        struct CommandPack
+        {
+            Command::Type commandType         = Command::None;
+            std::unique_ptr<CommandData> data = nullptr;
+        };
+
+        explicit Command(CommandPack &&);
+        explicit Command(Command::Type type)
+        {
+            pack.commandType = type;
+        }
+        auto getType() const noexcept -> Command::Type;
+        auto getData() -> DataVariant;
+
+      private:
+        CommandPack pack;
+    };
+
+} // namespace bluetooth

--- a/module-bluetooth/Bluetooth/command/CommandData.hpp
+++ b/module-bluetooth/Bluetooth/command/CommandData.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+#include <utility>
+#include <variant>
+#include <PhoneNumber.hpp>
+#include "Device.hpp"
+#include "EventStore.hpp"
+#include "OperatorName.hpp"
+
+namespace bluetooth
+{
+    using DataVariant = std::variant<OperatorName, Store::SignalStrength, Devicei, utils::PhoneNumber::View>;
+
+    class CommandData
+    {
+      public:
+        virtual auto getData() -> DataVariant = 0;
+        virtual ~CommandData()                = default;
+    };
+} // namespace bluetooth

--- a/module-bluetooth/Bluetooth/command/DeviceData.cpp
+++ b/module-bluetooth/Bluetooth/command/DeviceData.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "DeviceData.hpp"
+
+namespace bluetooth
+{
+    DeviceData::DeviceData(const Devicei &device) : device(device)
+    {}
+
+    auto DeviceData::getData() -> DataVariant
+    {
+        return device;
+    }
+
+} // namespace bluetooth

--- a/module-bluetooth/Bluetooth/command/DeviceData.hpp
+++ b/module-bluetooth/Bluetooth/command/DeviceData.hpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+#include "CommandData.hpp"
+#include "Device.hpp"
+
+namespace bluetooth
+{
+
+    class DeviceData : public CommandData
+    {
+      public:
+        explicit DeviceData(const Devicei &device);
+        auto getData() -> DataVariant override;
+
+      private:
+        Devicei device;
+    };
+
+} // namespace bluetooth

--- a/module-bluetooth/Bluetooth/command/OperatorName.hpp
+++ b/module-bluetooth/Bluetooth/command/OperatorName.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+#include <string>
+#include <string_view>
+namespace bluetooth
+{
+
+    class OperatorName
+    {
+      public:
+        explicit OperatorName(const std::string &name) : name(name){};
+        OperatorName() = default;
+        auto getName() const -> const std::string_view
+        {
+            return name;
+        }
+
+      private:
+        std::string name{""};
+    };
+} // namespace bluetooth

--- a/module-bluetooth/Bluetooth/command/OperatorNameData.cpp
+++ b/module-bluetooth/Bluetooth/command/OperatorNameData.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "OperatorNameData.hpp"
+
+#include <utility>
+
+namespace bluetooth
+{
+    OperatorNameData::OperatorNameData(OperatorName operatorName) : operatorName(std::move(operatorName))
+    {}
+    auto OperatorNameData::getData() -> DataVariant
+    {
+        return operatorName;
+    }
+} // namespace bluetooth

--- a/module-bluetooth/Bluetooth/command/OperatorNameData.hpp
+++ b/module-bluetooth/Bluetooth/command/OperatorNameData.hpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+#include "CommandData.hpp"
+
+namespace bluetooth
+{
+
+    class OperatorNameData : public CommandData
+    {
+      public:
+        explicit OperatorNameData(OperatorName operatorName);
+        auto getData() -> DataVariant override;
+
+      private:
+        OperatorName operatorName;
+    };
+
+} // namespace bluetooth

--- a/module-bluetooth/Bluetooth/command/PhoneNumberData.cpp
+++ b/module-bluetooth/Bluetooth/command/PhoneNumberData.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "PhoneNumberData.hpp"
+
+namespace bluetooth
+{
+    PhoneNumberData::PhoneNumberData(const utils::PhoneNumber::View &view) : view(view)
+    {}
+    PhoneNumberData::PhoneNumberData(const utils::PhoneNumber &number) : view(number.getView())
+    {}
+    auto PhoneNumberData::getData() -> DataVariant
+    {
+        return view;
+    }
+} // namespace bluetooth

--- a/module-bluetooth/Bluetooth/command/PhoneNumberData.hpp
+++ b/module-bluetooth/Bluetooth/command/PhoneNumberData.hpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+#include "CommandData.hpp"
+
+namespace bluetooth
+{
+
+    class PhoneNumberData : public CommandData
+    {
+      public:
+        explicit PhoneNumberData(const utils::PhoneNumber::View &view);
+        explicit PhoneNumberData(const utils::PhoneNumber &number);
+        auto getData() -> DataVariant override;
+
+      private:
+        utils::PhoneNumber::View view;
+    };
+
+} // namespace bluetooth

--- a/module-bluetooth/Bluetooth/command/SignalStrengthData.cpp
+++ b/module-bluetooth/Bluetooth/command/SignalStrengthData.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "SignalStrengthData.hpp"
+
+namespace bluetooth
+{
+    SignalStrengthData::SignalStrengthData(const Store::SignalStrength &signalStrength) : signalStrength(signalStrength)
+    {}
+    auto SignalStrengthData::getData() -> DataVariant
+    {
+        return signalStrength;
+    }
+} // namespace bluetooth

--- a/module-bluetooth/Bluetooth/command/SignalStrengthData.hpp
+++ b/module-bluetooth/Bluetooth/command/SignalStrengthData.hpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+#include "CommandData.hpp"
+
+namespace bluetooth
+{
+
+    class SignalStrengthData : public CommandData
+    {
+      public:
+        explicit SignalStrengthData(const Store::SignalStrength &signalStrength);
+        auto getData() -> DataVariant override;
+
+      private:
+        Store::SignalStrength signalStrength;
+    };
+
+} // namespace bluetooth

--- a/module-bluetooth/Bluetooth/interface/profiles/A2DP/A2DP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/A2DP/A2DP.cpp
@@ -123,6 +123,16 @@ namespace bluetooth
         LOG_INFO("Setting number in A2DP - ignoring");
         return Error::Success;
     }
+    auto A2DP::setSignalStrength(int bars) const noexcept -> Error::Code
+    {
+        LOG_INFO("Setting signal bars in A2DP - ignoring");
+        return Error::Success;
+    }
+    auto A2DP::setOperatorName(const std::string_view &name) const noexcept -> Error::Code
+    {
+        LOG_INFO("Setting operator name in A2DP - ignoring");
+        return Error::Success;
+    }
 
     const sys::Service *A2DP::A2DPImpl::ownerService;
     QueueHandle_t A2DP::A2DPImpl::sourceQueue = nullptr;

--- a/module-bluetooth/Bluetooth/interface/profiles/A2DP/A2DP.hpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/A2DP/A2DP.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -40,6 +40,10 @@ namespace bluetooth
         [[nodiscard]] auto callAnswered() const noexcept -> Error::Code override;
         /// @return Success - ignoring in A2DP
         [[nodiscard]] auto setIncomingCallNumber(const std::string &num) const noexcept -> Error::Code override;
+        /// @return Success - ignoring in A2DP
+        [[nodiscard]] auto setSignalStrength(int bars) const noexcept -> Error::Code override;
+        /// @return Success - ignoring in A2DP
+        [[nodiscard]] auto setOperatorName(const std::string_view &name) const noexcept -> Error::Code override;
 
         void setAudioDevice(std::shared_ptr<bluetooth::BluetoothAudioDevice> audioDevice) override;
 

--- a/module-bluetooth/Bluetooth/interface/profiles/HFP/HFP.hpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/HFP/HFP.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -46,6 +46,10 @@ namespace bluetooth
         [[nodiscard]] auto initializeCall() const noexcept -> Error::Code override;
         [[nodiscard]] auto callAnswered() const noexcept -> Error::Code override;
         [[nodiscard]] auto setIncomingCallNumber(const std::string &num) const noexcept -> Error::Code override;
+        /// @brief Sets the signal strength bars data
+        /// @return Success
+        [[nodiscard]] auto setSignalStrength(int bars) const noexcept -> Error::Code override;
+        [[nodiscard]] auto setOperatorName(const std::string_view &name) const noexcept -> Error::Code override;
 
         void setAudioDevice(std::shared_ptr<bluetooth::BluetoothAudioDevice> audioDevice) override;
 

--- a/module-bluetooth/Bluetooth/interface/profiles/HFP/HFPImpl.hpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/HFP/HFPImpl.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -30,6 +30,8 @@ namespace bluetooth
         void setAudioDevice(std::shared_ptr<bluetooth::BluetoothAudioDevice> audioDevice);
         [[nodiscard]] auto callAnswered() const noexcept -> Error::Code;
         [[nodiscard]] auto setIncomingCallNumber(const std::string &num) const noexcept -> Error::Code;
+        [[nodiscard]] auto setSignalStrength(int bars) const noexcept -> Error::Code;
+        [[nodiscard]] auto setOperatorName(const std::string_view &name) const noexcept -> Error::Code;
 
       private:
         static void sendAudioEvent(audio::EventType event, audio::Event::DeviceState state);

--- a/module-bluetooth/Bluetooth/interface/profiles/HSP/HSP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/HSP/HSP.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <log/log.hpp>
@@ -378,6 +378,14 @@ namespace bluetooth
         return Error::Success;
     }
     auto HSP::setIncomingCallNumber(const std::string &num) const noexcept -> Error::Code
+    {
+        return Error::Success;
+    }
+    auto HSP::setSignalStrength(int bars) const noexcept -> Error::Code
+    {
+        return Error::Success;
+    }
+    auto HSP::setOperatorName(const std::string_view &name) const noexcept -> Error::Code
     {
         return Error::Success;
     }

--- a/module-bluetooth/Bluetooth/interface/profiles/HSP/HSP.hpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/HSP/HSP.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -44,6 +44,10 @@ namespace bluetooth
         [[nodiscard]] auto initializeCall() const noexcept -> Error::Code override;
         [[nodiscard]] auto callAnswered() const noexcept -> Error::Code override;
         [[nodiscard]] auto setIncomingCallNumber(const std::string &num) const noexcept -> Error::Code override;
+        /// @return Success - ignoring in HSP
+        [[nodiscard]] auto setSignalStrength(int bars) const noexcept -> Error::Code override;
+        /// @return Success - ignoring in HSP
+        [[nodiscard]] auto setOperatorName(const std::string_view &name) const noexcept -> Error::Code override;
 
         void setAudioDevice(std::shared_ptr<bluetooth::BluetoothAudioDevice> audioDevice) override;
 

--- a/module-bluetooth/Bluetooth/interface/profiles/Profile.hpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/Profile.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -39,6 +39,12 @@ namespace bluetooth
         /// Sets the incoming call number
         /// @return Error code that determines, whether operation was successful or not
         [[nodiscard]] virtual auto setIncomingCallNumber(const std::string &num) const noexcept -> Error::Code = 0;
+        /// Sets the signal strength bars data in HFP profile
+        /// @return Error code that determines, whether operation was successful or not
+        [[nodiscard]] virtual auto setSignalStrength(int bars) const noexcept -> Error::Code = 0;
+        /// Sets the operator name in HFP profile
+        /// @return Error code that determines, whether operation was successful or not
+        [[nodiscard]] virtual auto setOperatorName(const std::string_view &name) const noexcept -> Error::Code = 0;
 
       protected:
         static void initSdp();

--- a/module-bluetooth/Bluetooth/interface/profiles/ProfileManager.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/ProfileManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <service-bluetooth/ServiceBluetooth.hpp>
@@ -119,10 +119,29 @@ namespace bluetooth
     {
         return currentProfilePtr->callAnswered();
     }
-    auto ProfileManager::setIncomingCallNumber(const std::string &num) -> Error::Code
+    auto ProfileManager::setIncomingCallNumber(const DataVariant &data) -> Error::Code
     {
+        auto number = std::get<utils::PhoneNumber::View>(data);
         if (currentProfilePtr) {
-            return currentProfilePtr->setIncomingCallNumber(num);
+            return currentProfilePtr->setIncomingCallNumber(number.getE164());
+        }
+        LOG_ERROR("No profile, returning!");
+        return Error::NotReady;
+    }
+    auto ProfileManager::setSignalStrengthData(const DataVariant &data) -> Error::Code
+    {
+        auto signalData = std::get<Store::SignalStrength>(data);
+        if (currentProfilePtr) {
+            return currentProfilePtr->setSignalStrength(static_cast<int>(signalData.rssiBar));
+        }
+        LOG_ERROR("No profile, returning!");
+        return Error::NotReady;
+    }
+    auto ProfileManager::setOperatorNameData(const DataVariant &data) -> Error::Code
+    {
+        auto operatorName = std::get<OperatorName>(data);
+        if (currentProfilePtr) {
+            return currentProfilePtr->setOperatorName(operatorName.getName());
         }
         LOG_ERROR("No profile, returning!");
         return Error::NotReady;

--- a/module-bluetooth/Bluetooth/interface/profiles/ProfileManager.hpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/ProfileManager.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -13,6 +13,7 @@
 #include "audio/BluetoothAudioDevice.hpp"
 
 #include <memory>
+#include <command/CommandData.hpp>
 
 extern "C"
 {
@@ -44,7 +45,10 @@ namespace bluetooth
         auto stopRinging() -> Error::Code;
         auto initializeCall() -> Error::Code;
         auto callAnswered() -> Error::Code;
-        auto setIncomingCallNumber(const std::string &num) -> Error::Code;
+        auto setIncomingCallNumber(const DataVariant &data) -> Error::Code;
+        auto setSignalStrengthData(const DataVariant &data) -> Error::Code;
+        auto setOperatorNameData(const DataVariant &data) -> Error::Code;
+
         auto setAudioDevice(std::shared_ptr<BluetoothAudioDevice> device) -> Error::Code;
 
       private:

--- a/module-bluetooth/CMakeLists.txt
+++ b/module-bluetooth/CMakeLists.txt
@@ -30,6 +30,13 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Bluetooth/interface/profiles/Profile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Bluetooth/interface/profiles/ProfileManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Bluetooth/interface/profiles/PhoneInterface.cpp
+
+    ${CMAKE_CURRENT_SOURCE_DIR}/Bluetooth/command/Command.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Bluetooth/command/DeviceData.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Bluetooth/command/PhoneNumberData.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Bluetooth/command/SignalStrengthData.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Bluetooth/command/OperatorNameData.cpp
+
         )
 
 include(lib/btstack.cmake)

--- a/module-bluetooth/tests/CMakeLists.txt
+++ b/module-bluetooth/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_catch2_executable(
         tests-StatefulController.cpp
         tests-BluetoothDevicesModel.cpp
         tests-Devicei.cpp
+        tests-command.cpp
     LIBS
         module-sys
         module-bluetooth

--- a/module-bluetooth/tests/tests-StatefulController.cpp
+++ b/module-bluetooth/tests/tests-StatefulController.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -53,7 +53,7 @@ auto InitializerMock = []() { return Error::Success; };
 class HandlerMock : public AbstractCommandHandler
 {
   public:
-    Error::Code handle(Command command) override
+    Error::Code handle(Command &command) override
     {
         return returnCode;
     }
@@ -167,7 +167,8 @@ TEST_CASE("Given StatefulController when process command successfully then turne
     controller.turnOn();
     REQUIRE(controller.isOn());
 
-    controller.processCommand(bluetooth::Command(Command::Type::PowerOn));
+    auto command = bluetooth::Command(Command::Type::PowerOn);
+    controller.processCommand(command);
     REQUIRE(controller.isOn());
 }
 
@@ -180,7 +181,9 @@ TEST_CASE("Given StatefulController when processing command failed then restarte
     controller.turnOn();
     REQUIRE(controller.isOn());
 
-    controller.processCommand(bluetooth::Command(Command::Type::PowerOn));
-    controller.processCommand(bluetooth::Command(Command::Type::PowerOn));
+    auto command = bluetooth::Command(Command::Type::PowerOn);
+    controller.processCommand(command);
+    controller.processCommand(command);
+
     REQUIRE(controller.isOn());
 }

--- a/module-bluetooth/tests/tests-command.cpp
+++ b/module-bluetooth/tests/tests-command.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <catch2/catch.hpp>
+#include "btstack_util.h"
+#include <command/Command.hpp>
+#include <command/DeviceData.hpp>
+#include <command/PhoneNumberData.hpp>
+
+using namespace bluetooth;
+
+TEST_CASE("Command data handling test")
+{
+    utils::PhoneNumber number("123456789", utils::country::getIdByAlpha2Code("PL"));
+    Command::CommandPack receivedPack;
+
+    auto queueSimulator = [](bluetooth::Command::CommandPack *pack, bluetooth::Command::CommandPack *targetPack) {
+        memcpy(targetPack, pack, sizeof(bluetooth::Command::CommandPack));
+        pack->data.release();
+    };
+
+    {
+        auto data = std::make_unique<PhoneNumberData>(number);
+        Command::CommandPack pack;
+        pack.commandType = Command::Type::PowerOn;
+        pack.data        = std::move(data);
+        queueSimulator(&pack, &receivedPack);
+    }
+
+    auto receivedCommand = bluetooth::Command(std::move(receivedPack));
+    REQUIRE(number == std::get<utils::PhoneNumber::View>(receivedCommand.getData()));
+    REQUIRE(receivedCommand.getType() == bluetooth::Command::PowerOn);
+}

--- a/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
@@ -55,10 +55,13 @@ namespace message::bluetooth
     class Ring;
     class StartAudioRouting;
     class GetBluetoothDevicesModel;
+    class RequestStatusIndicatorData;
 } // namespace message::bluetooth
 
 class CellularCallerIdMessage;
 class CellularCallActiveNotification;
+class CellularSignalStrengthUpdateNotification;
+class CellularCurrentOperatorNameNotification;
 
 class ServiceBluetooth : public sys::Service
 {
@@ -72,7 +75,8 @@ class ServiceBluetooth : public sys::Service
     sys::ReturnCodes DeinitHandler() override;
     void ProcessCloseReason(sys::CloseReason closeReason) override;
     virtual sys::ReturnCodes SwitchPowerModeHandler(const sys::ServicePowerMode mode) override;
-    void sendWorkerCommand(bluetooth::Command command);
+    void sendWorkerCommand(bluetooth::Command::Type commandType,
+                           std::unique_ptr<bluetooth::CommandData> data = nullptr);
     void handleTurnOff();
     QueueHandle_t workerQueue = nullptr;
     std::shared_ptr<bluetooth::SettingsHolder> settingsHolder;
@@ -117,8 +121,11 @@ class ServiceBluetooth : public sys::Service
     [[nodiscard]] auto handle(message::bluetooth::ResponseAuthenticatePin *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(message::bluetooth::ResponseAuthenticatePasskey *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(message::bluetooth::ResponseAuthenticatePairCancel *msg) -> std::shared_ptr<sys::Message>;
+    [[nodiscard]] auto handle(message::bluetooth::RequestStatusIndicatorData *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(CellularCallerIdMessage *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(CellularCallActiveNotification *msg) -> std::shared_ptr<sys::Message>;
+    [[nodiscard]] auto handle(CellularSignalStrengthUpdateNotification *msg) -> std::shared_ptr<sys::Message>;
+    [[nodiscard]] auto handle(CellularCurrentOperatorNameNotification *msg) -> std::shared_ptr<sys::Message>;
 };
 
 namespace sys

--- a/module-services/service-bluetooth/service-bluetooth/messages/RequestStatusIndicatorData.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/messages/RequestStatusIndicatorData.hpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+#include "service-bluetooth/BluetoothMessage.hpp"
+
+namespace message::bluetooth
+{
+    class RequestStatusIndicatorData : public BluetoothMessage
+    {
+      public:
+        RequestStatusIndicatorData() = default;
+    };
+} // namespace message::bluetooth

--- a/module-services/service-cellular/CellularUrcHandler.cpp
+++ b/module-services/service-cellular/CellularUrcHandler.cpp
@@ -49,6 +49,8 @@ void CellularUrcHandler::Handle(Creg &urc)
         }
         else {
             Store::GSM::get()->setNetworkOperatorName("");
+            auto notification = std::make_shared<CellularCurrentOperatorNameNotification>("");
+            cellularService.bus.sendMulticast(std::move(notification), sys::BusChannel::ServiceCellularNotifications);
         }
 
         Store::Network network{status, accessTechnology};

--- a/module-services/service-cellular/service-cellular/CellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/CellularMessage.hpp
@@ -171,12 +171,12 @@ class CellularRequestCurrentOperatorNameMessage : public CellularMessage
 class CellularSetOperatorAutoSelectMessage : public sys::DataMessage
 {};
 
-class CellularCurrentOperatorNameResponse : public CellularMessage
+class CellularCurrentOperatorNameNotification : public CellularMessage
 {
     std::string currentOperatorName;
 
   public:
-    explicit CellularCurrentOperatorNameResponse(const std::string &currentOperatorName)
+    explicit CellularCurrentOperatorNameNotification(const std::string &currentOperatorName)
         : CellularMessage(Type::Notification), currentOperatorName(currentOperatorName)
     {}
 

--- a/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
+++ b/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -53,8 +53,8 @@ namespace CellularServiceAPI
     void GetNetworkInfo(sys::Service *serv);
 
     /*
-     * @brief Get current operator, result async in
-     * CellularCurrentOperatorNameResponse message
+     * @brief Get current operator, result in
+     * CellularCurrentOperatorNameNotification message on notification channel
      */
     void RequestCurrentOperatorName(sys::Service *serv);
     /*

--- a/module-services/service-cellular/service-cellular/ServiceCellular.hpp
+++ b/module-services/service-cellular/service-cellular/ServiceCellular.hpp
@@ -238,8 +238,7 @@ class ServiceCellular : public sys::Service
 
     std::shared_ptr<CellularSetOperatorAutoSelectResponse> handleCellularSetOperatorAutoSelect(
         CellularSetOperatorAutoSelectMessage *msg);
-    std::shared_ptr<CellularCurrentOperatorNameResponse> handleCellularRequestCurrentOperatorName(
-        CellularRequestCurrentOperatorNameMessage *msg);
+    void handleCellularRequestCurrentOperatorName(CellularRequestCurrentOperatorNameMessage *msg);
     std::shared_ptr<CellularGetAPNResponse> handleCellularGetAPNMessage(CellularGetAPNMessage *msg);
     std::shared_ptr<CellularSetAPNResponse> handleCellularSetAPNMessage(CellularSetAPNMessage *msg);
     std::shared_ptr<CellularNewAPNResponse> handleCellularNewAPNMessage(CellularNewAPNMessage *msg);


### PR DESCRIPTION
**Description**

Connected signal strength and operator name with HFP profile so user can see the signal strength and operator name in the infotainment system.

There was also a stack modification needed:
https://github.com/mudita/btstack/pull/5

This PR is divided into 3 commits to be more eye-pleasant:
- Cellular preparation
- Command handling rework
- Connection of the signal strength and operator name messages

***IMPORTANT INFO***
Due to invalid logic in `profileManager` all of those statuses will be available after performing a phone call.
Or when the default profile in the manager will be changed to HFP. This bug will be investigated in MOS-347.

**Your checklist for this pull request**

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated
