### PR TITLE
[MOS-559] Fix unlock when phone started not in Connected mode

### DIFF
--- a/module-apps/apps-common/ApplicationCommon.hpp
+++ b/module-apps/apps-common/ApplicationCommon.hpp
@@ -187,6 +187,7 @@ namespace app
         std::unique_ptr<WindowsStack> windowsStackImpl;
         std::string default_window;
         State state = State::DEACTIVATED;
+        bool phoneIsLocked = true;
 
         sys::MessagePointer handleSignalStrengthUpdate(sys::Message *msgl);
         sys::MessagePointer handleNetworkAccessTechnologyUpdate(sys::Message *msgl);

--- a/module-apps/apps-common/WindowsStack.cpp
+++ b/module-apps/apps-common/WindowsStack.cpp
@@ -116,6 +116,11 @@ namespace app
         return std::find_if(stack.begin(), stack.end(), [&](auto &el) { return el.name == window; });
     }
 
+    bool WindowsStack::isWindowOnStack(const std::string &window)
+    {
+        return findInStack(window) != stack.end();
+    }
+
     void WindowsStack::dropPendingPopups()
     {
         auto it = stack.rbegin();

--- a/module-apps/apps-common/WindowsStack.hpp
+++ b/module-apps/apps-common/WindowsStack.hpp
@@ -73,6 +73,8 @@ namespace app
         void dropPendingPopups();
         void clear();
 
+        bool isWindowOnStack(const std::string &window);
+
         bool rebuildWindows(app::WindowsFactory &windowsFactory, ApplicationCommon *app);
     };
 

--- a/module-services/service-cellular/call/CellularCall.cpp
+++ b/module-services/service-cellular/call/CellularCall.cpp
@@ -3,22 +3,11 @@
 
 #include "call/CellularCall.hpp"
 #include "service-cellular/ServiceCellular.hpp"
-#include "service-db/agents/settings/SystemSettings.hpp"
 
-#include <CalllogRecord.hpp>
-#include <PhoneNumber.hpp>
-#include <Utils.hpp>
 #include <log/log.hpp>
 
-#include <cinttypes>
-#include <ctime>
 #include <memory>
-#include <optional>
-#include <sstream>
-#include <stdexcept>
-#include <string>
 #include <utility>
-#include <vector>
 #include "CallMachine.hpp"
 
 namespace call


### PR DESCRIPTION
**Description**

Fix of the issue that when phone was started in
mode different than Connected, next mode changed
resulted in bypassing of the lock.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
