### PR TITLE
[MOS-402] Time legibility on lock screen fix

### DIFF
--- a/image/user/db/settings_v2_002-devel.sql
+++ b/image/user/db/settings_v2_002-devel.sql
@@ -43,6 +43,7 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('gs_current_timezone_name', ''),
     ('gs_current_timezone_rules', ''),
     ('\ServiceTime\\gs_automatic_date_and_time_is_on', '1'),
-    ('\ServiceEink\\display_inverted_mode', '0');
+    ('\ServiceEink\\display_inverted_mode', '0'),
+    ('display_lock_screen_deep_refresh_rate', '30');
 
 

--- a/image/user/db/settings_v2_002.sql
+++ b/image/user/db/settings_v2_002.sql
@@ -44,7 +44,8 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('gs_current_timezone_name', ''),
     ('gs_current_timezone_rules', ''),
     ('\ServiceTime\\gs_automatic_date_and_time_is_on', '1'),
-    ('\ServiceEink\\display_inverted_mode', '0');
+    ('\ServiceEink\\display_inverted_mode', '0'),
+    ('display_lock_screen_deep_refresh_rate', '30');
 
 
 

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -211,7 +211,7 @@ namespace gui
         return app;
     }
 
-    bool DesktopMainWindow::updateTime()
+    RefreshModes DesktopMainWindow::updateTime()
     {
         auto ret = AppWindow::updateTime();
         clockDate->setTime(std::time(nullptr));

--- a/module-apps/application-desktop/windows/DesktopMainWindow.hpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.hpp
@@ -46,7 +46,7 @@ namespace gui
         void destroyInterface() override;
         status_bar::Configuration configureStatusBar(status_bar::Configuration appConfiguration) override;
 
-        bool updateTime() override;
+        RefreshModes updateTime() override;
 
       private:
         bool resolveDialAction(const std::string &number);

--- a/module-apps/apps-common/ApplicationCommon.cpp
+++ b/module-apps/apps-common/ApplicationCommon.cpp
@@ -467,13 +467,9 @@ namespace app
 
     sys::MessagePointer ApplicationCommon::handleMinuteUpdated(sys::Message *msgl)
     {
-        if (state == State::ACTIVE_FORGROUND && getCurrentWindow()->updateTime()) {
-
-            if (isOnPhoneLockWindow()) {
-                updateStatusBarOnPhoneLockWindow();
-            }
-
-            refreshWindow(gui::RefreshModes::GUI_REFRESH_FAST);
+        if (state == State::ACTIVE_FORGROUND) {
+            auto requestedRefreshMode = getCurrentWindow()->updateTime();
+            refreshWindow(requestedRefreshMode);
         }
         return sys::msgHandled();
     }
@@ -1049,13 +1045,5 @@ namespace app
     bool ApplicationCommon::isOnPhoneLockWindow()
     {
         return getCurrentWindow()->getName() == gui::popup::window::phone_lock_window;
-    }
-
-    void ApplicationCommon::updateStatusBarOnPhoneLockWindow()
-    {
-        getCurrentWindow()->updateSignalStrength();
-        getCurrentWindow()->updateNetworkAccessTechnology();
-        getCurrentWindow()->updateBatteryStatus();
-        getCurrentWindow()->updateSim();
     }
 } /* namespace app */

--- a/module-apps/apps-common/ApplicationCommon.hpp
+++ b/module-apps/apps-common/ApplicationCommon.hpp
@@ -433,7 +433,6 @@ namespace app
         locks::SimLockSubject simLockSubject;
 
         bool isOnPhoneLockWindow();
-        void updateStatusBarOnPhoneLockWindow();
 
       public:
         [[nodiscard]] auto getPhoneLockSubject() noexcept -> locks::PhoneLockSubject &;

--- a/module-apps/apps-common/windows/AppWindow.cpp
+++ b/module-apps/apps-common/windows/AppWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AppWindow.hpp"
@@ -139,12 +139,12 @@ namespace gui
         return preventsAutoLock;
     }
 
