### PR TITLE
[MOS-494] PIN settings infinite loop fix

### DIFF
--- a/module-apps/application-settings/ApplicationSettings.cpp
+++ b/module-apps/application-settings/ApplicationSettings.cpp
@@ -383,9 +383,11 @@ namespace app
         windowsFactory.attach(gui::window::name::sim_cards, [](ApplicationCommon *app, const std::string &name) {
             return std::make_unique<gui::SimCardsWindow>(app, static_cast<ApplicationSettings *>(app));
         });
-        windowsFactory.attach(gui::window::name::sim_pin_settings, [](ApplicationCommon *app, const std::string &name) {
-            return std::make_unique<gui::SimPINSettingsWindow>(app);
-        });
+        windowsFactory.attach(gui::window::name::sim_pin_settings,
+                              [&](ApplicationCommon *app, const std::string &name) {
+                                  auto presenter = std::make_unique<SimPINSettingsPresenter>(this);
+                                  return std::make_unique<gui::SimPINSettingsWindow>(app, std::move(presenter));
+                              });
         windowsFactory.attach(gui::window::name::import_contacts, [&](ApplicationCommon *app, const std::string &name) {
             auto repository = std::make_unique<SimContactsRepository>(this);
             auto model      = std::make_unique<SimContactsImportModel>(this, std::move(repository));

--- a/module-apps/application-settings/CMakeLists.txt
+++ b/module-apps/application-settings/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(application-settings
         models/system/TechnicalInformationRepository.cpp
         models/bluetooth/BluetoothSettingsModel.cpp
         presenter/network/SimContactsImportWindowPresenter.cpp
+        presenter/network/SimPINSettingsPresenter.cpp
         presenter/system/SARInfoWindowPresenter.cpp
         presenter/system/TechnicalWindowPresenter.cpp
         widgets/advanced/ColorTestListItem.cpp

--- a/module-apps/application-settings/presenter/network/SimPINSettingsPresenter.cpp
+++ b/module-apps/application-settings/presenter/network/SimPINSettingsPresenter.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "SimPINSettingsPresenter.hpp"
+
+#include <application-settings/data/PINSettingsLockStateData.hpp>
+#include <application-settings/data/PINSettingsSimData.hpp>
+#include <EventStore.hpp>
+
+SimPINSettingsPresenter::SimPINSettingsPresenter(app::ApplicationCommon *application) : application(application)
+{}
+
+void SimPINSettingsPresenter::setCurrentPinState(bool state) noexcept
+{
+    isPinOn = state;
+}
+
+void SimPINSettingsPresenter::togglePinState()
+{
+    isPinOn = !isPinOn;
+    if (!isPinOn) {
+        application->getSimLockSubject().disableSimPin();
+    }
+    else {
+        application->getSimLockSubject().enableSimPin();
+    }
+}
+
+bool SimPINSettingsPresenter::getPinState() const noexcept
+{
+    return isPinOn;
+}
+
+void SimPINSettingsPresenter::requestLockState() const
+{
+    application->bus.sendUnicast<cellular::msg::request::sim::GetLockState>();
+}
+
+void SimPINSettingsPresenter::onBeforeShow(gui::ShowMode mode, gui::SwitchData *data)
+{
+    const auto view = getView();
+
+    if (const auto pinSettingsSimData = dynamic_cast<gui::PINSettingsSimData *>(data); pinSettingsSimData != nullptr) {
+        view->setTitle(utils::translate("app_settings_network_pin_settings") + " (" + pinSettingsSimData->getSim() +
+                       ")");
+    }
+
+    if (const auto pinSettingsLockStateData = dynamic_cast<gui::PINSettingsLockStateData *>(data);
+        pinSettingsLockStateData != nullptr) {
+        view->setNavbarCenterActive(true);
+        pinLockStateChanged = getPinState() == pinSettingsLockStateData->getSimCardPinLockState() ? false : true;
+        if (pinLockStateChanged) {
+            const auto currentPinState = pinSettingsLockStateData->getSimCardPinLockState();
+            setCurrentPinState(currentPinState);
+        }
+    }
+    if (not Store::GSM::get()->simCardInserted()) {
+        view->setNavbarCenterActive(false);
+        return;
+    }
+    if (mode == gui::ShowMode::GUI_SHOW_RETURN) {
+        requestLockState();
+    }
+    if (mode == gui::ShowMode::GUI_SHOW_INIT || pinLockStateChanged) {
+        view->refreshOptionsList();
+    }
+}

--- a/module-apps/application-settings/presenter/network/SimPINSettingsPresenter.hpp
+++ b/module-apps/application-settings/presenter/network/SimPINSettingsPresenter.hpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <BasePresenter.hpp>
+#include <Application.hpp>
+#include <SwitchData.hpp>
+
+class SimPINSettingsWindowContract
+{
+  public:
+    class View
+    {
+      public:
+        virtual ~View() noexcept                       = default;
+        virtual void setNavbarCenterActive(bool state) = 0;
+        virtual void setTitle(const UTF8 &text)        = 0;
+        virtual void refreshOptionsList()              = 0;
+    };
+    class Presenter : public app::BasePresenter<SimPINSettingsWindowContract::View>
+    {
+      public:
+        virtual ~Presenter() noexcept                                        = default;
+        virtual void setCurrentPinState(bool state) noexcept                 = 0;
+        virtual void togglePinState()                                        = 0;
+        virtual bool getPinState() const noexcept                            = 0;
+        virtual void requestLockState() const                                = 0;
+        virtual void onBeforeShow(gui::ShowMode mode, gui::SwitchData *data) = 0;
+    };
+};
+
+class SimPINSettingsPresenter : public SimPINSettingsWindowContract::Presenter
+{
+  public:
+    explicit SimPINSettingsPresenter(app::ApplicationCommon *application);
+    void setCurrentPinState(bool state) noexcept override;
+    void togglePinState() override;
+    bool getPinState() const noexcept override;
+    void requestLockState() const override;
+    void onBeforeShow(gui::ShowMode mode, gui::SwitchData *data) override;
+
+  private:
+    app::ApplicationCommon *application = nullptr;
+    bool isPinOn                        = false;
+    bool pinLockStateChanged            = false;
+};

--- a/module-apps/application-settings/windows/network/SimPINSettingsWindow.hpp
+++ b/module-apps/application-settings/windows/network/SimPINSettingsWindow.hpp
@@ -4,20 +4,24 @@
 #pragma once
 
 #include <application-settings/windows/BaseSettingsWindow.hpp>
+#include <application-settings/presenter/network/SimPINSettingsPresenter.hpp>
 
 namespace gui
 {
-    class SimPINSettingsWindow : public BaseSettingsWindow
+    class SimPINSettingsWindow : public BaseSettingsWindow, public SimPINSettingsWindowContract::View
     {
       public:
-        explicit SimPINSettingsWindow(app::ApplicationCommon *app);
+        explicit SimPINSettingsWindow(app::ApplicationCommon *app,
+                                      std::unique_ptr<SimPINSettingsWindowContract::Presenter> simPINPresenter);
 
       private:
         auto buildOptionsList() -> std::list<Option> override;
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
-        void changePinState(bool &currentState);
+        void setNavbarCenterActive(bool state) override;
+        void setTitle(const UTF8 &text) override;
+        void refreshOptionsList() override;
 
-        bool pinIsOn = false;
+        std::unique_ptr<SimPINSettingsWindowContract::Presenter> presenter;
         OptionWindowDestroyer rai_destroyer = OptionWindowDestroyer(*this);
     };
 } // namespace gui


### PR DESCRIPTION
**Description**

Fix of the bug that after selecting SIM slot
in which there's no card and trying to
enter PIN settings menu phone was getting
stuck in infinite looping between
PIN settings window and 'Cannot connect
to SIM card' popup.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
