### PR TITLE
[BH-1520] Missing bottom texts

### DIFF
--- a/products/BellHybrid/apps/common/include/common/widgets/list_items/NumberWithSuffix.hpp
+++ b/products/BellHybrid/apps/common/include/common/widgets/list_items/NumberWithSuffix.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -40,7 +40,6 @@ namespace app::list_items
         void control_bottom_description(const spinner_type::value_type &value) final
         {
             bottomText->setVisible(value != 0);
-            body->resize();
         }
     };
 } // namespace app::list_items

--- a/products/BellHybrid/apps/common/include/common/widgets/list_items/details.hpp
+++ b/products/BellHybrid/apps/common/include/common/widgets/list_items/details.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -98,6 +98,7 @@ namespace app::list_items
                 body->setMinMaxArrowsVisibility(spinner->is_min(), spinner->is_max());
                 if (not this->bottomDescription.empty()) {
                     control_bottom_description(spinner->value());
+                    body->resize();
                 }
             }
             SpinnerType *spinner{};


### PR DESCRIPTION
**Description**

Controlling each list item's bottom
text by setVisibility does not give correct
results. It is required to explicitly resize
the bottom container.

From now on, resize call is
placed in ListItemBase so each new and existing
list items will be affected by this change resulting
in proper behavior without need for the programmer to
remember about it.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
