### PR TITLE
[MOS-418] Add zero padding when setting alarm time

### DIFF
--- a/module-apps/application-alarm-clock/widgets/AlarmTimeItem.hpp
+++ b/module-apps/application-alarm-clock/widgets/AlarmTimeItem.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -26,6 +26,8 @@ namespace gui
         void prepareForTimeMode();
         [[nodiscard]] bool isPm(const std::string &text) const;
         void validateHour();
+
+        template <typename T> UTF8 timeValueToPaddedString(const T &value);
 
       public:
         AlarmTimeItem(std::function<void(const UTF8 &text)> navBarTemporaryMode = nullptr,


### PR DESCRIPTION
**Description**

Added zero padding to alarm time fields when setting
alarm time.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
