### PR TITLE
Fix word splitting in shell scripts

### DIFF
--- a/config/apply_update.sh
+++ b/config/apply_update.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #
@@ -20,18 +20,18 @@ LINUX_DEV_FILE="usb-NXP_SEMI_NXP_MASS_STORAGE_0123456789ABCDEF-0:0-part1"
 
 function get_phone_dev() {
 	if [ "$OS" == "Darwin" ]; then
-		diskutil list | grep $PHONE_PARTITION_NAME | awk '{print $6}'
+		diskutil list | grep "${PHONE_PARTITION_NAME}" | awk '{print $6}'
 	else
-		readlink -f /dev/disk/by-id/$LINUX_DEV_FILE		
+		readlink -f "/dev/disk/by-id/${LINUX_DEV_FILE}"
 	fi
 }
 
 function eject_phone() {
 	if [ "$OS" == "Darwin" ]; then
-		diskutil eject $PHONE_DEV
+		diskutil eject "${PHONE_DEV}"
 	else
-		udisksctl unmount -b $PHONE_DEV
-		timeout --signal=SIGINT 1 udisksctl power-off -b $PHONE_DEV
+		udisksctl unmount -b "${PHONE_DEV}"
+		timeout --signal=SIGINT 1 udisksctl power-off -b "${PHONE_DEV}"
 	fi
 }
 
@@ -73,35 +73,35 @@ if [ "$PHONE_DEV" == "" ]; then
 	exit 1
 fi
 
-PHONE_MOUNT=`df -P | grep $PHONE_DEV | awk '{print $6}'`
+PHONE_MOUNT=`df -P | grep "${PHONE_DEV}" | awk '{print $6}'`
 
 if [ "$PHONE_MOUNT" == "" ]; then
-	echo dev: $PHONE_DEV not mounted, do that yorself and re-run
+	echo "dev: ${PHONE_DEV} not mounted, do that yorself and re-run"
 	exit 1
 fi
 
-if [ ! -e $UPDATE_FILE ]; then
+if [ ! -e "${UPDATE_FILE}" ]; then
 	echo "Update file $UPDATE_FILE does not exist"
 	exit 1
 fi
 
-rm -rf $TMPDIR
-mkdir $TMPDIR
-tar -C $TMPDIR -xpf $UPDATE_FILE
+rm -rf "${TMPDIR}"
+mkdir "${TMPDIR}"
+tar -C "${TMPDIR}" -xpf "${UPDATE_FILE}"
 
 if [ $CLEAN_PHONE == 1 ]; then
 	echo "Clean phone requested"
-	rm -rf $PHONE_MOUNT/current
-	mkdir -p $PHONE_MOUNT/current
+	rm -rf "${PHONE_MOUNT}/current"
+	mkdir -p "${PHONE_MOUNT}/current"
 	sync
 fi
 
 echo "Copyind data"
-cp $TMPDIR/boot.bin $PHONE_MOUNT/current/
-cp $TMPDIR/Luts.bin $PHONE_MOUNT/current/
-cp $TMPDIR/country-codes.db $PHONE_MOUNT/current/
-cp $TMPDIR/version.json $PHONE_MOUNT/current/
-cp -r $TMPDIR/assets $PHONE_MOUNT/current/
+cp "${TMPDIR}/boot.bin" "${PHONE_MOUNT}/current/"
+cp "${TMPDIR}/Luts.bin" "${PHONE_MOUNT}/current/"
+cp "${TMPDIR}/country-codes.db" "${PHONE_MOUNT}/current/"
+cp "${TMPDIR}/version.json" "${PHONE_MOUNT}/current/"
+cp -r "${TMPDIR}/assets" "${PHONE_MOUNT}/current/"
 
 echo "Ejecting phone from OS..."
 eject_phone

--- a/config/bootstrap.sh
+++ b/config/bootstrap.sh
@@ -12,11 +12,11 @@
 # it's support is added to default ccache
 
 # packages settings
-SCRIPT=$(readlink -f $0)
-SCRIPT_DIR="$(dirname ${SCRIPT})"
+SCRIPT=$(readlink -f "$0")
+SCRIPT_DIR=$(dirname "${SCRIPT}")
 
