### PR TITLE
Fix permissions issues with scripts

### DIFF
--- a/module-platform/linux/tests/gendisktestimg.sh
+++ b/module-platform/linux/tests/gendisktestimg.sh
@@ -1,25 +1,34 @@
 #!/bin/bash -e
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+#Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 #For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 if [ $# -ne 1 ]; then
 	echo "Error! Invalid argument count"
 	exit -1
 fi
+
+if [ -z ${L_GIT_DIR+unbound} ] && [ -z $(export L_GIT_DIR=$(git rev-parse --show-toplevel 2>/dev/null)) ]; then
+  export L_GIT_DIR=$(readlink -f "$(dirname "$0")/../../..");
+fi
+
+. "$L_GIT_DIR"/tools/locate_bins.sh
+require_unprivileged dd head tail
+require_commands sfdisk
+
 IMAGE_FILE_DIR="$1"
 
 dd if=/dev/zero of=$IMAGE_FILE_DIR/test_disk.img bs=512 count=8
-sfdisk $IMAGE_FILE_DIR/test_disk.img << ==sfdisk
+maysudo sfdisk "$IMAGE_FILE_DIR/test_disk.img" << ==sfdisk
 ,1,L
 ,1,L
 ,,L
 ==sfdisk
 
 dd if=/dev/zero of=$IMAGE_FILE_DIR/test_disk_ext.img bs=512 count=16
-sfdisk $IMAGE_FILE_DIR/test_disk_ext.img << ==sfdisk
+maysudo sfdisk "$IMAGE_FILE_DIR/test_disk_ext.img" << ==sfdisk
 ,1,L
 ,,E
 ,1,L
@@ -31,7 +40,7 @@ sfdisk $IMAGE_FILE_DIR/test_disk_ext.img << ==sfdisk
 ==sfdisk
 
 dd if=/dev/zero of=$IMAGE_FILE_DIR/test_disk_bad_tmp.img bs=512 count=16
-sfdisk $IMAGE_FILE_DIR/test_disk_bad_tmp.img << ==sfdisk
+maysudo sfdisk "$IMAGE_FILE_DIR/test_disk_bad_tmp.img" << ==sfdisk
 ,1,L
 ==sfdisk
 

--- a/tools/locate_bins.sh
+++ b/tools/locate_bins.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+# For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+set -euo pipefail
+#set -o posix
+
+test_for_sudo () {
+  if eval "sudo -n echo >> /dev/null 2>&1"; then
+    export can_sudo=1
+  else
+    export can_sudo=0
+  fi
+}
+
+get_command () {
+  if command -v "$name" >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ ! $can_sudo ]; then
+    return 1
+  fi
+  if ! path_val=$(sudo -nl "$1" 2>/dev/null); then
+    return 2
+  elif [ ! -f "$path_val" ]; then
+    return 1
+  fi
+  return 0
+}
+
+require_unprivileged () {
+  for name in "$@"; do
+    if ! command -v "$name" >/dev/null 2>&1; then
+      if [ $can_sudo ] && [ "$(sudo -nl "$name" 2>/dev/null)" ]; then
+        echo "Error: user level permissions are required for $name. Unable to proceed."
+      else
+        echo "Error: $name is not installed. Unable to proceed."
+      fi
+      exit 1
+    fi
+  done
+}
+
+require_commands () {
+  for name in "$@"; do
+    case $(command -v "$name" >/dev/null 2>&1) in
+      1)
+        if [ $can_sudo ]; then
+          echo "Error: $name is not installed. Unable to proceed."
+        else
+          echo "Error: $name is not installed OR you do not have sufficent permissions. Unable to proceed."
+        fi
+        exit 1
+      ;;
+      2)
+        echo "Error: You do not have sufficient permissions to execute $name. Unable to proceed."
+        exit 2
+      ;;
+      0)
+        echo "Success."
+      ;;
+    esac
+  done
+}
+
+maysudo () {
+  if [ "$(command -v "$1" >/dev/null 2>&1)" ] &&
+     [ -f "$(command -v "$1")" ]; then
+    "$@"
+  elif [ ! $can_sudo ] ||
+       [ ! -f "$(sudo -nl "$1" 2>/dev/null)" ]; then
+    exit 1
+  else
+    sudo -n "$@"
+  fi
+}
+
+test_for_sudo


### PR DESCRIPTION
**Description**

Some scripts use programs that require elevated permissions to execute properly because they use commands like `mke2fs` and `sfdisk` which are privileged by default. An additional script has been added to use the `sudo` command but only if `sudo` is installed, it's necessary, is non-interactive, it would provide the user with the required permissions.

**Problems with `sudo` in `config/bootstrap.sh` that are fixed by `maysudo`:**
* checks if `sudo` is _installed_
* checks if `sudo` is _required_ for a particular command (i.e. current user lacks rights)
* checks if you the appropriate _rights_ to run a program using `sudo` (i.e. if permitted via sudoers)
* checks if `sudo` will run _non-interactively_ (so you don't get prompted 20 times per build)

**Repository directory identification scheme**
```bash
if [ -z ${L_GIT_DIR+unbound} ] && [ -z $(export L_GIT_DIR=$(git rev-parse --show-toplevel 2>/dev/null)) ]; then
  export L_GIT_DIR=$(readlink -f "$(dirname "$0")/../../..");  # varies depending on the script location within the repository
fi
```
This line of code translates to this:
> **IF** `L_GIT_DIR` is unbound **AND** export results in a null string (because the `git` command failed) **THEN** export a relative location

Without this, when you run a script using `sudo` it will spit out
```
fatal: unsafe repository ('path2repo/MuditaOS' is owned by someone else)
To add an exception for this directory, call:

        git config --global --add safe.directory path2repo/MuditaOS
```

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated
<!-- Thanks for your work ♥ -->