### PR TITLE
[BH-1482] Fixed missing relaxation entries

### DIFF
--- a/products/BellHybrid/alarms/src/AlarmSoundPaths.cpp
+++ b/products/BellHybrid/alarms/src/AlarmSoundPaths.cpp
@@ -34,7 +34,7 @@ namespace alarms::paths
 
     std::filesystem::path getBackgroundSoundsDir() noexcept
     {
-        return purefs::dir::getCurrentOSPath() / "assets/audio/bg_sounds";
+        return purefs::dir::getCurrentOSPath() / "assets/audio/bell/bg_sounds";
     }
 
     std::filesystem::path getMeditationSoundsDir() noexcept


### PR DESCRIPTION
**Description**

Fixed missing relaxation entries by temporarily
replacing background sounds asset path.
1.6.0 update doesn't replace the old audio assets with the new ones.
As a result we have temporarily two identical copies placed under
different paths. This issue should be fixed with the proper migration
mechanism that we currently lack.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
