### PR TITLE
[MOS-386] Enable auto mode for DCDC converter

### DIFF
--- a/module-bsp/board/rt1051/bsp/lpm/RT1051LPMCommon.cpp
+++ b/module-bsp/board/rt1051/bsp/lpm/RT1051LPMCommon.cpp
@@ -66,8 +66,6 @@ namespace bsp
         if ((freq <= CpuFrequencyMHz::Level_1) && (newFrequency > CpuFrequencyMHz::Level_1)) {
             // connect internal the load resistor
             ConnectInternalLoadResistor();
-            // turn off power save mode for DCDC inverter
-            DisableDcdcPowerSaveMode();
             // Switch DCDC to full throttle during oscillator switch
             SetHighestCoreVoltage();
             // Enable regular 2P5 and 1P1 LDO and Turn off weak 2P5 and 1P1 LDO
@@ -96,8 +94,6 @@ namespace bsp
             if (driverSEMC) {
                 driverSEMC->SwitchToPeripheralClockSource();
             }
-            // turn on power save mode for DCDC inverter
-            EnableDcdcPowerSaveMode();
 
             // disconnect internal the load resistor
             DisconnectInternalLoadResistor();

--- a/module-bsp/board/rt1051/puretx/bsp/lpm/RT1051LPM.cpp
+++ b/module-bsp/board/rt1051/puretx/bsp/lpm/RT1051LPM.cpp
@@ -27,14 +27,17 @@ namespace bsp
                                             .pin = static_cast<uint32_t>(BoardDefinitions::DCDC_INVERTER_MODE_PIN)});
 
         gpio_1->WritePin(static_cast<uint32_t>(BoardDefinitions::POWER_SWITCH_HOLD_BUTTON), 1);
-        DisableDcdcPowerSaveMode();
+        EnableDcdcPowerSaveMode();
     }
 
+    // Sets the bucks to operate in auto PSM/PWM mode
+    // Current threshold for entry to and exit from the PSM mode is set to 100 mA
     void RT1051LPM::EnableDcdcPowerSaveMode()
     {
         gpio_2->WritePin(static_cast<uint32_t>(BoardDefinitions::DCDC_INVERTER_MODE_PIN), 0);
     }
 
+    // Forces both bucks to operate in PWM mode
     void RT1051LPM::DisableDcdcPowerSaveMode()
     {
         gpio_2->WritePin(static_cast<uint32_t>(BoardDefinitions::DCDC_INVERTER_MODE_PIN), 1);


### PR DESCRIPTION
**Description**

The buck regulators will run in PWM mode
when the load current exceeds a predefined threshold.
When the load current drops below the specified threshold,
the regulator will operate in energy saving mode (PSM)
improve performance under light loads.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
