### PR TITLE
[MOS-473] Long time to refresh network coverage fix

### DIFF
--- a/module-apps/apps-common/ApplicationCommon.cpp
+++ b/module-apps/apps-common/ApplicationCommon.cpp
@@ -398,8 +398,7 @@ namespace app
 
     sys::MessagePointer ApplicationCommon::handleSignalStrengthUpdate(sys::Message *msgl)
     {
-        if ((state == State::ACTIVE_FORGROUND) && !isOnPhoneLockWindow() &&
-            getCurrentWindow()->updateSignalStrength()) {
+        if ((state == State::ACTIVE_FORGROUND) && getCurrentWindow()->updateSignalStrength()) {
             refreshWindow(gui::RefreshModes::GUI_REFRESH_FAST);
         }
         return sys::msgHandled();
@@ -407,8 +406,7 @@ namespace app
 
     sys::MessagePointer ApplicationCommon::handleNetworkAccessTechnologyUpdate(sys::Message *msgl)
     {
-        if ((state == State::ACTIVE_FORGROUND) && !isOnPhoneLockWindow() &&
-            getCurrentWindow()->updateNetworkAccessTechnology()) {
+        if ((state == State::ACTIVE_FORGROUND) && getCurrentWindow()->updateNetworkAccessTechnology()) {
             refreshWindow(gui::RefreshModes::GUI_REFRESH_FAST);
         }
         return sys::msgHandled();
@@ -451,7 +449,7 @@ namespace app
 
     sys::MessagePointer ApplicationCommon::handleBatteryStatusChange()
     {
-        if ((state == State::ACTIVE_FORGROUND) && !isOnPhoneLockWindow() && getCurrentWindow()->updateBatteryStatus()) {
+        if ((state == State::ACTIVE_FORGROUND) && getCurrentWindow()->updateBatteryStatus()) {
             refreshWindow(gui::RefreshModes::GUI_REFRESH_FAST);
         }
         return sys::msgHandled();
@@ -459,7 +457,7 @@ namespace app
 
     sys::MessagePointer ApplicationCommon::handleUSBStatusChange()
     {
-        if ((state == State::ACTIVE_FORGROUND) && isOnPhoneLockWindow() && getCurrentWindow()->updateBatteryStatus()) {
+        if ((state == State::ACTIVE_FORGROUND) && getCurrentWindow()->updateBatteryStatus()) {
             refreshWindow(gui::RefreshModes::GUI_REFRESH_FAST);
         }
         return sys::msgHandled();
@@ -737,7 +735,7 @@ namespace app
 
     sys::MessagePointer ApplicationCommon::handleSimStateUpdateMessage(sys::Message *msgl)
     {
-        if (!isOnPhoneLockWindow() && getCurrentWindow()->updateSim()) {
+        if (getCurrentWindow()->updateSim()) {
             refreshWindow(gui::RefreshModes::GUI_REFRESH_FAST);
         }
         return sys::msgHandled();
@@ -1040,10 +1038,5 @@ namespace app
     auto ApplicationCommon::getSimLockSubject() noexcept -> locks::SimLockSubject &
     {
         return simLockSubject;
-    }
-
-    bool ApplicationCommon::isOnPhoneLockWindow()
-    {
-        return getCurrentWindow()->getName() == gui::popup::window::phone_lock_window;
     }
 } /* namespace app */

--- a/module-apps/apps-common/ApplicationCommon.hpp
+++ b/module-apps/apps-common/ApplicationCommon.hpp
@@ -432,8 +432,6 @@ namespace app
         locks::LockPolicyHandler lockPolicyHandler;
         locks::SimLockSubject simLockSubject;
 
-        bool isOnPhoneLockWindow();
-
       public:
         [[nodiscard]] auto getPhoneLockSubject() noexcept -> locks::PhoneLockSubject &;
         [[nodiscard]] auto getSimLockSubject() noexcept -> locks::SimLockSubject &;

--- a/module-gui/gui/widgets/StatusBar.cpp
+++ b/module-gui/gui/widgets/StatusBar.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <iomanip>
@@ -256,14 +256,17 @@ namespace gui::status_bar
         if (battery == nullptr) {
             return false;
         }
-        showBattery(configuration.isEnabled(Indicator::Battery));
-        return true;
+        return showBattery(configuration.isEnabled(Indicator::Battery));
     }
 
-    void StatusBar::showBattery(bool enabled)
+    bool StatusBar::showBattery(bool enabled)
     {
-        battery->update(Store::Battery::get());
+        const auto visibilityChanged = battery->isVisible() == enabled ? false : true;
         enabled ? battery->show() : battery->hide();
+        const auto stateChanged    = battery->update(Store::Battery::get());
+        const auto refreshRequired = stateChanged || visibilityChanged;
+
+        return refreshRequired;
     }
 
     void StatusBar::showBluetooth(bool enabled)

--- a/module-gui/gui/widgets/StatusBar.hpp
+++ b/module-gui/gui/widgets/StatusBar.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -221,7 +221,8 @@ namespace gui::status_bar
 
         /// Show/hide battery status widget
         /// @param enabled true to show false to hide the widget
-        void showBattery(bool enabled);
+        /// @return true if screen refresh is required, false if not required
+        bool showBattery(bool enabled);
 
         /// Show/hide signal strenght widget
         /// @param enabled true to show false to hide the widget

--- a/module-gui/gui/widgets/status-bar/BatteryBase.cpp
+++ b/module-gui/gui/widgets/status-bar/BatteryBase.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BatteryBase.hpp"
@@ -13,7 +13,7 @@ namespace gui::status_bar
         setAlignment(Alignment(Alignment::Horizontal::Right, Alignment::Vertical::Bottom));
     }
 
-    void BatteryBase::update(const Store::Battery &batteryContext)
+    bool BatteryBase::update(const Store::Battery &batteryContext)
     {
         switch (batteryContext.state) {
         case Store::Battery::State::Discharging:
@@ -28,5 +28,7 @@ namespace gui::status_bar
             showBatteryChargingDone();
             break;
         }
+
+        return Store::Battery::takeUpdated();
     }
 } // namespace gui::status_bar

--- a/module-gui/gui/widgets/status-bar/BatteryBase.hpp
+++ b/module-gui/gui/widgets/status-bar/BatteryBase.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -17,6 +17,6 @@ namespace gui::status_bar
 
       public:
         BatteryBase(Item *parent, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
-        void update(const Store::Battery &batteryContext);
+        bool update(const Store::Battery &batteryContext);
     };
 } // namespace gui::status_bar

--- a/module-utils/EventStore/EventStore.cpp
+++ b/module-utils/EventStore/EventStore.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "EventStore.hpp"
@@ -11,6 +11,7 @@ namespace Store
     // if it grows bigger than these few variables - consider moving it to ram with i.e.
     // delayed construction singletone
     Battery battery;
+    bool Battery::updated = true;
 
     const Battery &Battery::get()
     {
@@ -19,7 +20,22 @@ namespace Store
 
     Battery &Battery::modify()
     {
+        Battery::setUpdated();
         return battery;
+    }
+
+    void Battery::setUpdated()
+    {
+        battery.updated = true;
+    }
+
+    bool Battery::takeUpdated()
+    {
+        if (battery.updated) {
+            battery.updated = false;
+            return true;
+        }
+        return false;
     }
 
     cpp_freertos::MutexStandard GSM::mutex;

--- a/module-utils/EventStore/EventStore.hpp
+++ b/module-utils/EventStore/EventStore.hpp
@@ -24,6 +24,10 @@ namespace Store
 {
     struct Battery
     {
+      private:
+        static bool updated;
+
+      public:
         enum class LevelState : std::uint8_t
         {
             Normal,
@@ -41,8 +45,16 @@ namespace Store
         } state            = State::Discharging;
         unsigned int level = 0;
 
+        /// @brief Returns const reference to Battery instance, used to read battery state
+        /// @return const Battery&
         static const Battery &get();
+
+        /// @brief Returns reference to Battery instance, used to change battery state
+        /// @return Battery&
         static Battery &modify();
+
+        static void setUpdated();
+        static bool takeUpdated();
     };
 
     enum class RssiBar : size_t


### PR DESCRIPTION
**Description**

Fix of the issue that after the system has started
the network coverage wasn't updated for a long time
on the lock screen.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
