### PR TITLE
[MOS-23] Back button works as save button in Notes

### DIFF
--- a/module-apps/application-notes/ApplicationNotes.cpp
+++ b/module-apps/application-notes/ApplicationNotes.cpp
@@ -100,7 +100,7 @@ namespace app
         });
         windowsFactory.attach(gui::name::window::note_create, [](ApplicationCommon *app, const std::string &name) {
             auto notesRepository = std::make_unique<notes::NotesDBRepository>(app);
-            auto presenter       = std::make_unique<notes::NoteCreateWindowPresenter>(std::move(notesRepository));
+            auto presenter       = std::make_unique<notes::NoteEditWindowPresenter>(std::move(notesRepository));
             return std::make_unique<notes::NoteCreateWindow>(app, std::move(presenter));
         });
         windowsFactory.attach(gui::name::window::notes_search, [](ApplicationCommon *app, const std::string &name) {

--- a/module-apps/application-notes/presenter/NoteEditWindowPresenter.cpp
+++ b/module-apps/application-notes/presenter/NoteEditWindowPresenter.cpp
@@ -5,17 +5,6 @@
 
 namespace app::notes
 {
-    namespace
-    {
-        struct AutoSavePolicy
-        {
-            bool operator()(bool isNoteEmpty) const noexcept
-            {
-                return !isNoteEmpty;
-            }
-        };
-    } // namespace
-
     NoteEditWindowPresenter::NoteEditWindowPresenter(std::unique_ptr<AbstractNotesRepository> &&notesRepository)
         : notesRepository{std::move(notesRepository)}
     {}
@@ -23,11 +12,6 @@ namespace app::notes
     void NoteEditWindowPresenter::onNoteChanged()
     {
         noteChanged = true;
-    }
-
-    bool NoteEditWindowPresenter::isAutoSaveApproved() const noexcept
-    {
-        return noteChanged;
     }
 
     void NoteEditWindowPresenter::save(std::shared_ptr<NotesRecord> &note)
@@ -39,11 +23,5 @@ namespace app::notes
             }
         });
         noteChanged = false;
-    }
-
-    bool NoteCreateWindowPresenter::isAutoSaveApproved() const noexcept
-    {
-        AutoSavePolicy policy;
-        return NoteEditWindowPresenter::isAutoSaveApproved() && policy(getView()->isNoteEmpty());
     }
 } // namespace app::notes

--- a/module-apps/application-notes/presenter/NoteEditWindowPresenter.hpp
+++ b/module-apps/application-notes/presenter/NoteEditWindowPresenter.hpp
@@ -25,7 +25,6 @@ namespace app::notes
             virtual ~Presenter() noexcept = default;
 
             virtual void onNoteChanged()                          = 0;
-            virtual bool isAutoSaveApproved() const noexcept      = 0;
             virtual void save(std::shared_ptr<NotesRecord> &note) = 0;
         };
     };
@@ -36,19 +35,10 @@ namespace app::notes
         explicit NoteEditWindowPresenter(std::unique_ptr<AbstractNotesRepository> &&notesRepository);
 
         void onNoteChanged() override;
-        bool isAutoSaveApproved() const noexcept override;
         void save(std::shared_ptr<NotesRecord> &note) override;
 
       private:
         std::unique_ptr<AbstractNotesRepository> notesRepository;
         bool noteChanged = false;
-    };
-
-    class NoteCreateWindowPresenter : public NoteEditWindowPresenter
-    {
-      public:
-        using NoteEditWindowPresenter::NoteEditWindowPresenter;
-
-        bool isAutoSaveApproved() const noexcept override;
     };
 } // namespace app::notes

--- a/module-apps/application-notes/windows/NoteEditWindow.cpp
+++ b/module-apps/application-notes/windows/NoteEditWindow.cpp
@@ -127,13 +127,6 @@ namespace app::notes
         setNoteText(notesRecord->snippet);
     }
 
-    void NoteEditWindow::onClose([[maybe_unused]] CloseReason reason)
-    {
-        if (presenter->isAutoSaveApproved()) {
-            saveNote();
-        }
-    }
-
     void NoteEditWindow::setNoteText(const UTF8 &text)
     {
         edit->setText(text);

--- a/module-apps/application-notes/windows/NoteEditWindow.hpp
+++ b/module-apps/application-notes/windows/NoteEditWindow.hpp
@@ -25,7 +25,6 @@ namespace app::notes
         ~NoteEditWindow() noexcept override;
 
         void onBeforeShow(gui::ShowMode mode, gui::SwitchData *data) override;
-        void onClose(CloseReason reason) override;
         bool onInput(const gui::InputEvent &inputEvent) override;
 
         void rebuild() override;


### PR DESCRIPTION
Removed the auto-save facility from Notes as it was lacking any configuration and worked in unwanted moment(s).

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated
