### PR TITLE
[MOS-401] Fix critical battery level detection

### DIFF
--- a/module-services/service-evtmgr/battery/BatteryState.cpp
+++ b/module-services/service-evtmgr/battery/BatteryState.cpp
@@ -136,7 +136,7 @@ class BatteryState::Pimpl
     sml::sm<StateMachine, NotifyStateChangedCallback> sm{notifyCallback};
 
     static constexpr auto criticalThreshold = 10; // %
-    static constexpr auto shutdownThreshold = 1;  // %
+    static constexpr auto shutdownThreshold = 5;  // %
 };
 
 void BatteryState::check(const ChargingState state, const float soc)


### PR DESCRIPTION
**Description**

When the battery charge drops below 5%,
the phone turns off.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible.
- [ ] Has documentation updated

<!-- Thanks for your work ♥ -->
