### PR TITLE
[MOS-326] Change call logic removed from call window

### DIFF
--- a/module-apps/application-call/CMakeLists.txt
+++ b/module-apps/application-call/CMakeLists.txt
@@ -20,6 +20,8 @@ target_sources(application-call
 		ApplicationCall.cpp
 		data/CallAppStyle.hpp
 		data/CallSwitchData.hpp
+		model/CallModel.cpp
+		presenter/CallPresenter.cpp
 		widgets/StateIcon.hpp
 		widgets/StateIcons.cpp
 		widgets/StateIcons.hpp
@@ -33,7 +35,6 @@ target_sources(application-call
 		windows/NumberWindow.hpp
 	PUBLIC
 		include/application-call/ApplicationCall.hpp
-		include/application-call/CallState.hpp
 )
 
 target_link_libraries(application-call
@@ -55,3 +56,7 @@ target_link_libraries(application-call
 		service-cellular
 		service-evtmgr
 )
+
+if (${ENABLE_TESTS})
+	add_subdirectory( test )
+endif()

--- a/module-apps/application-call/data/CallSwitchData.hpp
+++ b/module-apps/application-call/data/CallSwitchData.hpp
@@ -57,29 +57,10 @@ namespace app
         }
     };
 
-    class IncomingCallData : public CallSwitchData
-    {
-      public:
-        IncomingCallData(const utils::PhoneNumber::View &phoneNumber)
-            : CallSwitchData(phoneNumber, CallSwitchData::Type::INCOMING_CALL){};
-    };
-
     class ExecuteCallData : public CallSwitchData
     {
       public:
         ExecuteCallData(const utils::PhoneNumber::View &phoneNumber)
             : CallSwitchData(phoneNumber, app::CallSwitchData::Type::EXECUTE_CALL){};
-    };
-
-    class CallAbortData : public gui::SwitchData
-    {
-      public:
-        CallAbortData() = default;
-    };
-
-    class CallActiveData : public gui::SwitchData
-    {
-      public:
-        CallActiveData() = default;
     };
 } /* namespace app */

