### PR TITLE
[MOS-532] Music player progress bar behaviour fix

### DIFF
--- a/module-apps/application-music-player/presenters/SongsPresenter.cpp
+++ b/module-apps/application-music-player/presenters/SongsPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SongsPresenter.hpp"
@@ -218,6 +218,10 @@ namespace app::music_player
                 changePlayingStateCallback(app::music::SongState::NotPlaying);
             }
             updateViewSongState();
+            songProgressTimer.stop();
+            updateTrackProgressRatio();
+            updateViewProgresState();
+            refreshView();
             return true;
         }
         return false;
@@ -231,6 +235,9 @@ namespace app::music_player
                 changePlayingStateCallback(app::music::SongState::Playing);
             }
             updateViewSongState();
+            songProgressTimestamp = std::chrono::system_clock::now();
+            songProgressTimer.start();
+            refreshView();
             return true;
         }
         return false;

--- a/module-apps/application-music-player/windows/MusicPlayerMainWindow.cpp
+++ b/module-apps/application-music-player/windows/MusicPlayerMainWindow.cpp
@@ -290,11 +290,11 @@ namespace gui
         bottomBox->setMinimumSize(trackProgress::barWidth, trackProgress::bottomHeight);
         bottomBox->setEdges(RectangleEdge::None);
 
-        auto letfBox = new HBox(bottomBox);
-        letfBox->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Bottom)); //
-        letfBox->setMinimumSize(trackProgress::barWidth / 2 - 1, trackProgress::bottomHeight);
-        letfBox->setEdges(RectangleEdge::None);
-        currentTimeText = new Text(letfBox, 0, 0, trackProgress::descriptionWidth, trackProgress::descriptionHeight);
+        auto leftBox = new HBox(bottomBox);
+        leftBox->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Bottom)); //
+        leftBox->setMinimumSize(trackProgress::barWidth / 2 - 1, trackProgress::bottomHeight);
+        leftBox->setEdges(RectangleEdge::None);
+        currentTimeText = new Text(leftBox, 0, 0, trackProgress::descriptionWidth, trackProgress::descriptionHeight);
         currentTimeText->setMaximumWidth(trackProgress::barWidth / 2 - 1);
         currentTimeText->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Center));
         currentTimeText->setTextType(TextType::SingleLine);


### PR DESCRIPTION
**Description**

Fix of the issue that after pausing playback
using Bluetooth device button, the progress
bar remained in progress and playback
time continued to count.
Correction of typo in variable name.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
