### PR TITLE
[MOS-37] Slider triggering unlock instructions popup fix

### DIFF
--- a/module-apps/apps-common/locks/input/PhoneLockedKeysWhitelist.cpp
+++ b/module-apps/apps-common/locks/input/PhoneLockedKeysWhitelist.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhoneLockedKeysWhitelist.hpp"
@@ -9,13 +9,19 @@ namespace locks::PhoneLockedKeysWhitelist
     namespace
     {
         using namespace gui;
-        constexpr std::array list = {
-            KeyCode::KEY_TORCH, KeyCode::KEY_VOLDN, KeyCode::HEADSET_VOLDN, KeyCode::KEY_VOLUP, KeyCode::HEADSET_VOLUP};
+        constexpr std::array keysWhitelist = {KeyCode::KEY_TORCH,
+                                              KeyCode::KEY_VOLDN,
+                                              KeyCode::HEADSET_VOLDN,
+                                              KeyCode::KEY_VOLUP,
+                                              KeyCode::HEADSET_VOLUP,
+                                              KeyCode::SWITCH_DN,
+                                              KeyCode::SWITCH_MID,
+                                              KeyCode::SWITCH_UP};
     } // anonymous namespace
 
     [[nodiscard]] bool isOnWhitelist(const gui::InputEvent &inputEvent)
     {
-        for (const auto &key : list) {
+        for (const auto &key : keysWhitelist) {
             if (inputEvent.is(key)) {
                 return true;
             }


### PR DESCRIPTION
**Description**

Fix of the issue that changing phone mode
using slider while the phone was locked
unnecessarily triggered the popup with
unlock instructions.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
