### PR TITLE
[BH-1510] Remove alarm notification text on alarm edit

### DIFF
--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
@@ -100,6 +100,7 @@ namespace gui
         case app::home_screen::ViewState::AlarmEdit:
             alarm->setEditMode(EditMode::Edit);
             setHeaderViewMode(HeaderViewMode::AlarmIconAndTime);
+            removeTextDescription();
             break;
         case app::home_screen::ViewState::ActivatedWait:
             alarm->setAlarmStatus(AlarmSetSpinner::Status::ACTIVATED);


### PR DESCRIPTION
Homescreen alarm editing will remove the bottom text if exists

**Description**

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [X] Has unit tests if possible.
- [X] Has documentation updated

<!-- Thanks for your work ♥ -->