--- a/module-apps/application-call/model/CallModel.cpp
+++ b/module-apps/application-call/model/CallModel.cpp
@@ -1,0 +1,169 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "CallModel.hpp"
+
+#include <service-cellular/service-cellular/CellularServiceAPI.hpp>
+#include <service-evtmgr/service-evtmgr/EVMessages.hpp>
+#include <service-evtmgr/Constants.hpp>
+
+namespace app::call
+{
+    time_t CallModel::getTime()
+    {
+        return callTime;
+    }
+
+    void CallModel::setTime(time_t newTime)
+    {
+        callTime = newTime;
+
+        if (notifyPresenterOnDurationChange != nullptr) {
+            notifyPresenterOnDurationChange();
+        }
+    }
+
+    CallState CallModel::getState()
+    {
+        return callState;
+    }
+
+    void CallModel::setState(CallState newState)
+    {
+        if (callState == newState) {
+            LOG_INFO("Dropping call state change");
+        }
+
+        if (callState == CallState::Incoming && newState == CallState::Ended && callWasRejected) {
+            callWasRejected = false;
+            callState       = CallState::Rejected;
+        }
+        else {
+            callState = newState;
+        }
+
+        if (callState == CallState::Active) {
+            turnOnKeypadBacklight();
+        }
+        else {
+            turnOffKeypadBacklight();
+        }
+
+        if (notifyPresenterOnCallStateChange != nullptr) {
+            notifyPresenterOnCallStateChange();
+        }
+    }
+
+    void CallModel::hangUpCall()
+    {
+        CellularServiceAPI::HangupCall(application);
+        if (callState == CallState::Incoming) {
+            callWasRejected = true;
+        }
+    }
+
+    void CallModel::answerCall()
+    {
+        CellularServiceAPI::AnswerIncomingCall(application);
+    }
+
+    void CallModel::transmitDtmfTone(const uint32_t &digit)
+    {
+        CellularServiceAPI::TransmitDtmfTones(application, digit);
+    }
+
+    utils::PhoneNumber CallModel::getPhoneNumber()
+    {
+        return phoneNumber;
+    }
+
+    void CallModel::muteCall()
+    {
+        CellularServiceAPI::CallAudioMuteEvent(application);
+    }
+
+    void CallModel::unmuteCall()
+    {
+        CellularServiceAPI::CallAudioUnmuteEvent(application);
+    }
+
+    void CallModel::turnLoudspeakerOn()
+    {
+        CellularServiceAPI::CallAudioLoudspeakerOnEvent(application);
+    }
+
+    void CallModel::turnLoudspeakerOff()
+    {
+        CellularServiceAPI::CallAudioLoudspeakerOffEvent(application);
+    }
+
+    void CallModel::turnOnKeypadBacklight()
+    {
+        application->bus.sendUnicast(
+            std::make_shared<sevm::KeypadBacklightMessage>(bsp::keypad_backlight::Action::turnOnCallMode),
+            service::name::evt_manager);
+    }
+
+    void CallModel::turnOffKeypadBacklight()
+    {
+        application->bus.sendUnicast(
+            std::make_shared<sevm::KeypadBacklightMessage>(bsp::keypad_backlight::Action::turnOffCallMode),
+            service::name::evt_manager);
+    }
+
+    void CallModel::clear()
+    {
+        callState = CallState::None;
+        callTime  = 0;
+        callerId.clear();
+        callWasRejected = false;
+        phoneNumber     = utils::PhoneNumber();
+
+        notifyPresenterOnDurationChange  = nullptr;
+        notifyPresenterOnCallStateChange = nullptr;
+    }
+    void CallModel::attachDurationChangeCallback(std::function<void()> callback)
+    {
+        notifyPresenterOnDurationChange = callback;
+    }
+
+    void CallModel::attachCallStateChangeCallback(std::function<void()> callback)
+    {
+        notifyPresenterOnCallStateChange = callback;
+    }
+
+    void CallModel::setPhoneNumber(const utils::PhoneNumber number)
+    {
+        if (phoneNumber.getFormatted() == number.getFormatted()) {
+            LOG_INFO("Dropping number duplication.");
+            return;
+        }
+
+        phoneNumber = number;
+
+        if (notifyPresenterOnCallStateChange != nullptr) {
+            notifyPresenterOnCallStateChange();
+        }
+    }
+
+    UTF8 CallModel::getCallerId()
+    {
+        if (phoneNumber.getFormatted().empty()) {
+            LOG_INFO("No number provided");
+            callerId = UTF8();
+            return callerId;
+        }
+
+        auto contact = DBServiceAPI::MatchContactByPhoneNumber(application, phoneNumber.getView());
+        if (contact && !contact->isTemporary()) {
+            LOG_INFO("number recognized as contact id = %" PRIu32, contact->ID);
+            callerId = contact->getFormattedName();
+        }
+        else {
+            LOG_INFO("number was not recognized as any valid contact");
+            callerId = UTF8(phoneNumber.getFormatted());
+        }
+
+        return callerId;
+    }
+} // namespace app::call

