### PR TITLE
[MOS-420] Fix Call ending with sms reworked

### DIFF
--- a/image/assets/lang/Deutsch.json
+++ b/image/assets/lang/Deutsch.json
@@ -614,6 +614,7 @@
   "app_desktop_update_ready_for_reset": "Bereit für Reset …",
   "app_desktop_update_success": "MuditaOS wurde erfolgreich auf Version $VERSION aktualisiert.",
   "app_call_private_number": "Private Nummer",
+  "app_call_ending_call": "Anruf beenden",
   "tethering": "Tethering",
   "tethering_turn_off_question": "Tethering ausschalten?",
   "tethering_enable_question": "<text>Sie sind mit dem Computer verbunden.<br />Tethering einschalten?<br /><text color='5'>(einige Funktionen können deaktiviert sein)</text></text>",

--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -589,6 +589,7 @@
   "app_desktop_update_ready_for_reset": "Ready for reset...",
   "app_desktop_update_success": "MuditaOS has been updated to ver. $VERSION succesfully.",
   "app_call_private_number": "Private number",
+  "app_call_ending_call": "Ending a call",
   "tethering": "Tethering",
   "tethering_turn_off_question": "Turn tethering off?",
   "tethering_enable_question": "<text>You're connected to the computer.<br />Turn tethering on?<br /><text color='5'>(some functions may be disabled)</text></text>",

--- a/image/assets/lang/Espanol.json
+++ b/image/assets/lang/Espanol.json
@@ -615,6 +615,7 @@
   "app_desktop_update_ready_for_reset": "Preparado para restablecer...",
   "app_desktop_update_success": "El SO de MuditaOS se ha actualizado a la ver. $VERSION correctamente.",
   "app_call_private_number": "Número privado",
+  "app_call_ending_call": "Terminar una llamada",
   "tethering": "Anclaje de red",
   "tethering_turn_off_question": "¿Desactivar el anclaje de red?",
   "tethering_enable_question": "<text>Estás conectado al ordenador.<br />¿Activar el anclaje de red?<br /><text color='5'>(algunas funciones podrían desactivarse)</text></text>",

--- a/image/assets/lang/Francais.json
+++ b/image/assets/lang/Francais.json
@@ -582,6 +582,7 @@
   "app_desktop_update_ready_for_reset": "Prêt pour la réinitialisation...",
   "app_desktop_update_success": "La mise à jour de MuditaOS à la version $VERSION a été effectuée avec succès.",
   "app_call_private_number": "Numéro privé",
+  "app_call_ending_call": "Terminer un appel",
   "tethering": "Partage de connexion",
   "tethering_turn_off_question": "Voulez-vous désactiver le partage de connexion?",
   "tethering_enable_question": "<text>Vous êtes connecté à l'ordinateur.<br />Voulez-vous activer le partage de connexion?<br /><text color='5'>(certaines fonctions peuvent être désactivées)</text></text>",

--- a/image/assets/lang/Polski.json
+++ b/image/assets/lang/Polski.json
@@ -626,6 +626,7 @@
   "app_desktop_update_ready_for_reset": "Gotowy do resetu…",
   "app_desktop_update_success": "System MuditaOS został pomyślnie zaktualizowany do wer. $VERSION.",
   "app_call_private_number": "Numer prywatny",
+  "app_call_ending_call": "Kończenie połączenia",
   "tethering": "Tethering",
   "tethering_turn_off_question": "Wyłączyć tethering?",
   "tethering_enable_question": "<text>Połączono z komputerem.<br />Włączyć tethering?<br /><text color='5'>(Niektóre funkcje mogą być niedostępne)</text></text>",

--- a/image/assets/lang/Svenska.json
+++ b/image/assets/lang/Svenska.json
@@ -520,6 +520,7 @@
   "app_desktop_update_bytes": "bytes",
   "app_desktop_update_unpacking": "Packar upp",
   "app_call_private_number": "Dolt nummer",
+  "app_call_ending_call": "Avsluta ett samtal",
   "tethering": "Internetdelning",
   "tethering_turn_off_question": "Stänga av Internetdelning?",
   "tethering_enable_question": "<text>Du är ansluten till datorn.<br />Slå på Internetdelning?<br /><text color='9'>(vissa funktioner kan vara inaktiverade)</text></text>",

--- a/module-apps/application-call/data/CallAppStyle.hpp
+++ b/module-apps/application-call/data/CallAppStyle.hpp
@@ -27,6 +27,7 @@ namespace callAppStyle
         inline constexpr auto speakeron     = "app_call_speaker_on";
         inline constexpr auto bluetooth     = "app_call_bluetooth";
         inline constexpr auto privateNumber = "app_call_private_number";
