### PR TITLE
[MOS-555] Fix misspelled cmake variable

### DIFF
--- a/cmake/modules/ConfigureVersionJson.cmake
+++ b/cmake/modules/ConfigureVersionJson.cmake
@@ -7,7 +7,7 @@ endif()
 if (NOT ${BOOT_FILE} STREQUAL "")
     file(MD5 ${BOOT_FILE} BOOT_MD5SUM)
 endif()
-if (NOT ${UPLOADER_FILE} STREQUAL "")
+if (NOT ${UPDATER_FILE} STREQUAL "")
     file(MD5 ${UPDATER_FILE} UPDATER_MD5SUM)
 endif()
 


### PR DESCRIPTION
**Description**

Misspelled variable could cause missing checksum for updater

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
