### PR TITLE
[MOS-444] Fix phone freezing on low battery screen

### DIFF
--- a/products/PurePhone/sys/SystemManager.cpp
+++ b/products/PurePhone/sys/SystemManager.cpp
@@ -138,6 +138,9 @@ namespace sys
     {
         SystemManagerCommon::batteryNormalLevelAction();
         CellularServiceAPI::ChangeModulePowerState(this, cellular::service::State::PowerState::On);
+        auto msg = std::make_shared<CriticalBatteryLevelNotification>(
+            false, Store::Battery::get().state == Store::Battery::State::Charging);
+        bus.sendUnicast(std::move(msg), service::name::appmgr);
     }
 
     void SystemManager::batteryCriticalLevelAction(bool charging)


### PR DESCRIPTION
**Description**

After exceeding the 10% threshold of the battery,
there was no reaction during charging and the phone freezes
on the screen with a low battery.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
