### PR TITLE
[CP-1150] Remove embedded-centerpure from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,5 +18,3 @@
 /module-utils/CMakeLists.txt                @mudita/chapter-bsp
 /cmake                                      @mudita/chapter-bsp
 /test/CMakeLists.txt                        @mudita/chapter-bsp
-/module-services/service-desktop            @mudita/embedded-centerpure
-


### PR DESCRIPTION
**Description**

Since only one developer is left in embedded-centerpure group,
there is no sense to keep it in CODEOWNERS.
Now it is not possible to merge some PRs created by that dev,
because it would require approval of embedded-centerpure.

