### PR TITLE
[BH-1508] Off string not translated correctly

### DIFF
--- a/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsTimerSelectWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-background-sounds/windows/BGSoundsTimerSelectWindow.cpp
@@ -15,10 +15,9 @@ namespace
     using minutes = std::chrono::minutes;
     constexpr minutes offValue{minutes::zero()};
 
-    const std::string &getOffValueText()
+    const std::string getOffValueText()
     {
-        static const std::string offValueText = utils::translate("app_settings_toggle_off");
-        return offValueText;
+        return utils::translate("app_settings_toggle_off");
     }
 
     UTF8 timerValueToUTF8(minutes value)


### PR DESCRIPTION
**Description**

<!-- Please describe your pull request here -->

Relaxation app off value was not correctly translated due
to being defined as static const.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
