### PR TITLE
[MOS-32] RF clears snoozed alarms fix

### DIFF
--- a/module-apps/application-desktop/models/ActiveNotificationsListPresenter.cpp
+++ b/module-apps/application-desktop/models/ActiveNotificationsListPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ActiveNotificationsListPresenter.hpp"
@@ -289,6 +289,6 @@ auto ActiveNotificationsListPresenter::create(const notifications::AlarmSnoozeNo
     setSnoozeActivatedCallback(item, this, parent->getApplication());
     setSnoozeOnInputCallback(item, parent->getApplication());
     setSnoozeDismissCallback(item, parent->getApplication());
-    item->setDismissible(true);
+    item->setDismissible(false);
     return item;
 }


### PR DESCRIPTION
**Description**

Fix of the issue that RF button clears
snoozed alarms notifications from desktop.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
