### PR TITLE
[MOS-451] Drop invalid SoC

### DIFF
--- a/module-bsp/board/linux/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/linux/hal/battery_charger/BatteryCharger.cpp
@@ -37,7 +37,7 @@ namespace hal::battery
         ~BatteryCharger();
 
         Voltage getBatteryVoltage() const final;
-        SOC getSOC() const final;
+        std::optional<SOC> getSOC() const final;
         ChargingStatus getChargingStatus() const final;
 
       private:
@@ -78,7 +78,7 @@ namespace hal::battery
         return dummyBatteryVoltageLevel;
     }
 
-    AbstractBatteryCharger::SOC BatteryCharger::getSOC() const
+    std::optional<AbstractBatteryCharger::SOC> BatteryCharger::getSOC() const
     {
         return batteryLevel;
     }

--- a/module-bsp/board/rt1051/bellpx/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/rt1051/bellpx/hal/battery_charger/BatteryCharger.cpp
@@ -56,14 +56,14 @@ namespace hal::battery
         ~BellBatteryCharger();
 
         Voltage getBatteryVoltage() const final;
-        SOC getSOC() const final;
+        std::optional<SOC> getSOC() const final;
         ChargingStatus getChargingStatus() const final;
 
         static BatteryWorkerQueue &getWorkerQueueHandle();
 
       private:
         void sendNotification(Events event);
-        SOC fetchBatterySOC() const;
+        std::optional<SOC> fetchBatterySOC() const;
         void pollFuelGauge();
         bool tryEnableCharging();
 
@@ -144,7 +144,7 @@ namespace hal::battery
         }
     }
 
-    AbstractBatteryCharger::SOC BellBatteryCharger::getSOC() const
+    std::optional<AbstractBatteryCharger::SOC> BellBatteryCharger::getSOC() const
     {
         return fetchBatterySOC();
     }
@@ -178,14 +178,14 @@ namespace hal::battery
             return ChargingStatus::PluggedNotCharging;
         }
     }
-    AbstractBatteryCharger::SOC BellBatteryCharger::fetchBatterySOC() const
+    std::optional<AbstractBatteryCharger::SOC> BellBatteryCharger::fetchBatterySOC() const
     {
         if (const auto soc = fuel_gauge.get_battery_soc(); const auto scaled_soc = scale_soc(*soc)) {
-            return *scaled_soc;
+            return scaled_soc;
         }
         else {
             LOG_ERROR("Error during fetching battery level");
-            return 0;
+            return std::nullopt;
         }
     }
     BellBatteryCharger::BatteryWorkerQueue &BellBatteryCharger::getWorkerQueueHandle()

--- a/module-bsp/board/rt1051/puretx/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/rt1051/puretx/hal/battery_charger/BatteryCharger.cpp
@@ -83,7 +83,7 @@ namespace hal::battery
         ~PureBatteryCharger();
 
         Voltage getBatteryVoltage() const final;
-        SOC getSOC() const final;
+        std::optional<SOC> getSOC() const final;
         ChargingStatus getChargingStatus() const final;
 
         static BatteryWorkerQueue &getWorkerQueueHandle();
@@ -154,15 +154,15 @@ namespace hal::battery
     {
         return bsp::battery_charger::getVoltageFilteredMeasurement();
     }
-    AbstractBatteryCharger::SOC PureBatteryCharger::getSOC() const
+    std::optional<AbstractBatteryCharger::SOC> PureBatteryCharger::getSOC() const
     {
         const auto soc        = bsp::battery_charger::getBatteryLevel();
         const auto scaled_soc = scale_soc(soc);
         if (not scaled_soc) {
-            LOG_ERROR("SOC is out of valid range.");
-            return 0;
+            LOG_ERROR("SOC is out of valid range. SoC: %d", soc);
+            return std::nullopt;
         }
-        return *scaled_soc;
+        return scaled_soc;
     }
     AbstractBatteryCharger::ChargingStatus PureBatteryCharger::getChargingStatus() const
     {

--- a/module-bsp/hal/include/hal/battery_charger/AbstractBatteryCharger.hpp
+++ b/module-bsp/hal/include/hal/battery_charger/AbstractBatteryCharger.hpp
@@ -7,6 +7,7 @@
 #include <FreeRTOS.h>
 #include <queue.h>
 
+#include <optional>
 #include <memory>
 #include <cstdint>
 
@@ -40,7 +41,7 @@ namespace hal::battery
         virtual ~AbstractBatteryCharger() = default;
 
         virtual Voltage getBatteryVoltage() const        = 0;
-        virtual SOC getSOC() const                       = 0;
+        virtual std::optional<SOC> getSOC() const        = 0;
         virtual ChargingStatus getChargingStatus() const = 0;
 
         static_assert(sizeof(Events) == sizeof(std::uint8_t),

--- a/module-services/service-evtmgr/battery/BatteryController.cpp
+++ b/module-services/service-evtmgr/battery/BatteryController.cpp
@@ -83,7 +83,7 @@ BatteryController::BatteryController(sys::Service *service, xQueueHandle notific
                        this->service->bus.sendUnicast(std::move(stateChangeMessage), service::name::system_manager);
                    }}
 {
-    Store::Battery::modify().level = charger->getSOC();
+    updateSoC();
     Store::Battery::modify().state = transformChargingState(charger->getChargingStatus());
     batteryState.check(transformChargingState(Store::Battery::modify().state), Store::Battery::modify().level);
 
@@ -124,7 +124,7 @@ void sevm::battery::BatteryController::update()
     const auto soc           = Store::Battery::get().level;
     const auto chargingState = Store::Battery::get().state;
 
-    Store::Battery::modify().level = charger->getSOC();
+    updateSoC();
     Store::Battery::modify().state = transformChargingState(charger->getChargingStatus());
 
     /// Send BatteryStatusChangeMessage only when battery SOC or charger state has changed
@@ -136,4 +136,12 @@ void sevm::battery::BatteryController::update()
     batteryState.check(transformChargingState(Store::Battery::modify().state), Store::Battery::modify().level);
 
     printCurrentState();
+}
+
+void sevm::battery::BatteryController::updateSoC()
+{
+    auto batteryLevel = charger->getSOC();
+    if (batteryLevel.has_value()) {
+        Store::Battery::modify().level = batteryLevel.value();
+    }
 }

--- a/module-services/service-evtmgr/battery/BatteryController.hpp
+++ b/module-services/service-evtmgr/battery/BatteryController.hpp
@@ -28,6 +28,7 @@ namespace sevm::battery
 
       private:
         void update();
+        void updateSoC();
         void printCurrentState();
         sys::Service *service{nullptr};
         std::unique_ptr<hal::battery::AbstractBatteryCharger> charger;


### PR DESCRIPTION
Invalid state of charge is now dropped. Invalid SoC was interpreted
as 0% battery.

**Description**

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
