### PR TITLE
[MOS-442] Incoming call sound both on HFP and Pure fix

### DIFF
--- a/module-services/service-audio/ServiceAudio.cpp
+++ b/module-services/service-audio/ServiceAudio.cpp
@@ -422,6 +422,11 @@ std::unique_ptr<AudioResponseMessage> ServiceAudio::HandleStart(const Operation:
     if (opType == Operation::Type::Playback) {
         auto input = audioMux.GetPlaybackInput(playbackType);
 
+        if (playbackType == audio::PlaybackType::CallRingtone && bluetoothVoiceProfileConnected && input) {
+            // don't play ringtone on HFP connection on Pure
+            return std::make_unique<AudioStartPlaybackResponse>(audio::RetCode::Success, retToken);
+        }
+
         if (bluetoothA2DPConnected && playbackType != audio::PlaybackType::CallRingtone) {
             LOG_DEBUG("Sending Bluetooth start stream request");
             bus.sendUnicast(std::make_shared<BluetoothMessage>(BluetoothMessage::Request::Play),


### PR DESCRIPTION
**Description**

Fix of the issue that incoming call sound was played
both in Pure speaker and HFP device while HFP profile
connected.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
