### PR TITLE
[MOS-53] Not enough stack for audio worker

### DIFF
--- a/module-audio/Audio/decoder/DecoderWorker.hpp
+++ b/module-audio/Audio/decoder/DecoderWorker.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -40,7 +40,7 @@ namespace audio
         auto disablePlayback() -> bool;
 
       private:
-        static constexpr std::size_t stackDepth = 6 * 1024;
+        static constexpr std::size_t stackDepth = 12 * 1024;
 
         virtual auto handleMessage(uint32_t queueID) -> bool override;
         void pushAudioData();


### PR DESCRIPTION
There were occasional crashes due to too small a stack for the audio worker.
These were not caught via stack overflow catching logic most of the times

![image](https://user-images.githubusercontent.com/6411862/171807740-56436244-33af-4848-b78a-3d0f29461540.png)