--- a/module-apps/application-call/model/CallModel.hpp
+++ b/module-apps/application-call/model/CallModel.hpp
@@ -1,0 +1,113 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <module-utils/time/time/time_conversion.hpp>
+#include <module-utils/phonenumber/PhoneNumber.hpp>
+
+#include <products/PurePhone/apps/include/Application.hpp>
+
+#include <cstdint>
+
+namespace app::call
+{
+    enum class CallState
+    {
+        None,
+        Incoming,
+        Outgoing,
+        Active,
+        Ended,
+        Rejected
+    };
+
+    inline auto c_str(app::call::CallState state) -> const char *
+    {
+        switch (state) {
+        case CallState::None:
+            return "None";
+        case CallState::Incoming:
+            return "Incoming";
+        case CallState::Outgoing:
+            return "Outgoing";
+        case CallState::Active:
+            return "Active";
+        case CallState::Ended:
+            return "Ended";
+        case CallState::Rejected:
+            return "Ended";
+        }
+        return "";
+    }
+
+    class AbstractCallModel
+    {
+      public:
+        virtual ~AbstractCallModel() noexcept                        = default;
+        virtual time_t getTime()                                     = 0;
+        virtual void setTime(time_t newTime)                         = 0;
+        virtual CallState getState()                                 = 0;
+        virtual void setState(CallState newState)                    = 0;
+        virtual void setPhoneNumber(const utils::PhoneNumber number) = 0;
+        virtual utils::PhoneNumber getPhoneNumber()                  = 0;
+        virtual UTF8 getCallerId()                                   = 0;
+
+        virtual void hangUpCall()                            = 0;
+        virtual void answerCall()                            = 0;
+        virtual void transmitDtmfTone(const uint32_t &digit) = 0;
+        virtual void muteCall()                              = 0;
+        virtual void unmuteCall()                            = 0;
+        virtual void turnLoudspeakerOn()                     = 0;
+        virtual void turnLoudspeakerOff()                    = 0;
+
+        virtual void turnOnKeypadBacklight()  = 0;
+        virtual void turnOffKeypadBacklight() = 0;
+
+        virtual void clear()                                                       = 0;
+        virtual void attachDurationChangeCallback(std::function<void()> callback)  = 0;
+        virtual void attachCallStateChangeCallback(std::function<void()> callback) = 0;
+    };
+
+    class CallModel : public AbstractCallModel
+    {
+      public:
+        CallModel() = delete;
+        explicit CallModel(app::Application *app) : application(app){};
+        time_t getTime() final;
+        void setTime(time_t newTime) final;
+        CallState getState() final;
+        void setState(CallState newState) final;
+        void setPhoneNumber(const utils::PhoneNumber number) final;
+        utils::PhoneNumber getPhoneNumber() final;
+        UTF8 getCallerId() final;
+
+        void hangUpCall() final;
+        void answerCall() final;
+        void transmitDtmfTone(const uint32_t &digit) final;
+        void muteCall();
+        void unmuteCall();
+        void turnLoudspeakerOn();
+        void turnLoudspeakerOff();
+
+        void turnOnKeypadBacklight() final;
+        void turnOffKeypadBacklight() final;
+
+        void clear() final;
+        void attachDurationChangeCallback(std::function<void()> callback) final;
+        void attachCallStateChangeCallback(std::function<void()> callback) final;
+
+      private:
+        Application *application;
+        CallState callState = CallState::None;
+        time_t callTime     = 0;
+
+        std::function<void()> notifyPresenterOnDurationChange;
+        std::function<void()> notifyPresenterOnCallStateChange;
+
+        utils::PhoneNumber phoneNumber;
+        UTF8 callerId;
+
+        bool callWasRejected = false;
+    };
+} // namespace app::call

