### PR TITLE
[MOS-484] Fix freezes on the screen with the logo

### DIFF
--- a/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
+++ b/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
@@ -381,6 +381,11 @@ namespace app::manager
 
         auto currentlyFocusedApp = getFocusedApplication();
         if (currentlyFocusedApp == nullptr) {
+            if (auto appState = app->state(); appState == ApplicationCommon::State::INITIALIZING ||
+                                              appState == ApplicationCommon::State::ACTIVATING) {
+                LOG_INFO("No focused application at the moment, but %s is starting already...", app->name().c_str());
+                return false;
+            }
             LOG_INFO("No focused application at the moment. Starting new application...");
             onApplicationSwitch(*app, std::move(msg->getData()), msg->getWindow());
             startApplication(*app);


### PR DESCRIPTION
**Description**

Sometimes the Mudita logo screen was still visible
even though the phone turned on and initialized properly.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
