### PR TITLE
[BH-1455] Fix jlink debug not working

### DIFF
--- a/evkbimxrt1050_sdram_init.jlinkscript
+++ b/evkbimxrt1050_sdram_init.jlinkscript
@@ -250,10 +250,21 @@ void INTRAM_Init() {
     MEM_WriteU32(gpr16_addr,ret);
     JLINK_SYS_Report("INTRAM Init Done");
 }
+
+void WDOG_Disable(){
+    unsigned int gpio_b1_13;
+
+    gpio_b1_13 = 0x401F81B0;
+
+    // Switch off WDOG1
+    MEM_WriteU32(gpio_b1_13, 1);
+}
+
 /* SetupTarget */
 int AfterResetTarget(void) {
   JLINK_SYS_Report("Enabling i.MXRT SDRAM");
   /*Load_Dcdc_Trim();*/
+  WDOG_Disable();
   Clock_Init();
   SDRAM_Init();
   INTRAM_Init();

--- a/evkbimxrt1050_sdram_init_T6.jlinkscript
+++ b/evkbimxrt1050_sdram_init_T6.jlinkscript
@@ -220,7 +220,6 @@ void INTRAM_Init() {
     // 448 KBytes of DTCM
     MEM_WriteU32(gpr17_addr,0x5AAAAAAA);
     
-    
     ret = MEM_ReadU32(gpr16_addr);
     
     // Turn off DTCM
@@ -246,10 +245,21 @@ void INTRAM_Init() {
     MEM_WriteU32(gpr16_addr,ret);
     JLINK_SYS_Report("INTRAM Init Done");
 }
+
+void WDOG_Disable(){
+    unsigned int gpio_b1_13;
+
+    gpio_b1_13 = 0x401F81B0;
+
+    // Switch off WDOG1
+    MEM_WriteU32(gpio_b1_13, 1);
+}
+
 /* SetupTarget */
 int AfterResetTarget(void) {
   JLINK_SYS_Report("Enabling i.MXRT SDRAM");
   /*Load_Dcdc_Trim();*/
+  WDOG_Disable();
   Clock_Init();
   SDRAM_Init();
   INTRAM_Init();


### PR DESCRIPTION
**Description**

Fix jlink debug not working for Harmony by turning off hardware watchdog on jlink start.
Added same watchdog switch to T7(Pure) script as it could possibly become a problem in the future.


**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
