### PR TITLE
[MOS-486] Fix the first day of month in the calendar

### DIFF
--- a/module-apps/application-calendar/models/MonthModel.cpp
+++ b/module-apps/application-calendar/models/MonthModel.cpp
@@ -34,12 +34,7 @@ uint32_t MonthModel::getLastDay()
 
 uint32_t MonthModel::getFirstWeekOffset()
 {
-    if (this->firstWeekDayNumb == 0) {
-        return 6;
-    }
-    else {
-        return this->firstWeekDayNumb;
-    }
+    return this->firstWeekDayNumb;
 }
 
 std::vector<std::string> MonthModel::split(const std::string &s, char delim)

--- a/module-apps/application-calendar/models/MonthModel.cpp
+++ b/module-apps/application-calendar/models/MonthModel.cpp
@@ -14,7 +14,7 @@ MonthModel::MonthModel(date::year_month_day yearMonthDay)
     date::year_month_day_last yearMonthDayLast = this->year / this->month / date::last;
     this->lastDay                              = static_cast<unsigned>(yearMonthDayLast.day());
     date::year_month_day yearMonthDayFirst     = this->year / this->month / 1;
-    this->firstWeekDayNumb                     = date::weekday{yearMonthDayFirst}.c_encoding();
+    this->firstWeekDayNumber                   = date::weekday{yearMonthDayFirst}.c_encoding();
 }
 
 date::year MonthModel::getYear()
@@ -34,7 +34,7 @@ uint32_t MonthModel::getLastDay()
 
 uint32_t MonthModel::getFirstWeekOffset()
 {
-    return this->firstWeekDayNumb;
+    return this->firstWeekDayNumber;
 }
 
 std::vector<std::string> MonthModel::split(const std::string &s, char delim)

--- a/module-apps/application-calendar/models/MonthModel.hpp
+++ b/module-apps/application-calendar/models/MonthModel.hpp
@@ -64,6 +64,6 @@ class MonthModel
     date::month month;
     uint32_t lastDay;
     // first week offset
-    uint32_t firstWeekDayNumb;
+    uint32_t firstWeekDayNumber;
     date::year year;
 };


### PR DESCRIPTION
By simplifying the logic, apparently the calendar got fixed.

Checked manually for the whole year 2022 and briefly for 2021, 2023.

Adding no unit tests because this was intended as a quick fix due to the plans to throw away and replace the whole logic.

**Your checklist for this pull request**

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated
