### PR TITLE
[BH-1489] Prevent popups from clearing settings screen

### DIFF
--- a/module-apps/apps-common/ApplicationCommon.hpp
+++ b/module-apps/apps-common/ApplicationCommon.hpp
@@ -210,10 +210,6 @@ namespace app
 
         std::list<std::unique_ptr<app::GuiTimer>> gui_timers;
         std::unordered_map<manager::actions::ActionId, OnActionReceived> receivers;
-        void switchWindowPopup(const std::string &windowName,
-                               const gui::popup::Disposition &disposition,
-                               std::unique_ptr<gui::SwitchData> data = nullptr,
-                               SwitchReason reason                   = SwitchReason::SwitchRequest);
 
       public:
         sys::TimerHandle longPressTimer;
@@ -345,7 +341,7 @@ namespace app
         /// Method to register all possible popups to handle in application
         virtual void registerPopupBlueprints();
         /// fallback method  to get popup if none is added
-        std::optional<gui::popup::Blueprint> popupBlueprintFallback(gui::popup::ID id);
+        virtual std::optional<gui::popup::Blueprint> popupBlueprintFallback(gui::popup::ID id);
         /// Method used to register all windows and widgets in application
         virtual void createUserInterface() = 0;
         /// Method closing application's windows.
@@ -362,6 +358,10 @@ namespace app
         virtual void clearPendingPopups();
         virtual bool tryShowPopup();
         void abortPopup(gui::popup::ID id);
+        void switchWindowPopup(const std::string &windowName,
+                               const gui::popup::Disposition &disposition,
+                               std::unique_ptr<gui::SwitchData> data = nullptr,
+                               SwitchReason reason                   = SwitchReason::SwitchRequest);
 
         bool userInterfaceDBNotification(sys::Message *msg, const UiNotificationFilter &filter = nullptr);
         virtual gui::popup::Filter &getPopupFilter() const;

--- a/products/BellHybrid/apps/Application.cpp
+++ b/products/BellHybrid/apps/Application.cpp
@@ -93,6 +93,16 @@ namespace app
         }
     }
 
+    std::optional<gui::popup::Blueprint> Application::popupBlueprintFallback(gui::popup::ID id)
+    {
+        popupBlueprint.registerBlueprint(
+            id, [&](gui::popup::ID id, std::unique_ptr<gui::PopupRequestParams> &p) -> bool {
+                switchWindowPopup(gui::popup::resolveWindowName(id), p->getDisposition(), nullptr, SwitchReason::Popup);
+                return true;
+            });
+        return *popupBlueprint.getBlueprint(id);
+    }
+
     sys::MessagePointer Application::handleKBDKeyEvent(sys::Message *msgl)
     {
         onKeyPressed();

--- a/products/BellHybrid/apps/include/Application.hpp
+++ b/products/BellHybrid/apps/include/Application.hpp
@@ -22,6 +22,7 @@ namespace app
 
       protected:
         void attachPopups(const std::vector<gui::popup::ID> &popupsList) override;
+        std::optional<gui::popup::Blueprint> popupBlueprintFallback(gui::popup::ID id) override;
         void startIdleTimer();
         void restartIdleTimer();
         void stopIdleTimer();


### PR DESCRIPTION
Prevent popups from clearing settings screen
Popups default switch reason is set to Popup instead of PhoneLock

**Description**

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [X] Has unit tests if possible.
- [X] Has documentation updated

<!-- Thanks for your work ♥ -->
