### PR TITLE
[MOS-374] Fix incomplete screen redraw

### DIFF
--- a/module-bsp/board/rt1051/bsp/eink/bsp_eink.cpp
+++ b/module-bsp/board/rt1051/bsp/eink/bsp_eink.cpp
@@ -278,7 +278,7 @@ void BSP_EinkDeinit(void)
 
 status_t BSP_EinkWriteData(void *txBuffer, uint32_t len, eink_spi_cs_config_e cs)
 {
-    const uint32_t TX_TIMEOUT_MS = 1000;
+    const uint32_t TX_TIMEOUT_MS = 2000;
     status_t tx_status           = 0;
     status_t status;
     lpspi_transfer_t xfer = {};
@@ -359,7 +359,7 @@ status_t BSP_EinkWriteData(void *txBuffer, uint32_t len, eink_spi_cs_config_e cs
 
 status_t BSP_EinkReadData(void *rxBuffer, uint32_t len, eink_spi_cs_config_e cs)
 {
-    const int RX_TIMEOUT_MS = 1000;
+    const int RX_TIMEOUT_MS = 2000;
     status_t tx_status      = 0;
     status_t status;
     lpspi_transfer_t xfer = {};


### PR DESCRIPTION
**Description**

At the lowest CPU frequency of 4 MHz, the DMA transfer to eInk
takes much longer, even ~ 1300ms. TIMEOUT has been increased as
exceeding it caused the screen to redraw incorrectly.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
