### PR TITLE
[MOS-371] Fix USB worker initialization

### DIFF
--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -224,12 +224,7 @@ sys::ReturnCodes ServiceDesktop::InitHandler()
         return btMsgHandler->handle(msgl);
     });
     connect(sevm::BatteryStatusChangeMessage(), [&](sys::Message *) {
-        if (Store::Battery::get().state == Store::Battery::State::Discharging) {
-            usbWorkerDeinit();
-        }
-        else {
-            usbWorkerInit();
-        }
+        checkChargingCondition();
         return sys::MessageNone{};
     });
 
@@ -255,9 +250,8 @@ sys::ReturnCodes ServiceDesktop::InitHandler()
         return sys::MessageNone{};
     });
 
-    if (auto resUsb = usbWorkerInit(); resUsb != sys::ReturnCodes::Success) {
-        return resUsb;
-    }
+    // initial check
+    checkChargingCondition();
 
     return (sys::ReturnCodes::Success);
 }
@@ -371,4 +365,14 @@ void ServiceDesktop::removeNotificationEntries(const std::vector<uint32_t> &uids
 void ServiceDesktop::restartConnectionActiveTimer()
 {
     connectionActiveTimer.restart(sdesktop::connectionActiveTimerDelayMs);
+}
+
+void ServiceDesktop::checkChargingCondition()
+{
+    if (Store::Battery::get().state == Store::Battery::State::Discharging) {
+        usbWorkerDeinit();
+    }
+    else {
+        usbWorkerInit();
+    }
 }

--- a/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
@@ -101,6 +101,7 @@ class ServiceDesktop : public sys::Service
     OutboxNotifications outboxNotifications;
     sys::TimerHandle connectionActiveTimer;
     void restartConnectionActiveTimer();
+    void checkChargingCondition();
 
     static constexpr unsigned int DefaultLogFlushTimeoutInMs = 1000U;
     bool initialized                                         = false;


### PR DESCRIPTION
When we start the system without the USB cable connected,
worker USB is initialized, which increases
the power consumption.

**Your checklist for this pull request**

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible.
- [ ] Has documentation updated

Thanks for your work ♥