--- a/module-apps/application-call/presenter/CallPresenter.cpp
+++ b/module-apps/application-call/presenter/CallPresenter.cpp
@@ -1,0 +1,162 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "CallPresenter.hpp"
+#include <application-call/data/CallAppStyle.hpp>
+
+namespace app::call
+{
+
+    CallWindowContract::Presenter::Presenter(std::shared_ptr<app::call::AbstractCallModel> callModel) : model(callModel)
+    {
+        model->attachCallStateChangeCallback([this]() { this->handleCallStateChange(); });
+        model->attachDurationChangeCallback([this]() { this->handleCallDurationChange(); });
+    }
+
+    CallWindowContract::Presenter::~Presenter() noexcept
+    {
+        model->clear();
+    }
+
+    void CallWindowContract::Presenter::handleCallDurationChange()
+    {
+        if (not isCallInProgress()) {
+            return;
+        }
+        auto view = getView();
+        view->updateDuration(utils::time::Duration(model->getTime()).str());
+        view->refreshWindow();
+    }
+
+    void CallWindowContract::Presenter::handleCallStateChange()
+    {
+        buildLayout();
+        auto view = getView();
+        view->refreshWindow();
+    }
+
+    void CallWindowContract::Presenter::buildLayout()
+    {
+        auto view      = getView();
+        auto callState = model->getState();
+
+        switch (callState) {
+        case app::call::CallState::Incoming:
+            view->updateDuration(utils::translate(callAppStyle::strings::iscalling));
+            view->setIncomingCallLayout(model->getCallerId().empty() ? true : false);
+            view->updateNumber(getCallerId());
+            break;
+        case app::call::CallState::Outgoing:
+            view->updateDuration(utils::translate(callAppStyle::strings::calling));
+            view->updateNumber(getCallerId());
+            view->setActiveCallLayout();
+            break;
+        case app::call::CallState::Active:
+            view->updateDuration(utils::time::Duration(model->getTime()).str());
+            view->setActiveCallLayout();
+            break;
+        case app::call::CallState::Rejected:
+            view->updateDuration(utils::translate(callAppStyle::strings::callrejected));
+            view->setCallEndedLayout();
+            break;
+        case app::call::CallState::Ended:
+            view->updateDuration(utils::translate(callAppStyle::strings::callended));
+            view->setCallEndedLayout();
+            break;
+        case app::call::CallState::None:
+            view->clearNavBar();
+            break;
+        }
+    }
+
+    UTF8 CallWindowContract::Presenter::getCallerId()
+    {
+        auto callerId = model->getCallerId();
+        if (not callerId.empty()) {
+            return callerId;
+        }
+        return UTF8(callAppStyle::strings::privateNumber);
+    }
+
+    bool CallWindowContract::Presenter::handleLeftButton()
+    {
+        if (model->getState() == app::call::CallState::Incoming) {
+            model->answerCall();
+            return true;
+        }
+        return false;
+    }
+
+    bool CallWindowContract::Presenter::handleRightButton()
+    {
+        if (isIncomingCall() || isCallInProgress()) {
+            model->hangUpCall();
+            return true;
+        }
+        return false;
+    }
+
+    bool CallWindowContract::Presenter::handleHeadsetOk()
+    {
+        if (isIncomingCall()) {
+            model->answerCall();
+            return true;
+        }
+
+        if (isCallInProgress()) {
+            model->hangUpCall();
+            return true;
+        }
+
+        return false;
+    }
+
+    void CallWindowContract::Presenter::hangUpCall()
+    {
+        model->hangUpCall();
+    }
+
+    bool CallWindowContract::Presenter::handleDigitButton(const uint32_t &digit)
+    {
+        model->transmitDtmfTone(digit);
+        return true;
+    }
+
+    void CallWindowContract::Presenter::muteCall()
+    {
+        model->muteCall();
+    }
+
+    void CallWindowContract::Presenter::unmuteCall()
+    {
+        model->unmuteCall();
+    }
+
+    void CallWindowContract::Presenter::turnLoudspeakerOn()
+    {
+        model->turnLoudspeakerOn();
+    }
+
+    void CallWindowContract::Presenter::turnLoudspeakerOff()
+    {
+        model->turnLoudspeakerOff();
+    }
+
+    bool CallWindowContract::Presenter::isIncomingCall()
+    {
+        return model->getState() == CallState::Incoming;
+    }
+
+    bool CallWindowContract::Presenter::isCallInProgress()
+    {
+        if (auto state = model->getState(); state == CallState::Outgoing || state == CallState::Active) {
+            return true;
+        }
+        return false;
+    }
+
+    utils::PhoneNumber CallWindowContract::Presenter::getPhoneNumber()
+    {
+        return model->getPhoneNumber();
+    }
+} // namespace app::call

