### PR TITLE
[MOS-400] Fix missing header

### DIFF
--- a/module-db/Common/Query.hpp
+++ b/module-db/Common/Query.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <endpoints/Context.hpp>
 
 namespace db


### PR DESCRIPTION
**Description**

The `<optional>` header is required to use std::optional.  This fixes unit test building.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
