### PR TITLE
[MOS-527] Fix bluetooth reconnection error

### DIFF
--- a/module-bluetooth/Bluetooth/interface/profiles/HFP/HFP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/HFP/HFP.cpp
@@ -523,7 +523,7 @@ namespace bluetooth
     {
         if (currentCallStatus != CallStatus::OutgoingPlacedFromHFP) {
             LOG_DEBUG("Started outgoing call from Pure");
-            hfp_ag_outgoing_call_initiated(number.c_str());
+            hfp_ag_outgoing_call_initiated();
             hfp_ag_outgoing_call_accepted();
             hfp_ag_outgoing_call_ringing();
             currentCallStatus = CallStatus::OutgoingPlacedFromPure;

--- a/module-bluetooth/lib/btstack.cmake
+++ b/module-bluetooth/lib/btstack.cmake
@@ -150,6 +150,7 @@ set(BOARD_DIR_SOURCES
     ${BT_STACK_ROOT}/3rd-party/hxcmod-player/mods/nao-deceased_by_disease.c
     ${BT_STACK_ROOT}/3rd-party/hxcmod-player/hxcmod.c
     ${BT_STACK_ROOT}/src/classic/btstack_sbc_encoder_bluedroid.c
+    ${BT_STACK_ROOT}/src/classic/a2dp.c
     ${BT_STACK_ROOT}/src/classic/a2dp_source.c
     ${BT_STACK_ROOT}/3rd-party/bluedroid/encoder/srce/sbc_encoder.c
     ${BT_STACK_ROOT}/src/classic/avdtp_util.c


### PR DESCRIPTION
**Description**

There was an error when user tried to connect using TRY AGAIN.
The bug was in the bluetooth stack, so we updated it as it has
a fix for it. Now it works and BT overall should work better now.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
