### PR TITLE
[MOS-419] Removed AbortCall as popup and handle tethering as part of call

### DIFF
--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -81,16 +81,6 @@ namespace app
             showNotificationAndRestartCallFlow(NotificationType::Info, utils::translate("app_call_offline"));
             return actionHandled();
         });
-        addActionReceiver(manager::actions::AbortCall, [this](auto &&data) {
-            if (const auto state = getState(); state == Application::State::ACTIVE_FORGROUND) {
-                switchWindow(window::name_call);
-            }
-            else if (state == Application::State::ACTIVE_BACKGROUND) {
-                callModel->setState(app::call::CallState::None);
-                manager::Controller::finish(this);
-            }
-            return actionHandled();
-        });
         addActionReceiver(manager::actions::ActivateCall, [this](auto &&data) {
             switchWindow(window::name_call);
             return actionHandled();

--- a/module-apps/application-call/include/application-call/ApplicationCall.hpp
+++ b/module-apps/application-call/include/application-call/ApplicationCall.hpp
@@ -98,7 +98,6 @@ namespace app
                      manager::actions::CallRejectedByOfflineNotification,
                      manager::actions::PhoneModeChanged,
                      manager::actions::ActivateCall,
-                     {manager::actions::AbortCall, manager::actions::ActionFlag::AcceptWhenInBackground},
                      manager::actions::HandleOutgoingCall,
                      manager::actions::HandleIncomingCall,
                      manager::actions::HandleCallerId,

--- a/module-services/service-appmgr/include/service-appmgr/Actions.hpp
+++ b/module-services/service-appmgr/include/service-appmgr/Actions.hpp
@@ -25,7 +25,6 @@ namespace app::manager
             AutoLock,
             Launch,
             Call,
-            AbortCall,
             ActivateCall,
             HandleOutgoingCall,
             HandleIncomingCall,

--- a/module-services/service-appmgr/tests/test-ApplicationManifest.cpp
+++ b/module-services/service-appmgr/tests/test-ApplicationManifest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -17,7 +17,6 @@ TEST_CASE("Check if manifest registers actions")
     SECTION("Check if doesn't contain an action that wasn't registered")
     {
         ApplicationManifest manifest{{actions::Launch}};
-        REQUIRE(!manifest.contains(actions::AbortCall));
     }
     SECTION("Checks if doesn't contain an action when the manifest is empty")
     {
@@ -28,9 +27,10 @@ TEST_CASE("Check if manifest registers actions")
 
 TEST_CASE("Check if manifest serves action flags")
 {
-    ApplicationManifest manifest{{actions::Launch, {actions::AbortCall, actions::ActionFlag::AcceptWhenInBackground}}};
+    ApplicationManifest manifest{
+        {actions::Launch, {actions::ChangeHomescreenLayout, actions::ActionFlag::AcceptWhenInBackground}}};
 
     REQUIRE(manifest.getActionFlag(actions::Launch) == actions::ActionFlag::None);
-    REQUIRE(manifest.getActionFlag(actions::AbortCall) == actions::ActionFlag::AcceptWhenInBackground);
+    REQUIRE(manifest.getActionFlag(actions::ChangeHomescreenLayout) == actions::ActionFlag::AcceptWhenInBackground);
     REQUIRE(manifest.getActionFlag(actions::UserAction) == actions::ActionFlag::None);
 }

--- a/module-services/service-cellular/call/CellularCall.cpp
+++ b/module-services/service-cellular/call/CellularCall.cpp
@@ -113,6 +113,15 @@ namespace call
         return true;
     }
 
+    bool Call::handle(const call::event::TetheringChange &change)
+    {
+        if (machine == nullptr) {
+            return false;
+        };
+        machine->call.tethering = change.tethering;
+        return true;
+    }
+
     bool Call::handle(const call::event::Answer &answer)
     {
         if (machine == nullptr) {

--- a/module-services/service-cellular/call/api/ModemCallApi.cpp
+++ b/module-services/service-cellular/call/api/ModemCallApi.cpp
@@ -58,4 +58,13 @@ namespace cellular
         }
         return cellular->phoneModeObserver->getCurrentPhoneMode();
     }
+
+    sys::phone_modes::Tethering Api::getTethering()
+    {
+        if (cellular == nullptr) {
+            throw std::runtime_error("call api not initialized");
+        }
+        return cellular->phoneModeObserver->isTetheringOn() ? sys::phone_modes::Tethering::On
+                                                            : sys::phone_modes::Tethering::Off;
+    }
 } // namespace cellular

--- a/module-services/service-cellular/call/api/ModemCallApi.hpp
+++ b/module-services/service-cellular/call/api/ModemCallApi.hpp
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "PhoneModes/PhoneMode.hpp"
+#include "PhoneModes/Tethering.hpp"
+
 class CellularMux;
 class ServiceCellular;
 
@@ -17,6 +19,7 @@ namespace call::api
         virtual bool rejectCall()                     = 0;
         virtual bool areCallsFromFavouritesEnabled()  = 0;
         virtual sys::phone_modes::PhoneMode getMode() = 0;
+        virtual sys::phone_modes::Tethering getTethering() = 0;
         virtual ~Api()                                = default;
     };
 } // namespace call::api
