### PR TITLE
[BH-1488] Remove refresh after back press on transport mode

### DIFF
--- a/products/BellHybrid/apps/application-bell-onboarding/windows/OnBoardingOnOffWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-onboarding/windows/OnBoardingOnOffWindow.cpp
@@ -129,7 +129,7 @@ namespace gui
         }
         else if (inputEvent.isShortRelease(KeyCode::KEY_RF)) {
             presenter->powerOff();
-            return true;
+            return false;
         }
         return false;
     }


### PR DESCRIPTION
Remove refresh after backpress in transport mode
so that last refresh will be welcome screen
(race deletion)

**Description**

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [X] Has unit tests if possible.
- [X] Has documentation updated

<!-- Thanks for your work ♥ -->
