### PR TITLE
[MOS-450] Fix turn off torch on critical battery level

### DIFF
--- a/module-services/service-evtmgr/api/EventManagerServiceAPI.cpp
+++ b/module-services/service-evtmgr/api/EventManagerServiceAPI.cpp
@@ -46,3 +46,8 @@ void EventManagerServiceAPI::setVibrationLevel(sys::Service *serv, unsigned int 
 {
     serv->bus.sendUnicast(std::make_shared<sevm::VibratorLevelMessage>(vibrationLevel), service::name::evt_manager);
 }
+
+void EventManagerServiceAPI::turnOffTorch(sys::Service *serv)
+{
+    serv->bus.sendUnicast(std::make_shared<sevm::TurnOffTorchRequest>(), service::name::evt_manager);
+}

--- a/module-services/service-evtmgr/service-evtmgr/EVMessages.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/EVMessages.hpp
@@ -145,4 +145,9 @@ namespace sevm
         const int data{};
     };
 
+    class TurnOffTorchRequest : public sys::DataMessage
+    {
+      public:
+        TurnOffTorchRequest() : DataMessage(MessageType::MessageTypeUninitialized){};
+    };
 } /* namespace sevm*/

--- a/module-services/service-evtmgr/service-evtmgr/EventManagerServiceAPI.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/EventManagerServiceAPI.hpp
@@ -31,4 +31,6 @@ namespace EventManagerServiceAPI
     /// Set vibrator level
     void setVibrationLevel(sys::Service *serv, unsigned int vibrationLevel);
 
+    /// Turn off torch
+    void turnOffTorch(sys::Service *serv);
 } // namespace EventManagerServiceAPI

--- a/products/PurePhone/services/evtmgr/EventManager.cpp
+++ b/products/PurePhone/services/evtmgr/EventManager.cpp
@@ -102,6 +102,11 @@ void EventManager::initProductEvents()
         pureEventWorker->requestSliderPositionRead();
         return sys::MessageNone{};
     });
+
+    connect(typeid(sevm::TurnOffTorchRequest), [&](sys::Message *msg) {
+        toggleTorchOff();
+        return sys::MessageNone{};
+    });
 }
 
 void EventManager::toggleTorchOnOff()
@@ -109,6 +114,11 @@ void EventManager::toggleTorchOnOff()
     auto state    = bsp::torch::getState();
     auto newState = (state == bsp::torch::State::off) ? bsp::torch::State::on : bsp::torch::State::off;
     bsp::torch::turn(newState, bsp::torch::ColourTemperature::coldest);
+}
+
+void EventManager::toggleTorchOff()
+{
+    bsp::torch::turn(bsp::torch::State::off, bsp::torch::ColourTemperature::coldest);
 }
 
 void EventManager::toggleTorchColor()

--- a/products/PurePhone/services/evtmgr/include/evtmgr/EventManager.hpp
+++ b/products/PurePhone/services/evtmgr/include/evtmgr/EventManager.hpp
@@ -21,6 +21,7 @@ class EventManager : public EventManagerCommon
   private:
     sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;
     void toggleTorchOnOff();
+    void toggleTorchOff();
     void toggleTorchColor();
     void ProcessCloseReason(sys::CloseReason closeReason) override;
     void handleKeyEvent(sys::Message *msg) override;

--- a/products/PurePhone/sys/SystemManager.cpp
+++ b/products/PurePhone/sys/SystemManager.cpp
@@ -14,6 +14,7 @@
 #include <service-cellular/CellularMessage.hpp>
 #include <service-cellular/CellularServiceAPI.hpp>
 #include <service-evtmgr/Constants.hpp>
+#include <service-evtmgr/EventManagerServiceAPI.hpp>
 
 namespace sys
 {
@@ -147,6 +148,7 @@ namespace sys
     {
         SystemManagerCommon::batteryCriticalLevelAction(charging);
         CellularServiceAPI::ChangeModulePowerState(this, cellular::service::State::PowerState::Off);
+        EventManagerServiceAPI::turnOffTorch(this);
         auto msg = std::make_shared<CriticalBatteryLevelNotification>(true, charging);
         bus.sendUnicast(std::move(msg), service::name::appmgr);
     }


### PR DESCRIPTION
Torch is now disabled on critical low battery level.
It will protect from battery draining.

**Description**

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
