### PR TITLE
Fix Clang detection/version checking

### DIFF
--- a/config/clang/clang-common.sh
+++ b/config/clang/clang-common.sh
@@ -1,19 +1,39 @@
-#!/bin/env bash
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+#!/bin/bash
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-set -eo pipefail
+set -euo pipefail
+#set -o posix
+LC_CTYPE="C"
+
+
+if [ -z "${L_GIT_DIR+unbound}" ] && [ -z "$(global L_GIT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)")" ]; then
+  global L_GIT_DIR="$(readlink -f "$(dirname "$0")/../..")"
+fi
+
+. "${L_GIT_DIR}/tools/version_check.sh"
+
+_extract_number () { echo "${1}" | sed -e "s|[^[:digit:]]*\([[:digit:]]\+\)|\1|"; }
+_do_search () { find "${2}" -name "${1}-[[:digit:]][[:digit:]]*"; }
+
+_get_latest () {
+  latest=${1}
+  set -f; IFS=":";
+  for p in $PATH; do
+    for file in $(_do_search "${1}" "${p}"); do
+      if [ "$(expr "$(_extract_number "${latest}")" ">" "$(_extract_number "${file}")")" ]; then
+        latest="${file}"
+      fi
+    done
+  done
+  echo "${latest}"
+}
 
 verify_clang_format_version()
 {
-    # check if clang-format in path is in proper version, version is 3rd column in `clang-format --version`
-    local clang_format
-    clang_format=$( find  /usr/bin/ -regextype egrep -regex ".*/clang-format(-[0-9][0-9])?")
-    local version
-    version=$( [[ $(which $clang_format) ]] && ($clang_format --version | sed "s/.*version \([^ ]*\).*$/\1/" |  cut -d'.' -f1) || echo "0")
-    echo $version
-    # check for either clang-format or clang-format-11
-    if [[ $version -lt 11 ]]; then
+  latest=$(_get_latest "clang-format")
+  if less_than_version "$(${latest} --version)" "11.0.0"
+  then
         cat << EOF >&1
 Either install:
     clang-format in at least version 11 and set as default"
@@ -29,44 +49,12 @@ EOF
     fi
 }
 
-## find `what` from list of directories `arr`
-get_tool() {
-    local what="$1"; shift
-    local arr=("$@")
-
-    local tool="";
-    for el in ${arr[*]}; do
-        if [[ -f "${el}" ]]; then
-            tool=${el}
-            break
-        fi
-    done
-    if [[ ${tool} == "" ]]; then
-        echo "$what not found in path and: ${arr[*]}" > /dev/stderr
-        exit 2
-    fi
-    echo "${tool}"
-}
-
-## Search for clang-format-diff.py
+## locate clang-format-diff
 get_clang_format() {
-    local searchpaths=(
-        "$(which "clang-format-diff.py" 2>/dev/null 1>/dev/null)"  # clang-format-diff in path
-        "/usr/share/clang/clang-format-*/clang-format-diff.py"     # clang-format-diff location on Ubuntu/Debian
-        "/usr/share/clang/clang-format-diff.py"                    # clang-format_diff location on Arch last resort
-    )
-    get_tool "clang-format-diff.py" "${searchpaths[@]}"
+  command -v "$(_get_latest "clang-format-diff")"
 }
 
-## search for clang-tidy-diff
-get_clang_tidy()
-{
-    local searchpaths=(
-        "$(which "clang-tidy-diff.py" 2>/dev/null 1>/dev/null)"  # clang-format-diff in path
-        "/usr/bin/clang-tidy-diff-10.py"                         # clang-format-diff location on Ubuntu
-        "/usr/bin/clang-tidy-diff-12.py"
-        "/usr/share/clang/clang-tidy-*/clang-tidy-diff.py"       # clang-format-diff location on Debian
-        "/usr/share/clang/clang-tidy-diff.py"                    # clang-format_diff location on Arch last resort
-    )
-    get_tool "clang-tidy-diff.py" "${searchpaths[@]}"
+## locate clang-tidy-diff
+get_clang_tidy() {
+  command -v "$(_get_latest "clang-tidy-diff")"
 }

--- a/config/clang_check.sh
+++ b/config/clang_check.sh
@@ -1,5 +1,5 @@
-#!/bin/env bash
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+#!/bin/bash
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 set -euo pipefail
@@ -49,12 +49,10 @@ get_compile_commands()
 
 main()
 {
-    if [[ $# -ne 1 ]]; then
+    if [ $# -ne 1 ]; then
         help
         exit 0
     fi
-    local tool
-    tool=$(get_clang_tidy)
     echo "Target branch: ${CHANGE_TARGET}"
 
     local files_to_check
@@ -73,7 +71,7 @@ main()
     verify_clang_format_version
     get_compile_commands "$1"
     # run tidy
-    git diff -U0 --no-color remotes/origin/${CHANGE_TARGET}...HEAD $files_to_check | ${tool[*]} -p 1 -path=/tmp/
+    git diff -U0 --no-color remotes/origin/${CHANGE_TARGET}...HEAD $files_to_check | "$(get_clang_tidy)" -p 1 -path=/tmp/
 }
 
 main "$1"

--- a/tools/version_check.sh
+++ b/tools/version_check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+# For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+set -euo pipefail
+#set -o posix;
+LC_CTYPE="C"
+
+# WARNING: depends on word splitting
+semver2num () { printf "%03.0f%03.0f%03.0f" $(echo "$1" | sed -e "s/[^[:digit:]]*\([[:digit:]]\+\)\.\([[:digit:]]\+\)\.\([[:digit:]]\+\).*/\\1 \\2 \\3/"); }
+
+# first argument is the "binname --version" output
+# second argument is the minimum acceptable version
+less_than_version () { expr $(semver2num "$1") "<" $(semver2num "$2"); }
+greater_than_version () { expr $(semver2num "$1") ">" $(semver2num "$2"); }


### PR DESCRIPTION
**Description**

The commit script will now properly check all paths in `$PATH`. The basic semantic version checking function is reusable for other scripts as well.

Not to be merged before PR #3770 or it will break the style check script.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
