### PR TITLE
Fix return codes in shell scripts

### DIFF
--- a/flash_emmc_experimental_littlefs.sh
+++ b/flash_emmc_experimental_littlefs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 usage() {
@@ -15,7 +15,7 @@ ASSETS_DIR="assets country-codes.db Luts.bin boot.bin"
 if [ $# -ne 2 ]; then
 	echo "Error! Invalid argument count"
 	usage
-	exit -1
+	exit 1
 fi
 
 BLK_DEV=$1
@@ -24,25 +24,25 @@ SRC_DATA=$(realpath $2)
 if [ ! -d "$SRC_DATA" ]; then
 	echo "Error! asset_root_dir is not a directory"
 	usage
-	exit -1
+	exit 1
 fi
 if [ ! -b "$BLK_DEV" ]; then
 	echo "Error: $BLK_DEV Not a block device"
 	usage
-	exit -1
+	exit 1
 fi
 
 if [ ! -w "$BLK_DEV" ]; then
 	echo "Error: Block device $BLK_DEV is not writable"
 	usage
-	exit -1
+	exit 1
 fi
 
 _REQ_CMDS="sfdisk mtools awk truncate blockdev"
 for cmd in $_REQ_CMDS; do
 	if [ ! $(command -v $cmd) ]; then
 		echo "Error! $cmd is not installed, please use 'sudo apt install' for install required tool"
-		exit -1
+		exit 1
 	fi
 done
 #mtools version
@@ -58,14 +58,14 @@ MTOOLS_OK=$(mtools --version | awk "${_AWK_SCRIPT}")
 
 if [ ! $MTOOLS_OK ]; then
 	echo "Invalid mtools version, please upgrade mtools to >= 4.0.24"
-	exit -1
+	exit 1
 fi
 
 SDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 GENLFS=$(find $SDIR -type f -iname genlittlefs -executable -print -quit)
 if [ -z ${GENLFS} ]; then
     echo "Unable to find genlilttlefs..."
-    exit -1
+    exit 1
 fi
 
 # Partition sizes in sector 512 units

--- a/module-platform/linux/tests/gendisktestimg.sh
+++ b/module-platform/linux/tests/gendisktestimg.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -e
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+#Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 #For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 if [ $# -ne 1 ]; then
 	echo "Error! Invalid argument count"
-	exit -1
+	exit 1
 fi
 IMAGE_FILE_DIR="$1"
 

--- a/module-platform/linux/tests/genext4diskimg.sh
+++ b/module-platform/linux/tests/genext4diskimg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-#Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+#Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 #For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 usage() {
@@ -14,7 +14,7 @@ Usage: $(basename $0) [image_size] [image_file] [sysroot]
 if [ $# -lt 2 ]; then
 	echo "Error! Invalid argument count"
 	usage
-	exit -1
+	exit 1
 fi
 IMAGE_SIZE="$1"
 IMAGE_FILE="$2"
@@ -23,14 +23,14 @@ shift 3
 
 if [ ! -d "${SYSROOT}" ]; then
 	echo "Invalid sysroot: ${SYSROOT}"
-	exit -1
+	exit 1
 fi
 
 _REQ_CMDS="sfdisk truncate mke2fs"
 for cmd in $_REQ_CMDS; do
 	if [ ! $(command -v $cmd) ]; then
 		echo "Error! $cmd is not installed, please use 'sudo apt install' for install required tool"
-		exit -1
+		exit 1
 	fi
 done
 truncate -s $IMAGE_SIZE $IMAGE_FILE

--- a/module-platform/linux/tests/genlfstestimg.sh
+++ b/module-platform/linux/tests/genlfstestimg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-#Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+#Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 #For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 usage() {
@@ -15,7 +15,7 @@ Usage: $(basename $0) [image_size] [image_file] [sysroot] [files]...
 if [ $# -lt 2 ]; then
 	echo "Error! Invalid argument count"
 	usage
-	exit -1
+	exit 1
 fi
 IMAGE_SIZE="$1"
 IMAGE_FILE="$2"
@@ -24,14 +24,14 @@ shift 3
 
 if [ ! -d "${SYSROOT}/sys" ]; then
 	echo "Invalid sysroot: ${SYSROOT}"
-	exit -1
+	exit 1
 fi
 
 _REQ_CMDS="sfdisk truncate"
 for cmd in $_REQ_CMDS; do
 	if [ ! $(command -v $cmd) ]; then
 		echo "Error! $cmd is not installed, please use 'sudo apt install' for install required tool"
-		exit -1
+		exit 1
 	fi
 done
 truncate -s $IMAGE_SIZE $IMAGE_FILE

--- a/run_simulator_on_filesystem_image.sh
+++ b/run_simulator_on_filesystem_image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 arraymenu ()
@@ -30,7 +30,7 @@ elif [ ${#dirs[@]} -gt 1 ]; then
     cd "${dirs[$REPLY-1]}"
 else
     echo "Error: Simulator directory doesn't exists"
-    exit -1
+    exit 1
 fi
 
 PRELOAD_LIB=$(realpath board/linux/libiosyscalls/libiosyscalls.so)

--- a/tools/generate_image.sh
+++ b/tools/generate_image.sh
@@ -17,7 +17,7 @@ Usage: $(basename $0) image_path image_partitions build_dir [version.json_file] 
 if [[ ( $# -lt 3 )  || ( $# -gt 8 ) ]]; then
 	echo "Error! Invalid argument count $# args: $*"
 	usage
-	exit -1
+	exit 1
 fi
 
 IMAGE_NAME=$(realpath $1)
@@ -33,13 +33,13 @@ UPDATER_FILE=$7
 if [ ! -d "$SYSROOT" ]; then
 	echo "Error! ${SYSROOT} is not a directory"
 	usage
-	exit -1
+	exit 1
 fi
 _REQ_CMDS="sfdisk mtools awk truncate"
 for cmd in $_REQ_CMDS; do
 	if [ ! $(command -v $cmd) ]; then
 		echo "Error! $cmd is not installed, please use 'sudo apt install' for install required tool"
-		exit -1
+		exit 1
 	fi
 done
 #mtools version
@@ -55,7 +55,7 @@ MTOOLS_OK=$(mtools --version | awk "${_AWK_SCRIPT}")
 
 if [ ! $MTOOLS_OK ]; then
 	echo "Invalid mtools version, please upgrade mtools to >= 4.0.24"
-	exit -1
+	exit 1
 fi
 
 source ${IMAGE_PARTITIONS}
@@ -91,7 +91,7 @@ mformat -i "$PART2" -F -T $PART2_SIZE -M $DEVICE_BLK_SIZE -v RECOVER
 
 if [ ! -d "${SYSROOT}/sys" ]; then
 	echo "Fatal! Image folder sys/ missing in build. Check build system."
-	exit -1
+	exit 1
 fi
 cd "${SYSROOT}/sys"
 


### PR DESCRIPTION
**Description**

Negative values (e.g. -1) use for shell script exit codes are invalid (only 0-255 are valid). The patch replaces several "-1" instances with the valid exit code of "1".  None of the scripts seem to check these exit codes therefore changing their value does not impact anything.

See [ShellCheck SC2242](https://github.com/koalaman/shellcheck/wiki/SC2242) for details.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
