### PR TITLE
[CP-1085][CP-1082] Collect sms and sms thread notifications in outbox ep

### DIFF
--- a/module-db/Common/Query.cpp
+++ b/module-db/Common/Query.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Query.hpp"
@@ -81,6 +81,16 @@ void QueryResult::setRequestQuery(const std::shared_ptr<Query> &requestQueryToSe
 std::shared_ptr<Query> QueryResult::getRequestQuery() const noexcept
 {
     return requestQuery;
+}
+
+void QueryResult::setRecordID(const uint32_t modifiedRecordID)
+{
+    recordID = modifiedRecordID;
+}
+
+auto QueryResult::getRecordID() -> std::optional<uint32_t>
+{
+    return recordID;
 }
 
 bool QueryResult::hasListener() const noexcept

--- a/module-db/Common/Query.hpp
+++ b/module-db/Common/Query.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -97,6 +97,8 @@ namespace db
 
         void setRequestQuery(const std::shared_ptr<Query> &requestQueryToSet);
         std::shared_ptr<Query> getRequestQuery() const noexcept;
+        void setRecordID(const uint32_t modifiedRecordID);
+        [[nodiscard]] auto getRecordID() -> std::optional<uint32_t>;
 
         bool handle();
 
@@ -105,6 +107,9 @@ namespace db
 
       protected:
         std::shared_ptr<Query> requestQuery;
+
+      private:
+        std::optional<uint32_t> recordID;
     };
 
 } // namespace db

--- a/module-db/Interface/SMSRecord.cpp
+++ b/module-db/Interface/SMSRecord.cpp
@@ -413,6 +413,9 @@ std::unique_ptr<db::QueryResult> SMSRecordInterface::addQuery(const std::shared_
     }
     auto response = std::make_unique<db::query::SMSAddResult>(record, ret);
     response->setRequestQuery(query);
+    if (ret) {
+        response->setRecordID(record.ID);
+    }
     return response;
 }
 std::unique_ptr<db::QueryResult> SMSRecordInterface::removeQuery(const std::shared_ptr<db::Query> &query)
@@ -421,6 +424,9 @@ std::unique_ptr<db::QueryResult> SMSRecordInterface::removeQuery(const std::shar
     auto ret              = RemoveByID(localQuery->id);
     auto response         = std::make_unique<db::query::SMSRemoveResult>(ret);
     response->setRequestQuery(query);
+    if (ret) {
+        response->setRecordID(localQuery->id);
+    }
     return response;
 }
 std::unique_ptr<db::QueryResult> SMSRecordInterface::updateQuery(const std::shared_ptr<db::Query> &query)
@@ -429,6 +435,9 @@ std::unique_ptr<db::QueryResult> SMSRecordInterface::updateQuery(const std::shar
     auto ret              = Update(localQuery->record);
     auto response         = std::make_unique<db::query::SMSUpdateResult>(ret);
     response->setRequestQuery(query);
+    if (ret) {
+        response->setRecordID(localQuery->record.ID);
+    }
     return response;
 }
 

--- a/module-db/Interface/SMSRecord.cpp
+++ b/module-db/Interface/SMSRecord.cpp
@@ -34,7 +34,7 @@ bool SMSRecordInterface::Add(const SMSRecord &rec)
         LOG_ERROR("Cannot find contact, for number %s", rec.number.getEntered().c_str());
         return false;
     }
-    auto numberID  = contactMatch->numberId;
+    auto numberID = contactMatch->numberId;
 
     ThreadRecordInterface threadInterface(smsDB, contactsDB);
     auto threadRec =