@@ -38,5 +41,6 @@ namespace cellular
         bool rejectCall() override;
         bool areCallsFromFavouritesEnabled() override;
         sys::phone_modes::PhoneMode getMode() override;
+        sys::phone_modes::Tethering getTethering() override;
     };
 } // namespace cellular

--- a/module-services/service-cellular/call/include/call/CallEvents.hpp
+++ b/module-services/service-cellular/call/include/call/CallEvents.hpp
@@ -36,6 +36,11 @@ namespace call::event
         sys::phone_modes::PhoneMode mode;
     };
 
+    struct TetheringChange
+    {
+        sys::phone_modes::Tethering tethering;
+    };
+
     struct OngoingTimer
     {};
 

--- a/module-services/service-cellular/call/include/call/CellularCall.hpp
+++ b/module-services/service-cellular/call/include/call/CellularCall.hpp
@@ -36,6 +36,7 @@ namespace call
     {
         CalllogRecord record             = {};
         sys::phone_modes::PhoneMode mode = sys::phone_modes::PhoneMode::Connected;
+        sys::phone_modes::Tethering tethering = sys::phone_modes::Tethering::Off;
     };
 
     struct Dependencies
@@ -71,6 +72,7 @@ namespace call
         bool handle(const call::event::CLIP &);
         bool handle(const call::event::AudioRequest &);
         bool handle(const call::event::ModeChange &);
+        bool handle(const call::event::TetheringChange &change);
         bool handle(const call::event::OngoingTimer &);
         bool handle(const call::event::RingTimeout &);
         bool handle(const call::event::Ended &);

--- a/module-services/service-cellular/service-cellular/CellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/CellularMessage.hpp
@@ -734,19 +734,12 @@ class CellularCallActiveNotification : public CellularNotificationMessage,
     }
 };
 
-class CellularCallAbortedNotification : public CellularNotificationMessage,
-                                        public app::manager::actions::ConvertibleToAction
+class CellularCallAbortedNotification : public CellularNotificationMessage
 {
   public:
     explicit CellularCallAbortedNotification(const std::string &data = "")
         : CellularNotificationMessage(CellularNotificationMessage::Content::CallAborted, data)
     {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(
-            sender, app::manager::actions::AbortCall, std::make_unique<app::manager::actions::CallParams>());
-    }
 };
 
 class CellularPowerUpProcedureCompleteNotification : public CellularNotificationMessage

--- a/module-sys/PhoneModes/include/PhoneModes/Common.hpp
+++ b/module-sys/PhoneModes/include/PhoneModes/Common.hpp
@@ -5,15 +5,10 @@
 
 #include <Service/Message.hpp>
 #include "PhoneMode.hpp"
+#include "Tethering.hpp"
 
 namespace sys::phone_modes
 {
-    enum class Tethering
-    {
-        Off,
-        On
-    };
-
     class PhoneModeChanged : public DataMessage
     {
       public:

--- a/module-sys/PhoneModes/include/PhoneModes/Tethering.hpp
+++ b/module-sys/PhoneModes/include/PhoneModes/Tethering.hpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+namespace sys::phone_modes
+{
+    enum class Tethering
+    {
+        Off,
+        On
+    };
+}


### PR DESCRIPTION
1. Removed AbortCall as popup and handled tethering in call machine.

Now: 
- there is no popup on dropped call from thethering mode
- there is incremented dropped call when in tethering mode ( and caller know it was dropped)

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
