### PR TITLE
Remove flag emoji suggestion

### DIFF
--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -113,7 +113,7 @@ It’s a good practice not to rename font names - these are stored in font metad
 
 ## How to start localizing the interface
 
-1. Create an issue with the localization you want to start working on. Please use the following issue title scheme: `[Language] localization [emoji_flag]` eg. `Polish localization 🇵🇱`. The emoji flag is a small detail that can help other community members in finding the localization they're interested in and helping you out in implementing it. Please make sure that the localization you want to implement has not been already implemented.
+1. Create an issue with the localization you want to start working on. Please use the following issue title scheme: `[Language] localization [ISO 639-1 code]` eg. `Polish localization [pl]`. The emoji flag is a small detail that can help other community members in finding the localization they're interested in and helping you out in implementing it. Please make sure that the localization you want to implement has not been already implemented.
 2. Add a `i18n` label to your new issue on GitHub.
 3. Follow [the "Contributing to MuditaOS" article](../CONTRIBUTING.md).
 4. As soon as you create a Pull Request with your localization we will review it and add it to the official MuditaOS distribution.


### PR DESCRIPTION
Flags do not represent languages, they represent countries/nations. There's so many problematic reasons for this that it would just be better to not even start any convention. [ISO 639-3 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) are acceptable. You could change this to the 639-2 or 639-3 codes, but please *don't* use flags. Related to emoji, the Unicode consortium is no longer making any new flag emojis as they are so problematic and Unicode doesn't want to play with geopolitics.

Some additional resources::
* https://wplang.org/never-use-flags-language-selection/
* https://jkorpela.fi/flags.html

**Description**

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible.
- [ ] Has documentation updated

<!-- Thanks for your work ♥ -->
