### PR TITLE
[MOS-384] BT paired devices list fix

### DIFF
--- a/module-bluetooth/tests/tests-BluetoothDevicesModel.cpp
+++ b/module-bluetooth/tests/tests-BluetoothDevicesModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -93,7 +93,7 @@ TEST_CASE("Device handling")
         REQUIRE(devicesModel.getDevices().size() == 4);
     }
 
-    SECTION("Merge device list")
+    SECTION("Merge device list - std::vector<Devicei> as argument")
     {
         std::vector<Devicei> devicesList, targetList;
         Devicei dummy{"dummyDevice"};
@@ -109,6 +109,24 @@ TEST_CASE("Device handling")
         REQUIRE(!devicesModel.getDeviceByAddress(addr1Str).value().get().name.empty());
         REQUIRE(!devicesModel.getDeviceByAddress(addr2Str).value().get().name.empty());
         REQUIRE(!devicesModel.getDeviceByAddress(addr3Str).value().get().name.empty());
+        REQUIRE(devicesModel.getDevices().size() == 3);
+    }
+
+    SECTION("Merge device list - Devicei as argument")
+    {
+        std::vector<Devicei> targetList;
+        Devicei newDevice{"newDevice"};
+        newDevice.setAddress(&addr3);
+
+        targetList.push_back(device1);
+        targetList.push_back(device2);
+        targetList.push_back(device3);
+
+        devicesModel.mergeDevicesList(newDevice);
+
+        REQUIRE_FALSE(devicesModel.getDeviceByAddress(addr1Str).value().get().name.empty());
+        REQUIRE_FALSE(devicesModel.getDeviceByAddress(addr2Str).value().get().name.empty());
+        REQUIRE_FALSE(devicesModel.getDeviceByAddress(addr3Str).value().get().name.empty());
         REQUIRE(devicesModel.getDevices().size() == 3);
     }
 

--- a/module-services/service-bluetooth/ServiceBluetooth.cpp
+++ b/module-services/service-bluetooth/ServiceBluetooth.cpp
@@ -250,13 +250,12 @@ auto ServiceBluetooth::handle(BluetoothPairResultMessage *msg) -> std::shared_pt
 {
     auto device = msg->getDevice();
     if (msg->isSucceed()) {
-        bluetoothDevicesModel->mergeDevicesList(bluetooth::GAP::getDevicesList());
+        bluetoothDevicesModel->mergeDevicesList(device);
         bluetoothDevicesModel->setInternalDeviceState(device, DeviceState::Paired);
     }
     else {
         bluetoothDevicesModel->removeDevice(device);
     }
-
     bluetoothDevicesModel->syncDevicesWithApp();
 
     /// TODO error code handing added in next PRs

--- a/module-services/service-bluetooth/service-bluetooth/BluetoothDevicesModel.cpp
+++ b/module-services/service-bluetooth/service-bluetooth/BluetoothDevicesModel.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BluetoothDevicesModel.hpp"
@@ -9,16 +9,25 @@
 BluetoothDevicesModel::BluetoothDevicesModel(sys::Service *service) : service{service}
 {}
 
-void BluetoothDevicesModel::mergeDevicesList(const std::vector<Devicei> &devicesList)
+void BluetoothDevicesModel::removeDeviceDuplicates()
 {
-    devices.insert(std::end(devices), std::begin(devicesList), std::end(devicesList));
-
-    // remove duplicates
     auto end = std::end(devices);
     for (auto it = std::begin(devices); it != end; ++it) {
         end = std::remove(it + 1, end, *it);
     }
     devices.erase(end, std::end(devices));
+}
+
+void BluetoothDevicesModel::mergeDevicesList(const Devicei &device)
+{
+    devices.emplace_back(device);
+    removeDeviceDuplicates();
+}
+
+void BluetoothDevicesModel::mergeDevicesList(const std::vector<Devicei> &devicesList)
+{
+    devices.insert(std::end(devices), std::begin(devicesList), std::end(devicesList));
+    removeDeviceDuplicates();
 }
 
 void BluetoothDevicesModel::insertDevice(const Devicei &device)

--- a/module-services/service-bluetooth/service-bluetooth/BluetoothDevicesModel.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/BluetoothDevicesModel.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -15,6 +15,7 @@ class BluetoothDevicesModel
   public:
     explicit BluetoothDevicesModel(sys::Service *service);
 
+    void mergeDevicesList(const Devicei &device);
     void mergeDevicesList(const std::vector<Devicei> &devicesList);
     auto getDeviceByAddress(const std::string &address) -> std::optional<std::reference_wrapper<Devicei>>;
     auto getDeviceByAddress(const bd_addr_t address) -> std::optional<std::reference_wrapper<Devicei>>;
@@ -28,4 +29,5 @@ class BluetoothDevicesModel
   private:
     std::vector<Devicei> devices{};
     sys::Service *service = nullptr;
+    void removeDeviceDuplicates();
 };


### PR DESCRIPTION
**Description**
<!-- Please describe your pull request here -->

Fix of the bug that after pairing with one device
the entire list of devices that were visible at
the pairing time is transferred to paired devices
list.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
