### PR TITLE
[CP-1334] Return templateID after adding new message template

### DIFF
--- a/module-db/Interface/SMSTemplateRecord.cpp
+++ b/module-db/Interface/SMSTemplateRecord.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SMSTemplateRecord.hpp"
@@ -35,7 +35,7 @@ uint32_t SMSTemplateRecordInterface::GetCount()
 }
 
 std::unique_ptr<std::vector<SMSTemplateRecord>> SMSTemplateRecordInterface::GetLimitOffsetByField(
-    uint32_t offset, uint32_t limit, SMSTemplateRecordField field, const char *str)
+    uint32_t offset, uint32_t limit, SMSTemplateRecordField /*field*/, const char * /*str*/)
 {
     assert(0 && "need proper implementation");
     return GetLimitOffset(offset, limit);
@@ -71,7 +71,7 @@ bool SMSTemplateRecordInterface::RemoveByID(uint32_t id)
     return smsDB->templates.removeById(id);
 }
 
-bool SMSTemplateRecordInterface::RemoveByField(SMSTemplateRecordField field, const char *str)
+bool SMSTemplateRecordInterface::RemoveByField(SMSTemplateRecordField /*field*/, const char * /*str*/)
 {
     assert(0 && "need implementation");
     return false;
@@ -172,8 +172,12 @@ std::unique_ptr<db::QueryResult> SMSTemplateRecordInterface::getCountQuery(const
 std::unique_ptr<db::QueryResult> SMSTemplateRecordInterface::addQuery(const std::shared_ptr<db::Query> &query)
 {
     const auto localQuery = static_cast<const db::query::SMSTemplateAdd *>(query.get());
-    auto ret              = SMSTemplateRecordInterface::Add(localQuery->rec);
-    auto response         = std::make_unique<db::query::SMSTemplateAddResult>(ret);
+    auto record           = localQuery->rec;
+    auto ret              = SMSTemplateRecordInterface::Add(record);
+    if (ret) {
+        record.ID = smsDB->templates.getLastId();
+    }
+    auto response = std::make_unique<db::query::SMSTemplateAddResult>(ret, record.ID);
     response->setRequestQuery(query);
     return response;
 }

--- a/module-db/Tables/SMSTemplateTable.cpp
+++ b/module-db/Tables/SMSTemplateTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SMSTemplateTable.hpp"
@@ -109,6 +109,15 @@ uint32_t SMSTemplateTable::countByFieldId(const char *field, uint32_t id)
 {
     auto queryRet = db->query("SELECT COUNT(*) FROM templates WHERE '%q'=%" PRIu32 ";", field, id);
 
+    if ((queryRet == nullptr) || (queryRet->getRowCount() == 0)) {
+        return 0;
+    }
+
+    return (*queryRet)[0].getUInt32();
+}
+uint32_t SMSTemplateTable::getLastId()
+{
+    auto queryRet = db->query("SELECT MAX(_id) FROM templates;");
     if ((queryRet == nullptr) || (queryRet->getRowCount() == 0)) {
         return 0;
     }

--- a/module-db/Tables/SMSTemplateTable.hpp
+++ b/module-db/Tables/SMSTemplateTable.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -41,4 +41,5 @@ class SMSTemplateTable : public Table<SMSTemplateTableRow, SMSTemplateTableField
     uint32_t count() override final;
     uint32_t count(EntryState state);
     uint32_t countByFieldId(const char *field, uint32_t id) override final;
+    uint32_t getLastId();
 };

--- a/module-db/queries/messages/templates/QuerySMSTemplateAdd.cpp
+++ b/module-db/queries/messages/templates/QuerySMSTemplateAdd.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "QuerySMSTemplateAdd.hpp"
@@ -8,10 +8,10 @@
 
 using namespace db::query;
 
-SMSTemplateAdd::SMSTemplateAdd(const SMSTemplateRecord &rec) : Query(Query::Type::Read), rec(std::move(rec))
+SMSTemplateAdd::SMSTemplateAdd(const SMSTemplateRecord &rec) : Query(Query::Type::Read), rec(rec)
 {}
 
-SMSTemplateAddResult::SMSTemplateAddResult(bool result) : result(result)
+SMSTemplateAddResult::SMSTemplateAddResult(bool result, unsigned int id) : result(result), id(id)
 {}
 
 [[nodiscard]] auto SMSTemplateAdd::debugInfo() const -> std::string

--- a/module-db/queries/messages/templates/QuerySMSTemplateAdd.hpp
+++ b/module-db/queries/messages/templates/QuerySMSTemplateAdd.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -16,7 +16,7 @@ namespace db::query
     class SMSTemplateAdd : public Query
     {
       public:
-        SMSTemplateAdd(const SMSTemplateRecord &rec);
+        explicit SMSTemplateAdd(const SMSTemplateRecord &rec);
         SMSTemplateRecord rec;
         [[nodiscard]] auto debugInfo() const -> std::string override;
     };
@@ -24,15 +24,20 @@ namespace db::query
     class SMSTemplateAddResult : public QueryResult
     {
       public:
-        SMSTemplateAddResult(bool result);
+        SMSTemplateAddResult(bool result, unsigned int id);
         auto getResult() -> bool
         {
             return result;
+        }
+        [[nodiscard]] auto getID() const noexcept -> unsigned int
+        {
+            return id;
         }
         [[nodiscard]] auto debugInfo() const -> std::string override;
 
       private:
         bool result;
+        unsigned int id;
     };
 
 }; // namespace db::query

--- a/module-db/tests/SMSTemplateTable_tests.cpp
+++ b/module-db/tests/SMSTemplateTable_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -85,6 +85,22 @@ TEST_CASE("SMS Templates Table tests")
         // Get table rows using invalid offset/limit parameters(should return empty object)
         auto retOffsetLimitFailed = templatesTbl.getLimitOffset(5, 4);
         REQUIRE(retOffsetLimitFailed.size() == 0);
+    }
+
+    SECTION("Get last ID")
+    {
+        REQUIRE(templatesTbl.getLastId() == 4);
+        REQUIRE(templatesTbl.add(testRow));
+        REQUIRE(templatesTbl.getLastId() == 5);
+        REQUIRE(templatesTbl.removeById(5));
+        REQUIRE(templatesTbl.getLastId() == 4);
+        REQUIRE(templatesTbl.add(testRow));
+        REQUIRE(templatesTbl.getLastId() == 5);
+        REQUIRE(templatesTbl.add(testRow));
+        REQUIRE(templatesTbl.getLastId() == 6);
+        REQUIRE(templatesTbl.removeById(5));
+        REQUIRE(templatesTbl.add(testRow));
+        REQUIRE(templatesTbl.getLastId() == 7);
     }
 
     SECTION("Remove entries")