--- a/module-apps/application-call/presenter/CallPresenter.hpp
+++ b/module-apps/application-call/presenter/CallPresenter.hpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <module-apps/application-call/model/CallModel.hpp>
+#include <module-apps/application-call/widgets/StateIcons.hpp>
+#include "BasePresenter.hpp"
+
+namespace app::call
+{
+    class CallWindowContract
+    {
+      public:
+        class View
+        {
+          public:
+            virtual void updateDuration(const UTF8 &text, bool isVisible = true) = 0;
+            virtual void refreshWindow()                                         = 0;
+            virtual void setNavBarForActiveCall()                                = 0;
+            virtual void setNavBarForIncomingCall()                              = 0;
+            virtual void clearNavBar()                                           = 0;
+            virtual void setIncomingCallLayout(bool isValidCallerId)             = 0;
+            virtual void setActiveCallLayout()                                   = 0;
+            virtual void setCallEndedLayout()                                    = 0;
+            virtual void updateNumber(const UTF8 &text)                          = 0;
+
+            virtual ~View() noexcept = default;
+        };
+
+        class Presenter : public BasePresenter<CallWindowContract::View>
+        {
+          public:
+            Presenter(std::shared_ptr<app::call::AbstractCallModel> callModel);
+            ~Presenter() noexcept override;
+
+            void handleCallDurationChange();
+            void handleCallStateChange();
+            void buildLayout();
+
+            bool handleLeftButton();
+            bool handleRightButton();
+            bool handleHeadsetOk();
+            bool handleDigitButton(const uint32_t &digit);
+            void muteCall();
+            void unmuteCall();
+            void turnLoudspeakerOn();
+            void turnLoudspeakerOff();
+
+            void hangUpCall();
+            utils::PhoneNumber getPhoneNumber();
+
+          private:
+            std::shared_ptr<app::call::AbstractCallModel> model;
+            UTF8 getCallerId();
+            bool isIncomingCall();
+            bool isCallInProgress();
+        };
+    };
+} // namespace app::call

--- a/module-apps/application-call/test/CMakeLists.txt
+++ b/module-apps/application-call/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_catch2_executable(
+        NAME
+        call-presenter
+        SRCS
+        unittest_call_presenter.cpp
+        LIBS
+        application-call
+        i18n
+        log
+        utils-time
+        module-utils
+        app
+        apps-common
+)

--- a/module-apps/application-call/test/mock/CallPresenterMocks.hpp
+++ b/module-apps/application-call/test/mock/CallPresenterMocks.hpp
@@ -1,0 +1,126 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <module-apps/application-call/model/CallModel.hpp>
+#include <module-apps/application-call/presenter/CallPresenter.hpp>
+
+namespace app::call
+{
+
+    class ViewMock : public CallWindowContract::View
+    {
+      public:
+        void updateDuration(const UTF8 &text, bool isVisible = true) override
+        {
+            duration = text;
+        };
+        void refreshWindow() override
+        {
+            windowRefreshed = true;
+        };
+        void setNavBarForActiveCall() override{};
+        void setNavBarForIncomingCall() override{};
+        void clearNavBar() override{};
+        void setIncomingCallLayout(bool isValidCallerId) override
+        {
+            layoutShowed = LayoutShowed::Incoming;
+        };
+        void setActiveCallLayout() override
+        {
+            layoutShowed = LayoutShowed::Active;
+        };
+        ;
+        void setCallEndedLayout() override
+        {
+            layoutShowed = LayoutShowed::Ended;
+        };
+        ;
+        void updateNumber(const UTF8 &text) override
+        {
+            number = text;
+        };
+
+        bool windowRefreshed = false;
+
+        enum class LayoutShowed
+        {
+            Incoming,
+            Active,
+            Ended,
+            None
+        };
+
+        LayoutShowed layoutShowed = LayoutShowed::None;
+        UTF8 number;
+        UTF8 duration;
+    };
+
+    class ModelMock : public AbstractCallModel
+    {
+      public:
+        time_t getTime() override
+        {
+            return callTime;
+        };
+        void setTime(time_t newTime) override
+        {
+            callTime = newTime;
+        };
+        CallState getState() override
+        {
+            return callState;
+        };
+        void setState(CallState newState) override
+        {
+            callState = newState;
+        };
+        void setPhoneNumber(const utils::PhoneNumber number) override{};
+        utils::PhoneNumber getPhoneNumber() override
+        {
+            return phoneNumber;
+        };
+        UTF8 getCallerId() override
+        {
+            return callerId;
+        };
+
+        void hangUpCall() override
+        {
+            hangupCallCalled = true;
+        };
+        void answerCall() override
+        {
+            answerCallCalled = true;
+        };
+        void transmitDtmfTone(const uint32_t &digit) override{};
+        void muteCall() override{};
+        void unmuteCall() override{};
+        void turnLoudspeakerOn() override{};
+        void turnLoudspeakerOff() override{};
+
+        void turnOnKeypadBacklight() override{};
+        void turnOffKeypadBacklight() override{};
+
+        void clear() override{};
+        void attachDurationChangeCallback(std::function<void()> callback) override{};
+        void attachCallStateChangeCallback(std::function<void()> callback) override{};
+
+        bool hangupCallCalled = false;
+        bool answerCallCalled = false;
+
+      private:
+        Application *application;
+        CallState callState = CallState::None;
+        time_t callTime     = 0;
+
+        std::function<void()> notifyPresenterOnDurationChange;
+        std::function<void()> notifyPresenterOnCallStateChange;
+
+        utils::PhoneNumber phoneNumber;
+        UTF8 callerId;
+
+        bool callWasRejected = false;
+    };
+} // namespace app::call

