### PR TITLE
[MOS-422] Fix pure gdb tools

### DIFF
--- a/module-bsp/board/rt1051/os/CMakeLists.txt
+++ b/module-bsp/board/rt1051/os/CMakeLists.txt
@@ -9,6 +9,10 @@ add_library(module-bsp-os
 
 add_library(module-bsp::os ALIAS module-bsp-os)
 
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug" OR ${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
+    target_compile_definitions(module-bsp-os PUBLIC DEBUG_FREERTOS)
+endif ()
+
 target_include_directories(module-bsp-os
         PUBLIC
         include

--- a/module-os/CMakeLists.txt
+++ b/module-os/CMakeLists.txt
@@ -41,10 +41,6 @@ if (${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
     set_source_files_properties(memory/usermem.c PROPERTIES COMPILE_OPTIONS "-O0")
 endif ()
 
-if (${CMAKE_BUILD_TYPE} STREQUAL "Debug" OR ${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
-    target_compile_definitions(${PROJECT_NAME} PUBLIC DEBUG_FREERTOS)
-endif ()
-
 target_include_directories(${PROJECT_NAME}
 
         PUBLIC


### PR DESCRIPTION
**Description**

Fixed issues with gdb pure due to the DEBUG_FREERTOS
flag not propagating correctly.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
