### PR TITLE
[CP-1232] Extend messages EP API with getThreadByID method

### DIFF
--- a/products/PurePhone/services/desktop/endpoints/include/endpoints/messages/MessageHelper.hpp
+++ b/products/PurePhone/services/desktop/endpoints/include/endpoints/messages/MessageHelper.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -24,6 +24,7 @@ namespace sdesktop::endpoints
         auto deleteDBEntry(Context &context) -> sys::ReturnCodes override;
 
         static auto toJson(const SMSRecord &record) -> json11::Json;
+        static auto toJson(const ThreadRecord &thread) -> json11::Json;
         static auto toJson(const ThreadRecord &thread, const utils::PhoneNumber::View &number) -> json11::Json;
         static auto toJson(const SMSTemplateRecord &record) -> json11::Json;
         static auto fromJson(const json11::Json &msgJson) -> SMSTemplateRecord;
@@ -42,6 +43,9 @@ namespace sdesktop::endpoints
         auto updateTemplate(Context &context) -> sys::ReturnCodes;
         auto deleteTemplate(Context &context) -> sys::ReturnCodes;
 
+        void getThreadById(Context &context);
+        auto getThreads(Context &context) -> sys::ReturnCodes;
+
         void requestCount(Context &context);
         void getMessageById(Context &context);
         auto getMessagesByThreadID(Context &context) -> sys::ReturnCodes;
@@ -53,8 +57,5 @@ namespace sdesktop::endpoints
         auto getMessagesTemplates(Context &context) -> sys::ReturnCodes;
 
         json11::Json receivedJson;
-
-        const int defaultLimit = 100; // will be removed after introducing pagination
     };
-
 } // namespace sdesktop::endpoints


### PR DESCRIPTION
**Description**
Add API for getting a single thread by its ID.
Documentation: https://appnroll.atlassian.net/wiki/spaces/CP/pages/990642315/Messages+Endpoint+API+8?focusedCommentId=1012794077#Get-a-thread-by-ID
<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