--- a/module-apps/application-call/test/unittest_call_presenter.cpp
+++ b/module-apps/application-call/test/unittest_call_presenter.cpp
@@ -1,0 +1,245 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <catch2/catch.hpp>
+#include <module-apps/application-call/presenter/CallPresenter.hpp>
+#include <module-apps/application-call/test/mock/CallPresenterMocks.hpp>
+#include <module-apps/application-call/data/CallAppStyle.hpp>
+
+using app::call::ViewMock;
+
+TEST_CASE("Call presenter")
+{
+    SECTION("Show incoming call layout")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+        auto view      = app::call::ViewMock();
+        presenter.attach(&view);
+
+        model->setState(app::call::CallState::Incoming);
+        presenter.handleCallStateChange();
+
+        REQUIRE(view.windowRefreshed == true);
+        REQUIRE(view.layoutShowed == ViewMock::LayoutShowed::Incoming);
+        REQUIRE(view.duration == callAppStyle::strings::iscalling);
+    }
+
+    SECTION("Show call active layout")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+        auto view      = app::call::ViewMock();
+        presenter.attach(&view);
+
+        model->setState(app::call::CallState::Active);
+        presenter.handleCallStateChange();
+
+        REQUIRE(view.windowRefreshed == true);
+        REQUIRE(view.layoutShowed == ViewMock::LayoutShowed::Active);
+    }
+
+    SECTION("Show call outgoing layout")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+        auto view      = app::call::ViewMock();
+        presenter.attach(&view);
+
+        model->setState(app::call::CallState::Outgoing);
+        presenter.handleCallStateChange();
+
+        REQUIRE(view.windowRefreshed == true);
+        REQUIRE(view.layoutShowed == ViewMock::LayoutShowed::Active);
+        REQUIRE(view.duration == callAppStyle::strings::calling);
+    }
+
+    SECTION("Show call ended layout")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+        auto view      = app::call::ViewMock();
+        presenter.attach(&view);
+
+        model->setState(app::call::CallState::Ended);
+        presenter.handleCallStateChange();
+
+        REQUIRE(view.windowRefreshed == true);
+        REQUIRE(view.duration == callAppStyle::strings::callended);
+    }
+
+    SECTION("Show call rejected layout")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+        auto view      = app::call::ViewMock();
+        presenter.attach(&view);
+
+        model->setState(app::call::CallState::Rejected);
+        presenter.handleCallStateChange();
+
+        REQUIRE(view.windowRefreshed == true);
+        REQUIRE(view.layoutShowed == ViewMock::LayoutShowed::Ended);
+        REQUIRE(view.duration == callAppStyle::strings::callrejected);
+    }
+
+    SECTION("Handle left button for incoming call")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+
+        model->setState(app::call::CallState::Incoming);
+        auto result = presenter.handleLeftButton();
+
+        REQUIRE(result == true);
+        REQUIRE(model->answerCallCalled == true);
+    }
+
+    SECTION("Handle left button for not incoming call")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+
+        model->setState(app::call::CallState::None);
+        auto result = presenter.handleLeftButton();
+
+        REQUIRE(result == false);
+        REQUIRE(model->answerCallCalled == false);
+
+        model->answerCallCalled = false;
+        model->setState(app::call::CallState::Outgoing);
+        result = presenter.handleLeftButton();
+
+        REQUIRE(result == false);
+
+        model->answerCallCalled = false;
+        model->setState(app::call::CallState::Active);
+        result = presenter.handleLeftButton();
+
+        REQUIRE(result == false);
+        REQUIRE(model->answerCallCalled == false);
+
+        model->answerCallCalled = false;
+        model->setState(app::call::CallState::Ended);
+        result = presenter.handleLeftButton();
+
+        REQUIRE(result == false);
+        REQUIRE(model->answerCallCalled == false);
+
+        model->answerCallCalled = false;
+        model->setState(app::call::CallState::Rejected);
+        result = presenter.handleLeftButton();
+
+        REQUIRE(result == false);
+        REQUIRE(model->answerCallCalled == false);
+    }
+
+    SECTION("Handle right button for incoming call")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+
+        model->setState(app::call::CallState::Incoming);
+        auto result = presenter.handleRightButton();
+
+        REQUIRE(result == true);
+        REQUIRE(model->hangupCallCalled == true);
+    }
+
+    SECTION("Handle right button for active call")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+
+        model->setState(app::call::CallState::Active);
+        auto result = presenter.handleRightButton();
+
+        REQUIRE(result == true);
+        REQUIRE(model->hangupCallCalled == true);
+
+        model->hangupCallCalled = false;
+        model->setState(app::call::CallState::Outgoing);
+        result = presenter.handleRightButton();
+
+        REQUIRE(result == true);
+        REQUIRE(model->hangupCallCalled == true);
+    }
+
+    SECTION("Handle right button for not active call")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+
+        model->setState(app::call::CallState::None);
+        auto result = presenter.handleRightButton();
+
+        REQUIRE(result == false);
+        REQUIRE(model->hangupCallCalled == false);
+
+        model->hangupCallCalled = false;
+        model->setState(app::call::CallState::Ended);
+        result = presenter.handleRightButton();
+
+        REQUIRE(result == false);
+        REQUIRE(model->hangupCallCalled == false);
+
+        model->hangupCallCalled = false;
+        model->setState(app::call::CallState::Rejected);
+        result = presenter.handleRightButton();
+
+        REQUIRE(result == false);
+        REQUIRE(model->hangupCallCalled == false);
+    }
+
+    SECTION("Handle headset ok for incoming call")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+
+        model->setState(app::call::CallState::Incoming);
+        auto result = presenter.handleHeadsetOk();
+
+        REQUIRE(result == true);
+        REQUIRE(model->answerCallCalled == true);
+    }
+
+    SECTION("Handle headset ok active call")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+
+        model->setState(app::call::CallState::Outgoing);
+        auto result = presenter.handleHeadsetOk();
+
+        REQUIRE(result == true);
+        REQUIRE(model->hangupCallCalled == true);
+
+        model->hangupCallCalled = false;
+        model->setState(app::call::CallState::Active);
+        result = presenter.handleHeadsetOk();
+
+        REQUIRE(result == true);
+        REQUIRE(model->hangupCallCalled == true);
+    }
+
+    SECTION("Handle headset ok for not active call")
+    {
+        auto model     = std::make_shared<app::call::ModelMock>();
+        auto presenter = app::call::CallWindowContract::Presenter(model);
+
+        model->setState(app::call::CallState::None);
+        auto result = presenter.handleHeadsetOk();
+
+        REQUIRE(result == false);
+        REQUIRE(model->hangupCallCalled == false);
+        REQUIRE(model->answerCallCalled == false);
+
+        model->hangupCallCalled = false;
+        model->setState(app::call::CallState::Ended);
+        result = presenter.handleHeadsetOk();
+
+        REQUIRE(result == false);
+        REQUIRE(model->hangupCallCalled == false);
+        REQUIRE(model->answerCallCalled == false);
+    }
+}

