### PR TITLE
[MOS-529] Forgotten BT device remains on the list

### DIFF
--- a/module-apps/apps-common/popups/BluetoothAuthenticatePopup.cpp
+++ b/module-apps/apps-common/popups/BluetoothAuthenticatePopup.cpp
@@ -173,6 +173,7 @@ namespace gui
                     application->bus.sendUnicast(std::make_shared<message::bluetooth::ResponseAuthenticatePairCancel>(
                                                      true, authenticateParams->getDevice()),
                                                  service::name::bluetooth);
+                    application->returnToPreviousWindow();
                     return true;
                 };
             }

--- a/module-bluetooth/Bluetooth/BluetoothStateMachine.hpp
+++ b/module-bluetooth/Bluetooth/BluetoothStateMachine.hpp
@@ -349,7 +349,7 @@ namespace bluetooth
                         *state<Idle> + sml::event<bluetooth::event::StartScan> / HandleOn = state<Idle>,
                         state<Idle> + sml::event<bluetooth::event::StopScan> / HandleOff = state<Idle>,
                         state<Idle> + sml::event<bluetooth::event::Pair> / HandlePair = state<Idle>,
-                        state<Idle> + sml::event<bluetooth::event::Unpair>[Connected] / (HandleDisconnect, HandleUnpair) = state<Idle>,
+                        state<Idle> + sml::event<bluetooth::event::Unpair>[Connected] / (HandleDisconnect, HandleUnpair, HandleDrop) = state<Idle>,
                         state<Idle> + sml::event<bluetooth::event::Unpair>[not Connected] / (HandleUnpair, HandleDrop) = state<Idle>,
 
                         state<Idle> + sml::event<bluetooth::event::VisibilityOn> / HandleSetVisibility = state<Idle>,


### PR DESCRIPTION
**Description**

Fix of the issue that forgotten BT device
reappeared on 'All devices' list after
reentering the list from home screen.
Additionally fixed pairing confirmation
popup that wouldn't hide after pressing
"Confirm".

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
