### PR TITLE
[BH-1513] ListItems shift

### DIFF
--- a/products/BellHybrid/apps/common/include/common/widgets/list_items/NumberWithSuffix.hpp
+++ b/products/BellHybrid/apps/common/include/common/widgets/list_items/NumberWithSuffix.hpp
@@ -39,7 +39,8 @@ namespace app::list_items
       private:
         void control_bottom_description(const spinner_type::value_type &value) final
         {
-            body->lastBox->setVisible(value != 0);
+            bottomText->setVisible(value != 0);
+            body->resize();
         }
     };
 } // namespace app::list_items


### PR DESCRIPTION
**Description**

NumberWithSuffix list item contents
was shifted when going from view without
bottom text to the visible one.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