-    bool AppWindow::updateTime()
+    RefreshModes AppWindow::updateTime()
     {
         if (statusBar == nullptr) {
-            return false;
+            return RefreshModes::GUI_REFRESH_NONE;
         }
-        return statusBar->updateTime();
+        return statusBar->updateTime() ? RefreshModes::GUI_REFRESH_FAST : RefreshModes::GUI_REFRESH_NONE;
     }
 
     void AppWindow::setTitle(const UTF8 &text)

--- a/module-apps/apps-common/windows/AppWindow.hpp
+++ b/module-apps/apps-common/windows/AppWindow.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -73,7 +73,7 @@ namespace gui
         bool updateNetworkAccessTechnology();
         void updatePhoneMode(sys::phone_modes::PhoneMode mode);
         [[nodiscard]] bool preventsAutoLocking() const noexcept;
-        virtual bool updateTime();
+        virtual RefreshModes updateTime();
 
         void rebuild() override;
         void buildInterface() override;

--- a/module-gui/gui/Common.hpp
+++ b/module-gui/gui/Common.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -62,6 +62,7 @@ namespace gui
 
     enum class RefreshModes
     {
+        GUI_REFRESH_NONE,
         GUI_REFRESH_FAST = 1,
         GUI_REFRESH_DEEP
     };
@@ -151,6 +152,8 @@ namespace gui
 inline const char *c_str(gui::RefreshModes refresh)
 {
     switch (refresh) {
+    case gui::RefreshModes::GUI_REFRESH_NONE:
+        return "GUI_REFRESH_NONE";
     case gui::RefreshModes::GUI_REFRESH_FAST:
         return "GUI_REFRESH_FAST";
     case gui::RefreshModes::GUI_REFRESH_DEEP:

--- a/module-services/service-db/agents/settings/SystemSettings.hpp
+++ b/module-services/service-db/agents/settings/SystemSettings.hpp
@@ -82,5 +82,6 @@ namespace settings
     namespace Display
     {
         constexpr inline auto invertedMode = "display_inverted_mode";
+        constexpr inline auto lockScreenDeepRefreshRate = "display_lock_screen_deep_refresh_rate";
     } // namespace Display
 }; // namespace settings

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsProgressWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BGSoundsProgressWindow.hpp"
@@ -162,11 +162,11 @@ namespace gui
         time->setTimeFormat(fmt);
     }
 
-    bool BGSoundsProgressWindow::updateTime()
+    RefreshModes BGSoundsProgressWindow::updateTime()
     {
         if (presenter) {
             presenter->handleUpdateTimeEvent();
         }
-        return true;
+        return RefreshModes::GUI_REFRESH_NONE;
     }
 } // namespace gui

--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsProgressWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsProgressWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -27,7 +27,7 @@ namespace gui
 
         void setTime(std::time_t newTime) override;
         void setTimeFormat(utils::time::Locale::TimeFormat fmt) override;
-        bool updateTime() override;
+        RefreshModes updateTime() override;
 
         void buildLayout();
         void configureTimer();

--- a/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.cpp
@@ -164,12 +164,12 @@ namespace gui
             presenter->handleAlarmRingingEvent();
         }
     }
-    bool BellHomeScreenWindow::updateTime()
+    RefreshModes BellHomeScreenWindow::updateTime()
     {
         if (presenter) {
             presenter->handleUpdateTimeEvent();
         }
-        return true;
+        return RefreshModes::GUI_REFRESH_NONE;
     }
 
     bool BellHomeScreenWindow::updateBatteryStatus()

--- a/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.hpp
@@ -22,7 +22,7 @@ namespace gui
       private:
         void buildInterface() override;
         void setLayout(LayoutGenerator layoutGenerator) override;
-        bool updateTime() override;
+        RefreshModes updateTime() override;
         bool onInput(const InputEvent &inputEvent) override;
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
         bool onDatabaseMessage(sys::Message *msg) override;

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.cpp
@@ -164,12 +164,12 @@ namespace gui
         time->setTimeFormat(fmt);
     }
 
