### PR TITLE
[MOS-395] Add new def QCFG settings

### DIFF
--- a/module-cellular/at/Commands.hpp
+++ b/module-cellular/at/Commands.hpp
@@ -70,8 +70,12 @@ namespace at
         QSIMSTAT,   /// sim insertion / removal notification in URC
         SIM_DET_ON, /// enable sim detection
         SIMSTAT_ON, /// enable sim stat urc
+        SET_DEFAULT_SCANMODE,
         SET_SCANMODE,
         GET_SCANMODE,
+        SET_DEFAULT_SERVICEDOMAIN,
+        SET_SERVICEDOMAIN,
+        GET_SERVICEDOMAIN,
         QGMR,               /// ditailed firmware revision (as required by Quectel)
         STORE_SETTINGS_ATW, /// required to save in firmware ex SIMSTAT_ON
         CEER,               /// get error description from modem

--- a/module-cellular/at/src/ATFactory.cpp
+++ b/module-cellular/at/src/ATFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ATFactory.hpp"
@@ -61,8 +61,12 @@ namespace at
         {AT::SIM_DET, {"AT+QSIMDET?"}},
         {AT::SIM_DET_ON, {"AT+QSIMDET=1,0"}},
         {AT::SIMSTAT_ON, {"AT+QSIMSTAT=1"}},
+        {AT::SET_DEFAULT_SCANMODE, {"AT+QCFG=\"nwscanmode\",0"}},
+        {AT::SET_DEFAULT_SERVICEDOMAIN, {"AT+QCFG=\"servicedomain\",2"}},
         {AT::SET_SCANMODE, {"AT+QCFG=\"nwscanmode\","}},
         {AT::GET_SCANMODE, {"AT+QCFG=\"nwscanmode\""}},
+        {AT::SET_SERVICEDOMAIN, {"AT+QCFG=\"servicedomain\","}},
+        {AT::GET_SERVICEDOMAIN, {"AT+QCFG=\"servicedomain\""}},
         {AT::QGMR, {"AT+QGMR"}},
         {AT::STORE_SETTINGS_ATW, {"AT&W"}},
         {AT::CEER, {"AT+CEER", 1s}},

--- a/module-cellular/at/src/Commands.cpp
+++ b/module-cellular/at/src/Commands.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <Commands.hpp>
@@ -20,6 +20,8 @@ namespace at
             ret.push_back(AT::URC_UART1);
             ret.push_back(AT::AT_PIN_READY_LOGIC);
             ret.push_back(AT::CSQ_URC_ON);
+            ret.push_back(AT::SET_DEFAULT_SCANMODE);
+            ret.push_back(AT::SET_DEFAULT_SERVICEDOMAIN);
             break;
         case commadsSet::simInit:
             ret.push_back(AT::CALLER_NUMBER_PRESENTATION);


### PR DESCRIPTION
**Description**

Add new default QCFG settings:
- servicedomain,
- nwscanmode.

This may help the issue, however we don't know for sure as we have no clear reproduction.
The solution was sourced from Quectel forums for similair issue. 

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [ ] Has documentation updated

<!-- Thanks for your work ♥ -->
