### PR TITLE
[BH-1517] Blank screen after deep press

### DIFF
--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/SettingsWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/SettingsWindow.cpp
@@ -41,8 +41,9 @@ namespace app::meditation
         setFocusItem(sideListView);
     }
 
-    void SettingsWindow::onBeforeShow(gui::ShowMode, gui::SwitchData *)
+    void SettingsWindow::onBeforeShow(gui::ShowMode mode, gui::SwitchData *data)
     {
+        AppWindow::onBeforeShow(mode, data);
         presenter->loadData();
         setFocusItem(sideListView);
     }
@@ -63,8 +64,10 @@ namespace app::meditation
         return AppWindow::onInput(inputEvent);
     }
 
-    void SettingsWindow::onClose(CloseReason)
+    void SettingsWindow::onClose(const CloseReason reason)
     {
-        presenter->eraseProviderData();
+        if (reason != CloseReason::Popup) {
+            presenter->eraseProviderData();
+        }
     }
 } // namespace app::meditation


### PR DESCRIPTION
**Description**

Deep press causes blank screen when in
meditation/settings.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