-. ${SCRIPT_DIR}/bootstrap_config
-. ${SCRIPT_DIR}/common_scripts_lib
+. "${SCRIPT_DIR}/bootstrap_config"
+. "${SCRIPT_DIR}/common_scripts_lib"
 
 function test_if_run_as_root() {
     echo -e "\e[32m${FUNCNAME[0]}\e[0m"
@@ -42,10 +42,10 @@ function add_to_path() {
 
     if [[ -n ${check_if_exists} ]]; then
         SED_SCRIPT="s%${TOOL_PATH_VAR}=\".*\"%${TOOL_PATH_VAR}=\"${TOOL_DIR}\"%"
-        sed -e "$SED_SCRIPT" -i ${BASH_RC}
+        sed -e "$SED_SCRIPT" -i "${BASH_RC}"
     else
-        echo "export ${TOOL_PATH_VAR}=\"${TOOL_DIR}\"" >> ${BASH_RC}
-        echo "PATH=\"\${${TOOL_PATH_VAR}:+\${${TOOL_PATH_VAR}}:}\${PATH}\"" >> ${BASH_RC}
+        echo "export ${TOOL_PATH_VAR}=\"${TOOL_DIR}\"" >> "${BASH_RC}"
+        echo "PATH=\"\${${TOOL_PATH_VAR}:+\${${TOOL_PATH_VAR}}:}\${PATH}\"" >> "${BASH_RC}"
     fi
 }
 function install_hooks(){
@@ -59,7 +59,7 @@ function install_hooks(){
     HOOK="pre-commit.hook"
 
     L_GIT_DIR=$(git rev-parse --show-toplevel)
-    ln -sf ${L_GIT_DIR}/config/${HOOK} ${L_GIT_DIR}/.git/hooks/pre-commit
+    ln -sf "${L_GIT_DIR}/config/${HOOK}" "${L_GIT_DIR}/.git/hooks/pre-commit"
 }
 
 function add_ignore_revs_for_blame() {
@@ -78,8 +78,8 @@ function setup_gcc_alternatives() {
 
 function install_pip_packages() {
     echo -e "\e[32m${FUNCNAME[0]}\e[0m"
-    pip3 install -r ${SCRIPT_DIR}/requirements.txt
-    pip3 install -r ${SCRIPT_DIR}/../test/requirements.txt
+    pip3 install -r "${SCRIPT_DIR}/requirements.txt"
+    pip3 install -r "${SCRIPT_DIR}/../test/requirements.txt"
 }
 
 function install_ubuntu_packages() {
@@ -105,7 +105,7 @@ function setup_arm_toolchain() {
     # untar to HOME
     if [[ ! -d ${HOME}/${ARM_GCC} ]]; then
         echo "extracting: ${ARM_GCC_PKG} to ${HOME}"
-        tar -xjf ${ARM_GCC_PKG} -C ${HOME}/
+        tar -xjf "${ARM_GCC_PKG}" -C "${HOME}/"
     fi
     echo "ARM GCC installed to ${HOME}/${ARM_GCC}"
     popd 
@@ -114,10 +114,10 @@ function setup_arm_toolchain() {
 function setup_cmake() {
     echo -e "\e[32m${FUNCNAME[0]}\e[0m"
     pushd /tmp
-    [[ ! -f ${CMAKE_NAME}.tgz ]] &&
+    [[ ! -f "${CMAKE_NAME}.tgz" ]] &&
         getCMake
-    [[ ! -d ${HOME}/${CMAKE_NAME} ]] &&
-        tar -xf ${CMAKE_PKG} -C ${HOME}/
+    [[ ! -d "${HOME}/${CMAKE_NAME}" ]] &&
+        tar -xf "${CMAKE_PKG}" -C "${HOME}/"
     popd
     echo "CMAKEV installed to ${HOME}/${CMAKE_NAME} and set in PATH"
 }
@@ -126,7 +126,7 @@ function install_docker() {
     if [[ -n $(command -v docker) ]]; then
         TESTED_VERSION="19.03.8"
         DOCKER_VERSION=$(docker version -f '{{.Server.Version}}')
-        if [[ ${TESTED_VERSION} != ${DOCKER_VERSION} ]]; then
+        if [[ "${TESTED_VERSION}" != "${DOCKER_VERSION}" ]]; then
             echo -e "Tested with docker ${DOCKER_VERSION} your is ${DOCKER_VERSION} consider updating"
         else
             echo "Docker already installed"
@@ -140,10 +140,10 @@ function install_docker() {
 
 function add_to_docker_group() {
     DOCKER_GRP="docker"
-    if grep -q $DOCKER_GRP /etc/group
+    if grep -q "$DOCKER_GRP" /etc/group
     then
         NAME=$(whoami)
-        sudo usermod -aG ${DOCKER_GRP} ${NAME}
+        sudo usermod -aG "${DOCKER_GRP}" "${NAME}"
         cat <<-MSGEND
 		Group is updated, please logout and login back so
 		the change has come into effect
@@ -167,7 +167,7 @@ BUILD_STEPS=(
 
 test_if_run_as_root
 
-if [ $# -eq 1 ]; then 
+if [ $# -eq 1 ]; then
     PARAM=$1
     if [ "${PARAM:$(( ${#PARAM} - 1 )):1}" == "-" ]; then
         START=${PARAM%*-}
@@ -199,7 +199,7 @@ echo "START:${BUILD_STEPS[$START]}(${START})"
 echo "END:${BUILD_STEPS[$END]}(${END})"
 
 I=${START}
-while [ ${I} -lt ${END} ]
+while [ "${I}" -lt "${END}" ]
 do
     eval ${BUILD_STEPS[${I}]}
     echo "${I}" > LAST_STEP

--- a/config/clang/clang-common.sh
+++ b/config/clang/clang-common.sh
@@ -1,5 +1,5 @@
 #!/bin/env bash
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 set -eo pipefail
@@ -11,7 +11,7 @@ verify_clang_format_version()
     clang_format=$( find  /usr/bin/ -regextype egrep -regex ".*/clang-format(-[0-9][0-9])?")
     local version
     version=$( [[ $(which $clang_format) ]] && ($clang_format --version | sed "s/.*version \([^ ]*\).*$/\1/" |  cut -d'.' -f1) || echo "0")
-    echo $version
+    echo "$version"
     # check for either clang-format or clang-format-11
     if [[ $version -lt 11 ]]; then
         cat << EOF >&1

--- a/config/clang_check.sh
+++ b/config/clang_check.sh
@@ -1,5 +1,5 @@
 #!/bin/env bash
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 set -euo pipefail
@@ -9,9 +9,9 @@ set -euo pipefail
 # shellcheck source=../config/clang/common.sh
 
 L_GIT_DIR=$(git rev-parse --show-toplevel)
-source $L_GIT_DIR/config/format-config.sh
-source $L_GIT_DIR/config/clang/clang-common.sh
-source $L_GIT_DIR/config/clang/colors.sh
+source "${L_GIT_DIR}/config/format-config.sh"
+source "${L_GIT_DIR}/config/clang/clang-common.sh"
+source "${L_GIT_DIR}/config/clang/colors.sh"
 
 help()
 {
@@ -41,8 +41,8 @@ get_files_to_check()
 get_compile_commands()
 {
     product=$1
-    [[ -f build-$product-linux-Debug/compile_commands.json ]] || ./configure.sh $product linux debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 > /dev/null 2>&1
-    cp build-$product-linux-Debug/compile_commands.json /tmp/compile_commands.json
+    [[ -f "build-${product}-linux-Debug/compile_commands.json" ]] || ./configure.sh "${product}" linux debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 > /dev/null 2>&1
+    cp "build-${product}-linux-Debug/compile_commands.json" /tmp/compile_commands.json
     sed -i 's|-static-libasan||g'     /tmp/compile_commands.json
     sed -i 's|-Wno-literal-suffix||g' /tmp/compile_commands.json
 }

--- a/config/common.sh
+++ b/config/common.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -e
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 check_any_arch() {
     local path="${1}"
     local product="${2}"
     local arch="${3}"
-    [ -d ${path} ] || ( echo "no such directory: ${path}" > /dev/stderr ; exit 1)
-    file ${path}/${product}.elf | grep "$arch" -q || ( echo "Bad file: ${path}/${product}.elf for selected architecture!" ; exit 1 )
+    [ -d "${path}" ] || ( echo "no such directory: ${path}" > /dev/stderr ; exit 1)
+    file "${path}/${product}.elf" | grep "$arch" -q || ( echo "Bad file: ${path}/${product}.elf for selected architecture!" ; exit 1 )
 }
 
 check_target_rt1051() {

--- a/config/license_header_check.sh
+++ b/config/license_header_check.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 
 #time update doesn't work below
-SCRIPT=$(readlink -f $0)
-SCRIPT_DIR="$(dirname ${SCRIPT})"
+SCRIPT=$(readlink -f "$0")
+SCRIPT_DIR=$(dirname "${SCRIPT}")
 REPO_ROOT="${SCRIPT_DIR%/*}"
 
-#. ${SCRIPT_DIR}/bootstrap_config
-. ${SCRIPT_DIR}/common_scripts_lib
-. ${SCRIPT_DIR}/format-config.sh
+#. "${SCRIPT_DIR}/bootstrap_config"
+. "${SCRIPT_DIR}/common_scripts_lib"
+. "${SCRIPT_DIR}/format-config.sh"
 
 #printVar SCRIPT
 #printVar SCRIPT_DIR
 #printVar REPO_ROOT
 
-pushd ${REPO_ROOT} >> /dev/null
+pushd "${REPO_ROOT}" >> /dev/null
 
 CURRENT_YEAR=$(date "+%Y")
 
@@ -29,7 +29,7 @@ CHECK_ONLY="false"
 EXIT_CODE=0
 
 #file extension; comment;checker/replacer function
-declare -A FileTypes=( 
+declare -A FileTypes=(
             ["c_header"]="h;cppChecker;"
             ["c_source"]="c;cppChecker;"
             ["header"]="hpp;cppChecker;"
@@ -41,17 +41,17 @@ declare -A FileTypes=(
 
 function addEmptyLine() {
     LINE=$1
-    CHECK_EMPTY=$(sed -n "${LINE}p" ${FILE})
+    CHECK_EMPTY=$(sed -n "${LINE}p" "${FILE}")
     if [[ -n ${CHECK_EMPTY} ]]; then
-        sed -i ${LINE}'s@^\(.*\)$@\n\1@' ${FILE}
+        sed -i "${LINE}"'s@^\(.*\)$@\n\1@' "${FILE}"
     fi
 }
 
 function updateYear() {
     if [[ ${CHECK_LICENSE} =~ ${LICENSE_CHEK_BASH_RE} ]]; then
-        sed -i "1,5s|${LICENSE_CHEK}|\1\2${CURRENT_YEAR}\4|g" ${FILE}
+        sed -i "1,5s|${LICENSE_CHEK}|\1\2${CURRENT_YEAR}\4|g" "${FILE}"
         echo -e "${YELLOW}Updated\e[0m"
-    else 
+    else
         echo -e "${OK}"
     fi
 }
@@ -59,18 +59,18 @@ function updateYear() {
 
 
 function codeChecker(){
-    CHECK_LICENSE=$(head -n5 ${FILE} | grep "${LICENSE_CHEK}")
+    CHECK_LICENSE=$(head -n5 "${FILE}" | grep "${LICENSE_CHEK}")
     if [[ -z ${CHECK_LICENSE} ]]; then
         if [[ ${CHECK_ONLY} == "true" ]]; then
             echo -e "${ERROR}"
             EXIT_CODE=1
-        else 
-            sed -i "1i${LICENSE_LINE1}" ${FILE}
-            sed -i "2i${LICENSE_LINE2}" ${FILE}
+        else
+            sed -i "1i${LICENSE_LINE1}" "${FILE}"
+            sed -i "2i${LICENSE_LINE2}" "${FILE}"
             addEmptyLine 3
             echo -e "${FIXED}"
         fi
-    else 
+    else
         updateYear
     fi
 }
@@ -90,25 +90,25 @@ function sqlChecker() {
 }
 
 function scriptChecker(){
-    CHECK_LICENSE=$( head -n5 ${FILE} | grep "${LICENSE_CHEK}")
-    if [[ -z ${CHECK_LICENSE} ]]; then
-        if [[ ${CHECK_ONLY} == "true" ]]; then
+    CHECK_LICENSE=$( head -n5 "${FILE}" | grep "${LICENSE_CHEK}")
+    if [[ -z "${CHECK_LICENSE}" ]]; then
+        if [[ "${CHECK_ONLY}" == "true" ]]; then
             echo -e "${ERROR}"
             EXIT_CODE=1
         else
-            FIST_LINE=$(head -n1 ${FILE}|grep "$SHA_BANG_EXEC")
+            FIST_LINE=$(head -n1 "${FILE}"|grep "$SHA_BANG_EXEC")
             if [[ -n "${FIST_LINE}" ]]; then
-                sed -i "2i${LICENSE_LINE1}" ${FILE}
-                sed -i "3i${LICENSE_LINE2}" ${FILE}
+                sed -i "2i${LICENSE_LINE1}" "${FILE}"
+                sed -i "3i${LICENSE_LINE2}" "${FILE}"
                 addEmptyLine 4
-            else 
-                sed -i "1i${LICENSE_LINE1}" ${FILE}
-                sed -i "2i${LICENSE_LINE2}" ${FILE}
+            else
+                sed -i "1i${LICENSE_LINE1}" "${FILE}"
+                sed -i "2i${LICENSE_LINE2}" "${FILE}"
                 addEmptyLine 3
             fi
             echo -e "${FIXED}"
         fi
-    else 
+    else
         updateYear
     fi
 
@@ -119,8 +119,7 @@ function pythonChecker(){
     LICENSE_LINE2="# ${LICENSE2}"
     SHA_BANG_EXEC="python"
     scriptChecker
-    
-} 
+}
 
 function bashChecker(){
     FILE=$1
@@ -146,19 +145,19 @@ function excludePathFromFind(){
     I=0
     SUB_COUNT=${#SUBMODULES[@]}
     while [[ $I -lt ${SUB_COUNT} ]];
-    do 
+    do
         module=${SUBMODULES[$I]}
         NOT_PATH="${NOT_PATH} -not ( -path ./${module} -prune )"
         I=$(( $I + 1))
     done
-    
+
     # ignore paths excluded from format
     I=0
     IGNORE_PATHS_COUNT=${#ignore_paths[@]}
-    while [[ $I -lt ${IGNORE_PATHS_COUNT} ]]
+    while [[ "${I}" -lt "${IGNORE_PATHS_COUNT}" ]]
     do
         path=${ignore_paths[$I]}
-        if [[ -d ${path} ]]; then
+        if [[ -d "${path}" ]]; then
             NOT_PATH="${NOT_PATH} -not ( -path ${path%*/} -prune )"
         fi
         I=$(( $I + 1 ))
@@ -167,13 +166,13 @@ function excludePathFromFind(){
 
 function findFiles() {
     # find files except submodule directories
-    readarray -d '' FILES_TO_CHECK < <(find . ${NOT_PATH} -iname "*.${FILE_EXT}" -printf "%P\0")
+    readarray -d '' FILES_TO_CHECK < <(find . "${NOT_PATH}" -iname "*.${FILE_EXT}" -printf "%P\0")
 }
 
 function shouldnt_ignore() {
     FILE=$1
     for el in ${ignore_paths[@]}; do
-        if [[ ${FILE}  =~ ^${el}.* ]]; then
+        if [[ "${FILE}"  =~ ^${el}.* ]]; then
             echo -e "${ORANGE}Ignore: ${FILE} checking due to: $el match!\e[0m"
             return 1
         fi
@@ -188,9 +187,9 @@ function help() {
         $0 [--help | --check-only]
         $0 --hook [ --check-only]
                 Run as git "pre-commith.hook", checks against files in stash
-        $0 --ci 
+        $0 --ci
                 Run on CI, check files that are new to the current master
-            
+
             --help              - this help message
             --check-only        - only checks, do not change a file
 
@@ -202,19 +201,19 @@ function hookMain() {
     parseArgs $@
     readarray -d '' FILES_TO_CHECK < <( ${GET_FILES_CMD} )
 
-    for FILE_TYPE in "${!FileTypes[@]}" 
+    for FILE_TYPE in "${!FileTypes[@]}"
     do
         echo "=== ${FILE_TYPE} ==="
-        extractValues ${FILE_TYPE}
+        extractValues "${FILE_TYPE}"
         I=0
         while [[ $I -lt ${#FILES_TO_CHECK[@]} ]]
         do
             FILE=${FILES_TO_CHECK[$I]}
-            if shouldnt_ignore ${FILE}; then
-                if [[ ${FILE} =~ .*\.${FILE_EXT}$ ]]; then
+            if shouldnt_ignore "${FILE}"; then
+                if [[ "${FILE}" =~ .*\.${FILE_EXT}$ ]]; then
                     echo -en "${FILE}:"
-                    ${CHECK_FUNCTION} ${FILE}
-                    git add ${FILE}
+                    ${CHECK_FUNCTION} "${FILE}"
+                    git add "${FILE}"
                 fi
             fi
             I=$(( $I + 1 ))
@@ -227,19 +226,19 @@ function hookMain() {
 function standAloneMain() {
     NOT_PATH=""
     excludePathFromFind
-    
+
     for FILE_TYPE in "${!FileTypes[@]}"
     do
         echo "=== ${FILE_TYPE} ==="
-        extractValues ${FILE_TYPE}
+        extractValues "${FILE_TYPE}"
         findFiles
         I=0
-        while [[ $I -lt ${#FILES_TO_CHECK[@]} ]]
+        while [[ "$I" -lt ${#FILES_TO_CHECK[@]} ]]
         do
             FILE=${FILES_TO_CHECK[$I]}
-            if shouldnt_ignore ${FILE}; then
+            if shouldnt_ignore "${FILE}"; then
                 echo -en "${I}/${#FILES_TO_CHECK[@]}:{${FILE}: "
-                ${CHECK_FUNCTION} ${FILE}
+                ${CHECK_FUNCTION} "${FILE}"
             fi
             I=$(( $I + 1 ))
         done

--- a/config/partition_emmc.sh
+++ b/config/partition_emmc.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 # set -eo pipefail
@@ -8,19 +8,19 @@ if [ ! -e config/common.sh ]; then
 	exit 1
 fi
 
-if [ ! $(which sfdisk) ]; then
+if [ ! "$(which sfdisk)" ]; then
 	echo "No sfdisk, please install"
 	exit 1
 fi
 
-if [ ! $(which parted) ]; then
+if [ ! "$(which parted)" ]; then
 	echo "No parted, please install"
 	exit 1
 fi
 
 source config/common.sh
 is_root=`id -u`
-if [ $is_root != 0 ]; then
+if [ "$is_root" != 0 ]; then
 	echo "Runme as root [uid=$is_root]"
 	exit 1
 fi
@@ -58,8 +58,8 @@ if [ ! -f "$emmc_partition_table_dump_path" ]; then
 	exit 1
 fi
 
-pcount=$(sfdisk --dump $dev | grep "start=" | wc -l)
-is_mounted=$(grep $dev /etc/mtab | awk '{print $2}')
+pcount=$(sfdisk --dump "${dev}" | grep "start=" | wc -l)
+is_mounted=$(grep "${dev}" /etc/mtab | awk '{print $2}')
 if [ "$is_mounted" == "" ]; then
 	echo "$dev is not mounted"
 else
@@ -67,7 +67,7 @@ else
 	exit 1
 fi
 
-if [ $pcount == 2 ] && [ $use_the_force == 0 ]; then
+if [ "${pcount}" == 2 ] && [ $use_the_force == 0 ]; then
 	echo "device $dev already has 2 partitions (use -f to force)"
 	exit 1
 else
@@ -80,9 +80,9 @@ echo -ne "?"
 read
 
 echo "wipe disk header"
-dd if=/dev/zero of=$dev bs=8192 count=8192
+dd if=/dev/zero of="${dev}" bs=8192 count=8192
 echo "create msdos partition table"
-parted $dev mklabel msdos
+parted "${dev}" mklabel msdos
 
 sleep 1
 
@@ -92,22 +92,22 @@ sleep 1
 partprobe
 
 echo "write partition table"
-sfdisk --wipe always $dev < "$emmc_partition_table_dump_path"
+sfdisk --wipe always "${dev}" < "$emmc_partition_table_dump_path"
 
 if [ $? != 0 ]; then
 	echo "partitioning device $dev failed"
 	exit 1
 fi
 
-part1=$(sfdisk $dev --dump | grep bootable | awk '{print $1}')
-part2=$(sfdisk $dev --dump | tail -n 2 | head -n -1 | awk '{print $1}')
+part1=$(sfdisk "${dev}" --dump | grep "bootable" | awk '{print $1}')
+part2=$(sfdisk "${dev}" --dump | tail -n 2 | head -n -1 | awk '{print $1}')
 
 echo "create FATs"
 echo "FAT: $MUDITAOS_PARTITION_PRIMARY $part1"
-mkfs.vfat -n $MUDITAOS_PARTITION_PRIMARY $part1
+mkfs.vfat -n "${MUDITAOS_PARTITION_PRIMARY}" "${part1}"
 
 echo "FAT: $MUDITAOS_PARTITION_RECOVERY $part2"
-mkfs.vfat -n $MUDITAOS_PARTITION_RECOVERY $part2
+mkfs.vfat -n "${MUDITAOS_PARTITION_RECOVERY}" "${part2}"
 
 echo "probe new partitions to OS"
 partprobe

--- a/config/style_check_hook.sh
+++ b/config/style_check_hook.sh
@@ -19,9 +19,9 @@ set -o pipefail
 # shellcheck source=../config/clang/common.sh
 
 L_GIT_DIR=$(git rev-parse --show-toplevel)
-source $L_GIT_DIR/config/format-config.sh
-source $L_GIT_DIR/config/clang/colors.sh
-source $L_GIT_DIR/config/clang/clang-common.sh
+source "${L_GIT_DIR}/config/format-config.sh"
+source "${L_GIT_DIR}/config/clang/colors.sh"
+source "${L_GIT_DIR}/config/clang/clang-common.sh"
 CHANGE_TARGET=${CHANGE_TARGET:-master}
 
 
@@ -148,7 +148,7 @@ declare -A results
 
 EXIT_CODE=0
 for file in ${FILES}; do
-    if [[ ${file} =~ ^.*\.(cpp|hpp|c|h|cxx|gcc|cc)$ ]] && shouldnt_ignore ${file}; then
+    if [[ ${file} =~ ^.*\.(cpp|hpp|c|h|cxx|gcc|cc)$ ]] && shouldnt_ignore "${file}"; then
         check_file "${file}" ${LAST} || RESULT=$?
         if [[ ${RESULT} -eq 1 ]]; then
             EXIT_CODE=1

--- a/tools/find_global_data.sh
+++ b/tools/find_global_data.sh
@@ -1,19 +1,19 @@
-#!/bin/bash 
+#!/bin/bash
 
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 # A script to find duplicated initialization code of global data
 
-rootdir="$(realpath $(dirname $(realpath $0))/..)"
-objfile="${1:-$(realpath ${rootdir}/build-rt1051-Debug/PurePhone.elf)}"
+rootdir=$(realpath $(dirname $(realpath "${0}"))/..)
+objfile=${1:-$(realpath "${rootdir}/build-rt1051-Debug/PurePhone.elf")}
 
-if [ ! -f ${objfile} ]; then
+if [ ! -f "${objfile}" ]; then
     echo "No such file: ${objfile}"
     exit 1
 fi
 
-type=$( file ${objfile} | grep "ARM" )
+type=$( file "${objfile}" | grep "ARM" )
 
 if [[ -z "${type}" ]]; then
     echo "x86"
@@ -27,7 +27,7 @@ fi
 
 STATIC_SYMBOL="_Z41__static_initialization_and_destruction_0ii"
 
-staticList=($(${NM} --print-size ${objfile} | grep "${STATIC_SYMBOL}"|cut -f1,2 -d" "|tr " " ":" ))
+staticList=($(${NM} --print-size "${objfile}" | grep "${STATIC_SYMBOL}"|cut -f1,2 -d" "|tr " " ":" ))
 
 echo "${#staticList[@]}"
 
@@ -37,14 +37,13 @@ statcListSize=${#staticList[@]}
 searchRegexp='(.*\.hpp:[0-9]+)'
 while [[ $I -lt $statcListSize ]]
 do
-    
     symbol=${staticList[${I}]}
     symbolStart="0x${staticList[${I}]%:*}"
     symbolSize="0x${staticList[${I}]#*:}"
     printf -v symbolEnd "0x%x" $(( ${symbolStart} + ${symbolSize} ))
     echo "${I}/${statcListSize}: ${symbolStart} - ${symbolEnd}"
 
-    items=( $(${OBJDUMP} --start-address=${symbolStart} --stop-address=${symbolEnd} -d -l ${objfile} ) )
+    items=( $(${OBJDUMP} --start-address="${symbolStart}" --stop-address="${symbolEnd}" -d -l "${objfile}" ) )
     J=0
     while [[ ${J} -lt ${#items[@]} ]]
     do

--- a/tools/generate_image.sh
+++ b/tools/generate_image.sh
@@ -4,7 +4,7 @@
 
 usage() {
 cat << ==usage
-Usage: $(basename $0) image_path image_partitions build_dir [version.json_file] [boot.bin_file] [updater.bin_file]
+Usage: $(basename "$0") image_path image_partitions build_dir [version.json_file] [boot.bin_file] [updater.bin_file]
     image_path        - Destination image path name e.g., PurePhone.img
     image_partitions  - Path to image_partitions.map product-specific file
     sysroot           - product's system root e.g., build-rt1051-RelWithDebInfo/sysroot
@@ -20,15 +20,15 @@ if [[ ( $# -lt 3 )  || ( $# -gt 8 ) ]]; then
 	exit -1
 fi
 
-IMAGE_NAME=$(realpath $1)
-PRODUCT_NAME=$(basename -s .img $1)
-IMAGE_PARTITIONS=$(realpath $2)
+IMAGE_NAME=$(realpath "${1}")
+PRODUCT_NAME=$(basename -s .img "${1}")
+IMAGE_PARTITIONS=$(realpath "${2}")
 
-SYSROOT=$(realpath $3)
-LUTS=$4
-VERSION_FILE=$5
-BIN_FILE=$6
-UPDATER_FILE=$7
+SYSROOT=$(realpath "${3}")
+LUTS=${4}
+VERSION_FILE=${5}
+BIN_FILE=${6}
+UPDATER_FILE=${7}
 
 if [ ! -d "$SYSROOT" ]; then
 	echo "Error! ${SYSROOT} is not a directory"
@@ -58,7 +58,7 @@ if [ ! $MTOOLS_OK ]; then
 	exit -1
 fi
 
-source ${IMAGE_PARTITIONS}
+source "${IMAGE_PARTITIONS}"
 DEVICE_BLK_SIZE=512
 
 # Partition sizes in sector 512 units
@@ -69,8 +69,8 @@ PART3_START=$(($PART2_START + $PART2_SIZE))
 PART3_SIZE=$(($DEVICE_BLK_COUNT - $PART1_SIZE - $PART2_SIZE - $PART1_START))
 
 echo "Remove previous image file"
-rm -f $IMAGE_NAME
-truncate -s $(($DEVICE_BLK_COUNT * $DEVICE_BLK_SIZE)) $IMAGE_NAME
+rm -f "${IMAGE_NAME}"
+truncate -s $(($DEVICE_BLK_COUNT * $DEVICE_BLK_SIZE)) "${IMAGE_NAME}"
 sfdisk $IMAGE_NAME << ==sfdisk
 label: dos
 label-id: 0x09650eb4

--- a/tools/generate_update_image.sh
+++ b/tools/generate_update_image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #create update image
@@ -57,14 +57,14 @@ function checkForDeps() {
 
 function cleanStagingDir(){
     local STAGEING_DIR=${1}
-    if [[ -d ${STAGEING_DIR} ]]; then
-        rm -Rf ${STAGEING_DIR}
+    if [[ -d "${STAGEING_DIR}" ]]; then
+        rm -Rf "${STAGEING_DIR}"
     fi
-    mkdir ${STAGEING_DIR} -v
+    mkdir "${STAGEING_DIR}" -v
 }
 
 function linkInStageing(){
-    pushd ${STAGEING_DIR} 1> /dev/null
+    pushd "${STAGEING_DIR}" 1> /dev/null
 
     mkdir assets
     pushd assets 1> /dev/null
@@ -74,23 +74,23 @@ function linkInStageing(){
     popd 1> /dev/null
 
     ln -s ../sysroot/sys/user
-    ln -s ../sysroot/sys/current/${SOURCE_TARGET}-boot.bin boot.bin
+    ln -s "../sysroot/sys/current/${SOURCE_TARGET}-boot.bin" boot.bin
     ln -s ../sysroot/sys/current/country-codes.db
     ln -s ../sysroot/sys/current/Luts.bin
     ln -s ../ecoboot.bin
     ln -s ../updater.bin
-    ln -s ../${SOURCE_TARGET}-version.json version.json
+    ln -s "../${SOURCE_TARGET}-version.json" version.json
     popd 1> /dev/null
 }
 
 function addChecksums() {
-    pushd ${STAGEING_DIR} 1> /dev/null
+    pushd "${STAGEING_DIR}" 1> /dev/null
     rhash -u checksums.txt -r .
     popd 1> /dev/null
 }
 
 function compress() {
-    tar chf ${PACKAGE_FILE} -C ${STAGEING_DIR} .
+    tar chf "${PACKAGE_FILE}" -C "${STAGEING_DIR}" .
 }
 
 if [[ $# -ne 3 ]]; then
@@ -99,8 +99,8 @@ if [[ $# -ne 3 ]]; then
 fi
 
 setVars "${1}" "${2}" "${3}"
-checkForDeps ${DEPS}
-cleanStagingDir ${STAGEING_DIR}
+checkForDeps "${DEPS}"
+cleanStagingDir "${STAGEING_DIR}"
 linkInStageing
 addChecksums
 compress

--- a/tools/macflash.sh
+++ b/tools/macflash.sh
@@ -10,16 +10,16 @@ PHONE_DEV=""
 
 function get_phone_dev() {
 	BLOCK_DEV="/dev/r"$(diskutil info $OS_PARTITION_NAME | grep "Part of Whole" | awk '{print $4}')
-	echo ${BLOCK_DEV}
+	echo "${BLOCK_DEV}"
 }
 
 function unmount_muditaos_partition() {
-	PART_NODE=$(diskutil info $OS_PARTITION_NAME | grep "Device Node" | awk '{print $3}')
-	diskutil unmount $PART_NODE  > /dev/null 2>&1
+	PART_NODE=$(diskutil info "$OS_PARTITION_NAME" | grep "Device Node" | awk '{print $3}')
+	diskutil unmount "$PART_NODE"  > /dev/null 2>&1
 }
 
 function eject_device() {
-	diskutil eject $1
+	diskutil eject "${1}"
 }
 
 MAC_DD="gdd"
@@ -37,7 +37,7 @@ function test_if_run_as_root() {
 }
 
 function test_if_gdd_installed() {
-    if ! command -v $MAC_DD &> /dev/null; then
+    if ! command -v "${MAC_DD}" &> /dev/null; then
         echo "$MAC_DD command could not be found. Please, run macflash_setup.sh"
         exit 1
     fi
@@ -76,16 +76,16 @@ done
 test_if_run_as_root
 test_if_gdd_installed
 
-if [ -z $PHONE_DEV ]; then
+if [ -z "${PHONE_DEV}" ]; then
 	PHONE_DEV=$(get_phone_dev)
 fi
 
-if [ ! -e $IMAGE_FILE ]; then
+if [ ! -e "${IMAGE_FILE}" ]; then
 	echo "Image file $IMAGE_FILE does not exist"
 	exit 1
 fi
 
-if [ ! -e $PHONE_DEV ]; then
+if [ ! -e "${PHONE_DEV}" ]; then
 	echo "Block device $PHONE_DEV does not exist"
 	exit 1
 fi
@@ -94,6 +94,6 @@ unmount_muditaos_partition
 
 echo "Flashing $IMAGE_FILE to $PHONE_DEV..."
 
-sudo gdd if=$IMAGE_FILE of=$PHONE_DEV bs=1M conv=sparse,fdatasync status=progress
+sudo gdd if="${IMAGE_FILE}" of="${PHONE_DEV}" bs=1M conv=sparse,fdatasync status=progress
 
-eject_device $PHONE_DEV
+eject_device "${PHONE_DEV}"

--- a/tools/macflash_setup.sh
+++ b/tools/macflash_setup.sh
@@ -39,7 +39,7 @@ function install_brew_packages() {
 
     for pkg in $BREW_PKGS
     do
-        brew install $pkg
+        brew install "${pkg}"
     done
 }
 

--- a/tools/stack-usage.sh
+++ b/tools/stack-usage.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/bash
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+#!/bin/bash
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 # make sure, that GENERATE_STACK_USAGE option has been enabled in cmake configuration
@@ -8,17 +8,17 @@ builddir=$1
 minsize=$2
 pattern=$3
 
-if [ -z "$builddir" ]; then
+if [ -z "${builddir}" ]; then
     echo "usage $0 builddir [minsize] [file name pattern]"
     exit 1
 fi
 
-if [ -z $minsize ]; then
+if [ -z "${minsize}" ]; then
     minsize=0
 fi
 
-if [ -n "$pattern" ]; then
-    FILTER="| egrep $pattern"
+if [ -n "${pattern}" ]; then
+    FILTER="| egrep ${pattern}"
 fi
 
-eval find $builddir -name "*.su" $FILTER | xargs awk '{if ( $(NF-1) > '$minsize') print $(NF-1)" "$0}' | sort -n
+eval find "${builddir}" -name "*.su" ${FILTER} | xargs awk '{if ( $(NF-1) > '$minsize') print $(NF-1)" "$0}' | sort -n


### PR DESCRIPTION
**Description**

This patch adds quotes around variable names in shell scripts to ensure that paths containing spaces will no longer cause the script to fail.  Adding quotes to arrays has been explicitly been avoided to ensure nothing is broken.

See [ShellCheck SC2086](https://www.shellcheck.net/wiki/SC2086) for details about the issues not quoting can cause.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
