### PR TITLE
[MOS-549] Linux simulator crashes on GCC12

### DIFF
--- a/board/linux/libiosyscalls/CMakeLists.txt
+++ b/board/linux/libiosyscalls/CMakeLists.txt
@@ -26,6 +26,8 @@ target_sources(
         src/syscalls_real.hpp
         src/syscalls_scan_family.cpp
         src/syscalls_stdio.cpp
+        src/syscalls_common.hpp
+        src/syscalls_wrapper.cpp
 
     PUBLIC
         include/debug.hpp

--- a/board/linux/libiosyscalls/src/syscalls_common.hpp
+++ b/board/linux/libiosyscalls/src/syscalls_common.hpp
@@ -1,0 +1,11 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+extern "C"
+{
+#if __GLIBC__ > 2 || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 33))
+    int _iosys_stat(const char *file, struct stat *pstat);
+#endif
+}

--- a/board/linux/libiosyscalls/src/syscalls_posix.cpp
+++ b/board/linux/libiosyscalls/src/syscalls_posix.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "iosyscalls-internal.hpp"
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 #include "syscalls_real.hpp"
+#include "syscalls_common.hpp"
 
 #include "debug.hpp"
 

--- a/board/linux/libiosyscalls/src/syscalls_wrapper.cpp
+++ b/board/linux/libiosyscalls/src/syscalls_wrapper.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "syscalls_common.hpp"
+
+extern "C"
+{
+#if __GLIBC__ > 2 || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 33))
+    // Replace ASAN stat to our stat
+    int stat(const char *file, struct stat *pstat)
+    {
+        return _iosys_stat(file, pstat);
+    }
+#endif
+}


### PR DESCRIPTION
Add wrapper for posix stat function
in order to invoke our implementation.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
