### PR TITLE
[MOS-463] Fix no dialing state during BT turned on

### DIFF
--- a/module-apps/application-desktop/widgets/DesktopInputWidget.cpp
+++ b/module-apps/application-desktop/widgets/DesktopInputWidget.cpp
@@ -1,14 +1,9 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DesktopInputWidget.hpp"
-
-#include <AppWindow.hpp>
-#include <Font.hpp>
 #include <service-cellular/CellularServiceAPI.hpp>
-#include <Style.hpp>
 
-#include <algorithm>
 
 namespace style::desktop
 {
@@ -65,7 +60,7 @@ namespace gui
         inputText->activatedCallback = [=](gui::Item &) {
             std::string data = inputText->getText().c_str();
             CellularServiceAPI::USSDRequest(
-                this->application, CellularUSSDMessage::RequestType::pullSesionRequest, data);
+                this->application, cellular::USSDMessage::RequestType::pullSessionRequest, data);
             inputText->clear();
             application->returnToPreviousWindow();
             return true;

--- a/module-apps/application-settings/ApplicationSettings.cpp
+++ b/module-apps/application-settings/ApplicationSettings.cpp
@@ -131,7 +131,7 @@ namespace app
             return retMsg;
         }
 
-        if (auto phoneMsg = dynamic_cast<CellularNotificationMessage *>(msgl); nullptr != phoneMsg) {
+        if (auto phoneMsg = dynamic_cast<cellular::NotificationMessage *>(msgl); nullptr != phoneMsg) {
             auto currentWindow = getCurrentWindow();
             if (gui::window::name::network == currentWindow->getName()) {
                 updateCurrentWindow();
@@ -260,9 +260,9 @@ namespace app
             return sys::MessageNone{};
         });
 
-        connect(typeid(CellularGetAPNResponse), [&](sys::Message *msg) {
+        connect(typeid(cellular::GetAPNResponse), [&](sys::Message *msg) {
             if (gui::window::name::apn_settings == getCurrentWindow()->getName()) {
-                auto apns = dynamic_cast<CellularGetAPNResponse *>(msg);
+                auto apns = dynamic_cast<cellular::GetAPNResponse *>(msg);
                 if (apns != nullptr) {
                     auto apnsData = std::make_unique<gui::ApnListData>(apns->getAPNs());
                     switchWindow(gui::window::name::apn_settings, std::move(apnsData));

--- a/module-apps/application-settings/models/network/ApnSettingsModel.cpp
+++ b/module-apps/application-settings/models/network/ApnSettingsModel.cpp
@@ -1,9 +1,7 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApnSettingsModel.hpp"
-
-#include <service-cellular/PacketDataCellularMessage.hpp>
 #include <service-cellular/ServiceCellular.hpp>
 
 ApnSettingsModel::ApnSettingsModel(app::ApplicationCommon *application) : application{application}
@@ -11,7 +9,7 @@ ApnSettingsModel::ApnSettingsModel(app::ApplicationCommon *application) : applic
 
 void ApnSettingsModel::requestAPNList()
 {
-    application->bus.sendUnicast(std::make_shared<CellularGetAPNMessage>(), ServiceCellular::serviceName);
+    application->bus.sendUnicast(std::make_shared<cellular::GetAPNMessage>(), ServiceCellular::serviceName);
 }
 
 void ApnSettingsModel::saveAPN(const std::shared_ptr<packet_data::APN::Config> &apn)
@@ -32,5 +30,5 @@ void ApnSettingsModel::removeAPN(const std::shared_ptr<packet_data::APN::Config>
 void ApnSettingsModel::setAsDefaultAPN(const std::shared_ptr<packet_data::APN::Config> &apn)
 {
     apn->apnType = packet_data::APN::APNType::Default;
-    application->bus.sendUnicast(std::make_shared<CellularSetAPNMessage>(apn), ServiceCellular::serviceName);
+    application->bus.sendUnicast(std::make_shared<cellular::SetAPNMessage>(apn), ServiceCellular::serviceName);
 }

--- a/module-apps/apps-common/ApplicationCommon.cpp
+++ b/module-apps/apps-common/ApplicationCommon.cpp
@@ -2,58 +2,31 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationCommon.hpp"
-#include "Common.hpp"      // for RefreshModes
 #include "GuiTimer.hpp"    // for GuiTimer
-#include "Item.hpp"        // for Item
-#include "MessageType.hpp" // for MessageType
-#include "Service/Message.hpp"
 #include "Timers/TimerFactory.hpp" // for Timer
-#include "StatusBar.hpp"
-#include "service-db/DBNotificationMessage.hpp"
 #include "status-bar/Time.hpp"
-#include "Translator.hpp" // for KeyInputSim...
-#include <EventStore.hpp> // for Battery
-#include <hal/key_input/RawKey.hpp>
-#include "gui/input/InputEvent.hpp" // for InputEvent
-#include <log/debug.hpp>            // for DEBUG_APPLI...
-#include <log/log.hpp>              // for LOG_INFO
-#include "messages/AppMessage.hpp"  // for AppSwitchMe...
 #include "messages/AppSwitchWindowPopupMessage.hpp"
 #include "service-appmgr/Controller.hpp" // for Controller
 #include "actions/AlarmClockStatusChangeParams.hpp"
-#include <service-cellular-api>
 #include <service-cellular/CellularMessage.hpp>
 #include <service-desktop/DesktopMessages.hpp>
-#include <service-evtmgr/BatteryMessages.hpp>
 #include <service-evtmgr/Constants.hpp>
 #include <service-evtmgr/EVMessages.hpp>
 #include <service-appmgr/messages/DOMRequest.hpp>
-#include <service-appmgr/messages/UserPowerDownRequest.hpp>
 #include <service-appmgr/data/NotificationsChangedActionsParams.hpp>
 #include "service-gui/messages/DrawMessage.hpp" // for DrawMessage
-#include "task.h"                               // for xTaskGetTic...
 #include "windows/AppWindow.hpp"                // for AppWindow
 #include "DOMResponder.hpp"
-#include <Text.hpp>    // for Text
-#include <algorithm>   // for find
-#include <iterator>    // for distance, next
-#include <type_traits> // for add_const<>...
-#include <WindowsFactory.hpp>
 #include <WindowsStack.hpp>
 #include <WindowsPopupFilter.hpp>
 #include <service-gui/Common.hpp>
-#include <Utils.hpp>
+
 #include <service-db/Settings.hpp>
 #include <service-db/agents/settings/SystemSettings.hpp>
 #include <service-audio/AudioServiceAPI.hpp> // for GetOutputVolume
 
-#include <popups/data/PopupData.hpp>
-#include <popups/data/PopupRequestParams.hpp>
-#include <popups/data/AlarmPopupRequestParams.hpp>
 #include <popups/data/PhoneModeParams.hpp>
 #include <popups/data/BluetoothModeParams.hpp>
-#include <locks/data/LockData.hpp>
-#include <magic_enum.hpp>
 
 #if DEBUG_INPUT_EVENTS == 1
 #define debug_input_events(...) LOG_DEBUG(__VA_ARGS__)
@@ -339,12 +312,12 @@ namespace app
 
     sys::MessagePointer ApplicationCommon::DataReceivedHandler(sys::DataMessage *msgl)
     {
-        auto msg = dynamic_cast<CellularNotificationMessage *>(msgl);
+        auto msg = dynamic_cast<cellular::NotificationMessage *>(msgl);
         if (msg != nullptr) {
-            if (msg->content == CellularNotificationMessage::Content::SignalStrengthUpdate) {
+            if (msg->content == cellular::NotificationMessage::Content::SignalStrengthUpdate) {
                 return handleSignalStrengthUpdate(msgl);
             }
-            if (msg->content == CellularNotificationMessage::Content::NetworkStatusUpdate) {
+            if (msg->content == cellular::NotificationMessage::Content::NetworkStatusUpdate) {
                 return handleNetworkAccessTechnologyUpdate(msgl);
             }
         }

--- a/module-apps/apps-common/notifications/NotificationsHandler.cpp
+++ b/module-apps/apps-common/notifications/NotificationsHandler.cpp
@@ -2,12 +2,8 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "NotificationsHandler.hpp"
-#include <service-db/DBServiceAPI.hpp>
-#include <log/log.hpp>
 #include <service-cellular/service-cellular/CellularMessage.hpp>
-#include <service-appmgr/Controller.hpp>
 #include <service-audio/AudioServiceAPI.hpp>
-#include <service-cellular/CellularServiceAPI.hpp>
 
 using namespace notifications;
 
@@ -17,7 +13,7 @@ NotificationsHandler::NotificationsHandler(sys::Service *parentService, Notifica
 
 void NotificationsHandler::registerMessageHandlers()
 {
-    parentService->connect(typeid(CellularIncomingSMSNotificationMessage),
+    parentService->connect(typeid(cellular::IncomingSMSNotificationMessage),
                            [&](sys::Message *request) -> sys::MessagePointer {
                                incomingSMSHandler();
                                return sys::msgHandled();

--- a/module-bluetooth/Bluetooth/BluetoothStateMachine.hpp
+++ b/module-bluetooth/Bluetooth/BluetoothStateMachine.hpp
@@ -5,7 +5,6 @@
 
 #define BOOST_SML_CFG_DISABLE_MIN_SIZE // GCC10 fix
 #include <boost/sml.hpp>
-#include <sml-utils/Logger.hpp>
 #include <stdexcept>
 #include "command/event/Events.hpp"
 #include "service-bluetooth/SettingsHolder.hpp"
@@ -13,6 +12,7 @@
 #include "WorkerController.hpp"
 #include "Device.hpp"
 #include <log/log.hpp>
+#include <sml-utils/Logger.hpp>
 
 namespace bluetooth
 {
@@ -364,10 +364,9 @@ namespace bluetooth
                         state<Idle> + sml::event<bluetooth::event::StartStream>/ StartAudio = state<Idle>,
                         state<Idle> + sml::event<bluetooth::event::StopStream>/ StopAudio = state<Idle>,
 
-                        state<Idle> + sml::event<bluetooth::event::StartRouting> / forwardEvent = state<Call>,
-
-                        state<Idle> + sml::event<bluetooth::event::IncomingCallNumber>  / forwardEvent = state<Call>,
-                        state<Idle> + sml::event<bluetooth::event::CallStarted> / forwardEvent = state<Call>,
+                        state<Idle> + sml::event<bluetooth::event::StartRouting> / forwardEvent= state<Call>,
+                        state<Idle> + sml::event<bluetooth::event::IncomingCallNumber>  / forwardEvent  = state<Call>,
+                        state<Idle> + sml::event<bluetooth::event::CallStarted> / forwardEvent= state<Call>,
                         state<Call> = state<Idle> // this one is needed to go out from Call substate properly!
 
                             );

--- a/module-bluetooth/Bluetooth/BtKeysStorage.cpp
+++ b/module-bluetooth/Bluetooth/BtKeysStorage.cpp
@@ -74,7 +74,7 @@ namespace bluetooth
 
             json11::Json finalJson = json11::Json::object{{strings::keys, keys}};
             auto keysEntryDump     = finalJson.dump();
-            LOG_INFO("Current keys state: %s", keysEntryDump.c_str());
+            LOG_DEBUG("Current keys state: %s", keysEntryDump.c_str());
 
             if (keys.empty()) {
                 LOG_ERROR("Keys empty!");
@@ -84,7 +84,7 @@ namespace bluetooth
             auto ret = processOnFoundKey(bd_addr, [&type, &link_key](const json11::Json &key, bd_addr_t) {
                 auto foundLinkKey = key[strings::link_key].string_value().c_str();
                 memcpy(link_key, reinterpret_cast<const uint8_t *>(foundLinkKey), sizeof(link_key_t));
-                LOG_INFO("Getting key: %s", foundLinkKey);
+                LOG_DEBUG("Getting key: %s", foundLinkKey);
                 *type = static_cast<link_key_type_t>(key[strings::type].int_value());
 
                 return 1;

--- a/module-bluetooth/Bluetooth/interface/profiles/HFP/HFP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/HFP/HFP.cpp
@@ -480,6 +480,9 @@ namespace bluetooth
         if (currentCallStatus == CallStatus::Incoming) {
             hfp_ag_answer_incoming_call(); // will answer the call if it wasn't answered
         }
+        else {
+            hfp_ag_outgoing_call_established();
+        }
         currentCallStatus = CallStatus::Active;
         return Error::Success;
     }
@@ -521,9 +524,10 @@ namespace bluetooth
         if (currentCallStatus != CallStatus::OutgoingPlacedFromHFP) {
             LOG_DEBUG("Started outgoing call from Pure");
             hfp_ag_outgoing_call_initiated(number.c_str());
+            hfp_ag_outgoing_call_accepted();
+            hfp_ag_outgoing_call_ringing();
             currentCallStatus = CallStatus::OutgoingPlacedFromPure;
         }
-        hfp_ag_outgoing_call_established();
         return Error::Success;
     }
     auto HFP::HFPImpl::setNetworkRegistrationStatus(bool registered) const noexcept -> Error::Code

--- a/module-bluetooth/Bluetooth/interface/profiles/PhoneInterface.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/PhoneInterface.cpp
@@ -18,7 +18,7 @@ namespace bluetooth
     }
     bool CellularInterfaceImpl::sendDTMFCode(sys::Service *service, DTMFCode code)
     {
-        auto msg = std::make_shared<CellularDtmfRequestMessage>(code);
+        auto msg = std::make_shared<cellular::DtmfRequestMessage>(code);
         service->bus.sendUnicast(std::move(msg), service::name::cellular);
         return true;
     }

--- a/module-cellular/modem/ATParser.cpp
+++ b/module-cellular/modem/ATParser.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ATParser.hpp"
@@ -90,7 +90,7 @@ at::Result ATParser::processNewData(sys::Service *service, const bsp::cellular::
         // 1) RDY
         // 2) +CFUN: 1
         if (urcs.size() == 2) {
-            auto msg = std::make_shared<CellularPowerUpProcedureCompleteNotification>();
+            auto msg = std::make_shared<cellular::PowerUpProcedureCompleteNotification>();
             service->bus.sendMulticast(std::move(msg), sys::BusChannel::ServiceCellularNotifications);
             urcs.clear();
 

--- a/module-cellular/modem/mux/CellularMux.cpp
+++ b/module-cellular/modem/mux/CellularMux.cpp
@@ -431,7 +431,7 @@ CellularMux::ConfState CellularMux::startMultiplexer()
             SignalStrength signalStrength(strength);
             if (signalStrength.isValid()) {
                 Store::GSM::get()->setSignalStrength(signalStrength.data);
-                auto msg = std::make_shared<CellularSignalStrengthUpdateNotification>();
+                auto msg = std::make_shared<cellular::SignalStrengthUpdateNotification>();
                 parentService->bus.sendMulticast(std::move(msg), sys::BusChannel::ServiceCellularNotifications);
             }
         }

--- a/module-db/tests/DbInitializer.cpp
+++ b/module-db/tests/DbInitializer.cpp
@@ -4,10 +4,8 @@
 #include "module-db/Database/DatabaseInitializer.hpp"
 
 #include <algorithm>
-#include <cstdio>
-#include <memory>
 #include <set>
-#include <string>
+#include <array>
 #include <log/log.hpp>
 
 DatabaseInitializer::DatabaseInitializer(Database *db) : db(db)

--- a/module-services/service-antenna/ServiceAntenna.cpp
+++ b/module-services/service-antenna/ServiceAntenna.cpp
@@ -382,7 +382,7 @@ void ServiceAntenna::registerMessageHandlers()
         return sys::MessageNone{};
     });
 
-    connect(typeid(CellularSignalStrengthUpdateNotification), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::SignalStrengthUpdateNotification), [&](sys::Message *request) -> sys::MessagePointer {
         currentCsq = Store::GSM::get()->getSignalStrength().rssi;
         if (state->get() == antenna::State::idle) {
             state->set(antenna::State::csqChange);
@@ -390,28 +390,28 @@ void ServiceAntenna::registerMessageHandlers()
         return sys::MessageNone{};
     });
 
-    connect(typeid(CellularIncominCallMessage), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::IncomingCallMessage), [&](sys::Message *request) -> sys::MessagePointer {
         auto message =
             std::make_shared<AntennaLockRequestMessage>(MessageType::AntennaLockService, antenna::lockState::locked);
         bus.sendUnicast(std::move(message), service::name::antenna);
         return sys::MessageNone{};
     });
 
-    connect(typeid(CellularRingingMessage), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::RingingMessage), [&](sys::Message *request) -> sys::MessagePointer {
         auto message =
             std::make_shared<AntennaLockRequestMessage>(MessageType::AntennaLockService, antenna::lockState::locked);
         bus.sendUnicast(std::move(message), service::name::antenna);
         return sys::MessageNone{};
     });
 
-    connect(typeid(CellularHangupCallMessage), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::HangupCallMessage), [&](sys::Message *request) -> sys::MessagePointer {
         auto message =
             std::make_shared<AntennaLockRequestMessage>(MessageType::AntennaLockService, antenna::lockState::unlocked);
         bus.sendUnicast(std::move(message), service::name::antenna);
         return sys::MessageNone{};
     });
 
-    connect(typeid(CellularCallAbortedNotification), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::CallAbortedNotification), [&](sys::Message *request) -> sys::MessagePointer {
         auto message =
             std::make_shared<AntennaLockRequestMessage>(MessageType::AntennaLockService, antenna::lockState::unlocked);
         bus.sendUnicast(std::move(message), service::name::antenna);

--- a/module-services/service-bluetooth/ServiceBluetooth.cpp
+++ b/module-services/service-bluetooth/ServiceBluetooth.cpp
@@ -110,7 +110,6 @@ sys::ReturnCodes ServiceBluetooth::InitHandler()
     connectHandler<message::bluetooth::ResponseAuthenticatePairCancel>();
     connectHandler<message::bluetooth::RequestStatusIndicatorData>();
     connectHandler<CellularCallerIdMessage>();
-    connectHandler<CellularCallActiveNotification>();
     connectHandler<CellularIncominCallMessage>();
     connectHandler<cellular::CallEndedNotification>();
     connectHandler<cellular::CallStartedNotification>();
@@ -118,6 +117,7 @@ sys::ReturnCodes ServiceBluetooth::InitHandler()
     connectHandler<CellularCurrentOperatorNameNotification>();
     connectHandler<CellularNetworkStatusUpdateNotification>();
     connectHandler<sevm::BatteryStatusChangeMessage>();
+    connectHandler<cellular::CallOutgoingAccepted>();
 
     settingsHolder->onStateChange = [this]() {
         auto initialState = std::visit(bluetooth::IntVisitor(), settingsHolder->getValue(bluetooth::Settings::State));
@@ -496,12 +496,6 @@ auto ServiceBluetooth::handle(CellularCallerIdMessage *msg) -> std::shared_ptr<s
     return sys::MessageNone{};
 }
 
-auto ServiceBluetooth::handle(CellularCallActiveNotification *msg) -> std::shared_ptr<sys::Message>
-{
-    sendWorkerCommand(std::make_unique<bluetooth::event::CallAnswered>());
-    return std::make_shared<sys::ResponseMessage>();
-}
-
 auto ServiceBluetooth::handle(CellularSignalStrengthUpdateNotification *msg) -> std::shared_ptr<sys::Message>
 {
     auto signalStrength = Store::GSM::get()->getSignalStrength();
@@ -589,5 +583,12 @@ auto ServiceBluetooth::handle(cellular::CallStartedNotification *msg) -> std::sh
 auto ServiceBluetooth::handle(CellularIncominCallMessage *msg) -> std::shared_ptr<sys::Message>
 {
     sendWorkerCommand(std::make_unique<bluetooth::event::StartRinging>());
+    return sys::MessageNone{};
+}
+auto ServiceBluetooth::handle(cellular::CallOutgoingAccepted *msg) -> std::shared_ptr<sys::Message>
+{
+    LOG_DEBUG("Outgoing call accepted");
+    sendWorkerCommand(std::make_unique<bluetooth::event::CallAnswered>());
+
     return sys::MessageNone{};
 }

--- a/module-services/service-bluetooth/ServiceBluetooth.cpp
+++ b/module-services/service-bluetooth/ServiceBluetooth.cpp
@@ -109,13 +109,13 @@ sys::ReturnCodes ServiceBluetooth::InitHandler()
     connectHandler<message::bluetooth::ResponseAuthenticatePasskey>();
     connectHandler<message::bluetooth::ResponseAuthenticatePairCancel>();
     connectHandler<message::bluetooth::RequestStatusIndicatorData>();
-    connectHandler<CellularCallerIdMessage>();
-    connectHandler<CellularIncominCallMessage>();
+    connectHandler<cellular::CallerIdMessage>();
+    connectHandler<cellular::IncomingCallMessage>();
     connectHandler<cellular::CallEndedNotification>();
     connectHandler<cellular::CallStartedNotification>();
-    connectHandler<CellularSignalStrengthUpdateNotification>();
-    connectHandler<CellularCurrentOperatorNameNotification>();
-    connectHandler<CellularNetworkStatusUpdateNotification>();
+    connectHandler<cellular::SignalStrengthUpdateNotification>();
+    connectHandler<cellular::CurrentOperatorNameNotification>();
+    connectHandler<cellular::NetworkStatusUpdateNotification>();
     connectHandler<sevm::BatteryStatusChangeMessage>();
     connectHandler<cellular::CallOutgoingAccepted>();
 
@@ -482,7 +482,7 @@ auto ServiceBluetooth::handle(message::bluetooth::StartAudioRouting *msg) -> std
     return std::make_shared<sys::ResponseMessage>();
 }
 
-auto ServiceBluetooth::handle(CellularCallerIdMessage *msg) -> std::shared_ptr<sys::Message>
+auto ServiceBluetooth::handle(cellular::CallerIdMessage *msg) -> std::shared_ptr<sys::Message>
 {
     auto number = msg->number;
     auto btOn   = std::visit(bluetooth::BoolVisitor(), settingsHolder->getValue(bluetooth::Settings::State));
@@ -496,7 +496,7 @@ auto ServiceBluetooth::handle(CellularCallerIdMessage *msg) -> std::shared_ptr<s
     return sys::MessageNone{};
 }
 
-auto ServiceBluetooth::handle(CellularSignalStrengthUpdateNotification *msg) -> std::shared_ptr<sys::Message>
+auto ServiceBluetooth::handle(cellular::SignalStrengthUpdateNotification *msg) -> std::shared_ptr<sys::Message>
 {
     auto signalStrength = Store::GSM::get()->getSignalStrength();
     LOG_DEBUG("Bluetooth: RSSI %d/5", static_cast<int>(signalStrength.rssiBar));
@@ -504,7 +504,7 @@ auto ServiceBluetooth::handle(CellularSignalStrengthUpdateNotification *msg) -> 
     return std::make_shared<sys::ResponseMessage>();
 }
 
-auto ServiceBluetooth::handle(CellularCurrentOperatorNameNotification *msg) -> std::shared_ptr<sys::Message>
+auto ServiceBluetooth::handle(cellular::CurrentOperatorNameNotification *msg) -> std::shared_ptr<sys::Message>
 {
     auto opName = msg->getCurrentOperatorName();
     LOG_DEBUG("Bluetooth: Operator name: %s", opName.c_str());
@@ -544,12 +544,12 @@ void ServiceBluetooth::handleTurnOff()
 }
 auto ServiceBluetooth::handle(message::bluetooth::RequestStatusIndicatorData *msg) -> std::shared_ptr<sys::Message>
 {
-    bus.sendUnicast(std::make_shared<CellularRequestCurrentOperatorNameMessage>(), cellular::service::name);
+    bus.sendUnicast(std::make_shared<cellular::RequestCurrentOperatorNameMessage>(), cellular::service::name);
 
     // just to execute proper handle method and sending it back to worker
-    bus.sendUnicast(std::make_shared<CellularSignalStrengthUpdateNotification>(), service::name::bluetooth);
+    bus.sendUnicast(std::make_shared<cellular::SignalStrengthUpdateNotification>(), service::name::bluetooth);
     bus.sendUnicast(std::make_shared<sevm::BatteryStatusChangeMessage>(), service::name::bluetooth);
-    bus.sendUnicast(std::make_shared<CellularNetworkStatusUpdateNotification>(), service::name::bluetooth);
+    bus.sendUnicast(std::make_shared<cellular::NetworkStatusUpdateNotification>(), service::name::bluetooth);
 
     return sys::MessageNone{};
 }
@@ -565,7 +565,7 @@ auto ServiceBluetooth::handle(cellular::CallEndedNotification *msg) -> std::shar
     sendWorkerCommand(std::make_unique<bluetooth::event::CallTerminated>());
     return sys::MessageNone{};
 }
-auto ServiceBluetooth::handle(CellularNetworkStatusUpdateNotification *msg) -> std::shared_ptr<sys::Message>
+auto ServiceBluetooth::handle(cellular::NetworkStatusUpdateNotification *msg) -> std::shared_ptr<sys::Message>
 {
     auto status = Store::GSM::get()->getNetwork().status;
     LOG_DEBUG("Bluetooth: Network status %s", magic_enum::enum_name(status).data());
@@ -580,7 +580,7 @@ auto ServiceBluetooth::handle(cellular::CallStartedNotification *msg) -> std::sh
     }
     return sys::MessageNone{};
 }
-auto ServiceBluetooth::handle(CellularIncominCallMessage *msg) -> std::shared_ptr<sys::Message>
+auto ServiceBluetooth::handle(cellular::IncomingCallMessage *msg) -> std::shared_ptr<sys::Message>
 {
     sendWorkerCommand(std::make_unique<bluetooth::event::StartRinging>());
     return sys::MessageNone{};

--- a/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
@@ -66,7 +66,6 @@ namespace sevm
 }
 
 class CellularCallerIdMessage;
-class CellularCallActiveNotification;
 class CellularSignalStrengthUpdateNotification;
 class CellularCurrentOperatorNameNotification;
 class CellularIncominCallMessage;
@@ -75,6 +74,7 @@ namespace cellular
 {
     class CallEndedNotification;
     class CallStartedNotification;
+    class CallOutgoingAccepted;
 }
 
 class ServiceBluetooth : public sys::Service
@@ -139,10 +139,10 @@ class ServiceBluetooth : public sys::Service
     [[nodiscard]] auto handle(message::bluetooth::ResponseAuthenticatePairCancel *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(message::bluetooth::RequestStatusIndicatorData *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(CellularCallerIdMessage *msg) -> std::shared_ptr<sys::Message>;
-    [[nodiscard]] auto handle(CellularCallActiveNotification *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(CellularIncominCallMessage *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(cellular::CallEndedNotification *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(cellular::CallStartedNotification *msg) -> std::shared_ptr<sys::Message>;
+    [[nodiscard]] auto handle(cellular::CallOutgoingAccepted *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(CellularSignalStrengthUpdateNotification *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(CellularCurrentOperatorNameNotification *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(CellularNetworkStatusUpdateNotification *msg) -> std::shared_ptr<sys::Message>;

--- a/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
@@ -65,16 +65,16 @@ namespace sevm
     class BatteryStatusChangeMessage;
 }
 
-class CellularCallerIdMessage;
-class CellularSignalStrengthUpdateNotification;
-class CellularCurrentOperatorNameNotification;
-class CellularIncominCallMessage;
-class CellularNetworkStatusUpdateNotification;
 namespace cellular
 {
     class CallEndedNotification;
     class CallStartedNotification;
     class CallOutgoingAccepted;
+    class IncomingCallMessage;
+    class CallerIdMessage;
+    class SignalStrengthUpdateNotification;
+    class CurrentOperatorNameNotification;
+    class NetworkStatusUpdateNotification;
 }
 
 class ServiceBluetooth : public sys::Service
@@ -138,14 +138,14 @@ class ServiceBluetooth : public sys::Service
     [[nodiscard]] auto handle(message::bluetooth::ResponseAuthenticatePasskey *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(message::bluetooth::ResponseAuthenticatePairCancel *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(message::bluetooth::RequestStatusIndicatorData *msg) -> std::shared_ptr<sys::Message>;
-    [[nodiscard]] auto handle(CellularCallerIdMessage *msg) -> std::shared_ptr<sys::Message>;
-    [[nodiscard]] auto handle(CellularIncominCallMessage *msg) -> std::shared_ptr<sys::Message>;
+    [[nodiscard]] auto handle(cellular::CallerIdMessage *msg) -> std::shared_ptr<sys::Message>;
+    [[nodiscard]] auto handle(cellular::IncomingCallMessage *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(cellular::CallEndedNotification *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(cellular::CallStartedNotification *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(cellular::CallOutgoingAccepted *msg) -> std::shared_ptr<sys::Message>;
-    [[nodiscard]] auto handle(CellularSignalStrengthUpdateNotification *msg) -> std::shared_ptr<sys::Message>;
-    [[nodiscard]] auto handle(CellularCurrentOperatorNameNotification *msg) -> std::shared_ptr<sys::Message>;
-    [[nodiscard]] auto handle(CellularNetworkStatusUpdateNotification *msg) -> std::shared_ptr<sys::Message>;
+    [[nodiscard]] auto handle(cellular::SignalStrengthUpdateNotification *msg) -> std::shared_ptr<sys::Message>;
+    [[nodiscard]] auto handle(cellular::CurrentOperatorNameNotification *msg) -> std::shared_ptr<sys::Message>;
+    [[nodiscard]] auto handle(cellular::NetworkStatusUpdateNotification *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(sevm::BatteryStatusChangeMessage *msg) -> std::shared_ptr<sys::Message>;
 };
 

--- a/module-services/service-cellular/CellularRequestHandler.cpp
+++ b/module-services/service-cellular/CellularRequestHandler.cpp
@@ -43,7 +43,7 @@ void CellularRequestHandler::handle(cellular::ImeiRequest &request, at::Result &
         response->addMessage(IMMICustomResultParams::MMIResultMessage::CommonFailure);
     }
 
-    auto msg = std::make_shared<CellularMMIResultMessage>(MMIResultParams::MMIResult::Success, response);
+    auto msg = std::make_shared<cellular::MMIResultMessage>(MMIResultParams::MMIResult::Success, response);
     cellular.bus.sendUnicast(msg, service::name::appmgr);
     request.setHandled(true);
 }
@@ -69,7 +69,7 @@ void CellularRequestHandler::handle(cellular::CallRequest &request, at::Result &
         return;
     }
     cellular.callStateTimer.start();
-    cellular.bus.sendMulticast(std::make_shared<CellularRingingMessage>(request.getNumber()),
+    cellular.bus.sendMulticast(std::make_shared<cellular::RingingMessage>(request.getNumber()),
                                sys::BusChannel::ServiceCellularNotifications);
     request.setHandled(true);
 }
@@ -77,15 +77,15 @@ void CellularRequestHandler::handle(cellular::CallRequest &request, at::Result &
 void CellularRequestHandler::handle(cellular::RejectRequest &request, at::Result &result)
 {
     if (request.getRejectReason() == cellular::RejectRequest::RejectReason::NoSim) {
-        auto message = std::make_shared<CellularNoSimNotification>(request.getNumber());
+        auto message = std::make_shared<cellular::NoSimNotification>(request.getNumber());
         cellular.bus.sendUnicast(message, service::name::appmgr);
     }
     else if (request.getRejectReason() == cellular::RejectRequest::RejectReason::NotAnEmergencyNumber) {
-        auto message = std::make_shared<CellularNotAnEmergencyNotification>(request.getNumber());
+        auto message = std::make_shared<cellular::NotAnEmergencyNotification>(request.getNumber());
         cellular.bus.sendUnicast(message, service::name::appmgr);
     }
     else if (request.getRejectReason() == cellular::RejectRequest::RejectReason::NoNetworkConnection) {
-        auto message = std::make_shared<CellularNoNetworkConenctionNotification>();
+        auto message = std::make_shared<cellular::NoNetworkConenctionNotification>();
         cellular.bus.sendUnicast(message, service::name::appmgr);
     }
     request.setHandled(true);
@@ -139,7 +139,7 @@ void CellularRequestHandler::handle(cellular::ClirRequest &request, at::Result &
             response->addMessage(IMMICustomResultParams::MMIResultMessage::CommonFailure);
         }
     }
-    auto msg = std::make_shared<CellularMMIResultMessage>(MMIResultParams::MMIResult::Success, response);
+    auto msg = std::make_shared<cellular::MMIResultMessage>(MMIResultParams::MMIResult::Success, response);
     cellular.bus.sendUnicast(msg, ::service::name::appmgr);
     request.setHandled(true);
 }
@@ -204,7 +204,7 @@ void CellularRequestHandler::handle(cellular::CallForwardingRequest &request, at
             std::make_shared<MMICallForwardingResult>(IMMICustomResultParams::MMIType::CallForwardingNotification);
         response->addMessage(IMMICustomResultParams::MMIResultMessage::CommonFailure);
     }
-    auto msg = std::make_shared<CellularMMIResultMessage>(MMIResultParams::MMIResult::Success, response);
+    auto msg = std::make_shared<cellular::MMIResultMessage>(MMIResultParams::MMIResult::Success, response);
     cellular.bus.sendUnicast(msg, ::service::name::appmgr);
     request.setHandled(true);
 }
@@ -253,7 +253,7 @@ void CellularRequestHandler::handle(cellular::CallBarringRequest &request, at::R
         response->addMessage(IMMICustomResultParams::MMIResultMessage::CommonFailure);
     }
 
-    auto msg = std::make_shared<CellularMMIResultMessage>(MMIResultParams::MMIResult::Success, response);
+    auto msg = std::make_shared<cellular::MMIResultMessage>(MMIResultParams::MMIResult::Success, response);
     cellular.bus.sendUnicast(msg, ::service::name::appmgr);
     request.setHandled(true);
 }
@@ -291,7 +291,7 @@ void CellularRequestHandler::handle(cellular::ClipRequest &request, at::Result &
         response->addMessage(IMMICustomResultParams::MMIResultMessage::CommonFailure);
     }
 
-    auto msg = std::make_shared<CellularMMIResultMessage>(MMIResultParams::MMIResult::Success, response);
+    auto msg = std::make_shared<cellular::MMIResultMessage>(MMIResultParams::MMIResult::Success, response);
     cellular.bus.sendUnicast(msg, ::service::name::appmgr);
     request.setHandled(true);
 }
@@ -338,7 +338,7 @@ void CellularRequestHandler::handle(cellular::CallWaitingRequest &request, at::R
         response = std::make_shared<MMICallWaitingResult>(IMMICustomResultParams::MMIType::CallWaitingNotification);
         response->addMessage(IMMICustomResultParams::MMIResultMessage::CommonFailure);
     }
-    auto msg = std::make_shared<CellularMMIResultMessage>(MMIResultParams::MMIResult::Success, response);
+    auto msg = std::make_shared<cellular::MMIResultMessage>(MMIResultParams::MMIResult::Success, response);
     cellular.bus.sendUnicast(msg, ::service::name::appmgr);
     request.setHandled(true);
 }
@@ -347,7 +347,7 @@ void CellularRequestHandler::sendMmiResult(bool result)
 {
     using namespace app::manager::actions;
 
-    auto msg = std::make_shared<CellularMMIResultMessage>(result ? MMIResultParams::MMIResult::Success
-                                                                 : MMIResultParams::MMIResult::Failed);
+    auto msg = std::make_shared<cellular::MMIResultMessage>(result ? MMIResultParams::MMIResult::Success
+                                                                   : MMIResultParams::MMIResult::Failed);
     cellular.bus.sendUnicast(msg, ::service::name::appmgr);
 }

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -220,7 +220,7 @@ void ServiceCellular::WakeUpHandler()
 void ServiceCellular::CallStateTimerHandler()
 {
     LOG_DEBUG("CallStateTimerHandler");
-    auto msg = std::make_shared<CellularListCallsMessage>();
+    auto msg = std::make_shared<cellular::ListCallsMessage>();
     bus.sendUnicast(std::move(msg), ServiceCellular::serviceName);
 }
 
@@ -336,59 +336,59 @@ void ServiceCellular::registerMessageHandlers()
     priv->connectImeiGetHandler();
     priv->connectCSQHandler();
 
-    connect(typeid(CellularStartOperatorsScanMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularStartOperatorsScanMessage *>(request);
+    connect(typeid(cellular::StartOperatorsScanMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::StartOperatorsScanMessage *>(request);
         return handleCellularStartOperatorsScan(msg);
     });
 
-    connect(typeid(CellularGetActiveContextsMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularGetActiveContextsMessage *>(request);
+    connect(typeid(cellular::GetActiveContextsMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::GetActiveContextsMessage *>(request);
         return handleCellularGetActiveContextsMessage(msg);
     });
 
-    connect(typeid(CellularRequestCurrentOperatorNameMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularRequestCurrentOperatorNameMessage *>(request);
+    connect(typeid(cellular::RequestCurrentOperatorNameMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::RequestCurrentOperatorNameMessage *>(request);
         handleCellularRequestCurrentOperatorName(msg);
         return sys::MessageNone{};
     });
 
-    connect(typeid(CellularGetAPNMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularGetAPNMessage *>(request);
+    connect(typeid(cellular::GetAPNMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::GetAPNMessage *>(request);
         return handleCellularGetAPNMessage(msg);
     });
 
-    connect(typeid(CellularSetAPNMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularSetAPNMessage *>(request);
+    connect(typeid(cellular::SetAPNMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::SetAPNMessage *>(request);
         return handleCellularSetAPNMessage(msg);
     });
 
-    connect(typeid(CellularNewAPNMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularNewAPNMessage *>(request);
+    connect(typeid(cellular::NewAPNMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::NewAPNMessage *>(request);
         return handleCellularNewAPNMessage(msg);
     });
 
-    connect(typeid(CellularSetDataTransferMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularSetDataTransferMessage *>(request);
+    connect(typeid(cellular::SetDataTransferMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::SetDataTransferMessage *>(request);
         return handleCellularSetDataTransferMessage(msg);
     });
 
-    connect(typeid(CellularGetDataTransferMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularGetDataTransferMessage *>(request);
+    connect(typeid(cellular::GetDataTransferMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::GetDataTransferMessage *>(request);
         return handleCellularGetDataTransferMessage(msg);
     });
 
-    connect(typeid(CellularActivateContextMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularActivateContextMessage *>(request);
+    connect(typeid(cellular::ActivateContextMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::ActivateContextMessage *>(request);
         return handleCellularActivateContextMessage(msg);
     });
 
-    connect(typeid(CellularDeactivateContextMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularDeactivateContextMessage *>(request);
+    connect(typeid(cellular::DeactivateContextMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::DeactivateContextMessage *>(request);
         return handleCellularDeactivateContextMessage(msg);
     });
 
-    connect(typeid(CellularChangeVoLTEDataMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularChangeVoLTEDataMessage *>(request);
+    connect(typeid(cellular::ChangeVoLTEDataMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::ChangeVoLTEDataMessage *>(request);
         volteOn  = msg->getVoLTEon();
         settings->setValue(settings::Cellular::volte_on, std::to_string(volteOn), settings::SettingsScope::Global);
         NetworkSettings networkSettings(*this);
@@ -405,16 +405,16 @@ void ServiceCellular::registerMessageHandlers()
                 priv->modemResetHandler->performSoftReset();
             }
         }
-        return std::make_shared<CellularResponseMessage>(true);
+        return std::make_shared<cellular::ResponseMessage>(true);
     });
 
-    connect(typeid(CellularSetFlightModeMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularSetFlightModeMessage *>(request);
+    connect(typeid(cellular::SetFlightModeMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::SetFlightModeMessage *>(request);
         return handleCellularSetFlightModeMessage(msg);
     });
 
-    connect(typeid(CellularPowerStateChange), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg             = static_cast<CellularPowerStateChange *>(request);
+    connect(typeid(cellular::PowerStateChange), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg             = static_cast<cellular::PowerStateChange *>(request);
         priv->nextPowerState = msg->getNewState();
         handle_power_state_change();
         return sys::MessageNone{};
@@ -452,35 +452,35 @@ void ServiceCellular::registerMessageHandlers()
         return sys::MessageNone{};
     });
 
-    connect(typeid(CellularNewIncomingSMSMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularNewIncomingSMSMessage *>(request);
+    connect(typeid(cellular::NewIncomingSMSMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::NewIncomingSMSMessage *>(request);
         auto ret = receiveSMS(msg->getData());
-        return std::make_shared<CellularResponseMessage>(ret);
+        return std::make_shared<cellular::ResponseMessage>(ret);
     });
 
-    connect(typeid(CellularAnswerIncomingCallMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularAnswerIncomingCallMessage *>(request);
+    connect(typeid(cellular::AnswerIncomingCallMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::AnswerIncomingCallMessage *>(request);
         return handleCellularAnswerIncomingCallMessage(msg);
     });
 
-    connect(typeid(CellularCallRequestMessage), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::CallRequestMessage), [&](sys::Message *request) -> sys::MessagePointer {
         if (phoneModeObserver->isInMode(sys::phone_modes::PhoneMode::Offline)) {
-            this->bus.sendUnicast(std::make_shared<CellularCallRejectedByOfflineNotification>(),
+            this->bus.sendUnicast(std::make_shared<cellular::CallRejectedByOfflineNotification>(),
                                   ::service::name::appmgr);
-            return std::make_shared<CellularResponseMessage>(true);
+            return std::make_shared<cellular::ResponseMessage>(true);
         }
 
-        auto msg = static_cast<CellularCallRequestMessage *>(request);
+        auto msg = static_cast<cellular::CallRequestMessage *>(request);
         return handleCellularCallRequestMessage(msg);
     });
 
-    connect(typeid(CellularHangupCallMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularHangupCallMessage *>(request);
+    connect(typeid(cellular::HangupCallMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::HangupCallMessage *>(request);
         handleCellularHangupCallMessage(msg);
         return sys::MessageNone{};
     });
 
-    connect(typeid(CellularDismissCallMessage), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::DismissCallMessage), [&](sys::Message *request) -> sys::MessagePointer {
         handleCellularDismissCallMessage(request);
         return sys::MessageNone{};
     });
@@ -490,8 +490,8 @@ void ServiceCellular::registerMessageHandlers()
         return handleDBQueryResponseMessage(msg);
     });
 
-    connect(typeid(CellularListCallsMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularListCallsMessage *>(request);
+    connect(typeid(cellular::ListCallsMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::ListCallsMessage *>(request);
         return handleCellularListCallsMessage(msg);
     });
 
@@ -500,97 +500,97 @@ void ServiceCellular::registerMessageHandlers()
         return handleDBNotificationMessage(msg);
     });
 
-    connect(typeid(CellularRingingMessage), [&](sys::Message *request) -> sys::MessagePointer {
-        auto msg = static_cast<CellularRingingMessage *>(request);
+    connect(typeid(cellular::RingingMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        auto msg = static_cast<cellular::RingingMessage *>(request);
         return handleCellularRingingMessage(msg);
     });
 
-    connect(typeid(CellularGetIMSIMessage),
+    connect(typeid(cellular::GetIMSIMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularGetIMSIMessage(request); });
 
-    connect(typeid(CellularGetOwnNumberMessage),
+    connect(typeid(cellular::GetOwnNumberMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularGetOwnNumberMessage(request); });
 
-    connect(typeid(CellularGetNetworkInfoMessage),
+    connect(typeid(cellular::GetNetworkInfoMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularGetNetworkInfoMessage(request); });
 
-    connect(typeid(CellularAntennaRequestMessage),
+    connect(typeid(cellular::AntennaRequestMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularSelectAntennaMessage(request); });
 
-    connect(typeid(CellularSetScanModeMessage),
+    connect(typeid(cellular::SetScanModeMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularSetScanModeMessage(request); });
 
-    connect(typeid(CellularGetScanModeMessage),
+    connect(typeid(cellular::GetScanModeMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularGetScanModeMessage(request); });
 
-    connect(typeid(CellularGetFirmwareVersionMessage), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::GetFirmwareVersionMessage), [&](sys::Message *request) -> sys::MessagePointer {
         return handleCellularGetFirmwareVersionMessage(request);
     });
 
     connect(typeid(sevm::StatusStateMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleEVMStatusMessage(request); });
 
-    connect(typeid(CellularGetCsqMessage),
+    connect(typeid(cellular::GetCsqMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularGetCsqMessage(request); });
 
-    connect(typeid(CellularGetCregMessage),
+    connect(typeid(cellular::GetCregMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularGetCregMessage(request); });
 
-    connect(typeid(CellularGetNwinfoMessage),
+    connect(typeid(cellular::GetNwinfoMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularGetNwinfoMessage(request); });
 
-    connect(typeid(CellularGetAntennaMessage),
+    connect(typeid(cellular::GetAntennaMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularGetAntennaMessage(request); });
 
-    connect(typeid(CellularDtmfRequestMessage),
+    connect(typeid(cellular::DtmfRequestMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularDtmfRequestMessage(request); });
 
-    connect(typeid(CellularUSSDMessage),
+    connect(typeid(cellular::USSDMessage),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularUSSDMessage(request); });
 
     connect(typeid(cellular::StateChange),
             [&](sys::Message *request) -> sys::MessagePointer { return handleStateRequestMessage(request); });
 
-    connect(typeid(CellularCallActiveNotification),
+    connect(typeid(cellular::CallActiveNotification),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCallActiveNotification(request); });
 
-    connect(typeid(CellularPowerUpProcedureCompleteNotification), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::PowerUpProcedureCompleteNotification), [&](sys::Message *request) -> sys::MessagePointer {
         return handlePowerUpProcedureCompleteNotification(request);
     });
 
-    connect(typeid(CellularPowerDownDeregisteringNotification), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::PowerDownDeregisteringNotification), [&](sys::Message *request) -> sys::MessagePointer {
         return handlePowerDownDeregisteringNotification(request);
     });
 
-    connect(typeid(CellularPowerDownDeregisteredNotification), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::PowerDownDeregisteredNotification), [&](sys::Message *request) -> sys::MessagePointer {
         return handlePowerDownDeregisteredNotification(request);
     });
 
-    connect(typeid(CellularNewIncomingSMSNotification),
+    connect(typeid(cellular::NewIncomingSMSNotification),
             [&](sys::Message *request) -> sys::MessagePointer { return handleNewIncomingSMSNotification(request); });
 
-    connect(typeid(CellularSmsDoneNotification),
+    connect(typeid(cellular::SmsDoneNotification),
             [&](sys::Message *request) -> sys::MessagePointer { return handleSmsDoneNotification(request); });
 
-    connect(typeid(CellularSignalStrengthUpdateNotification), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::SignalStrengthUpdateNotification), [&](sys::Message *request) -> sys::MessagePointer {
         csqCounter.count();
         return handleSignalStrengthUpdateNotification(request);
     });
 
-    connect(typeid(CellularNetworkStatusUpdateNotification), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::NetworkStatusUpdateNotification), [&](sys::Message *request) -> sys::MessagePointer {
         return handleNetworkStatusUpdateNotification(request);
     });
 
-    connect(typeid(CellularUrcIncomingNotification),
+    connect(typeid(cellular::UrcIncomingNotification),
             [&](sys::Message *request) -> sys::MessagePointer { return handleUrcIncomingNotification(request); });
 
-    connect(typeid(CellularRingNotification),
+    connect(typeid(cellular::RingNotification),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularRingNotification(request); });
 
-    connect(typeid(CellularCallerIdNotification),
+    connect(typeid(cellular::CallerIdNotification),
             [&](sys::Message *request) -> sys::MessagePointer { return handleCellularCallerIdNotification(request); });
 
-    connect(typeid(CellularSetConnectionFrequencyMessage), [&](sys::Message *request) -> sys::MessagePointer {
+    connect(typeid(cellular::SetConnectionFrequencyMessage), [&](sys::Message *request) -> sys::MessagePointer {
         return handleCellularSetConnectionFrequencyMessage(request);
     });
 
@@ -608,13 +608,13 @@ void ServiceCellular::registerMessageHandlers()
     /// aborted notification can come from:
     /// 1. URC
     /// 2. from here from handle cellular hangup
-    connect(typeid(CellularCallAbortedNotification), [&](sys::Message * /*request*/) -> sys::MessagePointer {
+    connect(typeid(cellular::CallAbortedNotification), [&](sys::Message * /*request*/) -> sys::MessagePointer {
         ongoingCall->handle(call::event::Ended{});
         return sys::MessageNone{};
     });
 
-    connect(typeid(CellularIsCallActive), [&](sys::Message * /*request*/) -> sys::MessagePointer {
-        return std::make_shared<CellularIsCallActiveResponse>(ongoingCall && ongoingCall->active());
+    connect(typeid(cellular::IsCallActive), [&](sys::Message * /*request*/) -> sys::MessagePointer {
+        return std::make_shared<cellular::IsCallActiveResponse>(ongoingCall && ongoingCall->active());
     });
 
     handle_CellularGetChannelMessage();
@@ -703,7 +703,7 @@ bool ServiceCellular::handle_idle()
 
 bool ServiceCellular::handle_wait_for_start_permission()
 {
-    auto msg = std::make_shared<CellularCheckIfStartAllowedMessage>();
+    auto msg = std::make_shared<cellular::CheckIfStartAllowedMessage>();
     bus.sendUnicast(msg, ::service::name::system_manager);
 
     return true;
@@ -1374,7 +1374,7 @@ void ServiceCellular::onSMSReceived(const utils::PhoneNumber::View &number)
         db::Interface::Name::Notifications,
         std::make_unique<db::query::notifications::Increment>(NotificationsRecord::Key::Sms, number));
 
-    bus.sendMulticast(std::make_shared<CellularIncomingSMSNotificationMessage>(),
+    bus.sendMulticast(std::make_shared<cellular::IncomingSMSNotificationMessage>(),
                       sys::BusChannel::ServiceCellularNotifications);
 }
 
@@ -1479,11 +1479,11 @@ bool ServiceCellular::transmitDtmfTone(DTMFCode code)
 
 void ServiceCellular::handle_CellularGetChannelMessage()
 {
-    connect(CellularGetChannelMessage(), [&](sys::Message *req) {
-        auto getChannelMsg = static_cast<CellularGetChannelMessage *>(req);
+    connect(cellular::GetChannelMessage(), [&](sys::Message *req) {
+        auto getChannelMsg = static_cast<cellular::GetChannelMessage *>(req);
         LOG_DEBUG("Handle request for channel: %s", CellularMux::name(getChannelMsg->dataChannel).c_str());
-        std::shared_ptr<CellularGetChannelResponseMessage> channelResponsMessage =
-            std::make_shared<CellularGetChannelResponseMessage>(cmux->get(getChannelMsg->dataChannel));
+        std::shared_ptr<cellular::GetChannelResponseMessage> channelResponsMessage =
+            std::make_shared<cellular::GetChannelResponseMessage>(cmux->get(getChannelMsg->dataChannel));
         LOG_DEBUG("channel ptr: %p", channelResponsMessage->dataChannelPtr);
         bus.sendUnicast(std::move(channelResponsMessage), req->sender);
         return sys::MessageNone{};
@@ -1573,13 +1573,13 @@ void ServiceCellular::handle_power_state_change()
     }
 }
 
-bool ServiceCellular::handleUSSDRequest(CellularUSSDMessage::RequestType requestType, const std::string &request)
+bool ServiceCellular::handleUSSDRequest(cellular::USSDMessage::RequestType requestType, const std::string &request)
 {
     constexpr uint32_t commandTimeout = 120000;
 
     auto channel = cmux->get(CellularMux::Channel::Commands);
     if (channel != nullptr) {
-        if (requestType == CellularUSSDMessage::RequestType::pullSesionRequest) {
+        if (requestType == cellular::USSDMessage::RequestType::pullSessionRequest) {
             channel->cmd(at::AT::SMS_GSM);
             std::string command = at::factory(at::AT::CUSD_SEND) + request + ",15";
             auto result         = channel->cmd(command, std::chrono::milliseconds(commandTimeout));
@@ -1588,20 +1588,20 @@ bool ServiceCellular::handleUSSDRequest(CellularUSSDMessage::RequestType request
                 setUSSDTimer();
             }
         }
-        else if (requestType == CellularUSSDMessage::RequestType::abortSesion) {
+        else if (requestType == cellular::USSDMessage::RequestType::abortSession) {
 
-            ussdState   = ussd::State::sesionAborted;
+            ussdState   = ussd::State::sessionAborted;
             auto result = channel->cmd(at::AT::CUSD_CLOSE_SESSION);
             if (result.code == at::Result::Code::OK) {
-                CellularServiceAPI::USSDRequest(this, CellularUSSDMessage::RequestType::pushSesionRequest);
+                CellularServiceAPI::USSDRequest(this, cellular::USSDMessage::RequestType::pushSessionRequest);
             }
             else {
-                CellularServiceAPI::USSDRequest(this, CellularUSSDMessage::RequestType::abortSesion);
+                CellularServiceAPI::USSDRequest(this, cellular::USSDMessage::RequestType::abortSession);
             }
         }
-        else if (requestType == CellularUSSDMessage::RequestType::pushSesionRequest) {
+        else if (requestType == cellular::USSDMessage::RequestType::pushSessionRequest) {
 
-            ussdState   = ussd::State::pushSesion;
+            ussdState   = ussd::State::pushSession;
             auto result = channel->cmd(at::AT::CUSD_OPEN_SESSION);
             if (result.code == at::Result::Code::OK) {}
         }
@@ -1616,9 +1616,9 @@ void ServiceCellular::handleUSSDTimer(void)
         ussdTimeout -= 1;
     }
     else {
-        LOG_WARN("USSD timeout occured, abotrig current session");
+        LOG_WARN("USSD timeout occurred, aborting current session");
         ussdTimer.stop();
-        CellularServiceAPI::USSDRequest(this, CellularUSSDMessage::RequestType::abortSesion);
+        CellularServiceAPI::USSDRequest(this, cellular::USSDMessage::RequestType::abortSession);
     }
 }
 void ServiceCellular::setUSSDTimer(void)
@@ -1630,8 +1630,8 @@ void ServiceCellular::setUSSDTimer(void)
     case ussd::State::pullResponseReceived:
         ussdTimeout = ussd::pullSesionTimeout;
         break;
-    case ussd::State::pushSesion:
-    case ussd::State::sesionAborted:
+    case ussd::State::pushSession:
+    case ussd::State::sessionAborted:
     case ussd::State::none:
         ussdTimeout = ussd::noTimeout;
         break;
@@ -1644,7 +1644,7 @@ void ServiceCellular::setUSSDTimer(void)
 }
 
 std::shared_ptr<cellular::RawCommandRespAsync> ServiceCellular::handleCellularStartOperatorsScan(
-    CellularStartOperatorsScanMessage *msg)
+    cellular::StartOperatorsScanMessage *msg)
 {
     LOG_INFO("CellularStartOperatorsScan handled");
     auto ret = std::make_shared<cellular::RawCommandRespAsync>(CellularMessage::Type::OperatorsScanResult);
@@ -1662,17 +1662,17 @@ bool ServiceCellular::handle_apn_conf_procedure()
     return true;
 }
 
-void ServiceCellular::handleCellularRequestCurrentOperatorName(CellularRequestCurrentOperatorNameMessage *msg)
+void ServiceCellular::handleCellularRequestCurrentOperatorName(cellular::RequestCurrentOperatorNameMessage *msg)
 {
     LOG_INFO("CellularRequestCurrentOperatorName handled");
     NetworkSettings networkSettings(*this);
     const auto currentNetworkOperatorName = networkSettings.getCurrentOperatorName();
     Store::GSM::get()->setNetworkOperatorName(currentNetworkOperatorName);
-    auto notification = std::make_shared<CellularCurrentOperatorNameNotification>(currentNetworkOperatorName);
+    auto notification = std::make_shared<cellular::CurrentOperatorNameNotification>(currentNetworkOperatorName);
     this->bus.sendMulticast(std::move(notification), sys::BusChannel::ServiceCellularNotifications);
 }
 
-std::shared_ptr<CellularGetAPNResponse> ServiceCellular::handleCellularGetAPNMessage(CellularGetAPNMessage *msg)
+std::shared_ptr<cellular::GetAPNResponse> ServiceCellular::handleCellularGetAPNMessage(cellular::GetAPNMessage *msg)
 {
     std::vector<std::shared_ptr<packet_data::APN::Config>> apns;
 
@@ -1680,83 +1680,84 @@ std::shared_ptr<CellularGetAPNResponse> ServiceCellular::handleCellularGetAPNMes
         if (auto apn = packetData->getAPNFirst(*type); apn) {
             apns.push_back(*apn);
         }
-        return std::make_shared<CellularGetAPNResponse>(apns);
+        return std::make_shared<cellular::GetAPNResponse>(apns);
     }
 
     if (auto ctxid = msg->getContextId(); ctxid) {
         if (auto apn = packetData->getAPN(*ctxid); apn) {
             apns.push_back(*apn);
         }
-        return std::make_shared<CellularGetAPNResponse>(apns);
+        return std::make_shared<cellular::GetAPNResponse>(apns);
     }
 
-    return std::make_shared<CellularGetAPNResponse>(packetData->getAPNs());
+    return std::make_shared<cellular::GetAPNResponse>(packetData->getAPNs());
 }
 
-std::shared_ptr<CellularSetAPNResponse> ServiceCellular::handleCellularSetAPNMessage(CellularSetAPNMessage *msg)
+std::shared_ptr<cellular::SetAPNResponse> ServiceCellular::handleCellularSetAPNMessage(cellular::SetAPNMessage *msg)
 {
     auto apn = msg->getAPNConfig();
     auto ret = packetData->setAPN(apn);
     settings->setValue(settings::Cellular::apn_list, packetData->saveAPNSettings(), settings::SettingsScope::Global);
-    return std::make_shared<CellularSetAPNResponse>(ret);
+    return std::make_shared<cellular::SetAPNResponse>(ret);
 }
-std::shared_ptr<CellularNewAPNResponse> ServiceCellular::handleCellularNewAPNMessage(CellularNewAPNMessage *msg)
+std::shared_ptr<cellular::NewAPNResponse> ServiceCellular::handleCellularNewAPNMessage(cellular::NewAPNMessage *msg)
 {
     auto apn           = msg->getAPNConfig();
     std::uint8_t newId = 0;
     auto ret           = packetData->newAPN(apn, newId);
     settings->setValue(settings::Cellular::apn_list, packetData->saveAPNSettings(), settings::SettingsScope::Global);
-    return std::make_shared<CellularNewAPNResponse>(ret, newId);
+    return std::make_shared<cellular::NewAPNResponse>(ret, newId);
 }
 
-std::shared_ptr<CellularSetDataTransferResponse> ServiceCellular::handleCellularSetDataTransferMessage(
-    CellularSetDataTransferMessage *msg)
+std::shared_ptr<cellular::SetDataTransferResponse> ServiceCellular::handleCellularSetDataTransferMessage(
+    cellular::SetDataTransferMessage *msg)
 {
     packetData->setDataTransfer(msg->getDataTransfer());
-    return std::make_shared<CellularSetDataTransferResponse>(at::Result::Code::OK);
+    return std::make_shared<cellular::SetDataTransferResponse>(at::Result::Code::OK);
 }
 
-std::shared_ptr<CellularGetDataTransferResponse> ServiceCellular::handleCellularGetDataTransferMessage(
-    CellularGetDataTransferMessage *msg)
+std::shared_ptr<cellular::GetDataTransferResponse> ServiceCellular::handleCellularGetDataTransferMessage(
+    cellular::GetDataTransferMessage *msg)
 {
-    return std::make_shared<CellularGetDataTransferResponse>(packetData->getDataTransfer());
+    return std::make_shared<cellular::GetDataTransferResponse>(packetData->getDataTransfer());
 }
 
-std::shared_ptr<CellularActivateContextResponse> ServiceCellular::handleCellularActivateContextMessage(
-    CellularActivateContextMessage *msg)
+std::shared_ptr<cellular::ActivateContextResponse> ServiceCellular::handleCellularActivateContextMessage(
+    cellular::ActivateContextMessage *msg)
 {
-    return std::make_shared<CellularActivateContextResponse>(packetData->activateContext(msg->getContextId()),
-                                                             msg->getContextId());
-}
-
-std::shared_ptr<CellularDeactivateContextResponse> ServiceCellular::handleCellularDeactivateContextMessage(
-    CellularDeactivateContextMessage *msg)
-{
-    return std::make_shared<CellularDeactivateContextResponse>(packetData->deactivateContext(msg->getContextId()),
+    return std::make_shared<cellular::ActivateContextResponse>(packetData->activateContext(msg->getContextId()),
                                                                msg->getContextId());
 }
 
-std::shared_ptr<CellularGetActiveContextsResponse> ServiceCellular::handleCellularGetActiveContextsMessage(
-    CellularGetActiveContextsMessage *msg)
+std::shared_ptr<cellular::DeactivateContextResponse> ServiceCellular::handleCellularDeactivateContextMessage(
+    cellular::DeactivateContextMessage *msg)
 {
-    return std::make_shared<CellularGetActiveContextsResponse>(packetData->getActiveContexts());
+    return std::make_shared<cellular::DeactivateContextResponse>(packetData->deactivateContext(msg->getContextId()),
+                                                                 msg->getContextId());
 }
 
-std::shared_ptr<CellularSetOperatorAutoSelectResponse> ServiceCellular::handleCellularSetOperatorAutoSelect(
-    CellularSetOperatorAutoSelectMessage *msg)
+std::shared_ptr<cellular::GetActiveContextsResponse> ServiceCellular::handleCellularGetActiveContextsMessage(
+    cellular::GetActiveContextsMessage *msg)
+{
+    return std::make_shared<cellular::GetActiveContextsResponse>(packetData->getActiveContexts());
+}
+
+std::shared_ptr<cellular::SetOperatorAutoSelectResponse> ServiceCellular::handleCellularSetOperatorAutoSelect(
+    cellular::SetOperatorAutoSelectMessage *msg)
 {
     LOG_INFO("CellularSetOperatorAutoSelect handled");
 
     NetworkSettings networkSettings(*this);
-    return std::make_shared<CellularSetOperatorAutoSelectResponse>(networkSettings.setOperatorAutoSelect());
+    return std::make_shared<cellular::SetOperatorAutoSelectResponse>(networkSettings.setOperatorAutoSelect());
 }
 
-std::shared_ptr<CellularSetOperatorResponse> ServiceCellular::handleCellularSetOperator(CellularSetOperatorMessage *msg)
+std::shared_ptr<cellular::SetOperatorResponse> ServiceCellular::handleCellularSetOperator(
+    cellular::SetOperatorMessage *msg)
 {
     LOG_INFO("CellularSetOperatorAutoSelect handled");
 
     NetworkSettings networkSettings(*this);
-    return std::make_shared<CellularSetOperatorResponse>(
+    return std::make_shared<cellular::SetOperatorResponse>(
         networkSettings.setOperator(msg->getMode(), msg->getFormat(), msg->getName()));
 }
 
@@ -1777,24 +1778,24 @@ void ServiceCellular::apnListChanged(const std::string &value)
 }
 
 auto ServiceCellular::handleCellularAnswerIncomingCallMessage(CellularMessage *msg)
-    -> std::shared_ptr<CellularResponseMessage>
+    -> std::shared_ptr<cellular::ResponseMessage>
 {
     LOG_INFO("%s", __PRETTY_FUNCTION__);
     auto ret = ongoingCall->handle(call::event::Answer{});
-    return std::make_shared<CellularResponseMessage>(ret);
+    return std::make_shared<cellular::ResponseMessage>(ret);
 }
 
 namespace
 {
-    constexpr auto translate(at::Result::Code code) -> CellularCallRequestGeneralError::ErrorType
+    constexpr auto translate(at::Result::Code code) -> cellular::CallRequestGeneralError::ErrorType
     {
         switch (code) {
         case at::Result::Code::ERROR:
         case at::Result::Code::CME_ERROR:
         case at::Result::Code::CMS_ERROR:
-            return CellularCallRequestGeneralError::ErrorType::Error;
+            return cellular::CallRequestGeneralError::ErrorType::Error;
         case at::Result::Code::TIMEOUT:
-            return CellularCallRequestGeneralError::ErrorType::ModemTimeout;
+            return cellular::CallRequestGeneralError::ErrorType::ModemTimeout;
         case at::Result::Code::TOKENS:
         case at::Result::Code::PARSING_ERROR:
         case at::Result::Code::FULL_MSG_BUFFER:
@@ -1802,27 +1803,27 @@ namespace
         case at::Result::Code::RECEIVING_NOT_STARTED:
         case at::Result::Code::DATA_NOT_USED:
         case at::Result::Code::CMUX_FRAME_ERROR:
-            return CellularCallRequestGeneralError::ErrorType::TransmissionError;
+            return cellular::CallRequestGeneralError::ErrorType::TransmissionError;
         case at::Result::Code::OK:
         case at::Result::Code::NONE:
         case at::Result::Code::UNDEFINED:
-            return CellularCallRequestGeneralError::ErrorType::UndefinedError;
+            return cellular::CallRequestGeneralError::ErrorType::UndefinedError;
         }
-        return CellularCallRequestGeneralError::ErrorType::UndefinedError;
+        return cellular::CallRequestGeneralError::ErrorType::UndefinedError;
     }
 } // namespace
 
-auto ServiceCellular::handleCellularCallRequestMessage(CellularCallRequestMessage *msg)
-    -> std::shared_ptr<CellularResponseMessage>
+auto ServiceCellular::handleCellularCallRequestMessage(cellular::CallRequestMessage *msg)
+    -> std::shared_ptr<cellular::ResponseMessage>
 {
     LOG_INFO("%s", __PRETTY_FUNCTION__);
     auto channel = cmux->get(CellularMux::Channel::Commands);
     if (channel == nullptr) {
         LOG_WARN("commands channel not ready");
-        auto message = std::make_shared<CellularCallRequestGeneralError>(
-            CellularCallRequestGeneralError::ErrorType::ChannelNotReadyError);
+        auto message = std::make_shared<cellular::CallRequestGeneralError>(
+            cellular::CallRequestGeneralError::ErrorType::ChannelNotReadyError);
         bus.sendUnicast(message, ::service::name::appmgr);
-        return std::make_shared<CellularResponseMessage>(false);
+        return std::make_shared<cellular::ResponseMessage>(false);
     }
     cellular::RequestFactory factory(
         msg->number.getEntered(), *channel, msg->callMode, Store::GSM::get()->simCardInserted());
@@ -1836,15 +1837,15 @@ auto ServiceCellular::handleCellularCallRequestMessage(CellularCallRequestMessag
     }
     LOG_INFO("isHandled %d, %s", static_cast<int>(request->isHandled()), utils::enumToString(result.code).c_str());
     if (!request->isHandled()) {
-        CellularCallRequestGeneralError::ErrorType errorType = translate(result.code);
-        auto message = std::make_shared<CellularCallRequestGeneralError>(errorType);
+        cellular::CallRequestGeneralError::ErrorType errorType = translate(result.code);
+        auto message = std::make_shared<cellular::CallRequestGeneralError>(errorType);
         bus.sendUnicast(message, ::service::name::appmgr);
     }
 
-    return std::make_shared<CellularResponseMessage>(request->isHandled());
+    return std::make_shared<cellular::ResponseMessage>(request->isHandled());
 }
 
-void ServiceCellular::handleCellularHangupCallMessage(CellularHangupCallMessage *msg)
+void ServiceCellular::handleCellularHangupCallMessage(cellular::HangupCallMessage *msg)
 {
     LOG_INFO("%s", __PRETTY_FUNCTION__);
     if (!ongoingCall->handle(call::event::Reject{})) {
@@ -1893,10 +1894,10 @@ auto ServiceCellular::handleCellularListCallsMessage(CellularMessage *msg) -> st
         if (it != std::end(data)) {
             ongoingCall->handle(call::event::Answer{});
             callStateTimer.stop();
-            return std::make_shared<CellularResponseMessage>(true);
+            return std::make_shared<cellular::ResponseMessage>(true);
         }
     }
-    return std::make_shared<CellularResponseMessage>(false);
+    return std::make_shared<cellular::ResponseMessage>(false);
 }
 
 auto ServiceCellular::handleDBNotificationMessage(db::NotificationMessage *msg) -> std::shared_ptr<sys::ResponseMessage>
@@ -1910,10 +1911,11 @@ auto ServiceCellular::handleDBNotificationMessage(db::NotificationMessage *msg) 
     return std::make_shared<sys::ResponseMessage>(sys::ReturnCodes::Failure);
 }
 
-auto ServiceCellular::handleCellularRingingMessage(CellularRingingMessage *msg) -> std::shared_ptr<sys::ResponseMessage>
+auto ServiceCellular::handleCellularRingingMessage(cellular::RingingMessage *msg)
+    -> std::shared_ptr<sys::ResponseMessage>
 {
     LOG_INFO("%s", __PRETTY_FUNCTION__);
-    return std::make_shared<CellularResponseMessage>(
+    return std::make_shared<cellular::ResponseMessage>(
         ongoingCall->handle(call::event::StartCall{CallType::CT_OUTGOING, msg->number}));
 }
 
@@ -1921,18 +1923,18 @@ auto ServiceCellular::handleCellularGetIMSIMessage(sys::Message *msg) -> std::sh
 {
     std::string temp;
     if (getIMSI(temp)) {
-        return std::make_shared<CellularResponseMessage>(true, temp);
+        return std::make_shared<cellular::ResponseMessage>(true, temp);
     }
-    return std::make_shared<CellularResponseMessage>(false);
+    return std::make_shared<cellular::ResponseMessage>(false);
 }
 
 auto ServiceCellular::handleCellularGetOwnNumberMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
     std::string temp;
     if (getOwnNumber(temp)) {
-        return std::make_shared<CellularGetOwnNumberResponseMessage>(true, temp);
+        return std::make_shared<cellular::GetOwnNumberResponseMessage>(true, temp);
     }
-    return std::make_shared<CellularGetOwnNumberResponseMessage>(false);
+    return std::make_shared<cellular::GetOwnNumberResponseMessage>(false);
 }
 
 auto ServiceCellular::handleCellularGetNetworkInfoMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
@@ -1941,12 +1943,12 @@ auto ServiceCellular::handleCellularGetNetworkInfoMessage(sys::Message *msg) -> 
     message->data = getNetworkInfo();
     bus.sendUnicast(message, msg->sender);
 
-    return std::make_shared<CellularResponseMessage>(true);
+    return std::make_shared<cellular::ResponseMessage>(true);
 }
 
 auto ServiceCellular::handleCellularSelectAntennaMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
-    auto message = static_cast<CellularAntennaRequestMessage *>(msg);
+    auto message = static_cast<cellular::AntennaRequestMessage *>(msg);
 
     cmux->selectAntenna(message->antenna);
     vTaskDelay(50); // sleep for 50 ms...
@@ -1962,14 +1964,14 @@ auto ServiceCellular::handleCellularSelectAntennaMessage(sys::Message *msg) -> s
     auto notification = std::make_shared<AntennaChangedMessage>();
     bus.sendMulticast(notification, sys::BusChannel::AntennaNotifications);
 
-    return std::make_shared<CellularResponseMessage>(changedAntenna);
+    return std::make_shared<cellular::ResponseMessage>(changedAntenna);
 }
 auto ServiceCellular::handleCellularSetScanModeMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
-    auto message = static_cast<CellularSetScanModeMessage *>(msg);
+    auto message = static_cast<cellular::SetScanModeMessage *>(msg);
     bool ret     = SetScanMode(message->data);
 
-    return std::make_shared<CellularResponseMessage>(ret);
+    return std::make_shared<cellular::ResponseMessage>(ret);
 }
 auto ServiceCellular::handleCellularGetScanModeMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
@@ -1978,9 +1980,9 @@ auto ServiceCellular::handleCellularGetScanModeMessage(sys::Message *msg) -> std
         auto response = std::make_shared<cellular::RawCommandRespAsync>(CellularMessage::Type::GetScanModeResult);
         response->data.push_back(mode);
         bus.sendUnicast(response, msg->sender);
-        return std::make_shared<CellularResponseMessage>(true);
+        return std::make_shared<cellular::ResponseMessage>(true);
     }
-    return std::make_shared<CellularResponseMessage>(false);
+    return std::make_shared<cellular::ResponseMessage>(false);
 }
 
 auto ServiceCellular::handleCellularGetFirmwareVersionMessage(sys::Message *msg)
@@ -1992,10 +1994,10 @@ auto ServiceCellular::handleCellularGetFirmwareVersionMessage(sys::Message *msg)
         auto resp = channel->cmd(at::AT::QGMR);
         if (resp.code == at::Result::Code::OK) {
             response = resp.response[0];
-            return std::make_shared<CellularResponseMessage>(true, response);
+            return std::make_shared<cellular::ResponseMessage>(true, response);
         }
     }
-    return std::make_shared<CellularResponseMessage>(false);
+    return std::make_shared<cellular::ResponseMessage>(false);
 }
 auto ServiceCellular::handleEVMStatusMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
@@ -2003,7 +2005,7 @@ auto ServiceCellular::handleEVMStatusMessage(sys::Message *msg) -> std::shared_p
     auto message    = static_cast<sevm::StatusStateMessage *>(msg);
     auto status_pin = message->state;
     if (priv->modemResetHandler->handleStatusPinEvent(status_pin == value::ACTIVE)) {
-        return std::make_shared<CellularResponseMessage>(true);
+        return std::make_shared<cellular::ResponseMessage>(true);
     }
 
     if (status_pin == value::ACTIVE) {
@@ -2016,7 +2018,7 @@ auto ServiceCellular::handleEVMStatusMessage(sys::Message *msg) -> std::shared_p
             priv->state->set(State::ST::PowerDown);
         }
     }
-    return std::make_shared<CellularResponseMessage>(true);
+    return std::make_shared<cellular::ResponseMessage>(true);
 }
 
 auto ServiceCellular::handleCellularGetCsqMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
@@ -2025,10 +2027,10 @@ auto ServiceCellular::handleCellularGetCsqMessage(sys::Message *msg) -> std::sha
     if (channel) {
         auto modemResponse = channel->cmd(at::AT::CSQ);
         if (modemResponse.code == at::Result::Code::OK) {
-            return std::make_shared<CellularResponseMessage>(true, modemResponse.response[0]);
+            return std::make_shared<cellular::ResponseMessage>(true, modemResponse.response[0]);
         }
     }
-    return std::make_shared<CellularResponseMessage>(false);
+    return std::make_shared<cellular::ResponseMessage>(false);
 }
 
 auto ServiceCellular::handleCellularGetCregMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
@@ -2037,10 +2039,10 @@ auto ServiceCellular::handleCellularGetCregMessage(sys::Message *msg) -> std::sh
     if (channel) {
         auto resp = channel->cmd(at::AT::CREG);
         if (resp.code == at::Result::Code::OK) {
-            return std::make_shared<CellularResponseMessage>(true, resp.response[0]);
+            return std::make_shared<cellular::ResponseMessage>(true, resp.response[0]);
         }
     }
-    return std::make_shared<CellularResponseMessage>(false);
+    return std::make_shared<cellular::ResponseMessage>(false);
 }
 
 auto ServiceCellular::handleCellularGetNwinfoMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
@@ -2049,38 +2051,38 @@ auto ServiceCellular::handleCellularGetNwinfoMessage(sys::Message *msg) -> std::
     if (channel) {
         auto resp = channel->cmd(at::AT::QNWINFO);
         if (resp.code == at::Result::Code::OK) {
-            return std::make_shared<CellularResponseMessage>(true, resp.response[0]);
+            return std::make_shared<cellular::ResponseMessage>(true, resp.response[0]);
         }
     }
-    return std::make_shared<CellularResponseMessage>(false);
+    return std::make_shared<cellular::ResponseMessage>(false);
 }
 
 auto ServiceCellular::handleCellularGetAntennaMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
     auto antenna = cmux->getAntenna();
-    return std::make_shared<CellularAntennaResponseMessage>(true, antenna, CellularMessage::Type::GetAntenna);
+    return std::make_shared<cellular::AntennaResponseMessage>(true, antenna, CellularMessage::Type::GetAntenna);
 }
 auto ServiceCellular::handleCellularDtmfRequestMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
-    auto message = static_cast<CellularDtmfRequestMessage *>(msg);
+    auto message = static_cast<cellular::DtmfRequestMessage *>(msg);
     auto resp    = transmitDtmfTone(message->getDTMFCode());
-    return std::make_shared<CellularResponseMessage>(resp);
+    return std::make_shared<cellular::ResponseMessage>(resp);
 }
 auto ServiceCellular::handleCellularUSSDMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
-    auto message = static_cast<CellularUSSDMessage *>(msg);
-    return std::make_shared<CellularResponseMessage>(handleUSSDRequest(message->type, message->data));
+    auto message = static_cast<cellular::USSDMessage *>(msg);
+    return std::make_shared<cellular::ResponseMessage>(handleUSSDRequest(message->type, message->data));
 }
 
 auto ServiceCellular::handleStateRequestMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
     change_state(dynamic_cast<cellular::StateChange *>(msg));
-    return std::make_shared<CellularResponseMessage>(true);
+    return std::make_shared<cellular::ResponseMessage>(true);
 }
 
 auto ServiceCellular::handleCallActiveNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
-    auto ret = std::make_shared<CellularResponseMessage>(true);
+    auto ret = std::make_shared<cellular::ResponseMessage>(true);
     NetworkSettings networkSettings(*this);
     auto currentNAT = networkSettings.getCurrentNAT();
     if (currentNAT) {
@@ -2107,43 +2109,43 @@ auto ServiceCellular::handlePowerUpProcedureCompleteNotification(sys::Message *m
     if (board == bsp::Board::Linux) {
         priv->state->set(State::ST::CellularConfProcedure);
     }
-    return std::make_shared<CellularResponseMessage>(true);
+    return std::make_shared<cellular::ResponseMessage>(true);
 }
 auto ServiceCellular::handlePowerDownDeregisteringNotification(sys::Message *msg)
     -> std::shared_ptr<sys::ResponseMessage>
 {
     if (priv->state->get() != State::ST::PowerDownWaiting) {
         priv->state->set(State::ST::PowerDownStarted);
-        return std::make_shared<CellularResponseMessage>(true);
+        return std::make_shared<cellular::ResponseMessage>(true);
     }
-    return std::make_shared<CellularResponseMessage>(false);
+    return std::make_shared<cellular::ResponseMessage>(false);
 }
 auto ServiceCellular::handlePowerDownDeregisteredNotification(sys::Message *msg)
     -> std::shared_ptr<sys::ResponseMessage>
 {
     priv->state->set(State::ST::PowerDownWaiting);
-    return std::make_shared<CellularResponseMessage>(true);
+    return std::make_shared<cellular::ResponseMessage>(true);
 }
 auto ServiceCellular::handleNewIncomingSMSNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
-    auto message      = static_cast<CellularNewIncomingSMSNotification *>(msg);
-    auto notification = std::make_shared<CellularNewIncomingSMSMessage>(message->data);
+    auto message      = static_cast<cellular::NewIncomingSMSNotification *>(msg);
+    auto notification = std::make_shared<cellular::NewIncomingSMSMessage>(message->data);
     bus.sendUnicast(std::move(notification), msg->sender);
-    return std::make_shared<CellularResponseMessage>(true);
+    return std::make_shared<cellular::ResponseMessage>(true);
 }
 
 auto ServiceCellular::handleSmsDoneNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
     auto resp = handleTextMessagesInit();
-    return std::make_shared<CellularResponseMessage>(resp);
+    return std::make_shared<cellular::ResponseMessage>(resp);
 }
 auto ServiceCellular::handleSignalStrengthUpdateNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
-    return std::make_shared<CellularResponseMessage>(false);
+    return std::make_shared<cellular::ResponseMessage>(false);
 }
 auto ServiceCellular::handleNetworkStatusUpdateNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
-    return std::make_shared<CellularResponseMessage>(false);
+    return std::make_shared<cellular::ResponseMessage>(false);
 }
 
 auto ServiceCellular::handleUrcIncomingNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
@@ -2152,44 +2154,44 @@ auto ServiceCellular::handleUrcIncomingNotification(sys::Message *msg) -> std::s
     // if there is no response from the host to incoming URC,
     // the modem will automatically sleep after time constants::maxUrcHandleTime
     sleepTimer.restart(constants::maxUrcHandleTime);
-    return std::make_shared<CellularResponseMessage>(true);
+    return std::make_shared<cellular::ResponseMessage>(true);
 }
 
 auto ServiceCellular::handleCellularSetFlightModeMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
-    auto setMsg = static_cast<CellularSetFlightModeMessage *>(msg);
+    auto setMsg = static_cast<cellular::SetFlightModeMessage *>(msg);
     settings->setValue(
         settings::Cellular::offlineMode, std::to_string(setMsg->flightModeOn), settings::SettingsScope::Global);
     connectionManager->setFlightMode(setMsg->flightModeOn);
     connectionManager->onPhoneModeChange(phoneModeObserver->getCurrentPhoneMode());
-    return std::make_shared<CellularResponseMessage>(true);
+    return std::make_shared<cellular::ResponseMessage>(true);
 }
 
 auto ServiceCellular::handleCellularRingNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
     LOG_INFO("%s", __PRETTY_FUNCTION__);
     ongoingCall->handle(call::event::RING{});
-    return std::make_shared<CellularResponseMessage>(true);
+    return std::make_shared<cellular::ResponseMessage>(true);
 }
 
 auto ServiceCellular::handleCellularCallerIdNotification(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>
 {
-    auto message = static_cast<CellularCallerIdNotification *>(msg);
+    auto message = static_cast<cellular::CallerIdNotification *>(msg);
     ongoingCall->handle(call::event::CLIP{message->getNubmer()});
-    return std::make_shared<CellularResponseMessage>(true);
+    return std::make_shared<cellular::ResponseMessage>(true);
 }
 
 auto ServiceCellular::handleCellularSetConnectionFrequencyMessage(sys::Message *msg)
     -> std::shared_ptr<sys::ResponseMessage>
 {
-    auto setMsg = static_cast<CellularSetConnectionFrequencyMessage *>(msg);
+    auto setMsg = static_cast<cellular::SetConnectionFrequencyMessage *>(msg);
     settings->setValue(settings::Offline::connectionFrequency,
                        std::to_string(setMsg->getConnectionFrequency()),
                        settings::SettingsScope::Global);
 
     connectionManager->setInterval(std::chrono::minutes{setMsg->getConnectionFrequency()});
     connectionManager->onPhoneModeChange(phoneModeObserver->getCurrentPhoneMode());
-    return std::make_shared<CellularResponseMessage>(true);
+    return std::make_shared<cellular::ResponseMessage>(true);
 }
 
 auto ServiceCellular::hangUpCall() -> bool

--- a/module-services/service-cellular/call/CallMachine.hpp
+++ b/module-services/service-cellular/call/CallMachine.hpp
@@ -172,7 +172,6 @@ namespace call
             }
             di.audio->routingStart();
             di.multicast->notifyCallActive();
-            di.gui->notifyCallActive();
             di.timer->start();
         }
     } constexpr HandleAnswerCall;
@@ -189,7 +188,7 @@ namespace call
     {
         void operator()(Dependencies &di, CallData &call)
         {
-            di.gui->notifyCallDurationUpdate(di.timer->duration());
+            di.multicast->notifyCallDurationUpdate(di.timer->duration());
         }
     } constexpr HandleCallTimer;
 
@@ -204,7 +203,7 @@ namespace call
 
             di.audio->routingStart();
             di.db->startCall(call.record);
-            di.gui->notifyCallStarted(call.record.phoneNumber, call.record.type);
+            di.multicast->notifyCallStarted(call.record.phoneNumber, call.record.type);
             di.sentinel->HoldMinimumFrequency(bsp::CpuFrequencyMHz::Level_6);
         }
     } constexpr HandleStartCall;
@@ -213,7 +212,7 @@ namespace call
     {
         void operator()(Dependencies &di, CallData &call)
         {
-            di.gui->notifyOutgoingCallAnswered();
+            di.multicast->notifyOutgoingCallAnswered();
             di.timer->start();
         }
     } constexpr HandleStartedCall;
@@ -226,7 +225,7 @@ namespace call
             call.record.type   = CallType::CT_REJECTED;
             call.record.isRead = false;
             di.db->endCall(call.record);
-            di.gui->notifyCallEnded();
+            di.multicast->notifyCallEnded();
             di.modem->hangupCall();
         }
     } constexpr HandleRejectCall;
@@ -239,7 +238,7 @@ namespace call
             call.record.type   = CallType::CT_MISSED;
             call.record.isRead = false;
             di.db->endCall(call.record);
-            di.gui->notifyCallEnded();
+            di.multicast->notifyCallEnded();
             di.modem->hangupCall();
         };
     } constexpr HandleMissedCall;
@@ -251,7 +250,7 @@ namespace call
             di.audio->stop();
             call.record.duration = di.timer->duration();
             di.db->endCall(call.record);
-            di.gui->notifyCallEnded();
+            di.multicast->notifyCallEnded();
             di.timer->stop();
             di.modem->hangupCall();
         }
@@ -285,7 +284,7 @@ namespace call
         void operator()(const std::runtime_error &err, Dependencies &di)
         {
             di.multicast->notifyCallAborted();
-            di.gui->notifyCallEnded();
+            di.multicast->notifyCallEnded();
             LOG_FATAL("EXCEPTION %s", err.what());
         }
     } constexpr ExceptionHandler;

--- a/module-services/service-cellular/call/CallMachine.hpp
+++ b/module-services/service-cellular/call/CallMachine.hpp
@@ -213,6 +213,7 @@ namespace call
     {
         void operator()(Dependencies &di, CallData &call)
         {
+            di.gui->notifyOutgoingCallAnswered();
             di.timer->start();
         }
     } constexpr HandleStartedCall;

--- a/module-services/service-cellular/call/api/CallGUI.cpp
+++ b/module-services/service-cellular/call/api/CallGUI.cpp
@@ -21,31 +21,5 @@ void CallGUI::notifyCLIP(const utils::PhoneNumber::View &number)
         owner, app::manager::actions::HandleCallerId, std::make_unique<app::manager::actions::CallParams>(number));
 }
 
-void CallGUI::notifyCallStarted(const utils::PhoneNumber &number, const CallType &type)
-{
-    owner->bus.sendMulticast(std::make_shared<cellular::CallStartedNotification>(number, type == CallType::CT_INCOMING),
-                             sys::BusChannel::ServiceCellularNotifications);
-}
 
-void CallGUI::notifyCallEnded()
-{
-    owner->bus.sendMulticast(std::make_shared<cellular::CallEndedNotification>(),
-                             sys::BusChannel::ServiceCellularNotifications);
-}
 
-void CallGUI::notifyCallActive()
-{
-    owner->bus.sendMulticast(std::make_shared<cellular::CallActiveNotification>(),
-                             sys::BusChannel::ServiceCellularNotifications);
-}
-
-void CallGUI::notifyCallDurationUpdate(const time_t &duration)
-{
-    owner->bus.sendMulticast(std::make_shared<cellular::CallDurationNotification>(duration),
-                             sys::BusChannel::ServiceCellularNotifications);
-}
-void CallGUI::notifyOutgoingCallAnswered()
-{
-    owner->bus.sendMulticast(std::make_shared<cellular::CallOutgoingAccepted>(),
-                             sys::BusChannel::ServiceCellularNotifications);
-}

--- a/module-services/service-cellular/call/api/CallGUI.cpp
+++ b/module-services/service-cellular/call/api/CallGUI.cpp
@@ -44,3 +44,8 @@ void CallGUI::notifyCallDurationUpdate(const time_t &duration)
     owner->bus.sendMulticast(std::make_shared<cellular::CallDurationNotification>(duration),
                              sys::BusChannel::ServiceCellularNotifications);
 }
+void CallGUI::notifyOutgoingCallAnswered()
+{
+    owner->bus.sendMulticast(std::make_shared<cellular::CallOutgoingAccepted>(),
+                             sys::BusChannel::ServiceCellularNotifications);
+}

--- a/module-services/service-cellular/call/api/CallGUI.hpp
+++ b/module-services/service-cellular/call/api/CallGUI.hpp
@@ -22,6 +22,7 @@ namespace call::api
         virtual void notifyCallEnded()                                                         = 0;
         virtual void notifyCallActive()                                                        = 0;
         virtual void notifyCallDurationUpdate(const time_t &duration)                          = 0;
+        virtual void notifyOutgoingCallAnswered()                                              = 0;
         virtual ~GUI()                                                                         = default;
     };
 }; // namespace call::api
@@ -40,4 +41,5 @@ class CallGUI : public call::api::GUI
     void notifyCallEnded() override;
     void notifyCallActive() override;
     void notifyCallDurationUpdate(const time_t &duration) override;
+    void notifyOutgoingCallAnswered() override;
 };

--- a/module-services/service-cellular/call/api/CallGUI.hpp
+++ b/module-services/service-cellular/call/api/CallGUI.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <PhoneNumber.hpp>
-#include <Tables/CalllogTable.hpp>
 
 namespace sys
 {
@@ -18,11 +17,6 @@ namespace call::api
       public:
         virtual void notifyRING()                                                              = 0;
         virtual void notifyCLIP(const utils::PhoneNumber::View &number)                        = 0;
-        virtual void notifyCallStarted(const utils::PhoneNumber &number, const CallType &type) = 0;
-        virtual void notifyCallEnded()                                                         = 0;
-        virtual void notifyCallActive()                                                        = 0;
-        virtual void notifyCallDurationUpdate(const time_t &duration)                          = 0;
-        virtual void notifyOutgoingCallAnswered()                                              = 0;
         virtual ~GUI()                                                                         = default;
     };
 }; // namespace call::api
@@ -37,9 +31,4 @@ class CallGUI : public call::api::GUI
 
     void notifyRING() override;
     void notifyCLIP(const utils::PhoneNumber::View &number) override;
-    void notifyCallStarted(const utils::PhoneNumber &number, const CallType &type) override;
-    void notifyCallEnded() override;
-    void notifyCallActive() override;
-    void notifyCallDurationUpdate(const time_t &duration) override;
-    void notifyOutgoingCallAnswered() override;
 };

--- a/module-services/service-cellular/call/api/CallMulticast.cpp
+++ b/module-services/service-cellular/call/api/CallMulticast.cpp
@@ -3,29 +3,50 @@
 
 #include "CallMulticast.hpp"
 #include "service-cellular/CellularMessage.hpp"
-#include <Service/Service.hpp>
 
 void CallMulticast::notifyIncommingCall()
 {
-    owner->bus.sendMulticast(std::make_shared<CellularIncominCallMessage>(),
+    owner->bus.sendMulticast(std::make_shared<cellular::IncomingCallMessage>(),
                              sys::BusChannel::ServiceCellularNotifications);
 }
 
 void CallMulticast::notifyIdentifiedCall(const utils::PhoneNumber::View &number)
 {
-    owner->bus.sendMulticast(std::make_shared<CellularCallerIdMessage>(number),
-                             sys::BusChannel::ServiceCellularNotifications);
-}
-
-void CallMulticast::notifyCallActive()
-{
-
-    owner->bus.sendMulticast(std::make_shared<CellularCallActiveNotification>(),
+    owner->bus.sendMulticast(std::make_shared<cellular::CallerIdMessage>(number),
                              sys::BusChannel::ServiceCellularNotifications);
 }
 
 void CallMulticast::notifyCallAborted()
 {
-    owner->bus.sendMulticast(std::make_shared<CellularCallAbortedNotification>(),
+    owner->bus.sendMulticast(std::make_shared<cellular::CallAbortedNotification>(),
+                             sys::BusChannel::ServiceCellularNotifications);
+}
+void CallMulticast::notifyOutgoingCallAnswered()
+{
+    owner->bus.sendMulticast(std::make_shared<cellular::CallOutgoingAccepted>(),
+                             sys::BusChannel::ServiceCellularNotifications);
+}
+
+void CallMulticast::notifyCallStarted(const utils::PhoneNumber &number, const CallType &type)
+{
+    owner->bus.sendMulticast(std::make_shared<cellular::CallStartedNotification>(number, type == CallType::CT_INCOMING),
+                             sys::BusChannel::ServiceCellularNotifications);
+}
+
+void CallMulticast::notifyCallEnded()
+{
+    owner->bus.sendMulticast(std::make_shared<cellular::CallEndedNotification>(),
+                             sys::BusChannel::ServiceCellularNotifications);
+}
+
+void CallMulticast::notifyCallActive()
+{
+    owner->bus.sendMulticast(std::make_shared<cellular::CallActiveNotification>(),
+                             sys::BusChannel::ServiceCellularNotifications);
+}
+
+void CallMulticast::notifyCallDurationUpdate(const time_t &duration)
+{
+    owner->bus.sendMulticast(std::make_shared<cellular::CallDurationNotification>(duration),
                              sys::BusChannel::ServiceCellularNotifications);
 }

--- a/module-services/service-cellular/call/api/CallMulticast.hpp
+++ b/module-services/service-cellular/call/api/CallMulticast.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <PhoneNumber.hpp>
+#include <Tables/CalllogTable.hpp>
 
 namespace sys
 {
@@ -19,6 +20,11 @@ namespace call::api
         virtual void notifyIdentifiedCall(const utils::PhoneNumber::View &number) = 0;
         virtual void notifyCallActive()                                           = 0;
         virtual void notifyCallAborted()                                          = 0;
+        virtual void notifyOutgoingCallAnswered()                                              = 0;
+        virtual void notifyCallStarted(const utils::PhoneNumber &number, const CallType &type) = 0;
+        virtual void notifyCallEnded()                                                         = 0;
+        virtual void notifyCallDurationUpdate(const time_t &duration)                          = 0;
+
         virtual ~Multicast()                                                      = default;
     };
 } // namespace call::api
@@ -34,4 +40,8 @@ class CallMulticast : public call::api::Multicast
     void notifyIdentifiedCall(const utils::PhoneNumber::View &number) override;
     void notifyCallActive() override;
     void notifyCallAborted() override;
+    void notifyOutgoingCallAnswered() override;
+    void notifyCallStarted(const utils::PhoneNumber &number, const CallType &type) override;
+    void notifyCallEnded() override;
+    void notifyCallDurationUpdate(const time_t &duration) override;
 };

--- a/module-services/service-cellular/call/tests/test-CallMachine.cpp
+++ b/module-services/service-cellular/call/tests/test-CallMachine.cpp
@@ -41,6 +41,8 @@ namespace mocks
         fakeit::When(Method(gui, notifyCallEnded)).AlwaysReturn();
         fakeit::When(Method(gui, notifyCallActive)).AlwaysReturn();
         fakeit::When(Method(gui, notifyCallDurationUpdate)).AlwaysReturn();
+        fakeit::When(Method(gui, notifyOutgoingCallAnswered)).AlwaysReturn();
+
         return gui;
     }
 
@@ -362,6 +364,7 @@ TEST_CASE("call outgoing - answered")
     REQUIRE(machine->machine.process_event(call::event::StartCall{CallType::CT_OUTGOING, number.getView()}));
     REQUIRE(machine->machine.process_event(call::event::Answer{}));
     fakeit::Verify(Method(di.audio, play)).Exactly(0);
+    fakeit::Verify(Method(di.gui, notifyOutgoingCallAnswered)).Exactly(1);
     REQUIRE(machine->machine.process_event(call::event::Ended{}));
     fakeit::Verify(Method(di.audio, stop)).Exactly(1);
 }

--- a/module-services/service-cellular/call/tests/test-CallMachine.cpp
+++ b/module-services/service-cellular/call/tests/test-CallMachine.cpp
@@ -37,12 +37,6 @@ namespace mocks
         fakeit::Mock<call::api::GUI> gui;
         fakeit::When(Method(gui, notifyRING)).AlwaysReturn();
         fakeit::When(Method(gui, notifyCLIP)).AlwaysReturn();
-        fakeit::When(Method(gui, notifyCallStarted)).AlwaysReturn();
-        fakeit::When(Method(gui, notifyCallEnded)).AlwaysReturn();
-        fakeit::When(Method(gui, notifyCallActive)).AlwaysReturn();
-        fakeit::When(Method(gui, notifyCallDurationUpdate)).AlwaysReturn();
-        fakeit::When(Method(gui, notifyOutgoingCallAnswered)).AlwaysReturn();
-
         return gui;
     }
 
@@ -53,6 +47,10 @@ namespace mocks
         fakeit::When(Method(multicast, notifyIdentifiedCall)).AlwaysReturn();
         fakeit::When(Method(multicast, notifyCallActive)).AlwaysReturn();
         fakeit::When(Method(multicast, notifyCallAborted)).AlwaysReturn();
+        fakeit::When(Method(multicast, notifyCallStarted)).AlwaysReturn();
+        fakeit::When(Method(multicast, notifyCallEnded)).AlwaysReturn();
+        fakeit::When(Method(multicast, notifyCallDurationUpdate)).AlwaysReturn();
+        fakeit::When(Method(multicast, notifyOutgoingCallAnswered)).AlwaysReturn();
         return multicast;
     };
 
@@ -171,7 +169,7 @@ TEST_CASE("base positive call flow, answered, end from caller")
     // answer the call from the pure
     REQUIRE(machine->machine.process_event(call::event::Answer{}));
     fakeit::Verify(Method(di.audio, routingStart)).Exactly(1);
-    fakeit::Verify(Method(di.gui, notifyCallActive)).Exactly(1);
+    fakeit::Verify(Method(di.multicast, notifyCallActive)).Exactly(1);
 
     REQUIRE(machine->machine.process_event(call::event::OngoingTimer{}));
     REQUIRE(machine->machine.process_event(call::event::Ended{}));
@@ -190,7 +188,7 @@ TEST_CASE("CLIP before ring, answered, end from caller")
 
     REQUIRE(machine->machine.process_event(call::event::Answer{}));
     fakeit::Verify(Method(di.audio, routingStart)).Exactly(1);
-    fakeit::Verify(Method(di.gui, notifyCallActive)).Exactly(1);
+    fakeit::Verify(Method(di.multicast, notifyCallActive)).Exactly(1);
 
     REQUIRE(machine->machine.process_event(call::event::OngoingTimer{}));
 
@@ -220,7 +218,7 @@ TEST_CASE("no CLIP at all, anonymus call answered, end from caller")
 
     REQUIRE(machine->machine.process_event(call::event::Answer{}));
     fakeit::Verify(Method(di.audio, routingStart)).Exactly(1);
-    fakeit::Verify(Method(di.gui, notifyCallActive)).Exactly(1);
+    fakeit::Verify(Method(di.multicast, notifyCallActive)).Exactly(1);
 
     REQUIRE(machine->machine.process_event(call::event::OngoingTimer{}));
 
@@ -259,7 +257,7 @@ TEST_CASE("reject on PURE after RING")
 
     fakeit::Verify(Method(di.audio, stop)).Exactly(1);
     // UI was notified to stop "calling" display
-    fakeit::Verify(Method(di.gui, notifyCallEnded)).Exactly(1);
+    fakeit::Verify(Method(di.multicast, notifyCallEnded)).Exactly(1);
 
     REQUIRE(record_when_called.type == CallType::CT_REJECTED);
 }
@@ -364,7 +362,7 @@ TEST_CASE("call outgoing - answered")
     REQUIRE(machine->machine.process_event(call::event::StartCall{CallType::CT_OUTGOING, number.getView()}));
     REQUIRE(machine->machine.process_event(call::event::Answer{}));
     fakeit::Verify(Method(di.audio, play)).Exactly(0);
-    fakeit::Verify(Method(di.gui, notifyOutgoingCallAnswered)).Exactly(1);
+    fakeit::Verify(Method(di.multicast, notifyOutgoingCallAnswered)).Exactly(1);
     REQUIRE(machine->machine.process_event(call::event::Ended{}));
     fakeit::Verify(Method(di.audio, stop)).Exactly(1);
 }

--- a/module-services/service-cellular/connection-manager/ConnectionManagerCellularCommands.cpp
+++ b/module-services/service-cellular/connection-manager/ConnectionManagerCellularCommands.cpp
@@ -58,7 +58,7 @@ auto ConnectionManagerCellularCommands::clearNetworkIndicator() -> bool
     constexpr auto rssi = 0;
     SignalStrength signalStrength(rssi);
     Store::GSM::get()->setSignalStrength(signalStrength.data);
-    auto msg = std::make_shared<CellularSignalStrengthUpdateNotification>();
+    auto msg = std::make_shared<cellular::SignalStrengthUpdateNotification>();
     cellular.bus.sendMulticast(msg, sys::BusChannel::ServiceCellularNotifications);
 
     return true;
@@ -66,7 +66,7 @@ auto ConnectionManagerCellularCommands::clearNetworkIndicator() -> bool
 
 void ConnectionManagerCellularCommands::hangUpOngoingCall()
 {
-    CellularHangupCallMessage msg;
+    cellular::HangupCallMessage msg;
     cellular.handleCellularHangupCallMessage(&msg);
 }
 

--- a/module-services/service-cellular/service-cellular/CellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/CellularMessage.hpp
@@ -84,803 +84,758 @@ class CellularMessage : public sys::DataMessage
     {}
     const Type type;
 };
-
-class CellularRingingMessage : public CellularMessage, public app::manager::actions::ConvertibleToAction
-{
-  public:
-    CellularRingingMessage(const utils::PhoneNumber::View &number) : CellularMessage(Type::Ringing), number(number)
-    {}
-    CellularRingingMessage(const utils::PhoneNumber &number) : CellularMessage(Type::Ringing), number(number.getView())
-    {}
-    CellularRingingMessage(const std::string &e164number)
-        : CellularMessage(Type::Ringing), number(utils::PhoneNumber::parse(e164number))
-    {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(
-            sender,
-            app::manager::actions::HandleOutgoingCall,
-            std::make_unique<app::manager::actions::CallParams>(number));
-    }
-
-    utils::PhoneNumber::View number;
-};
-
-class CellularIncominCallMessage : public CellularMessage
-{
-  public:
-    CellularIncominCallMessage() : CellularMessage(Type::IncomingCall)
-    {}
-};
-
-class CellularCallerIdMessage : public CellularMessage
-{
-  public:
-    CellularCallerIdMessage(const utils::PhoneNumber::View &number) : CellularMessage(Type::CallerId), number(number)
-    {}
-    CellularCallerIdMessage(const utils::PhoneNumber &number)
-        : CellularMessage(Type::CallerId), number(number.getView())
-    {}
-    CellularCallerIdMessage(const std::string &e164number)
-        : CellularMessage(Type::CallerId), number(utils::PhoneNumber::parse(e164number))
-    {}
-
-    utils::PhoneNumber::View number;
-};
-
-class CellularNotificationMessage : public CellularMessage
-{
-  public:
-    enum class Content
-    {
-        CallAborted, // user tried to call other device but receiving side dropped call or call unsuccessful
-        CallActive,  // call is in progress both if call was initialized by user and when user received incoming call.
-        NewIncomingSMS,           // device received new sms from network. (what about sms delivery reports?).
-        SignalStrengthUpdate,     // update of the strength of the network's signal.
-        NetworkStatusUpdate,      // update of the status of the network
-        PowerUpProcedureComplete, // modem without cmux on initialization complete (cold start || reset modem -> and
-        // cold start)
-        PowerDownDeregistering, // modem informed it has started to disconnect from network
-        PowerDownDeregistered,  // modem informed it has disconnected from network
-        SMSDone,                // SMS initialization finished
-        NewIncomingUrc,         // phone received new URC from network and we need to wake up modem and host
-        Ring,                   // phone received Ring notification
-        CallerID                // phone received Caller Id notification
-    };
-
-    // TODO check and fix all CellularNotificationMessage constructors
-
-    CellularNotificationMessage() = delete;
-    CellularNotificationMessage(Content content, const std::string &data = "")
-        : CellularMessage(Type::Notification), content(content), data(data)
-    {}
-
-    virtual ~CellularNotificationMessage() = default;
-
-    Content content;
-    std::string data;
-};
-
-class CellularRequestCurrentOperatorNameMessage : public CellularMessage
-{
-  public:
-    explicit CellularRequestCurrentOperatorNameMessage() : CellularMessage(Type::Notification)
-    {}
-};
-
-class CellularSetOperatorAutoSelectMessage : public sys::DataMessage
-{};
-
-class CellularCurrentOperatorNameNotification : public CellularMessage
-{
-    std::string currentOperatorName;
-
-  public:
-    explicit CellularCurrentOperatorNameNotification(const std::string &currentOperatorName)
-        : CellularMessage(Type::Notification), currentOperatorName(currentOperatorName)
-    {}
-
-    std::string getCurrentOperatorName() const
-    {
-        return currentOperatorName;
-    }
-};
-class CellularSetOperatorMessage : public sys::DataMessage
-{
-    at::response::cops::CopsMode mode;
-    at::response::cops::NameFormat format;
-    const std::string name;
-
-  public:
-    explicit CellularSetOperatorMessage(at::response::cops::CopsMode mode,
-                                        at::response::cops::NameFormat format,
-                                        std::string name)
-        : mode(mode), format(format), name(std::move(name))
-    {}
-
-    at::response::cops::CopsMode getMode() const noexcept
-    {
-        return mode;
-    }
-    at::response::cops::NameFormat getFormat() const noexcept
-    {
-        return format;
-    }
-
-    std::string getName() const
-    {
-        return name;
-    }
-};
-
-class CellularPowerStateChange : public CellularMessage
-{
-  public:
-    explicit CellularPowerStateChange(cellular::service::State::PowerState new_state)
-        : CellularMessage(Type::PowerStateChange), newState(new_state)
-    {}
-
-    cellular::service::State::PowerState getNewState() const noexcept
-    {
-        return newState;
-    }
-
-  private:
-    cellular::service::State::PowerState newState;
-};
-
-class CellularStartOperatorsScanMessage : public CellularMessage
-{
-    bool fullInfo = false;
-
-  public:
-    explicit CellularStartOperatorsScanMessage(bool fullInfoList = false)
-        : CellularMessage(Type::StartOperatorsScan), fullInfo(fullInfoList)
-    {}
-
-    bool getFullInfo() const noexcept
-    {
-        return fullInfo;
-    }
-};
-
-class CellularTimeNotificationMessage : public CellularMessage
-{
-  private:
-    std::optional<struct tm> time;
-    std::optional<int> timeZoneGmtOff;
-    std::optional<std::string> timeZoneString;
-
-  public:
-    CellularTimeNotificationMessage() = delete;
-    explicit CellularTimeNotificationMessage(struct tm time, long int timeZoneGmtOff, std::string timeZoneString)
-        : CellularMessage(Type::TimeUpdated), time(time), timeZoneGmtOff(timeZoneGmtOff), timeZoneString(timeZoneString)
-    {}
-
-    explicit CellularTimeNotificationMessage(long int timeZoneGmtOff, std::string timeZoneString)
-        : CellularMessage(Type::TimeUpdated), timeZoneGmtOff(timeZoneGmtOff), timeZoneString(timeZoneString)
-    {}
-
-    explicit CellularTimeNotificationMessage(struct tm time) : CellularMessage(Type::TimeUpdated), time(time)
-    {}
-
-    std::optional<struct tm> getTime(void)
-    {
-        return time;
-    }
-
-    std::optional<long int> getTimeZoneOffset(void)
-    {
-        return timeZoneGmtOff;
-    }
-
-    std::optional<const std::string> getTimeZoneString(void)
-    {
-        return timeZoneString;
-    }
-};
-class CellularUSSDMessage : public CellularMessage
-{
-  public:
-    enum class RequestType
-    {
-        pullSesionRequest,
-        pushSesionRequest,
-        abortSesion
-    };
-    CellularUSSDMessage() = delete;
-    CellularUSSDMessage(RequestType requestType, const std::string &data = "")
-        : CellularMessage(Type::USSDRequest), type(requestType), data(data)
-    {}
-
-    RequestType type;
-    std::string data;
-};
-class CellularRequestMessage : public CellularMessage
-{
-  public:
-    CellularRequestMessage(Type type, std::string data = "") : CellularMessage(type), data(data)
-    {}
-
-    std::string data;
-};
-
-class CellularDtmfRequestMessage : public CellularMessage
-{
-    DTMFCode code;
-
-  public:
-    CellularDtmfRequestMessage(DTMFCode code) : CellularMessage(Type::TransmitDtmfTones), code(code)
-    {}
-
-    DTMFCode getDTMFCode() const
-    {
-        return code;
-    }
-};
-
-class CellularAntennaRequestMessage : public CellularMessage
-{
-  public:
-    CellularAntennaRequestMessage() : CellularMessage(Type::SelectAntenna)
-    {}
-
-    bsp::cellular::antenna antenna;
-};
-
-class CellularCallRequestMessage : public CellularMessage
-{
-  public:
-    CellularCallRequestMessage(const utils::PhoneNumber::View &number,
-                               cellular::api::CallMode callMode = cellular::api::CallMode::Regular)
-        : CellularMessage(Type::CallRequest), number(number), callMode(callMode)
-    {}
-    utils::PhoneNumber::View number;
-    cellular::api::CallMode callMode = cellular::api::CallMode::Regular;
-};
-
-class CellularSmsNoSimRequestMessage : public CellularMessage, public app::manager::actions::ConvertibleToAction
-{
-  public:
-    CellularSmsNoSimRequestMessage() : CellularMessage{Type::Uninitialized}
-    {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(
-            sender, app::manager::actions::SmsRejectNoSim, std::make_unique<app::manager::actions::ActionParams>());
-    }
-};
-
-class CellularGetChannelMessage : public CellularMessage
-{
-  public:
-    explicit CellularGetChannelMessage(CellularMux::Channel dataChannel = CellularMux::Channel::None)
-        : CellularMessage{Type::GetChannel}, dataChannel(dataChannel)
-    {}
-    CellularMux::Channel dataChannel;
-};
-
-class CellularGetChannelResponseMessage : public CellularMessage
-{
-  public:
-    explicit CellularGetChannelResponseMessage(DLCChannel *dataChannelPtr = nullptr)
-        : CellularMessage{Type::GetChannelResponse}, dataChannelPtr(dataChannelPtr)
-    {}
-    DLCChannel *dataChannelPtr;
-};
-
-class CellularResponseMessage : public sys::ResponseMessage
-{
-  public:
-    CellularResponseMessage(bool retCode,
-                            std::string retdata              = std::string(),
-                            CellularMessage::Type responseTo = CellularMessage::Type::Uninitialized)
-        : sys::ResponseMessage(sys::ReturnCodes::Success), retCode(retCode), data(retdata), cellResponse(responseTo){};
-
-    CellularResponseMessage(bool retCode, CellularMessage::Type responseTo)
-        : sys::ResponseMessage(sys::ReturnCodes::Success), retCode(retCode), cellResponse(responseTo){};
-
-    virtual ~CellularResponseMessage(){};
-
-    bool retCode;
-    std::string data;
-    CellularMessage::Type cellResponse;
-};
-
-class CellularGetOwnNumberResponseMessage : public CellularResponseMessage
-{
-  public:
-    CellularGetOwnNumberResponseMessage(bool retCode, std::string number = std::string())
-        : CellularResponseMessage(retCode, std::move(number))
-    {}
-};
-
-class CellularAntennaResponseMessage : public CellularResponseMessage
-{
-  public:
-    CellularAntennaResponseMessage(bool retCode, bsp::cellular::antenna retAntenna, CellularMessage::Type responseTo)
-        : CellularResponseMessage(retCode, responseTo), antenna(retAntenna)
-    {}
-
-    bsp::cellular::antenna antenna;
-};
-
-class CellularMMIResult : public CellularMessage
-{
-  protected:
-    app::manager::actions::MMIResultParams params;
-
-    explicit CellularMMIResult(app::manager::actions::MMIResultParams::MMIResult result,
-                               std::shared_ptr<app::manager::actions::MMICustomResultParams> customResult = nullptr)
-        : CellularMessage(Type::MMIData), params(result, std::move(customResult))
-    {}
-};
-
-class CellularMMIResultMessage : public CellularMMIResult, public app::manager::actions::ConvertibleToAction
-{
-  public:
-    explicit CellularMMIResultMessage(
-        app::manager::actions::MMIResultParams::MMIResult result,
-        std::shared_ptr<app::manager::actions::MMICustomResultParams> customResult = nullptr)
-        : CellularMMIResult(result, std::move(customResult))
-    {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(
-            sender,
-            app::manager::actions::ShowMMIResult,
-            std::make_unique<app::manager::actions::MMIResultParams>(params));
-    }
-};
-class CellularMMIDataMessage : public CellularMessage
-{
-  protected:
-    app::manager::actions::MMIParams params;
-
-  public:
-    explicit CellularMMIDataMessage(std::string mmiData) : CellularMessage(Type::MMIData), params(mmiData)
-    {}
-};
-class CellularMMIResponseMessage : public CellularMMIDataMessage, public app::manager::actions::ConvertibleToAction
-{
-  public:
-    explicit CellularMMIResponseMessage(std::string mmiData) : CellularMMIDataMessage(std::move(mmiData))
-    {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(
-            sender, app::manager::actions::ShowMMIResponse, std::make_unique<app::manager::actions::MMIParams>(params));
-    }
-};
-class CellularMMIPushMessage : public CellularMMIDataMessage, public app::manager::actions::ConvertibleToAction
-{
-  public:
-    explicit CellularMMIPushMessage(std::string mmiData) : CellularMMIDataMessage(std::move(mmiData))
-    {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(
-            sender, app::manager::actions::ShowMMIPush, std::make_unique<app::manager::actions::MMIParams>(params));
-    }
-};
-
-class CellularSetOperatorAutoSelectResponse : public CellularResponseMessage
-{
-  public:
-    explicit CellularSetOperatorAutoSelectResponse(bool ret) : CellularResponseMessage(ret)
-    {}
-};
-
-class CellularSetOperatorResponse : public CellularResponseMessage
-{
-  public:
-    explicit CellularSetOperatorResponse(bool ret) : CellularResponseMessage(ret)
-    {}
-};
-
-class CellularVoLTEDataMessage : public CellularMessage
-{
-    bool VoLTEon = false;
-
-  public:
-    explicit CellularVoLTEDataMessage(bool VoLTEon) : CellularMessage{Type::SetVoLTE}, VoLTEon{VoLTEon}
-    {}
-    [[nodiscard]] bool getVoLTEon() const noexcept
-    {
-        return VoLTEon;
-    }
-};
-
-class CellularChangeVoLTEDataMessage : public CellularVoLTEDataMessage
-{
-  public:
-    explicit CellularChangeVoLTEDataMessage(bool VoLTEon) : CellularVoLTEDataMessage{VoLTEon}
-    {}
-};
-
-class CellularCheckIfStartAllowedMessage : public sys::DataMessage
-{};
-
-class CellularNoSimNotification : public CellularResponseMessage, public app::manager::actions::ConvertibleToAction
-{
-  public:
-    CellularNoSimNotification(std::string data) : CellularResponseMessage(false, data)
-    {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(
-            sender,
-            app::manager::actions::NoSimNotification,
-            std::make_unique<app::manager::actions::ActionParams>(data));
-    }
-};
-
-class CellularNotAnEmergencyNotification : public CellularResponseMessage,
-                                           public app::manager::actions::ConvertibleToAction
-{
-  public:
-    CellularNotAnEmergencyNotification(std::string data) : CellularResponseMessage(false, data)
-    {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(
-            sender,
-            app::manager::actions::NotAnEmergencyNotification,
-            std::make_unique<app::manager::actions::ActionParams>(data));
-    }
-};
-
-class CellularNoNetworkConenctionNotification : public CellularResponseMessage,
-                                                public app::manager::actions::ConvertibleToAction
-{
-  public:
-    CellularNoNetworkConenctionNotification() : CellularResponseMessage(false)
-    {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(sender,
-                                                             app::manager::actions::NoNetworkConnectionNotification,
-                                                             std::make_unique<app::manager::actions::ActionParams>());
-    }
-};
-
-class CellularCallRequestGeneralError : public CellularResponseMessage,
-                                        public app::manager::actions::ConvertibleToAction
-{
-  public:
-    using Error     = app::manager::actions::CallRequestGeneralErrorParams::Error;
-    using ErrorType = app::manager::actions::CallRequestGeneralErrorParams::Error::Type;
-
-    CellularCallRequestGeneralError(ErrorType errorType) : CellularResponseMessage(false), error{errorType}
-    {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(
-            sender,
-            app::manager::actions::CallRequestGeneralErrorNotification,
-            std::make_unique<app::manager::actions::CallRequestGeneralErrorParams>(error));
-    }
-
-  private:
-    Error error;
-};
-
-class CellularNewIncomingSMSMessage : public CellularMessage
-{
-  public:
-    explicit CellularNewIncomingSMSMessage(const std::string &data)
-        : CellularMessage(Type::NewIncomingSMS), notificationData(data)
-    {}
-    auto getData() const -> std::string
-    {
-        return notificationData;
-    }
-
-  private:
-    std::string notificationData;
-};
-
-class CellularIncomingSMSNotificationMessage : public CellularMessage
-{
-  public:
-    CellularIncomingSMSNotificationMessage() : CellularMessage(Type::IncomingSMSNotification)
-    {}
-};
-
-class CellularAnswerIncomingCallMessage : public CellularMessage
-{
-  public:
-    CellularAnswerIncomingCallMessage() : CellularMessage(Type::AnswerIncomingCall)
-    {}
-};
-
-class CellularHangupCallMessage : public CellularMessage
-{
-  public:
-    CellularHangupCallMessage() : CellularMessage(Type::HangupCall)
-    {}
-};
-
-class CellularDismissCallMessage : public CellularMessage
-{
-  public:
-    CellularDismissCallMessage() : CellularMessage(Type::DismissCall)
-    {}
-};
-
-class CellularListCallsMessage : public CellularMessage
-{
-  public:
-    CellularListCallsMessage() : CellularMessage(Type::ListCurrentCalls)
-    {}
-};
-
-class CellularGetIMSIMessage : public CellularMessage
-{
-  public:
-    CellularGetIMSIMessage() : CellularMessage(Type::GetIMSI)
-    {}
-};
-
-class CellularGetOwnNumberMessage : public CellularMessage
-{
-  public:
-    CellularGetOwnNumberMessage() : CellularMessage(Type::GetOwnNumber)
-    {}
-};
-
-class CellularGetNetworkInfoMessage : public CellularMessage
-{
-  public:
-    CellularGetNetworkInfoMessage() : CellularMessage(Type::GetNetworkInfo)
-    {}
-};
-
-class CellularSetScanModeMessage : public CellularMessage
-{
-  public:
-    CellularSetScanModeMessage(const std::string &mode) : CellularMessage(Type::SetScanMode), data(mode)
-    {}
-    std::string data;
-};
-
-class CellularGetScanModeMessage : public CellularMessage
-{
-  public:
-    CellularGetScanModeMessage() : CellularMessage(Type::GetScanMode)
-    {}
-};
-
-class CellularGetFirmwareVersionMessage : public CellularMessage
-{
-  public:
-    CellularGetFirmwareVersionMessage() : CellularMessage(Type::GetFirmwareVersion)
-    {}
-};
-
-class CellularGetCsqMessage : public CellularMessage
-{
-  public:
-    CellularGetCsqMessage() : CellularMessage(Type::GetCSQ)
-    {}
-};
-
-class CellularGetCregMessage : public CellularMessage
-{
-  public:
-    CellularGetCregMessage() : CellularMessage(Type::GetCREG)
-    {}
-};
-
-class CellularGetNwinfoMessage : public CellularMessage
-{
-  public:
-    CellularGetNwinfoMessage() : CellularMessage(Type::GetNWINFO)
-    {}
-};
-
-class CellularGetAntennaMessage : public CellularMessage
-{
-  public:
-    CellularGetAntennaMessage() : CellularMessage(Type::GetAntenna)
-    {}
-};
-
-class CellularSetFlightModeMessage : public CellularMessage
-{
-  public:
-    explicit CellularSetFlightModeMessage(bool flightModeOn)
-        : CellularMessage(Type::SetFlightMode), flightModeOn(flightModeOn)
-    {}
-    bool flightModeOn;
-};
-
-class CellularSetConnectionFrequencyMessage : public CellularMessage
-{
-  public:
-    explicit CellularSetConnectionFrequencyMessage(const uint8_t &connectionFrequency)
-        : CellularMessage(Type::CellularSetConnectionFrequency), connectionFrequency(connectionFrequency)
-    {}
-    auto getConnectionFrequency() const noexcept -> uint8_t
-    {
-        return connectionFrequency;
-    }
-
-  private:
-    uint8_t connectionFrequency;
-};
-
-class CellularCallActiveNotification : public CellularNotificationMessage,
-                                       public app::manager::actions::ConvertibleToAction
-{
-  public:
-    explicit CellularCallActiveNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Content::CallActive, data)
-    {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(
-            sender, app::manager::actions::ActivateCall, std::make_unique<app::manager::actions::CallParams>());
-    }
-};
-
-class CellularCallAbortedNotification : public CellularNotificationMessage
-{
-  public:
-    explicit CellularCallAbortedNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Content::CallAborted, data)
-    {}
-};
-
-class CellularPowerUpProcedureCompleteNotification : public CellularNotificationMessage
-{
-  public:
-    explicit CellularPowerUpProcedureCompleteNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Content::PowerUpProcedureComplete, data)
-    {}
-};
-
-class CellularPowerDownDeregisteringNotification : public CellularNotificationMessage
-{
-  public:
-    explicit CellularPowerDownDeregisteringNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Content::PowerDownDeregistering, data)
-    {}
-};
-
-class CellularPowerDownDeregisteredNotification : public CellularNotificationMessage
-{
-  public:
-    explicit CellularPowerDownDeregisteredNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Content::PowerDownDeregistered, data)
-    {}
-};
-
-class CellularNewIncomingSMSNotification : public CellularNotificationMessage
-{
-  public:
-    explicit CellularNewIncomingSMSNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Content::NewIncomingSMS, data)
-    {}
-};
-
-class CellularSmsDoneNotification : public CellularNotificationMessage
-{
-  public:
-    explicit CellularSmsDoneNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Content::SMSDone, data)
-    {}
-};
-
-class CellularSignalStrengthUpdateNotification : public CellularNotificationMessage
-{
-  public:
-    explicit CellularSignalStrengthUpdateNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Content::SignalStrengthUpdate, data)
-    {}
-};
-
-class CellularNetworkStatusUpdateNotification : public CellularNotificationMessage
-{
-  public:
-    explicit CellularNetworkStatusUpdateNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Content::NetworkStatusUpdate, data)
-    {}
-};
-
-class CellularUrcIncomingNotification : public CellularNotificationMessage
-{
-  public:
-    explicit CellularUrcIncomingNotification(const std::string &data = "")
-        : CellularNotificationMessage(CellularNotificationMessage::Content::NewIncomingUrc, data)
-    {}
-};
-
-class CellularSetRadioOnOffMessage : public CellularMessage
-{
-  public:
-    explicit CellularSetRadioOnOffMessage(bool radioOnOff) : CellularMessage(Type::RadioOnOff), radioOnOff(radioOnOff)
-    {}
-    auto getRadioOnOf() -> bool
-    {
-        return radioOnOff;
-    }
-
-  private:
-    bool radioOnOff;
-};
-
-class CellularSMSRejectedByOfflineNotification : public CellularResponseMessage,
-                                                 public app::manager::actions::ConvertibleToAction
-{
-  public:
-    CellularSMSRejectedByOfflineNotification() : CellularResponseMessage(false)
-    {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(sender,
-                                                             app::manager::actions::SMSRejectedByOfflineNotification,
-                                                             std::make_unique<app::manager::actions::ActionParams>());
-    }
-};
-
-class CellularCallRejectedByOfflineNotification : public CellularResponseMessage,
-                                                  public app::manager::actions::ConvertibleToAction
-{
-  public:
-    CellularCallRejectedByOfflineNotification() : CellularResponseMessage(false)
-    {}
-
-    [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
-    {
-        return std::make_unique<app::manager::ActionRequest>(sender,
-                                                             app::manager::actions::CallRejectedByOfflineNotification,
-                                                             std::make_unique<app::manager::actions::ActionParams>());
-    }
-};
-
-class CellularRingNotification : public CellularNotificationMessage
-{
-  public:
-    CellularRingNotification() : CellularNotificationMessage(CellularNotificationMessage::Content::Ring)
-    {}
-};
-
-class CellularCallerIdNotification : public CellularNotificationMessage
-{
-  public:
-    explicit CellularCallerIdNotification(const utils::PhoneNumber::View &number)
-        : CellularNotificationMessage(CellularNotificationMessage::Content::Ring), number(number)
-    {}
-    explicit CellularCallerIdNotification(const utils::PhoneNumber &number)
-        : CellularNotificationMessage(CellularNotificationMessage::Content::Ring), number(number.getView())
-    {}
-    explicit CellularCallerIdNotification(const std::string &e164number)
-        : CellularNotificationMessage(CellularNotificationMessage::Content::Ring),
-          number(utils::PhoneNumber::parse(e164number))
-    {}
-    auto getNubmer() const -> utils::PhoneNumber::View
-    {
-        return number;
-    }
-
-  private:
-    utils::PhoneNumber::View number;
-};
-
 namespace cellular
 {
+
+    class RingingMessage : public CellularMessage, public app::manager::actions::ConvertibleToAction
+    {
+      public:
+        RingingMessage(const utils::PhoneNumber::View &number) : CellularMessage(Type::Ringing), number(number)
+        {}
+        RingingMessage(const utils::PhoneNumber &number) : CellularMessage(Type::Ringing), number(number.getView())
+        {}
+        RingingMessage(const std::string &e164number)
+            : CellularMessage(Type::Ringing), number(utils::PhoneNumber::parse(e164number))
+        {}
+
+        [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+        {
+            return std::make_unique<app::manager::ActionRequest>(
+                sender,
+                app::manager::actions::HandleOutgoingCall,
+                std::make_unique<app::manager::actions::CallParams>(number));
+        }
+
+        utils::PhoneNumber::View number;
+    };
+
+    class NotificationMessage : public CellularMessage
+    {
+      public:
+        enum class Content
+        {
+            CallAborted,    // user tried to call other device but receiving side dropped call or call unsuccessful
+            CallActive,     // call is in progress both if call was initialized by user and when user received incoming
+                            // call.
+            NewIncomingSMS, // device received new sms from network. (what about sms delivery reports?).
+            SignalStrengthUpdate,     // update of the strength of the network's signal.
+            NetworkStatusUpdate,      // update of the status of the network
+            PowerUpProcedureComplete, // modem without cmux on initialization complete (cold start || reset modem -> and
+            // cold start)
+            PowerDownDeregistering, // modem informed it has started to disconnect from network
+            PowerDownDeregistered,  // modem informed it has disconnected from network
+            SMSDone,                // SMS initialization finished
+            NewIncomingUrc,         // phone received new URC from network and we need to wake up modem and host
+            Ring,                   // phone received Ring notification
+            CallerID                // phone received Caller Id notification
+        };
+
+        // TODO check and fix all NotificationMessage constructors
+
+        NotificationMessage() = delete;
+        NotificationMessage(Content content, const std::string &data = "")
+            : CellularMessage(Type::Notification), content(content), data(data)
+        {}
+
+        virtual ~NotificationMessage() = default;
+
+        Content content;
+        std::string data;
+    };
+
+    class RequestCurrentOperatorNameMessage : public CellularMessage
+    {
+      public:
+        explicit RequestCurrentOperatorNameMessage() : CellularMessage(Type::Notification)
+        {}
+    };
+
+    class SetOperatorAutoSelectMessage : public sys::DataMessage
+    {};
+
+    class CurrentOperatorNameNotification : public CellularMessage
+    {
+        std::string currentOperatorName;
+
+      public:
+        explicit CurrentOperatorNameNotification(const std::string &currentOperatorName)
+            : CellularMessage(Type::Notification), currentOperatorName(currentOperatorName)
+        {}
+
+        std::string getCurrentOperatorName() const
+        {
+            return currentOperatorName;
+        }
+    };
+    class SetOperatorMessage : public sys::DataMessage
+    {
+        at::response::cops::CopsMode mode;
+        at::response::cops::NameFormat format;
+        const std::string name;
+
+      public:
+        explicit SetOperatorMessage(at::response::cops::CopsMode mode,
+                                    at::response::cops::NameFormat format,
+                                    std::string name)
+            : mode(mode), format(format), name(std::move(name))
+        {}
+
+        at::response::cops::CopsMode getMode() const noexcept
+        {
+            return mode;
+        }
+        at::response::cops::NameFormat getFormat() const noexcept
+        {
+            return format;
+        }
+
+        std::string getName() const
+        {
+            return name;
+        }
+    };
+
+    class PowerStateChange : public CellularMessage
+    {
+      public:
+        explicit PowerStateChange(cellular::service::State::PowerState new_state)
+            : CellularMessage(Type::PowerStateChange), newState(new_state)
+        {}
+
+        cellular::service::State::PowerState getNewState() const noexcept
+        {
+            return newState;
+        }
+
+      private:
+        cellular::service::State::PowerState newState;
+    };
+
+    class StartOperatorsScanMessage : public CellularMessage
+    {
+        bool fullInfo = false;
+
+      public:
+        explicit StartOperatorsScanMessage(bool fullInfoList = false)
+            : CellularMessage(Type::StartOperatorsScan), fullInfo(fullInfoList)
+        {}
+
+        bool getFullInfo() const noexcept
+        {
+            return fullInfo;
+        }
+    };
+
+    class TimeNotificationMessage : public CellularMessage
+    {
+      private:
+        std::optional<struct tm> time;
+        std::optional<int> timeZoneGmtOff;
+        std::optional<std::string> timeZoneString;
+
+      public:
+        TimeNotificationMessage() = delete;
+        explicit TimeNotificationMessage(struct tm time, long int timeZoneGmtOff, std::string timeZoneString)
+            : CellularMessage(Type::TimeUpdated), time(time), timeZoneGmtOff(timeZoneGmtOff),
+              timeZoneString(timeZoneString)
+        {}
+
+        explicit TimeNotificationMessage(long int timeZoneGmtOff, std::string timeZoneString)
+            : CellularMessage(Type::TimeUpdated), timeZoneGmtOff(timeZoneGmtOff), timeZoneString(timeZoneString)
+        {}
+
+        explicit TimeNotificationMessage(struct tm time) : CellularMessage(Type::TimeUpdated), time(time)
+        {}
+
+        std::optional<struct tm> getTime(void)
+        {
+            return time;
+        }
+
+        std::optional<long int> getTimeZoneOffset(void)
+        {
+            return timeZoneGmtOff;
+        }
+
+        std::optional<const std::string> getTimeZoneString(void)
+        {
+            return timeZoneString;
+        }
+    };
+    class USSDMessage : public CellularMessage
+    {
+      public:
+        enum class RequestType
+        {
+            pullSessionRequest,
+            pushSessionRequest,
+            abortSession
+        };
+        USSDMessage() = delete;
+        USSDMessage(RequestType requestType, const std::string &data = "")
+            : CellularMessage(Type::USSDRequest), type(requestType), data(data)
+        {}
+
+        RequestType type;
+        std::string data;
+    };
+    class RequestMessage : public CellularMessage
+    {
+      public:
+        RequestMessage(Type type, std::string data = "") : CellularMessage(type), data(data)
+        {}
+
+        std::string data;
+    };
+
+    class DtmfRequestMessage : public CellularMessage
+    {
+        DTMFCode code;
+
+      public:
+        DtmfRequestMessage(DTMFCode code) : CellularMessage(Type::TransmitDtmfTones), code(code)
+        {}
+
+        DTMFCode getDTMFCode() const
+        {
+            return code;
+        }
+    };
+
+    class AntennaRequestMessage : public CellularMessage
+    {
+      public:
+        AntennaRequestMessage() : CellularMessage(Type::SelectAntenna)
+        {}
+
+        bsp::cellular::antenna antenna;
+    };
+
+    class CallRequestMessage : public CellularMessage
+    {
+      public:
+        CallRequestMessage(const utils::PhoneNumber::View &number,
+                           cellular::api::CallMode callMode = cellular::api::CallMode::Regular)
+            : CellularMessage(Type::CallRequest), number(number), callMode(callMode)
+        {}
+        utils::PhoneNumber::View number;
+        cellular::api::CallMode callMode = cellular::api::CallMode::Regular;
+    };
+
+    class SmsNoSimRequestMessage : public CellularMessage, public app::manager::actions::ConvertibleToAction
+    {
+      public:
+        SmsNoSimRequestMessage() : CellularMessage{Type::Uninitialized}
+        {}
+
+        [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+        {
+            return std::make_unique<app::manager::ActionRequest>(
+                sender, app::manager::actions::SmsRejectNoSim, std::make_unique<app::manager::actions::ActionParams>());
+        }
+    };
+
+    class GetChannelMessage : public CellularMessage
+    {
+      public:
+        explicit GetChannelMessage(CellularMux::Channel dataChannel = CellularMux::Channel::None)
+            : CellularMessage{Type::GetChannel}, dataChannel(dataChannel)
+        {}
+        CellularMux::Channel dataChannel;
+    };
+
+    class GetChannelResponseMessage : public CellularMessage
+    {
+      public:
+        explicit GetChannelResponseMessage(DLCChannel *dataChannelPtr = nullptr)
+            : CellularMessage{Type::GetChannelResponse}, dataChannelPtr(dataChannelPtr)
+        {}
+        DLCChannel *dataChannelPtr;
+    };
+
+    class ResponseMessage : public sys::ResponseMessage
+    {
+      public:
+        ResponseMessage(bool retCode,
+                        std::string retdata              = std::string(),
+                        CellularMessage::Type responseTo = CellularMessage::Type::Uninitialized)
+            : sys::ResponseMessage(sys::ReturnCodes::Success), retCode(retCode), data(retdata),
+              cellResponse(responseTo){};
+
+        ResponseMessage(bool retCode, CellularMessage::Type responseTo)
+            : sys::ResponseMessage(sys::ReturnCodes::Success), retCode(retCode), cellResponse(responseTo){};
+
+        virtual ~ResponseMessage(){};
+
+        bool retCode;
+        std::string data;
+        CellularMessage::Type cellResponse;
+    };
+
+    class GetOwnNumberResponseMessage : public ResponseMessage
+    {
+      public:
+        GetOwnNumberResponseMessage(bool retCode, std::string number = std::string())
+            : ResponseMessage(retCode, std::move(number))
+        {}
+    };
+
+    class AntennaResponseMessage : public ResponseMessage
+    {
+      public:
+        AntennaResponseMessage(bool retCode, bsp::cellular::antenna retAntenna, CellularMessage::Type responseTo)
+            : ResponseMessage(retCode, responseTo), antenna(retAntenna)
+        {}
+
+        bsp::cellular::antenna antenna;
+    };
+
+    class MMIResult : public CellularMessage
+    {
+      protected:
+        app::manager::actions::MMIResultParams params;
+
+        explicit MMIResult(app::manager::actions::MMIResultParams::MMIResult result,
+                           std::shared_ptr<app::manager::actions::MMICustomResultParams> customResult = nullptr)
+            : CellularMessage(Type::MMIData), params(result, std::move(customResult))
+        {}
+    };
+
+    class MMIResultMessage : public MMIResult, public app::manager::actions::ConvertibleToAction
+    {
+      public:
+        explicit MMIResultMessage(app::manager::actions::MMIResultParams::MMIResult result,
+                                  std::shared_ptr<app::manager::actions::MMICustomResultParams> customResult = nullptr)
+            : MMIResult(result, std::move(customResult))
+        {}
+
+        [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+        {
+            return std::make_unique<app::manager::ActionRequest>(
+                sender,
+                app::manager::actions::ShowMMIResult,
+                std::make_unique<app::manager::actions::MMIResultParams>(params));
+        }
+    };
+    class MMIDataMessage : public CellularMessage
+    {
+      protected:
+        app::manager::actions::MMIParams params;
+
+      public:
+        explicit MMIDataMessage(std::string mmiData) : CellularMessage(Type::MMIData), params(mmiData)
+        {}
+    };
+    class MMIResponseMessage : public MMIDataMessage, public app::manager::actions::ConvertibleToAction
+    {
+      public:
+        explicit MMIResponseMessage(std::string mmiData) : MMIDataMessage(std::move(mmiData))
+        {}
+
+        [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+        {
+            return std::make_unique<app::manager::ActionRequest>(
+                sender,
+                app::manager::actions::ShowMMIResponse,
+                std::make_unique<app::manager::actions::MMIParams>(params));
+        }
+    };
+    class MMIPushMessage : public MMIDataMessage, public app::manager::actions::ConvertibleToAction
+    {
+      public:
+        explicit MMIPushMessage(std::string mmiData) : MMIDataMessage(std::move(mmiData))
+        {}
+
+        [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+        {
+            return std::make_unique<app::manager::ActionRequest>(
+                sender, app::manager::actions::ShowMMIPush, std::make_unique<app::manager::actions::MMIParams>(params));
+        }
+    };
+
+    class SetOperatorAutoSelectResponse : public ResponseMessage
+    {
+      public:
+        explicit SetOperatorAutoSelectResponse(bool ret) : ResponseMessage(ret)
+        {}
+    };
+
+    class SetOperatorResponse : public ResponseMessage
+    {
+      public:
+        explicit SetOperatorResponse(bool ret) : ResponseMessage(ret)
+        {}
+    };
+
+    class VoLTEDataMessage : public CellularMessage
+    {
+        bool VoLTEon = false;
+
+      public:
+        explicit VoLTEDataMessage(bool VoLTEon) : CellularMessage{Type::SetVoLTE}, VoLTEon{VoLTEon}
+        {}
+        [[nodiscard]] bool getVoLTEon() const noexcept
+        {
+            return VoLTEon;
+        }
+    };
+
+    class ChangeVoLTEDataMessage : public VoLTEDataMessage
+    {
+      public:
+        explicit ChangeVoLTEDataMessage(bool VoLTEon) : VoLTEDataMessage{VoLTEon}
+        {}
+    };
+
+    class CheckIfStartAllowedMessage : public sys::DataMessage
+    {};
+
+    class NoSimNotification : public ResponseMessage, public app::manager::actions::ConvertibleToAction
+    {
+      public:
+        NoSimNotification(std::string data) : ResponseMessage(false, data)
+        {}
+
+        [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+        {
+            return std::make_unique<app::manager::ActionRequest>(
+                sender,
+                app::manager::actions::NoSimNotification,
+                std::make_unique<app::manager::actions::ActionParams>(data));
+        }
+    };
+
+    class NotAnEmergencyNotification : public ResponseMessage, public app::manager::actions::ConvertibleToAction
+    {
+      public:
+        NotAnEmergencyNotification(std::string data) : ResponseMessage(false, data)
+        {}
+
+        [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+        {
+            return std::make_unique<app::manager::ActionRequest>(
+                sender,
+                app::manager::actions::NotAnEmergencyNotification,
+                std::make_unique<app::manager::actions::ActionParams>(data));
+        }
+    };
+
+    class NoNetworkConenctionNotification : public ResponseMessage, public app::manager::actions::ConvertibleToAction
+    {
+      public:
+        NoNetworkConenctionNotification() : ResponseMessage(false)
+        {}
+
+        [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+        {
+            return std::make_unique<app::manager::ActionRequest>(
+                sender,
+                app::manager::actions::NoNetworkConnectionNotification,
+                std::make_unique<app::manager::actions::ActionParams>());
+        }
+    };
+
+    class CallRequestGeneralError : public ResponseMessage, public app::manager::actions::ConvertibleToAction
+    {
+      public:
+        using Error     = app::manager::actions::CallRequestGeneralErrorParams::Error;
+        using ErrorType = app::manager::actions::CallRequestGeneralErrorParams::Error::Type;
+
+        CallRequestGeneralError(ErrorType errorType) : ResponseMessage(false), error{errorType}
+        {}
+
+        [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+        {
+            return std::make_unique<app::manager::ActionRequest>(
+                sender,
+                app::manager::actions::CallRequestGeneralErrorNotification,
+                std::make_unique<app::manager::actions::CallRequestGeneralErrorParams>(error));
+        }
+
+      private:
+        Error error;
+    };
+
+    class NewIncomingSMSMessage : public CellularMessage
+    {
+      public:
+        explicit NewIncomingSMSMessage(const std::string &data)
+            : CellularMessage(Type::NewIncomingSMS), notificationData(data)
+        {}
+        auto getData() const -> std::string
+        {
+            return notificationData;
+        }
+
+      private:
+        std::string notificationData;
+    };
+
+    class IncomingSMSNotificationMessage : public CellularMessage
+    {
+      public:
+        IncomingSMSNotificationMessage() : CellularMessage(Type::IncomingSMSNotification)
+        {}
+    };
+
+    class AnswerIncomingCallMessage : public CellularMessage
+    {
+      public:
+        AnswerIncomingCallMessage() : CellularMessage(Type::AnswerIncomingCall)
+        {}
+    };
+
+    class HangupCallMessage : public CellularMessage
+    {
+      public:
+        HangupCallMessage() : CellularMessage(Type::HangupCall)
+        {}
+    };
+
+    class DismissCallMessage : public CellularMessage
+    {
+      public:
+        DismissCallMessage() : CellularMessage(Type::DismissCall)
+        {}
+    };
+
+    class ListCallsMessage : public CellularMessage
+    {
+      public:
+        ListCallsMessage() : CellularMessage(Type::ListCurrentCalls)
+        {}
+    };
+
+    class GetIMSIMessage : public CellularMessage
+    {
+      public:
+        GetIMSIMessage() : CellularMessage(Type::GetIMSI)
+        {}
+    };
+
+    class GetOwnNumberMessage : public CellularMessage
+    {
+      public:
+        GetOwnNumberMessage() : CellularMessage(Type::GetOwnNumber)
+        {}
+    };
+
+    class GetNetworkInfoMessage : public CellularMessage
+    {
+      public:
+        GetNetworkInfoMessage() : CellularMessage(Type::GetNetworkInfo)
+        {}
+    };
+
+    class SetScanModeMessage : public CellularMessage
+    {
+      public:
+        SetScanModeMessage(const std::string &mode) : CellularMessage(Type::SetScanMode), data(mode)
+        {}
+        std::string data;
+    };
+
+    class GetScanModeMessage : public CellularMessage
+    {
+      public:
+        GetScanModeMessage() : CellularMessage(Type::GetScanMode)
+        {}
+    };
+
+    class GetFirmwareVersionMessage : public CellularMessage
+    {
+      public:
+        GetFirmwareVersionMessage() : CellularMessage(Type::GetFirmwareVersion)
+        {}
+    };
+
+    class GetCsqMessage : public CellularMessage
+    {
+      public:
+        GetCsqMessage() : CellularMessage(Type::GetCSQ)
+        {}
+    };
+
+    class GetCregMessage : public CellularMessage
+    {
+      public:
+        GetCregMessage() : CellularMessage(Type::GetCREG)
+        {}
+    };
+
+    class GetNwinfoMessage : public CellularMessage
+    {
+      public:
+        GetNwinfoMessage() : CellularMessage(Type::GetNWINFO)
+        {}
+    };
+
+    class GetAntennaMessage : public CellularMessage
+    {
+      public:
+        GetAntennaMessage() : CellularMessage(Type::GetAntenna)
+        {}
+    };
+
+    class SetFlightModeMessage : public CellularMessage
+    {
+      public:
+        explicit SetFlightModeMessage(bool flightModeOn)
+            : CellularMessage(Type::SetFlightMode), flightModeOn(flightModeOn)
+        {}
+        bool flightModeOn;
+    };
+
+    class SetConnectionFrequencyMessage : public CellularMessage
+    {
+      public:
+        explicit SetConnectionFrequencyMessage(const uint8_t &connectionFrequency)
+            : CellularMessage(Type::CellularSetConnectionFrequency), connectionFrequency(connectionFrequency)
+        {}
+        auto getConnectionFrequency() const noexcept -> uint8_t
+        {
+            return connectionFrequency;
+        }
+
+      private:
+        uint8_t connectionFrequency;
+    };
+
+    class PowerUpProcedureCompleteNotification : public NotificationMessage
+    {
+      public:
+        explicit PowerUpProcedureCompleteNotification(const std::string &data = "")
+            : NotificationMessage(NotificationMessage::Content::PowerUpProcedureComplete, data)
+        {}
+    };
+
+    class PowerDownDeregisteringNotification : public NotificationMessage
+    {
+      public:
+        explicit PowerDownDeregisteringNotification(const std::string &data = "")
+            : NotificationMessage(NotificationMessage::Content::PowerDownDeregistering, data)
+        {}
+    };
+
+    class PowerDownDeregisteredNotification : public NotificationMessage
+    {
+      public:
+        explicit PowerDownDeregisteredNotification(const std::string &data = "")
+            : NotificationMessage(NotificationMessage::Content::PowerDownDeregistered, data)
+        {}
+    };
+
+    class NewIncomingSMSNotification : public NotificationMessage
+    {
+      public:
+        explicit NewIncomingSMSNotification(const std::string &data = "")
+            : NotificationMessage(NotificationMessage::Content::NewIncomingSMS, data)
+        {}
+    };
+
+    class SmsDoneNotification : public NotificationMessage
+    {
+      public:
+        explicit SmsDoneNotification(const std::string &data = "")
+            : NotificationMessage(NotificationMessage::Content::SMSDone, data)
+        {}
+    };
+
+    class SignalStrengthUpdateNotification : public NotificationMessage
+    {
+      public:
+        explicit SignalStrengthUpdateNotification(const std::string &data = "")
+            : NotificationMessage(NotificationMessage::Content::SignalStrengthUpdate, data)
+        {}
+    };
+
+    class NetworkStatusUpdateNotification : public NotificationMessage
+    {
+      public:
+        explicit NetworkStatusUpdateNotification(const std::string &data = "")
+            : NotificationMessage(NotificationMessage::Content::NetworkStatusUpdate, data)
+        {}
+    };
+
+    class UrcIncomingNotification : public NotificationMessage
+    {
+      public:
+        explicit UrcIncomingNotification(const std::string &data = "")
+            : NotificationMessage(NotificationMessage::Content::NewIncomingUrc, data)
+        {}
+    };
+
+    class SetRadioOnOffMessage : public CellularMessage
+    {
+      public:
+        explicit SetRadioOnOffMessage(bool radioOnOff) : CellularMessage(Type::RadioOnOff), radioOnOff(radioOnOff)
+        {}
+        auto getRadioOnOf() -> bool
+        {
+            return radioOnOff;
+        }
+
+      private:
+        bool radioOnOff;
+    };
+
+    class SMSRejectedByOfflineNotification : public ResponseMessage, public app::manager::actions::ConvertibleToAction
+    {
+      public:
+        SMSRejectedByOfflineNotification() : ResponseMessage(false)
+        {}
+
+        [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+        {
+            return std::make_unique<app::manager::ActionRequest>(
+                sender,
+                app::manager::actions::SMSRejectedByOfflineNotification,
+                std::make_unique<app::manager::actions::ActionParams>());
+        }
+    };
+
+    class CallRejectedByOfflineNotification : public ResponseMessage, public app::manager::actions::ConvertibleToAction
+    {
+      public:
+        CallRejectedByOfflineNotification() : ResponseMessage(false)
+        {}
+
+        [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+        {
+            return std::make_unique<app::manager::ActionRequest>(
+                sender,
+                app::manager::actions::CallRejectedByOfflineNotification,
+                std::make_unique<app::manager::actions::ActionParams>());
+        }
+    };
+
+    class RingNotification : public NotificationMessage
+    {
+      public:
+        RingNotification() : NotificationMessage(NotificationMessage::Content::Ring)
+        {}
+    };
+
+    class CallerIdNotification : public NotificationMessage
+    {
+      public:
+        explicit CallerIdNotification(const utils::PhoneNumber::View &number)
+            : NotificationMessage(NotificationMessage::Content::Ring), number(number)
+        {}
+        explicit CallerIdNotification(const utils::PhoneNumber &number)
+            : NotificationMessage(NotificationMessage::Content::Ring), number(number.getView())
+        {}
+        explicit CallerIdNotification(const std::string &e164number)
+            : NotificationMessage(NotificationMessage::Content::Ring), number(utils::PhoneNumber::parse(e164number))
+        {}
+        auto getNubmer() const -> utils::PhoneNumber::View
+        {
+            return number;
+        }
+
+      private:
+        utils::PhoneNumber::View number;
+    };
 
     class StateChange : public CellularMessage
     {
@@ -1030,6 +985,13 @@ namespace cellular
         EventType eventType;
     };
 
+    class IncomingCallMessage : public CellularMessage
+    {
+      public:
+        IncomingCallMessage() : CellularMessage(Type::IncomingCall)
+        {}
+    };
+
     class CallStartedNotification : public sys::DataMessage
     {
       public:
@@ -1056,10 +1018,26 @@ namespace cellular
         explicit CallEndedNotification() : sys::DataMessage(MessageType::MessageTypeUninitialized){};
     };
 
-    class CallActiveNotification : public sys::DataMessage
+    class CallAbortedNotification : public NotificationMessage
     {
       public:
-        explicit CallActiveNotification() : sys::DataMessage(MessageType::MessageTypeUninitialized){};
+        explicit CallAbortedNotification(const std::string &data = "")
+            : NotificationMessage(NotificationMessage::Content::CallAborted, data)
+        {}
+    };
+
+    class CallActiveNotification : public NotificationMessage, public app::manager::actions::ConvertibleToAction
+    {
+      public:
+        explicit CallActiveNotification(const std::string &data = "")
+            : NotificationMessage(NotificationMessage::Content::CallActive, data)
+        {}
+
+        [[nodiscard]] auto toAction() const -> std::unique_ptr<app::manager::ActionRequest>
+        {
+            return std::make_unique<app::manager::ActionRequest>(
+                sender, app::manager::actions::ActivateCall, std::make_unique<app::manager::actions::CallParams>());
+        }
     };
 
     class CallDurationNotification : public sys::DataMessage
@@ -1069,18 +1047,30 @@ namespace cellular
             : sys::DataMessage(MessageType::MessageTypeUninitialized), callDuration(duration){};
         time_t callDuration;
     };
+    class CallerIdMessage : public CellularMessage
+    {
+      public:
+        CallerIdMessage(const utils::PhoneNumber::View &number) : CellularMessage(Type::CallerId), number(number)
+        {}
+        CallerIdMessage(const utils::PhoneNumber &number) : CellularMessage(Type::CallerId), number(number.getView())
+        {}
+        CallerIdMessage(const std::string &e164number)
+            : CellularMessage(Type::CallerId), number(utils::PhoneNumber::parse(e164number))
+        {}
 
+        utils::PhoneNumber::View number;
+    };
     class CallOutgoingAccepted : public sys::DataMessage
     {
       public:
         explicit CallOutgoingAccepted() : sys::DataMessage(MessageType::MessageTypeUninitialized){};
     };
 
-    class CellularIsCallActive : public sys::DataMessage
+    class IsCallActive : public sys::DataMessage
     {};
-    struct CellularIsCallActiveResponse : public sys::ResponseMessage
+    struct IsCallActiveResponse : public sys::ResponseMessage
     {
-        explicit CellularIsCallActiveResponse(bool active) : active{active}
+        explicit IsCallActiveResponse(bool active) : active{active}
         {}
 
         const bool active = false;

--- a/module-services/service-cellular/service-cellular/CellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/CellularMessage.hpp
@@ -1070,6 +1070,12 @@ namespace cellular
         time_t callDuration;
     };
 
+    class CallOutgoingAccepted : public sys::DataMessage
+    {
+      public:
+        explicit CallOutgoingAccepted() : sys::DataMessage(MessageType::MessageTypeUninitialized){};
+    };
+
     class CellularIsCallActive : public sys::DataMessage
     {};
     struct CellularIsCallActiveResponse : public sys::ResponseMessage

--- a/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
+++ b/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
@@ -96,7 +96,7 @@ namespace CellularServiceAPI
      */
     bool TransmitDtmfTones(sys::Service *serv, DTMFCode code);
 
-    bool USSDRequest(sys::Service *serv, CellularUSSDMessage::RequestType type, std::string data = "");
+    bool USSDRequest(sys::Service *serv, cellular::USSDMessage::RequestType type, std::string data = "");
 
     /**
      * @brief get all APNs from phone configuration

--- a/module-services/service-cellular/service-cellular/PacketDataCellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/PacketDataCellularMessage.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -10,239 +10,242 @@
 #include "PacketDataTypes.hpp"
 #include "Result.hpp"
 
-class CellularGetAPNMessage : public CellularMessage
+namespace cellular
 {
-    std::optional<std::uint8_t> contextId            = std::nullopt;
-    std::optional<packet_data::APN::APNType> apnType = std::nullopt;
 
-  public:
-    CellularGetAPNMessage() : CellularMessage(Type::PacketData)
-    {}
-    CellularGetAPNMessage(std::uint8_t contextId) : CellularMessage(Type::PacketData), contextId(contextId)
-    {}
-    CellularGetAPNMessage(packet_data::APN::APNType apnType) : CellularMessage(Type::PacketData), apnType(apnType)
-    {}
-    [[nodiscard]] const std::optional<packet_data::APN::APNType> getAPNType() const noexcept
+    class GetAPNMessage : public CellularMessage
     {
-        return apnType;
-    }
-    [[nodiscard]] const std::optional<std::uint8_t> getContextId() const noexcept
-    {
-        return contextId;
-    }
-};
+        std::optional<std::uint8_t> contextId            = std::nullopt;
+        std::optional<packet_data::APN::APNType> apnType = std::nullopt;
 
-class CellularSetAPNMessage : public CellularMessage // also as DeleteAPN
-{
-    std::shared_ptr<packet_data::APN::Config> apnConfig;
-
-  public:
-    CellularSetAPNMessage(std::shared_ptr<packet_data::APN::Config> apnConfig)
-        : CellularMessage(Type::PacketData), apnConfig(std::move(apnConfig))
-    {}
-
-    [[nodiscard]] std::shared_ptr<packet_data::APN::Config> getAPNConfig() const noexcept
-    {
-        return apnConfig;
-    }
-};
-
-class CellularNewAPNMessage : public CellularMessage
-{
-    std::shared_ptr<packet_data::APN::Config> apnConfig;
-
-  public:
-    CellularNewAPNMessage(std::shared_ptr<packet_data::APN::Config> apnConfig)
-        : CellularMessage(Type::PacketData), apnConfig(std::move(apnConfig))
-    {}
-
-    [[nodiscard]] std::shared_ptr<packet_data::APN::Config> getAPNConfig() const noexcept
-    {
-        return apnConfig;
-    }
-};
-
-class CellularSetDataTransferMessage : public CellularMessage
-{
-    packet_data::DataTransfer dataTransfer;
-
-  public:
-    CellularSetDataTransferMessage(packet_data::DataTransfer dataTransfer)
-        : CellularMessage(Type::PacketData), dataTransfer(dataTransfer)
-    {}
-    [[nodiscard]] packet_data::DataTransfer getDataTransfer() const noexcept
-    {
-        return dataTransfer;
-    }
-};
-
-class CellularGetDataTransferMessage : public CellularMessage
-{
-  public:
-    CellularGetDataTransferMessage() : CellularMessage(Type::PacketData)
-    {}
-};
-
-class CellularGetActiveContextsMessage : public CellularMessage
-{
-  public:
-    CellularGetActiveContextsMessage() : CellularMessage(Type::PacketData)
-    {}
-};
-
-class CellularActivateContextMessage : public CellularMessage
-{
-    std::uint8_t contextId;
-
-  public:
-    CellularActivateContextMessage(std::uint8_t contextId) : CellularMessage(Type::PacketData), contextId(contextId)
-    {}
-    [[nodiscard]] std::uint8_t getContextId() const noexcept
-    {
-        return contextId;
-    }
-};
-class CellularDeactivateContextMessage : public CellularMessage
-{
-    std::uint8_t contextId;
-
-  public:
-    CellularDeactivateContextMessage(std::uint8_t contextId) : CellularMessage(Type::PacketData), contextId(contextId)
-    {}
-    [[nodiscard]] std::uint8_t getContextId() const noexcept
-    {
-        return contextId;
-    }
-};
-
-// Send from Cellular
-class CellularGetAPNResponse : public CellularMessage
-{
-    std::vector<std::shared_ptr<packet_data::APN::Config>> apns;
-
-  public:
-    CellularGetAPNResponse(std::vector<std::shared_ptr<packet_data::APN::Config>> apns)
-        : CellularMessage(Type::PacketData), apns(std::move(apns))
-    {}
-
-    [[nodiscard]] const std::vector<std::shared_ptr<packet_data::APN::Config>> &getAPNs() const noexcept
-    {
-        return apns;
-    }
-};
-
-class CellularATResponse : public CellularMessage
-{
-    at::Result::Code result;
-
-  public:
-    CellularATResponse(at::Result::Code result) : CellularMessage(Type::PacketData), result(result)
-    {}
-
-    [[nodiscard]] at::Result::Code getResult() const noexcept
-    {
-        return result;
-    }
-};
-
-class CellularSetAPNResponse : public CellularATResponse
-{
-  public:
-    CellularSetAPNResponse(at::Result::Code result) : CellularATResponse(result)
-    {}
-};
-
-class CellularNewAPNResponse : public CellularATResponse
-{
-    std::uint8_t contextId;
-
-  public:
-    CellularNewAPNResponse(at::Result::Code result, std::uint8_t contextId)
-        : CellularATResponse(result), contextId(contextId)
-    {}
-    [[nodiscard]] std::uint8_t getContextId() const noexcept
-    {
-        return contextId;
-    }
-};
-
-class CellularSetDataTransferResponse : public CellularATResponse
-{
-  public:
-    CellularSetDataTransferResponse(at::Result::Code result) : CellularATResponse(result)
-    {}
-};
-
-class CellularGetDataTransferResponse : public CellularMessage
-{
-    packet_data::DataTransfer dataTransfer;
-
-  public:
-    CellularGetDataTransferResponse(packet_data::DataTransfer dataTransfer)
-        : CellularMessage(Type::PacketData), dataTransfer(dataTransfer)
-    {}
-
-    [[nodiscard]] packet_data::DataTransfer getDataTransfer() const noexcept
-    {
-        return dataTransfer;
-    }
-};
-
-class CellularGetActiveContextsResponse : public CellularMessage
-{
-    std::optional<std::vector<std::shared_ptr<packet_data::APN::Config>>> result;
-
-  public:
-    CellularGetActiveContextsResponse(std::optional<std::vector<std::shared_ptr<packet_data::APN::Config>>> result)
-        : CellularMessage(Type::PacketData)
-    {
-        if (result) {
-            result = std::move(*result);
+      public:
+        GetAPNMessage() : CellularMessage(Type::PacketData)
+        {}
+        GetAPNMessage(std::uint8_t contextId) : CellularMessage(Type::PacketData), contextId(contextId)
+        {}
+        GetAPNMessage(packet_data::APN::APNType apnType) : CellularMessage(Type::PacketData), apnType(apnType)
+        {}
+        [[nodiscard]] const std::optional<packet_data::APN::APNType> getAPNType() const noexcept
+        {
+            return apnType;
         }
-        else {
-            result = std::nullopt;
+        [[nodiscard]] const std::optional<std::uint8_t> getContextId() const noexcept
+        {
+            return contextId;
         }
-    }
+    };
 
-    [[nodiscard]] std::optional<const std::vector<std::shared_ptr<packet_data::APN::Config>>> getActive()
+    class SetAPNMessage : public CellularMessage // also as DeleteAPN
     {
-        return result;
-    }
-};
+        std::shared_ptr<packet_data::APN::Config> apnConfig;
 
-class CellularActivateContextResponse : public CellularATResponse
-{
-    std::uint8_t contextId;
+      public:
+        SetAPNMessage(std::shared_ptr<packet_data::APN::Config> apnConfig)
+            : CellularMessage(Type::PacketData), apnConfig(std::move(apnConfig))
+        {}
 
-  public:
-    CellularActivateContextResponse(at::Result::Code result, std::uint8_t contextId)
-        : CellularATResponse(result), contextId(contextId)
-    {}
-    [[nodiscard]] std::uint8_t getContextId() const noexcept
+        [[nodiscard]] std::shared_ptr<packet_data::APN::Config> getAPNConfig() const noexcept
+        {
+            return apnConfig;
+        }
+    };
+
+    class NewAPNMessage : public CellularMessage
     {
-        return contextId;
-    }
-};
-class CellularDeactivateContextResponse : public CellularATResponse
-{
-    std::uint8_t contextId;
-    bool isUrc;
+        std::shared_ptr<packet_data::APN::Config> apnConfig;
 
-  public:
-    CellularDeactivateContextResponse(at::Result::Code result, std::uint8_t contextId, bool isUrc = false)
-        : CellularATResponse(result), contextId(contextId), isUrc(isUrc)
-    {}
+      public:
+        NewAPNMessage(std::shared_ptr<packet_data::APN::Config> apnConfig)
+            : CellularMessage(Type::PacketData), apnConfig(std::move(apnConfig))
+        {}
 
-    [[nodiscard]] std::uint8_t getContextId() const noexcept
+        [[nodiscard]] std::shared_ptr<packet_data::APN::Config> getAPNConfig() const noexcept
+        {
+            return apnConfig;
+        }
+    };
+
+    class SetDataTransferMessage : public CellularMessage
     {
-        return contextId;
-    }
-    /**
-     * @breif inform that message come from URC (eg. because call AT+CFUN=0, reset by BTS, ...)
-     * @return
-     */
-    [[nodiscard]] bool isURC()
+        packet_data::DataTransfer dataTransfer;
+
+      public:
+        SetDataTransferMessage(packet_data::DataTransfer dataTransfer)
+            : CellularMessage(Type::PacketData), dataTransfer(dataTransfer)
+        {}
+        [[nodiscard]] packet_data::DataTransfer getDataTransfer() const noexcept
+        {
+            return dataTransfer;
+        }
+    };
+
+    class GetDataTransferMessage : public CellularMessage
     {
-        return isUrc;
-    }
-};
+      public:
+        GetDataTransferMessage() : CellularMessage(Type::PacketData)
+        {}
+    };
+
+    class GetActiveContextsMessage : public CellularMessage
+    {
+      public:
+        GetActiveContextsMessage() : CellularMessage(Type::PacketData)
+        {}
+    };
+
+    class ActivateContextMessage : public CellularMessage
+    {
+        std::uint8_t contextId;
+
+      public:
+        ActivateContextMessage(std::uint8_t contextId) : CellularMessage(Type::PacketData), contextId(contextId)
+        {}
+        [[nodiscard]] std::uint8_t getContextId() const noexcept
+        {
+            return contextId;
+        }
+    };
+    class DeactivateContextMessage : public CellularMessage
+    {
+        std::uint8_t contextId;
+
+      public:
+        DeactivateContextMessage(std::uint8_t contextId) : CellularMessage(Type::PacketData), contextId(contextId)
+        {}
+        [[nodiscard]] std::uint8_t getContextId() const noexcept
+        {
+            return contextId;
+        }
+    };
+
+    // Send from Cellular
+    class GetAPNResponse : public CellularMessage
+    {
+        std::vector<std::shared_ptr<packet_data::APN::Config>> apns;
+
+      public:
+        GetAPNResponse(std::vector<std::shared_ptr<packet_data::APN::Config>> apns)
+            : CellularMessage(Type::PacketData), apns(std::move(apns))
+        {}
+
+        [[nodiscard]] const std::vector<std::shared_ptr<packet_data::APN::Config>> &getAPNs() const noexcept
+        {
+            return apns;
+        }
+    };
+
+    class ATResponse : public CellularMessage
+    {
+        at::Result::Code result;
+
+      public:
+        ATResponse(at::Result::Code result) : CellularMessage(Type::PacketData), result(result)
+        {}
+
+        [[nodiscard]] at::Result::Code getResult() const noexcept
+        {
+            return result;
+        }
+    };
+
+    class SetAPNResponse : public ATResponse
+    {
+      public:
+        SetAPNResponse(at::Result::Code result) : ATResponse(result)
+        {}
+    };
+
+    class NewAPNResponse : public ATResponse
+    {
+        std::uint8_t contextId;
+
+      public:
+        NewAPNResponse(at::Result::Code result, std::uint8_t contextId) : ATResponse(result), contextId(contextId)
+        {}
+        [[nodiscard]] std::uint8_t getContextId() const noexcept
+        {
+            return contextId;
+        }
+    };
+
+    class SetDataTransferResponse : public ATResponse
+    {
+      public:
+        SetDataTransferResponse(at::Result::Code result) : ATResponse(result)
+        {}
+    };
+
+    class GetDataTransferResponse : public CellularMessage
+    {
+        packet_data::DataTransfer dataTransfer;
+
+      public:
+        GetDataTransferResponse(packet_data::DataTransfer dataTransfer)
+            : CellularMessage(Type::PacketData), dataTransfer(dataTransfer)
+        {}
+
+        [[nodiscard]] packet_data::DataTransfer getDataTransfer() const noexcept
+        {
+            return dataTransfer;
+        }
+    };
+
+    class GetActiveContextsResponse : public CellularMessage
+    {
+        std::optional<std::vector<std::shared_ptr<packet_data::APN::Config>>> result;
+
+      public:
+        GetActiveContextsResponse(std::optional<std::vector<std::shared_ptr<packet_data::APN::Config>>> result)
+            : CellularMessage(Type::PacketData)
+        {
+            if (result) {
+                result = std::move(*result);
+            }
+            else {
+                result = std::nullopt;
+            }
+        }
+
+        [[nodiscard]] std::optional<const std::vector<std::shared_ptr<packet_data::APN::Config>>> getActive()
+        {
+            return result;
+        }
+    };
+
+    class ActivateContextResponse : public ATResponse
+    {
+        std::uint8_t contextId;
+
+      public:
+        ActivateContextResponse(at::Result::Code result, std::uint8_t contextId)
+            : ATResponse(result), contextId(contextId)
+        {}
+        [[nodiscard]] std::uint8_t getContextId() const noexcept
+        {
+            return contextId;
+        }
+    };
+    class DeactivateContextResponse : public ATResponse
+    {
+        std::uint8_t contextId;
+        bool isUrc;
+
+      public:
+        DeactivateContextResponse(at::Result::Code result, std::uint8_t contextId, bool isUrc = false)
+            : ATResponse(result), contextId(contextId), isUrc(isUrc)
+        {}
+
+        [[nodiscard]] std::uint8_t getContextId() const noexcept
+        {
+            return contextId;
+        }
+        /**
+         * @breif inform that message come from URC (eg. because call AT+CFUN=0, reset by BTS, ...)
+         * @return
+         */
+        [[nodiscard]] bool isURC()
+        {
+            return isUrc;
+        }
+    };
+} // namespace cellular

--- a/module-services/service-cellular/service-cellular/ServiceCellular.hpp
+++ b/module-services/service-cellular/service-cellular/ServiceCellular.hpp
@@ -221,32 +221,32 @@ class ServiceCellular : public sys::Service
     // ussd handlers
     uint32_t ussdTimeout = 0;
     void setUSSDTimer();
-    bool handleUSSDRequest(CellularUSSDMessage::RequestType requestType, const std::string &request = "");
+    bool handleUSSDRequest(cellular::USSDMessage::RequestType requestType, const std::string &request = "");
     bool handleIMEIRequest();
 
     bool handleUSSDURC();
     void handleUSSDTimer();
 
     std::shared_ptr<cellular::RawCommandRespAsync> handleCellularStartOperatorsScan(
-        CellularStartOperatorsScanMessage *msg);
+        cellular::StartOperatorsScanMessage *msg);
 
-    std::shared_ptr<CellularSetOperatorAutoSelectResponse> handleCellularSetOperatorAutoSelect(
-        CellularSetOperatorAutoSelectMessage *msg);
-    void handleCellularRequestCurrentOperatorName(CellularRequestCurrentOperatorNameMessage *msg);
-    std::shared_ptr<CellularGetAPNResponse> handleCellularGetAPNMessage(CellularGetAPNMessage *msg);
-    std::shared_ptr<CellularSetAPNResponse> handleCellularSetAPNMessage(CellularSetAPNMessage *msg);
-    std::shared_ptr<CellularNewAPNResponse> handleCellularNewAPNMessage(CellularNewAPNMessage *msg);
-    std::shared_ptr<CellularSetOperatorResponse> handleCellularSetOperator(CellularSetOperatorMessage *msg);
-    std::shared_ptr<CellularSetDataTransferResponse> handleCellularSetDataTransferMessage(
-        CellularSetDataTransferMessage *msg);
-    std::shared_ptr<CellularGetDataTransferResponse> handleCellularGetDataTransferMessage(
-        CellularGetDataTransferMessage *msg);
-    std::shared_ptr<CellularActivateContextResponse> handleCellularActivateContextMessage(
-        CellularActivateContextMessage *msg);
-    std::shared_ptr<CellularDeactivateContextResponse> handleCellularDeactivateContextMessage(
-        CellularDeactivateContextMessage *msg);
-    std::shared_ptr<CellularGetActiveContextsResponse> handleCellularGetActiveContextsMessage(
-        CellularGetActiveContextsMessage *msg);
+    std::shared_ptr<cellular::SetOperatorAutoSelectResponse> handleCellularSetOperatorAutoSelect(
+        cellular::SetOperatorAutoSelectMessage *msg);
+    void handleCellularRequestCurrentOperatorName(cellular::RequestCurrentOperatorNameMessage *msg);
+    std::shared_ptr<cellular::GetAPNResponse> handleCellularGetAPNMessage(cellular::GetAPNMessage *msg);
+    std::shared_ptr<cellular::SetAPNResponse> handleCellularSetAPNMessage(cellular::SetAPNMessage *msg);
+    std::shared_ptr<cellular::NewAPNResponse> handleCellularNewAPNMessage(cellular::NewAPNMessage *msg);
+    std::shared_ptr<cellular::SetOperatorResponse> handleCellularSetOperator(cellular::SetOperatorMessage *msg);
+    std::shared_ptr<cellular::SetDataTransferResponse> handleCellularSetDataTransferMessage(
+        cellular::SetDataTransferMessage *msg);
+    std::shared_ptr<cellular::GetDataTransferResponse> handleCellularGetDataTransferMessage(
+        cellular::GetDataTransferMessage *msg);
+    std::shared_ptr<cellular::ActivateContextResponse> handleCellularActivateContextMessage(
+        cellular::ActivateContextMessage *msg);
+    std::shared_ptr<cellular::DeactivateContextResponse> handleCellularDeactivateContextMessage(
+        cellular::DeactivateContextMessage *msg);
+    std::shared_ptr<cellular::GetActiveContextsResponse> handleCellularGetActiveContextsMessage(
+        cellular::GetActiveContextsMessage *msg);
     friend class CellularUrcHandler;
     friend class SimCard;
     friend class cellular::internal::ServiceCellularPriv;
@@ -261,16 +261,17 @@ class ServiceCellular : public sys::Service
     void apnListChanged(const std::string &value);
     bool volteOn = false;
 
-    auto handleCellularAnswerIncomingCallMessage(CellularMessage *msg) -> std::shared_ptr<CellularResponseMessage>;
-    auto handleCellularCallRequestMessage(CellularCallRequestMessage *msg) -> std::shared_ptr<CellularResponseMessage>;
-    void handleCellularHangupCallMessage(CellularHangupCallMessage *msg);
+    auto handleCellularAnswerIncomingCallMessage(CellularMessage *msg) -> std::shared_ptr<cellular::ResponseMessage>;
+    auto handleCellularCallRequestMessage(cellular::CallRequestMessage *msg)
+        -> std::shared_ptr<cellular::ResponseMessage>;
+    void handleCellularHangupCallMessage(cellular::HangupCallMessage *msg);
     void handleCellularDismissCallMessage(sys::Message *msg);
     auto handleDBQueryResponseMessage(db::QueryResponse *msg) -> std::shared_ptr<sys::ResponseMessage>;
     /// when we start call from Pure -> to the calee, then we poll for the moment that the calee answered the call
     auto handleCellularListCallsMessage(CellularMessage *msg) -> std::shared_ptr<sys::ResponseMessage>;
     auto handleDBNotificationMessage(db::NotificationMessage *msg) -> std::shared_ptr<sys::ResponseMessage>;
     /// handle mudita phone -> world ringing (not AT RING!)
-    auto handleCellularRingingMessage(CellularRingingMessage *msg) -> std::shared_ptr<sys::ResponseMessage>;
+    auto handleCellularRingingMessage(cellular::RingingMessage *msg) -> std::shared_ptr<sys::ResponseMessage>;
     auto handleCellularCallerIdMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>;
     auto handleCellularGetIMSIMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>;
     auto handleCellularGetOwnNumberMessage(sys::Message *msg) -> std::shared_ptr<sys::ResponseMessage>;

--- a/module-services/service-cellular/service-cellular/USSD.hpp
+++ b/module-services/service-cellular/service-cellular/USSD.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -15,9 +15,9 @@ namespace ussd
     enum class State
     {
         none,
-        pushSesion,
+        pushSession,
         pullRequestSent,
         pullResponseReceived,
-        sesionAborted
+        sessionAborted
     };
 } // namespace ussd

--- a/module-services/service-cellular/src/ServiceCellularPriv.cpp
+++ b/module-services/service-cellular/src/ServiceCellularPriv.cpp
@@ -188,7 +188,7 @@ namespace cellular::internal
         outSMSHandler.onSIMNotInitialized = [this]() -> bool {
             bool ret = false;
             if (!simCard->initialized()) {
-                owner->bus.sendUnicast(std::make_shared<CellularSmsNoSimRequestMessage>(), ::service::name::appmgr);
+                owner->bus.sendUnicast(std::make_shared<cellular::SmsNoSimRequestMessage>(), ::service::name::appmgr);
                 ret = true;
             }
             return ret;
@@ -197,7 +197,7 @@ namespace cellular::internal
         outSMSHandler.onGetOfflineMode = [this]() -> bool {
             bool ret = false;
             if (owner->phoneModeObserver->isInMode(sys::phone_modes::PhoneMode::Offline)) {
-                owner->bus.sendUnicast(std::make_shared<CellularSMSRejectedByOfflineNotification>(),
+                owner->bus.sendUnicast(std::make_shared<cellular::SMSRejectedByOfflineNotification>(),
                                        ::service::name::appmgr);
                 ret = true;
             }
@@ -452,7 +452,7 @@ namespace cellular::internal
         csqHandler->onPropagateCSQ = [this](uint32_t csq) {
             SignalStrength signalStrength(static_cast<int>(csq));
             Store::GSM::get()->setSignalStrength(signalStrength.data);
-            auto message = std::make_shared<CellularSignalStrengthUpdateNotification>("");
+            auto message = std::make_shared<cellular::SignalStrengthUpdateNotification>("");
             owner->bus.sendMulticast(message, sys::BusChannel::ServiceCellularNotifications);
         };
 

--- a/module-services/service-time/ServiceTime.cpp
+++ b/module-services/service-time/ServiceTime.cpp
@@ -1,33 +1,17 @@
 ﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include "AlarmMessageHandler.hpp"
 #include "ServiceTime.hpp"
-#include <service-time/AlarmMessage.hpp>
 #include <service-time/internal/StaticData.hpp>
 #include <service-time/RTCCommand.hpp>
 #include <service-time/TimeMessage.hpp>
 #include <service-time/TimeSettings.hpp>
 #include <service-time/TimezoneHandler.hpp>
 
-#include <BaseInterface.hpp>
-#include <Common/Query.hpp>
-#include <log/log.hpp>
-#include <MessageType.hpp>
-#include <module-db/Interface/EventRecord.hpp>
-#include <service-db/DBNotificationMessage.hpp>
-#include <service-db/QueryMessage.hpp>
-#include <service-cellular/service-cellular/CellularMessage.hpp>
 #include <service-cellular/ServiceCellular.hpp>
-#include <time/time_constants.hpp>
-#include <time/time_conversion_factory.hpp>
 #include <time/TimeZone.hpp>
-#include <service-evtmgr/Constants.hpp>
-#include <service-db/agents/settings/SystemSettings.hpp>
 
-#include <memory>
-#include <utility>
-#include <chrono>
+#include <service-db/agents/settings/SystemSettings.hpp>
 
 namespace stm
 {
@@ -105,7 +89,7 @@ namespace stm
 
     void ServiceTime::registerMessageHandlers()
     {
-        connect(typeid(CellularTimeNotificationMessage), [&](sys::Message *request) -> sys::MessagePointer {
+        connect(typeid(cellular::TimeNotificationMessage), [&](sys::Message *request) -> sys::MessagePointer {
             return handleCellularTimeNotificationMessage(request);
         });
 
@@ -273,7 +257,7 @@ namespace stm
     auto ServiceTime::handleCellularTimeNotificationMessage(sys::Message *request)
         -> std::shared_ptr<sys::ResponseMessage>
     {
-        auto message       = static_cast<CellularTimeNotificationMessage *>(request);
+        auto message       = static_cast<cellular::TimeNotificationMessage *>(request);
         auto timezoneRules = TimezoneHandler(std::chrono::duration_cast<std::chrono::minutes>(
                                                  std::chrono::seconds{message->getTimeZoneOffset().value()}))
                                  .getTimezone();

--- a/module-sys/Service/CMakeLists.txt
+++ b/module-sys/Service/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(sys-service
         module-os
         sys-common
         sys-watchdog
+        module-utils
 
         magic_enum::magic_enum
 )

--- a/module-utils/Clipboard/Clipboard.cpp
+++ b/module-utils/Clipboard/Clipboard.cpp
@@ -1,8 +1,7 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Clipboard.hpp"
-
 cpp_freertos::MutexStandard Clipboard::mutex;
 
 Clipboard &Clipboard::getInstance()

--- a/module-utils/Clipboard/test/CMakeLists.txt
+++ b/module-utils/Clipboard/test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_catch2_executable(
     SRCS
         unittest_clipboard.cpp
     LIBS
-        module-sys
+        log-api
         clipboard
+
 )

--- a/module-utils/Clipboard/test/unittest_clipboard.cpp
+++ b/module-utils/Clipboard/test/unittest_clipboard.cpp
@@ -1,13 +1,7 @@
 // Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include <cstring>
-#include <iostream>
-#include <memory>
-#include <unistd.h>
-
 #include <catch2/catch.hpp>
-
 #include <Clipboard.hpp>
 
 TEST_CASE("Clipboard")

--- a/module-utils/log/api/CMakeLists.txt
+++ b/module-utils/log/api/CMakeLists.txt
@@ -5,7 +5,10 @@ target_sources(log-api
         log/log.hpp
         log/debug.hpp
 )
-
+target_link_libraries(log-api
+        INTERFACE
+        log
+)
 target_include_directories(log-api
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>

--- a/products/PurePhone/services/appmgr/ApplicationManager.cpp
+++ b/products/PurePhone/services/appmgr/ApplicationManager.cpp
@@ -7,7 +7,6 @@
 #include <application-desktop/ApplicationDesktop.hpp>
 #include <application-onboarding/ApplicationOnBoarding.hpp>
 #include <apps-common/popups/data/PhoneModeParams.hpp>
-#include <apps-common/popups/data/PopupRequestParams.hpp>
 #include <apps-common/actions/AlarmClockStatusChangeParams.hpp>
 #include <module-db/queries/notifications/QueryNotificationsGetAll.hpp>
 #include <system/messages/TetheringQuestionRequest.hpp>
@@ -17,13 +16,10 @@
 #include <service-appmgr/messages/GetAllNotificationsRequest.hpp>
 #include <service-appmgr/messages/GetWallpaperOptionRequest.hpp>
 #include <service-bluetooth/messages/BluetoothModeChanged.hpp>
-#include <service-bluetooth/messages/Authenticate.hpp>
 #include <service-cellular/CellularMessage.hpp>
 #include <service-db/DBNotificationMessage.hpp>
 #include <service-db/agents/settings/SystemSettings.hpp>
 #include <service-desktop/Constants.hpp>
-#include <service-desktop/DesktopMessages.hpp>
-#include <service-desktop/DeveloperModeMessage.hpp>
 #include <service-evtmgr/EVMessages.hpp>
 #include <service-evtmgr/Constants.hpp>
 #include <service-evtmgr/torch.hpp>
@@ -383,23 +379,23 @@ namespace app::manager
         });
 
         auto convertibleToActionHandler = [this](sys::Message *request) { return handleMessageAsAction(request); };
-        connect(typeid(CellularMMIResultMessage), convertibleToActionHandler);
-        connect(typeid(CellularMMIResponseMessage), convertibleToActionHandler);
-        connect(typeid(CellularMMIPushMessage), convertibleToActionHandler);
-        connect(typeid(CellularNoSimNotification), convertibleToActionHandler);
-        connect(typeid(CellularNotAnEmergencyNotification), convertibleToActionHandler);
-        connect(typeid(CellularNoNetworkConenctionNotification), convertibleToActionHandler);
-        connect(typeid(CellularCallRequestGeneralError), convertibleToActionHandler);
-        connect(typeid(CellularSmsNoSimRequestMessage), convertibleToActionHandler);
-        connect(typeid(CellularSMSRejectedByOfflineNotification), convertibleToActionHandler);
-        connect(typeid(CellularCallRejectedByOfflineNotification), convertibleToActionHandler);
+        connect(typeid(cellular::MMIResultMessage), convertibleToActionHandler);
+        connect(typeid(cellular::MMIResponseMessage), convertibleToActionHandler);
+        connect(typeid(cellular::MMIPushMessage), convertibleToActionHandler);
+        connect(typeid(cellular::NoSimNotification), convertibleToActionHandler);
+        connect(typeid(cellular::NotAnEmergencyNotification), convertibleToActionHandler);
+        connect(typeid(cellular::NoNetworkConenctionNotification), convertibleToActionHandler);
+        connect(typeid(cellular::CallRequestGeneralError), convertibleToActionHandler);
+        connect(typeid(cellular::SmsNoSimRequestMessage), convertibleToActionHandler);
+        connect(typeid(cellular::SMSRejectedByOfflineNotification), convertibleToActionHandler);
+        connect(typeid(cellular::CallRejectedByOfflineNotification), convertibleToActionHandler);
         connect(typeid(sys::TetheringQuestionRequest), convertibleToActionHandler);
         connect(typeid(sys::TetheringQuestionAbort), convertibleToActionHandler);
         connect(typeid(sys::TetheringPhoneModeChangeProhibitedMessage), convertibleToActionHandler);
-        connect(typeid(CellularCallAbortedNotification), convertibleToActionHandler);
-        connect(typeid(CellularRingingMessage), convertibleToActionHandler);
-        connect(typeid(CellularCallActiveNotification), convertibleToActionHandler);
-        connect(typeid(CellularHangupCallMessage), convertibleToActionHandler);
+        connect(typeid(cellular::CallAbortedNotification), convertibleToActionHandler);
+        connect(typeid(cellular::RingingMessage), convertibleToActionHandler);
+        connect(typeid(cellular::CallActiveNotification), convertibleToActionHandler);
+        connect(typeid(cellular::HangupCallMessage), convertibleToActionHandler);
     }
 
     void ApplicationManager::handlePhoneModeChanged(sys::phone_modes::PhoneMode phoneMode)

--- a/products/PurePhone/services/evtmgr/EventManager.cpp
+++ b/products/PurePhone/services/evtmgr/EventManager.cpp
@@ -5,14 +5,10 @@
 
 #include "WorkerEvent.hpp"
 
-#include <bsp/magnetometer/magnetometer.hpp>
-#include <bsp/torch/torch.hpp>
 #include <evtmgr/EVMessages.hpp>
-#include <screen-light-control/ScreenLightControl.hpp>
 #include <service-cellular/ServiceCellular.hpp>
 #include <service-evtmgr/EVMessages.hpp>
 #include <service-evtmgr/ScreenLightControlMessage.hpp>
-#include <service-evtmgr/WorkerEventCommon.hpp>
 #include <sys/SystemManager.hpp>
 #include <sys/messages/PhoneModeRequest.hpp>
 
@@ -157,7 +153,7 @@ sys::MessagePointer EventManager::DataReceivedHandler(sys::DataMessage *msgl, sy
         handled = true;
     }
     else if (msgl->messageType == MessageType::EVMRingIndicator) {
-        auto msg = std::make_shared<CellularUrcIncomingNotification>();
+        auto msg = std::make_shared<cellular::UrcIncomingNotification>();
         bus.sendUnicast(std::move(msg), ServiceCellular::serviceName);
         handled = true;
     }

--- a/products/PurePhone/sys/SystemManager.cpp
+++ b/products/PurePhone/sys/SystemManager.cpp
@@ -9,9 +9,7 @@
 #include <system/messages/SystemManagerMessage.hpp>
 #include <system/messages/TetheringQuestionRequest.hpp>
 #include <system/messages/TetheringStateRequest.hpp>
-#include <EventStore.hpp>
 #include <service-appmgr/Constants.hpp>
-#include <service-cellular/CellularMessage.hpp>
 #include <service-cellular/CellularServiceAPI.hpp>
 #include <service-evtmgr/Constants.hpp>
 #include <service-evtmgr/EventManagerServiceAPI.hpp>
@@ -38,8 +36,7 @@ namespace sys
                     storeGsm->simCardInserted());
         };
         auto isCallOngoing = [this]() {
-            auto request = async_call<cellular::CellularIsCallActive, cellular::CellularIsCallActiveResponse>(
-                cellular::service::name);
+            auto request = async_call<cellular::IsCallActive, cellular::IsCallActiveResponse>(cellular::service::name);
             sync(request);
             return request.getResult().active;
         };
@@ -67,7 +64,7 @@ namespace sys
             return enableTethering(response);
         });
 
-        connect(CellularCheckIfStartAllowedMessage(), [&](Message *) {
+        connect(cellular::CheckIfStartAllowedMessage(), [&](Message *) {
             switch (Store::Battery::get().levelState) {
             case Store::Battery::LevelState::Normal:
                 CellularServiceAPI::ChangeModulePowerState(this, cellular::service::State::PowerState::On);


### PR DESCRIPTION
**Description**

When BT was connected (or just turned on) there was no dialing state -
the call went directly to ongoing call. Moreover, fixed no ringing
sound during ringing state - there was a bug in BT stack.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