@@ -44,7 +44,7 @@ bool SMSRecordInterface::Add(const SMSRecord &rec)
     if (threadRec->size() == 0) {
 
         ThreadRecord re;
-        re.numberID  = numberID;
+        re.numberID = numberID;
         if (!threadInterface.Add(re)) {
             LOG_ERROR("Cannot create new thread");
             return false;
@@ -407,37 +407,31 @@ std::unique_ptr<db::QueryResult> SMSRecordInterface::addQuery(const std::shared_
 {
     const auto localQuery = static_cast<const db::query::SMSAdd *>(query.get());
     auto record           = localQuery->record;
-    const auto ret        = Add(record);
-    if (ret) {
+    const auto result     = Add(record);
+    if (result) {
         record.ID = GetLastID();
     }
-    auto response = std::make_unique<db::query::SMSAddResult>(record, ret);
+    auto response = std::make_unique<db::query::SMSAddResult>(record, result);
     response->setRequestQuery(query);
-    if (ret) {
-        response->setRecordID(record.ID);
-    }
+    response->setRecordID(record.ID);
     return response;
 }
 std::unique_ptr<db::QueryResult> SMSRecordInterface::removeQuery(const std::shared_ptr<db::Query> &query)
 {
     const auto localQuery = static_cast<const db::query::SMSRemove *>(query.get());
-    auto ret              = RemoveByID(localQuery->id);
-    auto response         = std::make_unique<db::query::SMSRemoveResult>(ret);
+    auto result           = RemoveByID(localQuery->id);
+    auto response         = std::make_unique<db::query::SMSRemoveResult>(result);
     response->setRequestQuery(query);
-    if (ret) {
-        response->setRecordID(localQuery->id);
-    }
+    response->setRecordID(localQuery->id);
     return response;
 }
 std::unique_ptr<db::QueryResult> SMSRecordInterface::updateQuery(const std::shared_ptr<db::Query> &query)
 {
     const auto localQuery = static_cast<const db::query::SMSUpdate *>(query.get());
-    auto ret              = Update(localQuery->record);
-    auto response         = std::make_unique<db::query::SMSUpdateResult>(ret);
+    auto result           = Update(localQuery->record);
+    auto response         = std::make_unique<db::query::SMSUpdateResult>(result);
     response->setRequestQuery(query);
-    if (ret) {
-        response->setRecordID(localQuery->record.ID);
-    }
+    response->setRecordID(localQuery->record.ID);
     return response;
 }
 
@@ -500,8 +494,8 @@ std::unique_ptr<db::QueryResult> SMSRecordInterface::getForListQuery(const std::
         smsVector.begin(), smsVector.end(), std::back_inserter(recordVector), [number](const auto &recordRow) {
             return SMSRecord{recordRow, number};
         });
-    auto count        = smsDB->sms.countWithoutDraftsByThreadId(localQuery->threadId);
-    auto draft        = smsDB->sms.getDraftByThreadId(localQuery->threadId);
+    auto count = smsDB->sms.countWithoutDraftsByThreadId(localQuery->threadId);
+    auto draft = smsDB->sms.getDraftByThreadId(localQuery->threadId);
 
     auto response = std::make_unique<db::query::SMSGetForListResult>(recordVector, count, draft, number);
     response->setRequestQuery(query);

--- a/module-services/service-db/ServiceDBCommon.cpp
+++ b/module-services/service-db/ServiceDBCommon.cpp
@@ -35,8 +35,10 @@ sys::MessagePointer ServiceDBCommon::DataReceivedHandler(sys::DataMessage *msgl,
         auto query     = msg->getQuery();
         auto queryType = query->type;
         auto result    = interface->runQuery(std::move(query));
+        auto recordID  = result->getRecordID().value_or(0);
         responseMsg    = std::make_shared<db::QueryResponse>(std::move(result));
-        sendUpdateNotification(msg->getInterface(), queryType);
+
+        sendUpdateNotification(msg->getInterface(), queryType, recordID);
     } break;
 
     default:

--- a/module-services/service-db/include/service-db/ServiceDBCommon.hpp
+++ b/module-services/service-db/include/service-db/ServiceDBCommon.hpp
@@ -31,5 +31,5 @@ class ServiceDBCommon : public sys::Service
 
     sys::ReturnCodes SwitchPowerModeHandler(const sys::ServicePowerMode mode) final;
 
-    void sendUpdateNotification(db::Interface::Name interface, db::Query::Type type, uint32_t recordId = 0);
+    void sendUpdateNotification(db::Interface::Name interface, db::Query::Type type, uint32_t recordId);
 };


### PR DESCRIPTION
**Description**

<!-- Please describe your pull request here -->
When sms thread record or sms record is modified during connection
with Mudita Center, notification of that action
should be collected in outbox endpoint to
keep contacts data synchronized between MuditaOS
and Mudita Center.
Documentation: 
[Outbox endpoint API](https://appnroll.atlassian.net/wiki/spaces/CP/pages/1599996137/Outbox+Endpoint+API+14)
[How to notify MC about updates to user data in almost real time](https://appnroll.atlassian.net/wiki/spaces/CP/pages/1598193852/How+to+notify+MC+about+updates+to+User+data+in+almost+real+time)

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
