### PR TITLE
[MOS-452] Fix BT keys duplicates

### DIFF
--- a/module-bluetooth/Bluetooth/BtKeysStorage.hpp
+++ b/module-bluetooth/Bluetooth/BtKeysStorage.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -17,7 +17,6 @@ namespace bluetooth
       public:
         static auto getKeyStorage() -> btstack_link_key_db_t *;
         static std::shared_ptr<bluetooth::SettingsHolder> settings;
-
       private:
         static void openStorage();
         static void closeStorage();
@@ -31,11 +30,11 @@ namespace bluetooth
                                       link_key_type_t *type) -> int;
         static void iterator_done(btstack_link_key_iterator_t *it);
         static void set_local_bd_addr(bd_addr_t bd_addr);
+        static auto processOnFoundKey(bd_addr_t bd_addr, const std::function<int(json11::Json, bd_addr_t)> &fun) -> int;
         static void writeSettings();
         static json11::Json keysJson;
         static btstack_link_key_db_t keyStorage;
         static json11::Json::array keys;
-        static std::string keysEntry;
     };
 
 } // namespace Bt

--- a/module-bluetooth/tests/CMakeLists.txt
+++ b/module-bluetooth/tests/CMakeLists.txt
@@ -6,7 +6,11 @@ add_catch2_executable(
         tests-BluetoothDevicesModel.cpp
         tests-Devicei.cpp
         tests-command.cpp
+        tests-BTKeysStorage.cpp
     LIBS
         module-sys
         module-bluetooth
+        service-bluetooth
 )
+
+

--- a/module-bluetooth/tests/tests-BTKeysStorage.cpp
+++ b/module-bluetooth/tests/tests-BTKeysStorage.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <catch2/catch.hpp>
+#include <service-bluetooth/SettingsHolder.hpp>
+#include <BtKeysStorage.hpp>
+
+namespace bluetooth
+{
+    class TestSettingsHolder : public SettingsHolder
+    {
+      public:
+        std::string entryValue;
+        Settings settingType;
+        auto getValue(const Settings setting) -> SettingEntry override
+        {
+            if (setting == settingType) {
+                return entryValue;
+            }
+            else {
+                return std::string{};
+            }
+        }
+        void setValue(const Settings &newSetting, const SettingEntry &value) override
+        {
+            settingType = newSetting;
+            entryValue  = std::get<std::string>(value);
+        }
+    };
+
+} // namespace bluetooth
+
+using namespace bluetooth;
+
+TEST_CASE("BT Keys storage")
+{
+    KeyStorage storage;
+    auto settingHolder = std::make_shared<TestSettingsHolder>();
+
+    storage.settings = settingHolder;
+
+    auto btKeyStorage = storage.getKeyStorage();
+    SECTION("put key to the storage")
+    {
+        bd_addr_t addr;
+        sscanf_bd_addr("94:B2:CC:F1:92:B1", addr);
+        link_key_t key       = "12345";
+        link_key_type_t type = COMBINATION_KEY;
+        btKeyStorage->put_link_key(addr, key, type);
+
+        REQUIRE(settingHolder->settingType == Settings::BtKeys);
+        REQUIRE(settingHolder->entryValue ==
+                "{\"keys\": [{\"bd_addr\": \"94:B2:CC:F1:92:B1\", \"link_key\": \"12345\", \"type\": 0}]}");
+    }
+    SECTION("get key from the storage")
+    {
+        bd_addr_t addr;
+        sscanf_bd_addr("94:B2:CC:F1:92:B1", addr);
+        link_key_t key;
+        link_key_type_t type;
+        settingHolder->entryValue =
+            "{\"keys\": [{\"bd_addr\": \"94:B2:CC:F1:92:B1\", \"link_key\": \"12345\", \"type\": 0}]}";
+
+        btKeyStorage->open();
+        auto ret = btKeyStorage->get_link_key(addr, key, &type);
+
+        REQUIRE(std::string(reinterpret_cast<char *>(key)) == "12345");
+        REQUIRE(type == COMBINATION_KEY);
+        REQUIRE(ret == 1);
+    }
+    SECTION("get key from the storage when there's no key")
+    {
+        bd_addr_t addr;
+        sscanf_bd_addr("94:B2:CC:F1:92:B1", addr);
+        link_key_t key;
+        link_key_type_t type;
+        settingHolder->entryValue = "";
+        btKeyStorage->open();
+        btKeyStorage->delete_link_key(addr);
+        auto ret = btKeyStorage->get_link_key(addr, key, &type);
+
+        REQUIRE(ret != 1);
+    }
+    SECTION("put key to the storage few times")
+    {
+        bd_addr_t addr;
+        sscanf_bd_addr("94:B2:CC:F1:92:B1", addr);
+        link_key_t key       = "12345";
+        link_key_type_t type = COMBINATION_KEY;
+
+        btKeyStorage->open();
+        btKeyStorage->put_link_key(addr, key, type);
+        btKeyStorage->put_link_key(addr, key, type);
+        btKeyStorage->put_link_key(addr, key, type);
+
+        REQUIRE(settingHolder->settingType == Settings::BtKeys);
+        REQUIRE(settingHolder->entryValue ==
+                "{\"keys\": [{\"bd_addr\": \"94:B2:CC:F1:92:B1\", \"link_key\": \"12345\", \"type\": 0}]}");
+    }
+    SECTION("delete key from the storage")
+    {
+        bd_addr_t addr;
+        sscanf_bd_addr("94:B2:CC:F1:92:B1", addr);
+        settingHolder->entryValue =
+            "{\"keys\": [{\"bd_addr\": \"94:B2:CC:F1:92:B1\", \"link_key\": \"12345\", \"type\": 0}]}";
+
+        btKeyStorage->open();
+        btKeyStorage->delete_link_key(addr);
+
+        REQUIRE(settingHolder->settingType == Settings::BtKeys);
+        REQUIRE(settingHolder->entryValue == "{\"keys\": []}");
+    }
+    SECTION("double-delete key from the storage")
+    {
+        bd_addr_t addr;
+        sscanf_bd_addr("94:B2:CC:F1:92:B1", addr);
+        settingHolder->entryValue =
+            "{\"keys\": [{\"bd_addr\": \"94:B2:CC:F1:92:B1\", \"link_key\": \"12345\", \"type\": 0}]}";
+
+        btKeyStorage->open();
+        btKeyStorage->delete_link_key(addr);
+        btKeyStorage->delete_link_key(addr);
+
+        REQUIRE(settingHolder->settingType == Settings::BtKeys);
+        REQUIRE(settingHolder->entryValue == "{\"keys\": []}");
+    }
+}

--- a/module-services/service-bluetooth/service-bluetooth/SettingsHolder.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/SettingsHolder.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 #pragma once
 #include <json11.hpp>
@@ -78,9 +78,11 @@ namespace bluetooth
     class SettingsHolder
     {
       public:
+        SettingsHolder()          = default;
+        virtual ~SettingsHolder() = default;
         explicit SettingsHolder(std::unique_ptr<settings::Settings> settingsPtr);
-        auto getValue(const Settings setting) -> SettingEntry;
-        void setValue(const Settings &newSetting, const SettingEntry &value);
+        virtual auto getValue(const Settings setting) -> SettingEntry;
+        virtual void setValue(const Settings &newSetting, const SettingEntry &value);
         std::function<void()> onStateChange;
         std::function<void(const std::string &)> onLinkKeyAdded;
         void deinit();


### PR DESCRIPTION
**Description**

Due to possibility to have duplicated entries per BT address
BT stack was requesting pairing when wrong key has been provided.
Now, all previous key entries are deleted prior adding.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
