### PR TITLE
[CP-1310] Add timeLeftToNextAttempt field to security EP

### DIFF
--- a/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
@@ -108,13 +108,14 @@ namespace sdesktop::endpoints::json
 
     namespace usb
     {
-        inline constexpr auto config          = "config";
-        inline constexpr auto locked          = "locked";
-        inline constexpr auto unlocked        = "unlocked";
-        inline constexpr auto security        = "usbSecurity";
-        inline constexpr auto phoneLockCode   = "phoneLockCode";
-        inline constexpr auto phoneLockStatus = "phoneLockStatus";
-        inline constexpr auto phoneLockTime   = "phoneLockTime";
+        inline constexpr auto config                = "config";
+        inline constexpr auto locked                = "locked";
+        inline constexpr auto unlocked              = "unlocked";
+        inline constexpr auto security              = "usbSecurity";
+        inline constexpr auto phoneLockCode         = "phoneLockCode";
+        inline constexpr auto phoneLockStatus       = "phoneLockStatus";
+        inline constexpr auto phoneLockTime         = "phoneLockTime";
+        inline constexpr auto timeLeftToNextAttempt = "timeLeftToNextAttempt";
     } // namespace usb
 
 } // namespace sdesktop::endpoints::json

--- a/test/pytest/service-desktop/test_security.py
+++ b/test/pytest/service-desktop/test_security.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 import logging
 
@@ -192,6 +192,7 @@ def test_security_time_lock(harness):
     assert security_tester.confirm_phone_is_locked(), "Phone is unlocked, but should be locked!"
 
     assert time.time() < GetPhoneLockTime().run(harness).phoneLockTime <= time.time() + 30
+    assert GetPhoneLockTime().run(harness).timeLeftToNextAttempt <= 15
 
     """
     Attempt unlocking with default (correct) passcode while phone is time locked


### PR DESCRIPTION
**Description**

The time of the next attempt to unlock the phone on
the MC side was bonded with the system time of
the MC host system. This could lead to issues when
the time on Pure was different than on MC host
operating system. Now everything relies on Pure
system time.

Documentation updated: https://appnroll.atlassian.net/wiki/pages/diffpagesbyversion.action?pageId=1299415622&selectedPageVersions=15&selectedPageVersions=13

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
