### PR TITLE
[MOS-499] Turn off the one-minute screen refresh for quotes

### DIFF
--- a/module-apps/apps-common/popups/lock-popups/PhoneLockedInfoWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/PhoneLockedInfoWindow.cpp
@@ -94,11 +94,11 @@ status_bar::Configuration PhoneLockedInfoWindow::configureStatusBar(status_bar::
 {
     appConfiguration.disable(status_bar::Indicator::NetworkAccessTechnology);
     appConfiguration.disable(status_bar::Indicator::Time);
+    appConfiguration.disable(status_bar::Indicator::SimCard);
     appConfiguration.enable(status_bar::Indicator::PhoneMode);
     appConfiguration.enable(status_bar::Indicator::Lock);
     appConfiguration.enable(status_bar::Indicator::Battery);
     appConfiguration.enable(status_bar::Indicator::Signal);
-    appConfiguration.enable(status_bar::Indicator::SimCard);
     appConfiguration.enable(status_bar::Indicator::Bluetooth);
     appConfiguration.enable(status_bar::Indicator::AlarmClock);
     return appConfiguration;

--- a/module-apps/apps-common/popups/lock-popups/PhoneLockedWindow.hpp
+++ b/module-apps/apps-common/popups/lock-popups/PhoneLockedWindow.hpp
@@ -64,8 +64,6 @@ namespace gui
                 return temp;
             }
         } deepRefreshCounter;
-
-        void updateStatusBar();
     };
 
 } /* namespace gui */

--- a/module-apps/apps-common/popups/presenter/WallpaperPresenter.cpp
+++ b/module-apps/apps-common/popups/presenter/WallpaperPresenter.cpp
@@ -64,10 +64,22 @@ namespace gui
         return notificationsModel;
     }
 
-    void WallpaperPresenter::updateTime()
+    bool WallpaperPresenter::updateWallpaper()
     {
-        if (clockWallpaper) {
-            clockWallpaper->updateTime();
+        switch (selectedOption) {
+        case WallpaperOption::Clock:
+            if (clockWallpaper) {
+                clockWallpaper->updateTime();
+            }
+            return true;
+            break;
+        case WallpaperOption::Quote:
+            [[fallthrough]];
+        case WallpaperOption::Logo:
+            [[fallthrough]];
+        default:
+            return false;
+            break;
         }
     }
 

--- a/module-apps/apps-common/popups/presenter/WallpaperPresenter.hpp
+++ b/module-apps/apps-common/popups/presenter/WallpaperPresenter.hpp
@@ -18,7 +18,7 @@ namespace gui
         WallpaperPresenter(app::ApplicationCommon *app);
         void setupWallpaper(Item *parent);
         std::shared_ptr<gui::NotificationsModel> getNotificationsModel();
-        void updateTime();
+        bool updateWallpaper();
         void forceClockWallpaper();
         /// returns true if actual switch back occured
         bool switchBackWallpaper();

--- a/module-gui/gui/widgets/StatusBar.cpp
+++ b/module-gui/gui/widgets/StatusBar.cpp
@@ -380,17 +380,21 @@ namespace gui::status_bar
         enabled ? networkAccessTechnology->show() : networkAccessTechnology->hide();
     }
 
-    void StatusBar::showTime(bool enabled)
+    bool StatusBar::showTime(bool enabled)
     {
+        const auto visibilityChanged = time->isVisible() == enabled ? false : true;
         time->update();
         if (enabled) {
             centralBox->setMinimumSize(boxes::center::maxX, this->drawArea.h);
             time->show();
             lock->hide();
             centralBox->resizeItems();
-            return;
         }
-        time->hide();
+        else {
+            time->hide();
+        }
+        const auto refreshRequired = visibilityChanged || enabled;
+        return refreshRequired;
     }
 
     void StatusBar::showLock(bool enabled)
@@ -409,8 +413,7 @@ namespace gui::status_bar
         if (time == nullptr) {
             return false;
         }
-        showTime(configuration.isEnabled(Indicator::Time));
-        return true;
+        return showTime(configuration.isEnabled(Indicator::Time));
     }
 
     void StatusBar::accept(GuiVisitor &visitor)

--- a/module-gui/gui/widgets/StatusBar.hpp
+++ b/module-gui/gui/widgets/StatusBar.hpp
@@ -213,7 +213,7 @@ namespace gui::status_bar
 
         /// Show/hide clock widget
         /// @param enabled true to show false to hide the widget
-        void showTime(bool enabled);
+        bool showTime(bool enabled);
 
         /// Show/hide lock status widget
         /// @param enabled true to show false to hide the widget


### PR DESCRIPTION
Refresh lock screen only when clock wallpaper 
or status bar time is set.
Remove unused items from status bar to avoid refresh
every minute. Add status in debug log to make
sure which module performed the refresh.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