--- a/module-services/service-cellular/call/CallGUI.cpp
+++ b/module-services/service-cellular/call/CallGUI.cpp
@@ -21,9 +21,9 @@ void CallGUI::notifyCLIP(const utils::PhoneNumber::View &number)
         &owner, app::manager::actions::HandleCallerId, std::make_unique<app::manager::actions::CallParams>(number));
 }
 
-void CallGUI::notifyCallStarted()
+void CallGUI::notifyCallStarted(utils::PhoneNumber phoneNumber)
 {
-    owner.bus.sendMulticast(std::make_shared<cellular::CallStartedNotification>(),
+    owner.bus.sendMulticast(std::make_shared<cellular::CallStartedNotification>(phoneNumber),
                             sys::BusChannel::ServiceCellularNotifications);
 }
 
@@ -38,6 +38,7 @@ void CallGUI::notifyCallActive()
     owner.bus.sendMulticast(std::make_shared<cellular::CallActiveNotification>(),
                             sys::BusChannel::ServiceCellularNotifications);
 }
+
 void CallGUI::notifyCallDurationUpdate(const time_t &duration)
 {
     owner.bus.sendMulticast(std::make_shared<cellular::CallDurationNotification>(duration),

--- a/module-services/service-cellular/call/CallGUI.hpp
+++ b/module-services/service-cellular/call/CallGUI.hpp
@@ -20,7 +20,7 @@ class CallGUI
 
     void notifyRING();
     void notifyCLIP(const utils::PhoneNumber::View &number);
-    void notifyCallStarted();
+    void notifyCallStarted(utils::PhoneNumber phoneNumber);
     void notifyCallEnded();
     void notifyCallActive();
     void notifyCallDurationUpdate(const time_t &duration);

--- a/module-services/service-cellular/call/CellularCall.cpp
+++ b/module-services/service-cellular/call/CellularCall.cpp
@@ -109,7 +109,7 @@ namespace CellularCall
             return false;
         }
 
-        gui.notifyCallStarted();
+        gui.notifyCallStarted(number);
         LOG_INFO("call started");
         return true;
     }