+        inline constexpr auto endingcall    = "app_call_ending_call";
     } // namespace strings
 
     namespace numberLabel

--- a/module-apps/application-call/model/CallModel.cpp
+++ b/module-apps/application-call/model/CallModel.cpp
@@ -67,6 +67,24 @@ namespace app::call
         CellularServiceAPI::AnswerIncomingCall(application);
     }
 
+    bool CallModel::sendSms(const UTF8 &smsBody)
+    {
+        if (phoneNumber.getView().getEntered().empty() || smsBody.length() == 0) {
+            LOG_WARN("Number or sms body is empty");
+            return false;
+        }
+        SMSRecord record;
+        record.number = phoneNumber.getView();
+        record.body   = smsBody;
+        record.type   = SMSType::QUEUED;
+        record.date   = std::time(nullptr);
+
+        using db::query::SMSAdd;
+        const auto [succeed, _] =
+            DBServiceAPI::GetQuery(application, db::Interface::Name::SMS, std::make_unique<SMSAdd>(record));
+        return succeed;
+    }
+
     void CallModel::transmitDtmfTone(const uint32_t &digit)
     {
         CellularServiceAPI::TransmitDtmfTones(application, digit);

--- a/module-apps/application-call/model/CallModel.hpp
+++ b/module-apps/application-call/model/CallModel.hpp
@@ -19,7 +19,8 @@ namespace app::call
         Outgoing,
         Active,
         Ended,
-        Rejected
+        Rejected,
+        Disconnecting
     };
 
     inline auto c_str(app::call::CallState state) -> const char *
@@ -37,6 +38,8 @@ namespace app::call
             return "Ended";
         case CallState::Rejected:
             return "Ended";
+        case CallState::Disconnecting:
+            return "Disconnecting";
         }
         return "";
     }
@@ -55,6 +58,7 @@ namespace app::call
 
         virtual void hangUpCall()                            = 0;
         virtual void answerCall()                            = 0;
+        virtual bool sendSms(const UTF8 &smsBody)            = 0;
         virtual void transmitDtmfTone(const uint32_t &digit) = 0;
         virtual void muteCall()                              = 0;
         virtual void unmuteCall()                            = 0;
@@ -84,6 +88,7 @@ namespace app::call
 
         void hangUpCall() final;
         void answerCall() final;
+        bool sendSms(const UTF8 &smsBody) final;
         void transmitDtmfTone(const uint32_t &digit) final;
         void muteCall();
         void unmuteCall();

--- a/module-apps/application-call/presenter/CallPresenter.cpp
+++ b/module-apps/application-call/presenter/CallPresenter.cpp
@@ -63,6 +63,10 @@ namespace app::call
             view->updateDuration(utils::translate(callAppStyle::strings::callended));
             view->setCallEndedLayout();
             break;
+        case app::call::CallState::Disconnecting:
+            view->updateDuration(utils::translate(callAppStyle::strings::endingcall));
+            view->setCallEndedLayout(false);
+            break;
         case app::call::CallState::None:
             view->clearNavBar();
             break;
@@ -114,6 +118,14 @@ namespace app::call
     void CallWindowContract::Presenter::hangUpCall()
     {
         model->hangUpCall();
+        model->setState(app::call::CallState::Disconnecting);
+    }
+
+    void CallWindowContract::Presenter::sendSms(const UTF8 &smsBody)
+    {
+        if (not model->sendSms(smsBody)) {
+            LOG_ERROR("SMS sending failed!");
+        }
     }
 
     bool CallWindowContract::Presenter::handleDigitButton(const uint32_t &digit)

--- a/module-apps/application-call/presenter/CallPresenter.hpp
+++ b/module-apps/application-call/presenter/CallPresenter.hpp
@@ -22,7 +22,7 @@ namespace app::call
             virtual void clearNavBar()                                           = 0;
             virtual void setIncomingCallLayout(bool isValidCallerId)             = 0;
             virtual void setActiveCallLayout()                                   = 0;
-            virtual void setCallEndedLayout()                                    = 0;
+            virtual void setCallEndedLayout(bool delayedClose = true)            = 0;
             virtual void updateNumber(const UTF8 &text)                          = 0;
 
             virtual ~View() noexcept = default;
@@ -48,6 +48,7 @@ namespace app::call
             void turnLoudspeakerOff();
 
             void hangUpCall();
+            void sendSms(const UTF8 &smsBody);
             utils::PhoneNumber getPhoneNumber();
 
           private:

--- a/module-apps/application-call/test/mock/CallPresenterMocks.hpp
+++ b/module-apps/application-call/test/mock/CallPresenterMocks.hpp
@@ -32,11 +32,11 @@ namespace app::call
             layoutShowed = LayoutShowed::Active;
         };
         ;
-        void setCallEndedLayout() override
+        void setCallEndedLayout(bool delayedClose = true) override
         {
             layoutShowed = LayoutShowed::Ended;
         };
-        ;
+
         void updateNumber(const UTF8 &text) override
         {
             number = text;
@@ -94,6 +94,10 @@ namespace app::call
         {
             answerCallCalled = true;
         };
+        bool sendSms(const UTF8 &smsBody) override
+        {
+            return true;
+        }
         void transmitDtmfTone(const uint32_t &digit) override{};
         void muteCall() override{};
         void unmuteCall() override{};

--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -154,8 +154,9 @@ namespace gui
     {
         presenter->buildLayout();
 
-        if (dynamic_cast<SMSTemplateSent *>(data) != nullptr) {
+        if (auto switchData = dynamic_cast<SMSTemplateSent *>(data); switchData != nullptr) {
             presenter->hangUpCall();
+            presenter->sendSms(switchData->getText());
             return;
         }
     }
@@ -273,7 +274,7 @@ namespace gui
         setFocusItem(microphoneIcon);
     }
 
-    void CallWindow::setCallEndedLayout()
+    void CallWindow::setCallEndedLayout(bool delayedClose)
     {
         navBar->setActive(gui::nav_bar::Side::Left, false);
         navBar->setActive(gui::nav_bar::Side::Center, false);
@@ -286,7 +287,9 @@ namespace gui
         iconsBox->resizeItems();
 
         setFocusItem(nullptr);
-        connectTimerOnExit();
+        if (delayedClose) {
+            connectTimerOnExit();
+        }
     }
 
     void CallWindow::updateNumber(const UTF8 &text)

--- a/module-apps/application-call/windows/CallWindow.hpp
+++ b/module-apps/application-call/windows/CallWindow.hpp
@@ -66,7 +66,7 @@ namespace gui
         void clearNavBar() override;
         void setIncomingCallLayout(bool isValidCallerId) override;
         void setActiveCallLayout() override;
-        void setCallEndedLayout() override;
+        void setCallEndedLayout(bool delayedClose = true) override;
         void updateNumber(const UTF8 &text) override;
     };
 

--- a/module-apps/application-messages/data/SMSdata.hpp
+++ b/module-apps/application-messages/data/SMSdata.hpp
@@ -86,7 +86,17 @@ class SMSSendTemplateRequest : public SMSRequest
 };
 
 class SMSTemplateSent : public gui::SwitchData
-{};
+{
+  public:
+    explicit SMSTemplateSent(const UTF8 &text) : smsText(text){};
+    auto getText() -> UTF8
+    {
+        return smsText;
+    }
+
+  private:
+    UTF8 smsText;
+};
 
 class SMSTextData : public gui::SwitchData
 {

--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -76,13 +76,12 @@ namespace gui
         auto app         = dynamic_cast<app::ApplicationMessages *>(application);
         assert(app != nullptr);
 
-        auto phoneNumber       = switchData->getPhoneNumber();
         app->templatesCallback = [=](std::shared_ptr<SMSTemplateRecord> templ) {
             LOG_DEBUG("SMS template id = %" PRIu32 "sent", templ->ID);
-            app->sendSms(phoneNumber, templ->text);
-            app::manager::Controller::switchBack(app,
-                                                 std::make_unique<app::manager::SwitchBackRequest>(
-                                                     application->GetName(), std::make_unique<SMSTemplateSent>()));
+            app::manager::Controller::switchBack(
+                app,
+                std::make_unique<app::manager::SwitchBackRequest>(application->GetName(),
+                                                                  std::make_unique<SMSTemplateSent>(templ->text)));
             app->popCurrentWindow();
             return true;
         };

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -1948,7 +1948,6 @@ auto ServiceCellular::handleDBNotificationMessage(db::NotificationMessage *msg) 
         (msg->type == db::Query::Type::Create || msg->type == db::Query::Type::Update)) {
 
         priv->outSMSHandler.handleDBNotification();
-
         return std::make_shared<sys::ResponseMessage>();
     }
     return std::make_shared<sys::ResponseMessage>(sys::ReturnCodes::Failure);


### PR DESCRIPTION
Reworked ending with sms is now reworked. Sms is send by call app,
application messages is only providing template text.
Also call hangup and sms send order is changed due to delays caused by
sending sms.

**Description**

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
