### PR TITLE
Fix documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MuditaOS is a mobile operating system optimized for E Ink displays. Built on Fre
 ## Products
 
 There are two released products based on MuditaOS:
-1. [PurePhone](https://store.mudita.com/mudita-pure-minimalist-phone) - low distraction phone with rich [key features](products/PurePhone/ProductKeyFeatures.md)
+1. [PurePhone](https://store.mudita.com/mudita-pure-minimalist-phone) - low distraction phone with rich [key features](/products/PurePhone/ProductKeyFeatures.md)
 2. [Mudita Harmony](https://store.mudita.com/mudita-harmony-your-healthy-bedtime-habits) - eink based distraction free alarm clock.
 
 ## Table of contents
@@ -25,7 +25,7 @@ There are two released products based on MuditaOS:
 
 ## Contributing
 
-Pull requests are welcome. Please follow the guidelines in the ["Contributing to MuditaOS"](CONTRIBUTING.md) article. Before contributing or starting a discussion, please make sure that you read our [Code of Conduct](CODE_OF_CONDUCT.md).
+Pull requests are welcome. Please follow the guidelines in the ["Contributing to MuditaOS"](/CONTRIBUTING.md) article. Before contributing or starting a discussion, please make sure that you read our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ### Discussions
 
@@ -33,29 +33,29 @@ For general questions and ideas regarding MuditaOS please post in the [“Mudita
 
 ### Reporting bugs and feature requests
 
-You can report bugs and feature requests on [GitHub](https://github.com/mudita/MuditaOS/issues). This is also a good place to discuss architecture decisions and things that aren’t yet covered by the documentation. Please refer to the ["Contributing to MuditaOS"](CONTRIBUTING.md) article for more details.
+You can report bugs and feature requests on [GitHub](https://github.com/mudita/MuditaOS/issues). This is also a good place to discuss architecture decisions and things that aren’t yet covered by the documentation. Please refer to the ["Contributing to MuditaOS"](/CONTRIBUTING.md) article for more details.
 
 ### Internationalization
 
-If you want to start localizing MuditaOS interface please start from [the "Internationalization" article](doc/i18n.md).
+If you want to start localizing MuditaOS interface please start from [the "Internationalization" article](/doc/i18n.md).
 
 ### Development environment setup
 
-To develop MuditaOS please follow guide on [environment setup](doc/quickstart.md#Quickstart)
+To develop MuditaOS please follow guide on [environment setup](/doc/quickstart.md#Quickstart)
 
 ### Development workflow
 
-When contributing code or documentation changes please follow the guidleines inside the ["Development workflow"](doc/development_workflow.md) article.
+When contributing code or documentation changes please follow the guidleines inside the ["Development workflow"](/doc/development_workflow.md) article.
 
 ## Documentation
 
-For everything you need to kickstart your development environment please go to the [Documentation](doc/README.md) on GitHub.
+For everything you need to kickstart your development environment please go to the [Documentation](/doc/README.md) on GitHub.
 
 A fully detailed documentation can be build locally using [Doxygen](https://www.doxygen.nl/index.html).
 
 ## Changelog
 
-The [MuditaOS changelog](changelog.md) is not regularly updated by the core development team.
+The [MuditaOS changelog](/changelog.md) is not regularly updated by the core development team.
 
 ## License
 MuditaOS is licensed under [GNU GPLv3](https://choosealicense.com/licenses/gpl-3.0/).

--- a/doc/ProjectConfig.md
+++ b/doc/ProjectConfig.md
@@ -50,7 +50,7 @@ Or change printer configuration in `CPUStatistics.cpp` to other than messagepack
 
 ## CurrentMeasurement enable option
 To use direct current polling and have it in logs set `CURRENT_MEASUREMENT` to `ON`
-you can plot this with [plot_current_measurement.py](../tools/plot_current_measurement.py)
+you can plot this with [plot_current_measurement.py](/tools/plot_current_measurement.py)
 
 # USB
 
@@ -68,7 +68,7 @@ To test if USB-CDC works you can set USB-CDC echo with `USBCDC_ECHO`
 
 # Config options for the lwext4
 
-Following configurations are for: [lwext4](third-party/lwext4/) - third party ext4 library
+Following configurations are for: [lwext4](/third-party/lwext4/) - third party ext4 library
 
 ## LWEXT4 debug options
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,20 +1,20 @@
-MuditaOS Documentation
+(MuditaOS Documentation
 ======================
 
 This folder contains the documentation of the MuditaOS.
 
 ## Developer guides
 
-- [Development environment](quickstart.md)
-- [Build targets supported by MuditaOS](build_targets.md)
-- [Setting up integrated development environment](setup_ide.md)
-- [How to use Mudita Pure simulator](howto_simulator.md)
-- [Keybindings on Linux](host_keyboard_bindings.md)
-- [Running MuditaOS on a phone](running_on_phone.md)
-- [Windows and macOS - flashing Pure with image](flashing_win_macos.md)
-- [Test harness](../test/README.md)
-- [Tethering](tethering.md)
-- [Coding Guidelines](MuditaCppCodingGuidelines.md)
+- [Development environment](./quickstart.md)
+- [Build targets supported by MuditaOS](./build_targets.md)
+- [Setting up integrated development environment](./setup_ide.md)
+- [How to use Mudita Pure simulator](./howto_simulator.md)
+- [Keybindings on Linux](./host_keyboard_bindings.md)
+- [Running MuditaOS on a phone](./running_on_phone.md)
+- [Windows and macOS - flashing Pure with image](./flashing_win_macos.md)
+- [Test harness](/test/README.md)
+- [Tethering](./tethering.md)
+- [Coding Guidelines](./MuditaCppCodingGuidelines.md)
 
 ## System documentation
 
@@ -22,36 +22,36 @@ Documentation listed below is system documentation listed depending on where it 
 
 - System architecture
 - Modules
-   - [Applications](../module-apps/ModuleApps.md)
-        - [Application Desktop](../module-apps/application-desktop/doc/README.md)
-        - [Notifications](../module-apps/apps-common/notifications/README.md)
-    - [Audio](../module-audio/README.md)
-    - [Bluetooth](../module-bluetooth/README.md)
+   - [Applications](/module-apps/ModuleApps.md)
+        - [Application Desktop](/module-apps/application-desktop/doc/README.md)
+        - [Notifications](/module-apps/apps-common/notifications/README.md)
+    - [Audio](/module-audio/README.md)
+    - [Bluetooth](/module-bluetooth/README.md)
     - Database
-        - [Queries](../module-db/queries/README.md)
-        - [Tables](../module-db/Tables/README.md)
-        - [SMS and Contacts database](database_v2.md)
-    - [Filesystem](../module-vfs/README.md)
-    - [GUI](../module-gui/README.md)
-    - [Modem](../module-cellular/modem/README.md)
-    - [System](../module-sys/README.md)
-- [Services](../module-services/ModuleServices.md)
-    - [Application Manager](../module-services/service-appmgr/doc/README.md)
-    - [Bluetooth](../module-services/service-bluetooth/doc/readme.md)
-    - [Cellular](../module-services/service-cellular/doc/README.md)
-    - [Desktop](../module-services/service-desktop/README.md)
-    - [GUI](../module-services/service-gui/doc/README.md)
+        - [Queries](/module-db/queries/README.md)
+        - [Tables](/module-db/Tables/README.md)
+        - [SMS and Contacts database](./database_v2.md)
+    - [Filesystem](/module-vfs/README.md)
+    - [GUI](/module-gui/README.md)
+    - [Modem](/module-cellular/modem/README.md)
+    - [System](/module-sys/README.md)
+- [Services](/module-services/ModuleServices.md)
+    - [Application Manager](/module-services/service-appmgr/doc/README.md)
+    - [Bluetooth](/module-services/service-bluetooth/doc/readme.md)
+    - [Cellular](/module-services/service-cellular/doc/README.md)
+    - [Desktop](/module-services/service-desktop/README.md)
+    - [GUI](/module-services/service-gui/doc/README.md)
 - Utilities
-    - [How to use Logging engine](../module-utils/log/doc/logging_engine.md)
+    - [How to use Logging engine](/module-utils/log/doc/logging_engine.md)
 - Tools
     - [MapParser](https://github.com/mudita/misc-tools/blob/master/mapparser/README.md)
     - [PureGDB](https://github.com/mudita/misc-tools/blob/master/puregdb/README.md)
-- [System cmake configuration](ProjectConfig.md)
-- [Development workflow](development_workflow.md)
-- [Contributing](../CONTRIBUTING.md)
-- [Internationalization](i18n.md)
+- [System cmake configuration](./ProjectConfig.md)
+- [Development workflow](./development_workflow.md)
+- [Contributing](/CONTRIBUTING.md)
+- [Internationalization](./i18n.md)
 
 ## Changelog
-- [HOWTO](changelog_howto.md)
-- [The latest changelog](../changelog.md)
+- [HOWTO](./changelog_howto.md)
+- [The latest changelog](/changelog.md)
 

--- a/doc/build_targets.md
+++ b/doc/build_targets.md
@@ -23,7 +23,7 @@ For each product there are targets:
 
 | Arch | Name | Alias | Description |
 |------|------|-------|-------------|
-|common| doc                            |                                                   | Target to build doxygen documentation, [documentation](generate_doxygen.md) |
+|common| doc                            |                                                   | Target to build doxygen documentation, [documentation](./generate_doxygen.md) |
 |common| \<Product\>                    |                                                   | Binary target for the product |
 |common| \<Product\>-disk-img           | \<Product\>.img                                   | Disk image for the product    |
 |RT1051| \<Product\>-StandaloneImage    | PurePhone-\<version\>-RT1051-package-standalone   | Creates image that can be `dd` or `pureflash` to the device|
@@ -72,7 +72,7 @@ Currently, the update package has all of the base data that should be on the dev
 ## Check
 
 Builds and executes all of the unit tests in the repository for the selected product.
-Uses [download_assets](download_assets.md) to download unit test's required assets (fonts)
+Uses [download_assets](./download_assets.md) to download unit test's required assets (fonts)
 
 ### Code coverage
 
@@ -112,13 +112,13 @@ These are distributed with the image and update targets available for each produ
 
 ## ecoboot.bin
 
-Downloads the bootloader with [download_assets](download_assets.md).
+Downloads the bootloader with [download_assets](./download_assets.md).
 
 OS bootloader, used to pre-init hardware and launch either OS or updater utility.
 
 ## updater.bin
 
-Downloads the updater with [download_assets](download_assets.md).
+Downloads the updater with [download_assets](./download_assets.md).
 
 Updater is used to perform the firmware upgrade via update packages. 
 

--- a/doc/changelog_howto.md
+++ b/doc/changelog_howto.md
@@ -4,7 +4,7 @@ This article is based on [keep a changelog](https://keepachangelog.com/en/1.0.0/
 
 **Note:** MuditaOS changelog should be **edited by the MuditaOS core development team only**.
 
-[View MuditaOS changelog](changelog.md).
+[View MuditaOS changelog](/changelog.md).
 
 ## 1. The purpose of a changelog
 To let the end user (not necessarily technically-skilled) know what your Pull Request changes. In practice, this means that if some spectacular crash has been fixed, changelog entry should say e.g. `Fixed system crash on saving SMS draft`.

--- a/doc/development_workflow.md
+++ b/doc/development_workflow.md
@@ -54,10 +54,10 @@ Before submitting a Pull Request please go through some basic checks:
 - test your changes on both Linux and RT1051 platforms (please pay special attention to the things you might break unintentionally, e.g. when working on calling, check call log too,
 - run unit tests (`make check`),
 - [run static analysis](static_analysis.md)
-- check if your code formatting complies with [`.clang-format`](../.clang-format),
-- whenever you add third-party software to MuditaOS source code, please make sure that the software component is added to a dedicated [section in `LICENSE.md` file on MuditaOS GitHub repository](../LICENSE.md) with a link to the text of the license where applicable.
+- check if your code formatting complies with [`.clang-format`](/.clang-format),
+- whenever you add third-party software to MuditaOS source code, please make sure that the software component is added to a dedicated [section in `LICENSE.md` file on MuditaOS GitHub repository](/LICENSE.md) with a link to the text of the license where applicable.
 
-As a part of our continuous integration process we will be soon introducing our own [test harness](../test/README.md).
+As a part of our continuous integration process we will be soon introducing our own [test harness](/test/README.md).
 
 ## Submit a Pull Request
 

--- a/doc/flashing_win_macos.md
+++ b/doc/flashing_win_macos.md
@@ -13,7 +13,7 @@
 
 - download [balenaEtcher](https://www.balena.io/etcher/) from the website for your operating system. The downloaded file is either called `balenaEtcher-Setup-{version}.exe` (for Windows) or `balenaEtcher-{version}.dmg` (for MacOS) and will be used to install the application on your computer.
 
-![balenaEtcher_download](Images/balenaetcher/ss4.png)
+![balenaEtcher_download](./Images/balenaetcher/ss4.png)
 
 - install the balenaEtcher application.
 - download the MuditaOS image you want to use and extract it locally. 
@@ -24,14 +24,14 @@ The `.xz` image is compressed twice using both `tar` and `xz`. Some unpackers wi
 
 - Run balenaEtcher application and choose `Flash from file` and the ISO image as the image type. Load unzipped image onto the target device. It might look something like this:
 
-![balenaEtcher interface screenshot](Images/balenaetcher/ss1.png)
+![balenaEtcher interface screenshot](./Images/balenaetcher/ss1.png)
 
-![balenaEtcher interface screenshot](Images/balenaetcher/ss2.png)
+![balenaEtcher interface screenshot](./Images/balenaetcher/ss2.png)
 
 - press `Flash!`` and confirm if asked for the superuser password.
 - wait for the flashing to complete:
 
-![balenaEtcher interface screenshots](Images/balenaetcher/ss3.png)
+![balenaEtcher interface screenshots](./Images/balenaetcher/ss3.png)
 
 - reboot the phone.
 

--- a/doc/generate_doxygen.md
+++ b/doc/generate_doxygen.md
@@ -2,8 +2,8 @@ How to generate documentation using Doxygen
 =============================================
 
 **NOTE:** doxygen documentation is just another target.
-Basic targets documentation can be found [here](build_targets.md).
-How to setup environment to be able to build the targets is here: [quickstart](quickstart.md)
+Basic targets documentation can be found [here](./build_targets.md).
+How to setup environment to be able to build the targets is here: [quickstart](./quickstart.md)
 
 
 Fully detailed doxygen documentation can be built locally using [Doxygen](https://www.doxygen.nl/index.html).

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -3,7 +3,7 @@
 ## File and data structure
 
 ### Display language
-Currently all the wording used in MuditaOS interface is collected in the form of JSON files which are located in [the image/assets/lang folder](../image/assets/lang/).
+Currently all the wording used in MuditaOS interface is collected in the form of JSON files which are located in [the image/assets/lang folder](/image/assets/lang/).
 
 The default fallback file for every language is currently the English version - `English.json`.
 
@@ -24,7 +24,7 @@ The keys on the left side refer to the values on the right side. These values ar
 
 ### Keyboard input language
 
-Keyboard input language files have JSON extension and are located in [the image/assets/profiles folder](../image/assets/profiles/).
+Keyboard input language files have JSON extension and are located in [the image/assets/profiles folder](/image/assets/profiles/).
 
 Every language has its own files for upper and lower letters. Here's an example of a working JSON file for `English_lower.json`:
 ```c++
@@ -62,7 +62,7 @@ We also distinguish two types of button presses:
 
 Example: If you are using English keyboard language for lower letters and press `1` button (keycode `31`) and quickly release it, then in SMS textbox `a` letter will appear. But if you hold this button pressed for at least 2 seconds and then release it, `1` number will appear.
 
-Definition for every key code used in the phone is in [the key_codes.hpp file (KeyCodes enum)](../module-bsp/bsp/keyboard/key_codes.hpp)
+Definition for every key code used in the phone is in [the key_codes.hpp file (KeyCodes enum)](/module-bsp/bsp/keyboard/key_codes.hpp)
 
 ### Date and time
 
@@ -70,7 +70,7 @@ MuditaOS follows [Linux `date`](https://man7.org/linux/man-pages/man1/date.1.htm
 
 ## Font conversion
 
-MuditaOS doesn't have built-in support for ttf/otf fonts, so we generate bitmap files for fonts. The official release uses GT Pressura Typeface which is a licensed font ([more info](../LICENSE.md))
+MuditaOS doesn't have built-in support for ttf/otf fonts, so we generate bitmap files for fonts. The official release uses GT Pressura Typeface which is a licensed font ([more info](/LICENSE.md))
 
 MuditaOS supports the following languages (and characters) out-of-the-box:
 
@@ -115,5 +115,5 @@ It’s a good practice not to rename font names - these are stored in font metad
 
 1. Create an issue with the localization you want to start working on. Please use the following issue title scheme: `[Language] localization [emoji_flag]` eg. `Polish localization 🇵🇱`. The emoji flag is a small detail that can help other community members in finding the localization they're interested in and helping you out in implementing it. Please make sure that the localization you want to implement has not been already implemented.
 2. Add a `i18n` label to your new issue on GitHub.
-3. Follow [the "Contributing to MuditaOS" article](../CONTRIBUTING.md).
+3. Follow [the "Contributing to MuditaOS" article](/CONTRIBUTING.md).
 4. As soon as you create a Pull Request with your localization we will review it and add it to the official MuditaOS distribution.

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -206,7 +206,7 @@ This can be done manually, by editing the `.cmake` files (not recommended though
 
 By using `ENABLE_APP_X` (where `X` is the name of the application) you can enable/disable any application.
 
-CMake-wide system config documentation is here: [Project config](ProjectConfig.md)
+CMake-wide system config documentation is here: [Project config](./ProjectConfig.md)
 
 #### Catching logs using UART
 

--- a/module-apps/ModuleApps.md
+++ b/module-apps/ModuleApps.md
@@ -12,10 +12,10 @@ In MuditaOS, application is a service derivative which:
 
 This paragraph is using `applicaton-test` as an example.
 
-**WARNING** All applications are enabled by default. Please disable yours if it's not always needed in [CMakeLists.txt](CMakeLists.txt). I.e.: `option(ENABLE_APP_TEST "Enable application test" OFF)`
+**WARNING** All applications are enabled by default. Please disable yours if it's not always needed in [CMakeLists.txt](./CMakeLists.txt). I.e.: `option(ENABLE_APP_TEST "Enable application test" OFF)`
 
 * Add new `application` catalog in `module-apps` i.e. `application-test`
-* Add a CMake for it, simple example here: [application-test/CMakeLists.txt](application-test/CMakeLists.txt)
+* Add a CMake for it, simple example here: [application-test/CMakeLists.txt](./application-test/CMakeLists.txt)
 * Create:
     * `include/application-test/` for public includes for this application
     * create the application header with:
@@ -26,13 +26,13 @@ This paragraph is using `applicaton-test` as an example.
 * Write `InitHandler()` for application.
     * **NOTE** This is your application entry point!
     * **NOTE** if it's not copied properly - application won't start and work
-Please see example in: [ApplicationTest.cpp](application-test/ApplicationTest.cpp) for `InitHandler()`
+Please see example in: [ApplicationTest.cpp](./application-test/ApplicationTest.cpp) for `InitHandler()`
 * Write `createUserInterface()`, which role is:
     * provide `windowsFactory` with windows blueprints for this application
     * inform what popups this application handles
 **WARNING** default window for each application is always named `gui::name::window::main_window`. Without that window application may be never shown properly
 
-Basic example can be found in this catalog: [application-test](./application-test)
+Basic example can be found in this catalog: [application-test](./application-test/)
 
 # How to launch app:
 
@@ -83,14 +83,14 @@ if (msgl->messageType == MessageType::DBServiceNotification) {
 
 # Asynchronous database queries
 
-You can perform datababase queries via [query interface](../../module-db/queries/README.md). 
+You can perform datababase queries via [query interface](/module-db/queries/README.md). 
 
 To have a safe way to perform asynchronous calls there is `app::AsyncQuery` which:
 * creates a query
 * when it's done results are passed to the callback
 * if i.e. UI element is removed its callback is automatically removed
 
-It's defined here: [AsyncTask.hpp](../apps-common/AsyncTask.hpp)
+It's defined here: [AsyncTask.hpp](apps-common/AsyncTask.hpp)
 
 **NOTE** to automatically pass async `db::query` data to an application you have to:
 * inherit in application/item from `public app::AsyncCallbackReceiver`
@@ -99,7 +99,7 @@ It's defined here: [AsyncTask.hpp](../apps-common/AsyncTask.hpp)
 
 # GUI library
 
-GUI library documentation: [module-gui](../module-gui/README.md)
+GUI library documentation: [module-gui](/module-gui/README.md)
 Please mind that it has Doxygen documentation explaining its use for all base elements and functions.
 
 # System actions
@@ -153,19 +153,19 @@ Now we can open such popup in the application via: `app::manager::Controller::se
 
 # System communication caveats
 
-* [Caveats and good practices](../module-sys/README.md#caveats-and-good-practices)
+* [Caveats and good practices](/module-sys/README.md#caveats-and-good-practices)
 
 # Adding 3rd party library
 
-Please follow information here: [third party libraries](../third-party/ThirdParty.md)
+Please follow information here: [third party libraries](/third-party/ThirdParty.md)
 
 # Adding tests to service
 
-Please follow information here: [unit tests gathering cmake](../test/AddingUnitTests.md)
+Please follow information here: [unit tests gathering cmake](/test/AddingUnitTests.md)
 
 # Application Manifest
 
-[ApplicationManifest.hpp](module-services/service-appmgr/include/service-appmgr/ApplicationManifest.hpp) is undocumented.
+[ApplicationManifest.hpp](/module-services/service-appmgr/include/service-appmgr/ApplicationManifest.hpp) is undocumented.
 Its role is to:
 - inform what actions the application can perform - actions are asynchronous application capabilities. Action can result in no change in UI, but a major change in logic behavior.
     - a special type of action is `ActionPopup` - it enables applications to show popup

--- a/module-audio/README.md
+++ b/module-audio/README.md
@@ -7,10 +7,10 @@ PureOS's audio subsystem was heavily inspired by two fine pieces of software:
 Implementation of module-audio was developed after going through [Linux Sound Subsystem Documentation](https://www.kernel.org/doc/html/latest/sound/index.html) and various other documents describing audio Linux audio. These documents were mainly used as inspiration as requested PureOS audio functionality is much less sophisticated. Also due to hardware limitations (mainly processor speed and hardware audio codec features) some additional assumptions were made.
 #### Paths
 
- * [../module-bsp/bsp/audio](../module-bsp/bsp/audio) - audio device interface and switching logic
- * [../module-bsp/board/linux/audio](../module-bsp/board/linux/audio) - Linux audio devices
- * [../module-bsp/board/rt1051/bsp/audio](../module-bsp/board/rt1051/bsp/audio) - RT1051 audio devices
- * [../module-audio/Audio/](../module-audio/Audio) - audio module
+ * [/module-bsp/bsp/audio](/module-bsp/bsp/audio) - audio device interface and switching logic
+ * [/module-bsp/board/linux/audio](/module-bsp/board/linux/audio) - Linux audio devices
+ * [/module-bsp/board/rt1051/bsp/audio](/module-bsp/board/rt1051/bsp/audio) - RT1051 audio devices
+ * [/module-audio/Audio](/module-audio/Audio) - audio module
 
 #### [PortAudio library](http://www.portaudio.com/)
 Audio device layer (which can be found in [audio paths](#paths)). concept of audio devices and audio module API were based on PortAudio library.
@@ -59,7 +59,7 @@ Currently we have four implementations of audio devices
 * Linux audio (via PortAudio library)
 * Linux audio cellular (also via PortAudio library)
 
-Each audio device must conform to API interface which is specified in `bsp::AudioDevice` class in [bsp_audio](../module-bsp/bsp/audio/bsp_audio.hpp)
+Each audio device must conform to API interface which is specified in `bsp::AudioDevice` class in [bsp_audio](/module-bsp/bsp/audio/bsp_audio.hpp)
 
 ### Decoders
 Decoders layer was developed in order to have unified API over vast range of audio decoders. Another very important part of decoders are ability to fetch audio metadata. Different kinds of decoders support different metadata, for instance MP3 decoder supports ID3 tags and so on. All of this implementation details are hidden to the higher layers. User receives metadata via unified structure describing metadata. See `struct Tags`.
@@ -118,12 +118,12 @@ Profiles configurations can be found in directory: [Profiles](./Audio/Profiles)
 `Operations` may not implement support for all possible `Profile` parameters i.e. `inputGain` and `inputPath` will be ignored in playback `Operation`.
 
 ~~**IMPORTANT:** For the time being profiles are not loaded and stored into database. This should be fixed.~~  
-**NOTE:** Currently some of the profiles are configurable via json files located [here](../image/user/data/equalizer). The json format explanation can be found [here](./Audio/Profiles/README.md).
+**NOTE:** Currently some of the profiles are configurable via json files located [here](/image/user/data/equalizer). The json format explanation can be found [here](./Audio/Profiles/README.md).
 
 **IMPORTANT:** Callbacks mechanism is only experimental and should be considered as incomplete.
 
 # Audio class
-Audio class [Audio class](./Audio/Audio.hpp) is main interface to audio subsystem. It is exclusively used by [audio-service](../module-services/service-audio) Audio class stores internally current `Operation`, `Profile`, `State`, async callback, db callback etc. 
+Audio class [Audio class](./Audio/Audio.hpp) is main interface to audio subsystem. It is exclusively used by [audio-service](/module-services/service-audio) Audio class stores internally current `Operation`, `Profile`, `State`, async callback, db callback etc. 
 
 `AsyncCallback` holds a wrapper for function that is invoked asynchronously when audio subsystem event occurs. It can be used for signalling user of audio subsystem about audio events. Possible events are listen in `audio::PlaybackEventType`  
 

--- a/module-gui/README.md
+++ b/module-gui/README.md
@@ -189,5 +189,5 @@ in a sequence flow analogous to the one presented above. Please find an exemplar
 
 ## Widgets
 
-- [Window](WINDOW.md)
-- [Text](gui/widgets/text/doc/HowDoesTextWork.md)
+- [Window](./WINDOW.md)
+- [Text](./gui/widgets/text/doc/HowDoesTextWork.md)

--- a/module-services/ModuleServices.md
+++ b/module-services/ModuleServices.md
@@ -18,7 +18,7 @@ Table of Contents
 
 # General services documentation
 
-Services documentation is available [in module-sys here](../module-sys/README.md#Services).
+Services documentation is available [in module-sys here](/module-sys/README.md#Services).
 
 # How to add new service
 
@@ -71,27 +71,27 @@ option(ENABLE_SERVICE_TEST "Enable service test" OFF)
 
 ## To change service startup order
 
-Please see the [SystemManager services synchronization](./SystemManager/doc/ServicesSynchronization.md) documentation
+Please see the [SystemManager services synchronization](/module-sys/SystemManager/doc/ServicesSynchronization.md) documentation
 
 ## To use settings::Settings
 
-Documentation: [settings::Settings](Settings.md)
+Documentation: [settings::Settings](./service-db/doc/Settings.md)
 
 ## To add timer
 
-Documentation [timers](../module-sys/README.md#Timers)
+Documentation [timers](/module-sys/README.md#Timers)
 
 ## To add 3rd party library
 
-Documentation: [third party libraries](../third-party/ThirdParty.md)
+Documentation: [third party libraries](/third-party/ThirdParty.md)
 
 ## To add tests
 
-Documentation: [unit tests gathering cmake](../test/AddingUnitTests.md)
+Documentation: [unit tests gathering cmake](/test/AddingUnitTests.md)
 
 ## To change service order, failure timeout or name
 
-Documentation [service manifest](../module-sys/SystemManager/doc/ServicesSynchronization.md)
+Documentation [service manifest](/module-sys/SystemManager/doc/ServicesSynchronization.md)
 
 # More on services configuration
 

--- a/module-services/service-db/doc/ServiceDB.md
+++ b/module-services/service-db/doc/ServiceDB.md
@@ -13,10 +13,10 @@ We have a few features built in service-db
 
 DB Query interface is a way to define a request -> response behavior to service-db. It's strongly recommended to use it asynchronously.
 
-Documentation available [here](../../module-db/queries/README.md)
+Documentation available [here](/module-db/queries/README.md)
 
 ## database settings agent : settings::Settings
 
-Documentation here: [settings::Settings](Settings.md)
+Documentation here: [settings::Settings](./Settings.md)
 
 ## **deprecated** DBServiceAPI

--- a/module-services/service-db/doc/Settings.md
+++ b/module-services/service-db/doc/Settings.md
@@ -15,7 +15,7 @@ Caveats:
 
 **IMPORTANT:**
 You need to initialize settings::Settings in Service/Application when init function, not in the constructor.
-Please see [module-sys documentation](../../module-sys/README.md#Services)
+Please see [module-sys documentation](/module-sys/README.md#Services)
 
 # How to add settings to use
 

--- a/module-sys/README.md
+++ b/module-sys/README.md
@@ -44,7 +44,7 @@ The whole MuditaOS system can, with great simplification, be seen as a connectio
     * [Bus](#Bus) connected threads
     * operating on workers to perform hardware tasks
     * communicating with other services
-    * notifying applications via broadcast/multicasts & [actions](../module-apps/ModuleApps.md#System-actions)
+    * notifying applications via broadcast/multicasts & [actions](/module-apps/ModuleApps.md#System-actions)
     * Managed via [SystemManager](#System-manager)
 * Applications
     * Bus-connected threads
@@ -111,7 +111,7 @@ It's invoked for all messages without designated handlers.
 
 ## Applcations
 
-[module-apps](../module-apps/ModuleApps.md)
+[module-apps](/module-apps/ModuleApps.md)
 
 ## Timers
 
@@ -154,7 +154,7 @@ th.start();
 The Bus subsystem was developed in order to allow cross-services communication.
 Preferred method to achieve service -> application communication is either:
 - request and initialize communication from application to service
-- use [actions](../module-apps/ModuleApps.md#System-actions)
+- use [actions](/module-apps/ModuleApps.md#System-actions)
 
 The Bus enables us to:
 * send asynchronous unicast messages
@@ -270,7 +270,7 @@ If you ever set empty shared pointer to the response on message - the handling w
 * you can't call blocking bus unicasts to it - as there will be no response
 
 **NOTE**: This might render your application/service useless in some scenarions
-**NOTE**: you can see system messages handled by services unlocking flag in [debug.hpp](../module-utils/log/api/log/debug.hpp)
+**NOTE**: you can see system messages handled by services unlocking flag in [debug.hpp](/module-utils/log/api/log/debug.hpp)
 
 ## blocking requests
 

--- a/module-sys/SystemManager/doc/PowerManagement.md
+++ b/module-sys/SystemManager/doc/PowerManagement.md
@@ -77,4 +77,4 @@ and requesting resources from `service_cellular` to make a phone call:
 
 # CpuStatistics
 
-CpuStatistics measurement is described in: [link](./module-sys/SystemManager/doc/CpuStatistics.md)
+CpuStatistics measurement is described in: [link](/module-sys/SystemManager/doc/CpuStatistics.md)

--- a/module-sys/SystemManager/doc/ServicesSynchronization.md
+++ b/module-sys/SystemManager/doc/ServicesSynchronization.md
@@ -15,7 +15,7 @@ Each service should export its manifest. The manifest may contain the following 
 
 **WARNING**: Currently there is no fail-safe mechanism to handle service startup failure - it will cause non-handled exception `SystemInitialisationError{"System startup failed: unable to start a system service."};`
 
-Please see: [ServiceManifest.hpp](../../Service/include/Service/ServiceManifest.hpp) to check current defaults
+Please see: [ServiceManifest.hpp](/module-sys/Service/include/Service/ServiceManifest.hpp) to check current defaults
 
 The System Manager needs to read the manifests to run the services in the correct order.
 

--- a/test/AddingUnitTests.md
+++ b/test/AddingUnitTests.md
@@ -25,7 +25,7 @@ if (${ENABLE_TESTS})
 endif ()
 ```
 
-**NOTE:** To see how test gathering works please see: [CMake for UT](CMakeLists.txt)
+**NOTE:** To see how test gathering works please see: [CMake for UT](./CMakeLists.txt)
 
 To add test target use either of functions:
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -9,16 +9,16 @@ python3 -m pip install -r requirements.txt
 
 # Updating packages
 
-1. Create venv with curent setup:  
+1. Create venv with curent setup:
 ```
 python3 -m venv venv
 source venv/bin/activate
 python3 -m pip install -r requirements.txt
 ```
 
-2. Install required packages  
+2. Install required packages
 
-3. Freeze requirements:  
+3. Freeze requirements:
 ```
 pip freeze > requirements.txt
 ```
@@ -26,4 +26,4 @@ pip freeze > requirements.txt
 # Downloading assets
 
 To download assets required to build release we have `download_asset.py` tool which is documented here:
-[doc/download_assets.md](../doc/download_assets.md)
+[/doc/download_assets.md](/doc/download_assets.md)


### PR DESCRIPTION
**Description**

I've used a validator to determine if all the links were proper and corrected those that were improper. The most common cause was reliance on relative directory links.  To avoid future issues and confusion, all link are either absolute (to the repository) starting the `/` or relative to their own location, starting with `./` avoid location confusion and make grepping easier.

One bad link remains in `module-audio/README.md`.
Validator output:
```
Issues found in 1 input. Find details below.
                                                                                                                                                                            
[./module-audio/README.md]:                                                                                                                                                 
✗ [ERROR] file:///home/gravis/project/MuditaOS/module-audio/TODO | Cannot find file                                                                                         

🔍 5240 Total ✅ 196 OK 🚫 1 Error (HTTP:1) 💤 5043 Excluded
```

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
