### PR TITLE
[MOS-377] Update community assets version for unit tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,7 +30,7 @@ download_asset_release_json(json-test-community-target
                             ${CMAKE_CURRENT_SOURCE_DIR}/assets/assets_community.json
                             ${TEST_ASSETS_DEST_DIR}/current/
                             MuditaOSPublicAssets
-                            0.0.4
+                            0.0.7
                             ${MUDITA_CACHE_DIR}
     )
 


### PR DESCRIPTION
This updates version number for the `MuditaOSPublicAssets` from version 0.0.4 to version 0.0.7 the CMake file for unit testing.

Without this update, the unit tests will fail because `image/assets/fonts/fontmap.json` is not in the asset tarball.

resolves #3719 