### PR TITLE
[MOS-570] Fix HFP answering bug

### DIFF
--- a/module-bluetooth/Bluetooth/BluetoothStateMachine.hpp
+++ b/module-bluetooth/Bluetooth/BluetoothStateMachine.hpp
@@ -367,6 +367,7 @@ namespace bluetooth
                         state<Idle> + sml::event<bluetooth::event::StartRouting> / forwardEvent= state<Call>,
                         state<Idle> + sml::event<bluetooth::event::IncomingCallNumber>  / forwardEvent  = state<Call>,
                         state<Idle> + sml::event<bluetooth::event::CallStarted> / forwardEvent= state<Call>,
+
                         state<Call> = state<Idle> // this one is needed to go out from Call substate properly!
 
                             );

--- a/module-services/service-bluetooth/ServiceBluetooth.cpp
+++ b/module-services/service-bluetooth/ServiceBluetooth.cpp
@@ -118,6 +118,7 @@ sys::ReturnCodes ServiceBluetooth::InitHandler()
     connectHandler<cellular::NetworkStatusUpdateNotification>();
     connectHandler<sevm::BatteryStatusChangeMessage>();
     connectHandler<cellular::CallOutgoingAccepted>();
+    connectHandler<cellular::CallActiveNotification>();
 
     settingsHolder->onStateChange = [this]() {
         auto initialState = std::visit(bluetooth::IntVisitor(), settingsHolder->getValue(bluetooth::Settings::State));
@@ -588,6 +589,13 @@ auto ServiceBluetooth::handle(cellular::IncomingCallMessage *msg) -> std::shared
 auto ServiceBluetooth::handle(cellular::CallOutgoingAccepted *msg) -> std::shared_ptr<sys::Message>
 {
     LOG_DEBUG("Outgoing call accepted");
+    sendWorkerCommand(std::make_unique<bluetooth::event::CallAnswered>());
+
+    return sys::MessageNone{};
+}
+auto ServiceBluetooth::handle(cellular::CallActiveNotification *msg) -> std::shared_ptr<sys::Message>
+{
+    LOG_DEBUG("Incoming call accepted");
     sendWorkerCommand(std::make_unique<bluetooth::event::CallAnswered>());
 
     return sys::MessageNone{};

--- a/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
@@ -75,6 +75,7 @@ namespace cellular
     class SignalStrengthUpdateNotification;
     class CurrentOperatorNameNotification;
     class NetworkStatusUpdateNotification;
+    class CallActiveNotification;
 }
 
 class ServiceBluetooth : public sys::Service
@@ -147,6 +148,7 @@ class ServiceBluetooth : public sys::Service
     [[nodiscard]] auto handle(cellular::CurrentOperatorNameNotification *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(cellular::NetworkStatusUpdateNotification *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(sevm::BatteryStatusChangeMessage *msg) -> std::shared_ptr<sys::Message>;
+    [[nodiscard]] auto handle(cellular::CallActiveNotification *msg) -> std::shared_ptr<sys::Message>;
 };
 
 namespace sys


### PR DESCRIPTION
**Description**

The call answer event was incorrectly routed to BT, thus
the device was not aware of answering the call

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible.
- [ ] Has documentation updated

<!-- Thanks for your work ♥ -->