@@ -209,6 +209,9 @@ namespace CellularCall
     }
     void Call::handleCallDurationTimer()
     {
+        if (not isActiveCall) {
+            return;
+        }
         auto now         = utils::time::getCurrentTimestamp();
         callDurationTime = (now - startActiveTime).getSeconds();
         gui.notifyCallDurationUpdate(callDurationTime);

--- a/module-services/service-cellular/service-cellular/CellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/CellularMessage.hpp
@@ -602,17 +602,11 @@ class CellularAnswerIncomingCallMessage : public CellularMessage
     {}
 };
 
-class CellularHangupCallMessage : public CellularMessage, public app::manager::actions::ConvertibleToAction
+class CellularHangupCallMessage : public CellularMessage
 {
   public:
     CellularHangupCallMessage() : CellularMessage(Type::HangupCall)
     {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(
-            sender, app::manager::actions::AbortCall, std::make_unique<app::manager::actions::ActionParams>());
-    }
 };
 
 class CellularDismissCallMessage : public CellularMessage
@@ -1048,7 +1042,15 @@ namespace cellular
     class CallStartedNotification : public sys::DataMessage
     {
       public:
-        explicit CallStartedNotification() : sys::DataMessage(MessageType::MessageTypeUninitialized){};
+        explicit CallStartedNotification(utils::PhoneNumber phoneNumber)
+            : sys::DataMessage(MessageType::MessageTypeUninitialized), phoneNumber(phoneNumber){};
+        utils::PhoneNumber getNumber()
+        {
+            return phoneNumber;
+        };
+
+      private:
+        utils::PhoneNumber phoneNumber;
     };
 
     class CallEndedNotification : public sys::DataMessage
@@ -1070,4 +1072,5 @@ namespace cellular
             : sys::DataMessage(MessageType::MessageTypeUninitialized), callDuration(duration){};
         time_t callDuration;
     };
+
 } // namespace cellular

--- a/module-utils/time/time/time_conversion.hpp
+++ b/module-utils/time/time/time_conversion.hpp
@@ -6,7 +6,7 @@
 /// this calss uses strftime to convert timestamp to text, but for UTF8 elements (mon,day) it uses our locale
 /// as stdlib builtin locale doesn't provide way to substitute C-LOCALE
 
-#include "time/time_locale.hpp"
+#include <time/time_locale.hpp>
 #include <log/log.hpp>
 
 #include <vector>


### PR DESCRIPTION
Call logic is now removed from call window and call app.
There was spaghetti logic mixed in window and app, now
call logic is based on notificatins from service cellular.

**Description**

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