--- a/products/PurePhone/services/desktop/endpoints/messages/MessageHelper.cpp
+++ b/products/PurePhone/services/desktop/endpoints/messages/MessageHelper.cpp
@@ -314,8 +314,9 @@ namespace sdesktop::endpoints
         auto listener = std::make_unique<db::EndpointListener>(
             [=](db::QueryResult *result, Context context) {
                 if (auto smsTemplateResult = dynamic_cast<db::query::SMSTemplateAddResult *>(result)) {
-
-                    context.setResponseStatus(smsTemplateResult->getResult() ? http::Code::NoContent
+                    context.setResponseBody(json11::Json::object{
+                        {json::messages::templateID, static_cast<int>(smsTemplateResult->getID())}});
+                    context.setResponseStatus(smsTemplateResult->getResult() ? http::Code::OK
                                                                              : http::Code::InternalServerError);
                     putToSendQueue(context.createSimpleResponse());
                     return true;

--- a/test/pytest/service-desktop/test_templates.py
+++ b/test/pytest/service-desktop/test_templates.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 import pytest
 from harness.interface.defs import status
@@ -19,7 +19,8 @@ class TemplatesTester:
     def __add_template(self):
         body = {"category": "template", "templateBody": self.template_body}
         ret = self.harness.endpoint_request("messages", "post", body)
-        assert ret["status"] == status["NoContent"]
+        assert ret["status"] == status["OK"]
+        assert type(ret["body"]["templateID"]) == int
         return ret
 
     def __get_templates(self, limit, offset):


### PR DESCRIPTION
**Description**

No information about the newly added message template
was returned. Now temaplateID helps to identify
the newly added record.
Documentation:  https://appnroll.atlassian.net/wiki/spaces/CP/pages/990642315/Messages+Endpoint+API+8#Add-a-message-template
**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
