### PR TITLE
[BH-1480] Reset timer on state machine reset

### DIFF
--- a/products/BellHybrid/apps/application-bell-main/presenters/StateController.cpp
+++ b/products/BellHybrid/apps/application-bell-main/presenters/StateController.cpp
@@ -546,6 +546,7 @@ namespace app::home_screen
         using namespace sml;
 
         if (not pimpl->sm->is("Init"_s)) {
+            presenter.detachTimer();
             pimpl->resetSM();
         }
     }


### PR DESCRIPTION
Reset timer on state machine reset (homescreen)

**Description**

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [X] Has unit tests if possible.
- [X] Has documentation updated

<!-- Thanks for your work ♥ -->