-    bool MeditationRunningWindow::updateTime()
+    RefreshModes MeditationRunningWindow::updateTime()
     {
         if (presenter != nullptr) {
             presenter->handleUpdateTimeEvent();
         }
-        return true;
+        return RefreshModes::GUI_REFRESH_FAST;
     }
 
     void MeditationRunningWindow::intervalTimeout()

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -36,7 +36,7 @@ namespace gui
 
         void setTime(std::time_t newTime) override;
         void setTimeFormat(utils::time::Locale::TimeFormat fmt) override;
-        bool updateTime() override;
+        RefreshModes updateTime() override;
 
         void buildLayout();
         void configureTimer();

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
@@ -138,12 +138,12 @@ namespace gui
         time->setTimeFormat(fmt);
     }
 
-    bool PowerNapProgressWindow::updateTime()
+    RefreshModes PowerNapProgressWindow::updateTime()
     {
         if (presenter) {
             presenter->handleUpdateTimeEvent();
         }
-        return true;
+        return RefreshModes::GUI_REFRESH_NONE;
     }
 
     void PowerNapProgressWindow::onBeforeShow(ShowMode mode, SwitchData *data)

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -23,7 +23,7 @@ namespace gui
 
         void setTime(std::time_t newTime);
         void setTimeFormat(utils::time::Locale::TimeFormat fmt);
-        bool updateTime() override;
+        RefreshModes updateTime() override;
 
         void buildLayout();
         void configureTimer();

--- a/products/PurePhone/apps/Application.cpp
+++ b/products/PurePhone/apps/Application.cpp
@@ -19,6 +19,7 @@
 #include <popups/lock-popups/SimLockInputWindow.hpp>
 #include <popups/lock-popups/SimInfoWindow.hpp>
 #include <popups/lock-popups/SimNotReadyWindow.hpp>
+#include <service-db/agents/settings/SystemSettings.hpp>
 
 namespace app
 {
@@ -30,7 +31,6 @@ namespace app
         window->updateSim();
         window->updateSignalStrength();
         window->updateNetworkAccessTechnology();
-        window->updateTime();
         window->updatePhoneMode(statusIndicators.phoneMode);
     }
 
@@ -78,11 +78,14 @@ namespace app
             case ID::PhoneLockInput:
             case ID::PhoneLockInfo:
             case ID::PhoneLockChangeInfo:
-                windowsFactory.attach(window::phone_lock_window, [](ApplicationCommon *app, const std::string &name) {
-                    auto presenter = std::make_unique<gui::WallpaperPresenter>(app);
-                    return std::make_unique<gui::PhoneLockedWindow>(
-                        app, window::phone_lock_window, std::move(presenter));
-                });
+                windowsFactory.attach(
+                    window::phone_lock_window, [this](ApplicationCommon *app, const std::string &name) {
+                        auto presenter                 = std::make_unique<gui::WallpaperPresenter>(app);
+                        auto lockScreenDeepRefreshRate = utils::getNumericValue<unsigned>(settings->getValue(
+                            settings::Display::lockScreenDeepRefreshRate, settings::SettingsScope::Global));
+                        return std::make_unique<gui::PhoneLockedWindow>(
+                            app, window::phone_lock_window, std::move(presenter), lockScreenDeepRefreshRate);
+                    });
                 windowsFactory.attach(
                     window::phone_lock_info_window, [](ApplicationCommon *app, const std::string &name) {
                         return std::make_unique<gui::PhoneLockedInfoWindow>(app, window::phone_lock_info_window);


### PR DESCRIPTION
**Description**

Fix of the issue that time on the lock screen was
getting illegible after a few hours. This change
fixes the problem by performing deep refresh
instead of fast refresh every 30 minutes. The
refresh rate can be easily changed, as it is stored
in settings database.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
