### PR TITLE
[BH-1519] Shared alarm model instance

### DIFF
--- a/products/BellHybrid/apps/Application.cpp
+++ b/products/BellHybrid/apps/Application.cpp
@@ -1,9 +1,7 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <Application.hpp>
-
-#include <common/models/AlarmModel.hpp>
 
 #include <audio/AudioMessage.hpp>
 #include <appmgr/messages/IdleTimerMessage.hpp>
@@ -40,24 +38,34 @@ namespace app
         });
     }
 
+    sys::ReturnCodes Application::InitHandler()
+    {
+        auto ret = ApplicationCommon::InitHandler();
+        if (ret != sys::ReturnCodes::Success) {
+            return ret;
+        }
+
+        alarmModel = std::make_unique<app::AlarmModel>(this);
+        return sys::ReturnCodes::Success;
+    }
+
     void Application::attachPopups(const std::vector<gui::popup::ID> &popupsList)
     {
         using namespace gui::popup;
+
         for (auto popup : popupsList) {
             switch (popup) {
             case ID::AlarmActivated:
                 windowsFactory.attach(
-                    window::alarm_activated_window, [](app::ApplicationCommon *app, const std::string &name) {
-                        auto alarmModel = std::make_shared<app::AlarmModel>(app);
-                        auto presenter  = std::make_unique<app::popup::AlarmActivatedPresenter>(alarmModel);
+                    window::alarm_activated_window, [this](app::ApplicationCommon *app, const std::string &name) {
+                        auto presenter = std::make_unique<app::popup::AlarmActivatedPresenter>(*alarmModel);
                         return std::make_unique<gui::AlarmActivatedWindow>(app, std::move(presenter));
                     });
                 break;
             case ID::AlarmDeactivated:
                 windowsFactory.attach(
-                    window::alarm_deactivated_window, [](app::ApplicationCommon *app, const std::string &name) {
-                        auto alarmModel = std::make_shared<app::AlarmModel>(app);
-                        auto presenter  = std::make_unique<app::popup::AlarmActivatedPresenter>(alarmModel);
+                    window::alarm_deactivated_window, [this](app::ApplicationCommon *app, const std::string &name) {
+                        auto presenter = std::make_unique<app::popup::AlarmActivatedPresenter>(*alarmModel);
                         return std::make_unique<gui::AlarmDeactivatedWindow>(app, std::move(presenter));
                     });
                 break;

--- a/products/BellHybrid/apps/CMakeLists.txt
+++ b/products/BellHybrid/apps/CMakeLists.txt
@@ -15,10 +15,11 @@ target_include_directories(app
 target_link_libraries(app
     PRIVATE
         apps-common
-        bell::app-common
         bell::appmgr
         bell::alarms
         bell::audio
+    PUBLIC 
+        bell::app-common
 )
 
 add_subdirectory(application-bell-main)

--- a/products/BellHybrid/apps/application-bell-alarm/include/application-bell-alarm/ApplicationBellAlarm.hpp
+++ b/products/BellHybrid/apps/application-bell-alarm/include/application-bell-alarm/ApplicationBellAlarm.hpp
@@ -8,18 +8,10 @@
 
 namespace app
 {
-    namespace internal
-    {
-        class BellAlarmPriv;
-    } // namespace internal
-
     inline constexpr auto applicationBellAlarmName = "ApplicationBellAlarm";
 
     class ApplicationBellAlarm : public Application
     {
-      private:
-        std::unique_ptr<internal::BellAlarmPriv> priv;
-
       public:
         explicit ApplicationBellAlarm(std::string name                    = applicationBellAlarmName,
                                       std::string parent                  = "",

--- a/products/BellHybrid/apps/application-bell-alarm/presenter/BellAlarmSetPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-alarm/presenter/BellAlarmSetPresenter.cpp
@@ -9,19 +9,18 @@
 
 namespace app::bell_alarm
 {
-    BellAlarmSetPresenter::BellAlarmSetPresenter(app::ApplicationCommon *app,
-                                                 std::shared_ptr<AbstractAlarmModel> alarmModel)
-        : app{app}, alarmModel{std::move(alarmModel)}
+    BellAlarmSetPresenter::BellAlarmSetPresenter(app::ApplicationCommon *app, AbstractAlarmModel &alarmModel)
+        : app{app}, alarmModel{alarmModel}
     {}
 
     bool BellAlarmSetPresenter::isAlarmActive() const noexcept
     {
-        return alarmModel->isActive();
+        return alarmModel.isActive();
     }
 
     time_t BellAlarmSetPresenter::getAlarmTime() const noexcept
     {
-        return alarmModel->getAlarmTime();
+        return alarmModel.getAlarmTime();
     }
 
     void BellAlarmSetPresenter::activate()

--- a/products/BellHybrid/apps/application-bell-alarm/presenter/BellAlarmSetPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-alarm/presenter/BellAlarmSetPresenter.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -34,7 +34,7 @@ namespace app::bell_alarm
     class BellAlarmSetPresenter : public BellAlarmSetContract::Presenter
     {
       public:
-        explicit BellAlarmSetPresenter(app::ApplicationCommon *app, std::shared_ptr<AbstractAlarmModel> alarmModel);
+        explicit BellAlarmSetPresenter(app::ApplicationCommon *app, AbstractAlarmModel &alarmModel);
 
         time_t getAlarmTime() const noexcept;
         bool isAlarmActive() const noexcept;
@@ -43,6 +43,6 @@ namespace app::bell_alarm
       private:
         app::ApplicationCommon *app{};
 
-        std::shared_ptr<AbstractAlarmModel> alarmModel;
+        AbstractAlarmModel &alarmModel;
     };
 } // namespace app::bell_alarm

--- a/products/BellHybrid/apps/application-bell-alarm/presenter/BellAlarmWindowPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-alarm/presenter/BellAlarmWindowPresenter.cpp
@@ -1,13 +1,13 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BellAlarmWindowPresenter.hpp"
 
 namespace app::bell_alarm
 {
-    BellAlarmWindowPresenter::BellAlarmWindowPresenter(std::shared_ptr<AbstractAlarmModel> alarmModel,
+    BellAlarmWindowPresenter::BellAlarmWindowPresenter(AbstractAlarmModel &alarmModel,
                                                        std::shared_ptr<AbstractTimeModel> timeModel)
-        : alarmModel{std::move(alarmModel)}, timeModel{std::move(timeModel)}
+        : alarmModel{alarmModel}, timeModel{std::move(timeModel)}
     {}
 
     auto BellAlarmWindowPresenter::onBeforeShow() -> void
@@ -19,18 +19,18 @@ namespace app::bell_alarm
     {
         auto view       = getView();
         const auto time = view->getAlarmTime();
-        alarmModel->setAlarmTime(time);
+        alarmModel.setAlarmTime(time);
     }
 
     auto BellAlarmWindowPresenter::createData() -> void
     {
         auto updateAlarmTimeCallback = [&]() {
-            const auto time = alarmModel->getAlarmTime();
+            const auto time = alarmModel.getAlarmTime();
             auto view       = getView();
             view->setAlarmTime(time);
         };
 
-        alarmModel->update(updateAlarmTimeCallback);
+        alarmModel.update(updateAlarmTimeCallback);
     }
 
     auto BellAlarmWindowPresenter::setTimeFormat(utils::time::Locale::TimeFormat fmt) -> void

--- a/products/BellHybrid/apps/application-bell-alarm/presenter/BellAlarmWindowPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-alarm/presenter/BellAlarmWindowPresenter.hpp
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -37,15 +37,14 @@ namespace app::bell_alarm
     class BellAlarmWindowPresenter : public BellAlarmWindowContract::Presenter
     {
       public:
-        BellAlarmWindowPresenter(std::shared_ptr<AbstractAlarmModel> alarmModel,
-                                 std::shared_ptr<AbstractTimeModel> timeModel);
+        BellAlarmWindowPresenter(AbstractAlarmModel &alarmModel, std::shared_ptr<AbstractTimeModel> timeModel);
         auto createData() -> void override;
         auto saveData() -> void override;
         auto setTimeFormat(utils::time::Locale::TimeFormat fmt) -> void override;
         auto onBeforeShow() -> void override;
 
       private:
-        std::shared_ptr<AbstractAlarmModel> alarmModel;
+        AbstractAlarmModel &alarmModel;
         std::shared_ptr<AbstractTimeModel> timeModel;
     };
 } // namespace app::bell_alarm

--- a/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
+++ b/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
@@ -83,7 +83,6 @@ namespace app
         auto timeModel        = std::make_unique<app::TimeModel>();
         auto batteryModel     = std::make_unique<app::home_screen::BatteryModel>(this);
         auto temperatureModel = std::make_unique<app::home_screen::TemperatureModel>(this);
-        auto alarmModel       = std::make_unique<app::AlarmModel>(this);
         homeScreenPresenter   = std::make_shared<app::home_screen::HomeScreenPresenter>(
             this, std::move(alarmModel), std::move(batteryModel), std::move(temperatureModel), std::move(timeModel));
 

--- a/products/BellHybrid/apps/common/include/common/popups/presenter/AlarmActivatedPresenter.hpp
+++ b/products/BellHybrid/apps/common/include/common/popups/presenter/AlarmActivatedPresenter.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -47,7 +47,7 @@ namespace app::popup
     class AlarmActivatedPresenter : public AlarmActivatedContract::Presenter
     {
       public:
-        AlarmActivatedPresenter(std::shared_ptr<AbstractAlarmModel> alarmModel);
+        AlarmActivatedPresenter(AbstractAlarmModel &alarmModel);
 
         void updateAlarmModel(AlarmModelReadyHandler callback);
         time_t getAlarmTime() const noexcept;
@@ -56,6 +56,6 @@ namespace app::popup
         void deactivate();
 
       private:
-        std::shared_ptr<AbstractAlarmModel> alarmModel;
+        AbstractAlarmModel &alarmModel;
     };
 } // namespace app::popup

--- a/products/BellHybrid/apps/common/src/popups/presenter/AlarmActivatedPresenter.cpp
+++ b/products/BellHybrid/apps/common/src/popups/presenter/AlarmActivatedPresenter.cpp
@@ -8,32 +8,31 @@
 
 namespace app::popup
 {
-    AlarmActivatedPresenter::AlarmActivatedPresenter(std::shared_ptr<AbstractAlarmModel> alarmModel)
-        : alarmModel{std::move(alarmModel)}
+    AlarmActivatedPresenter::AlarmActivatedPresenter(AbstractAlarmModel &alarmModel) : alarmModel{alarmModel}
     {}
 
     bool AlarmActivatedPresenter::isAlarmActive() const noexcept
     {
-        return alarmModel->isActive();
+        return alarmModel.isActive();
     }
 
     time_t AlarmActivatedPresenter::getAlarmTime() const noexcept
     {
-        return alarmModel->getAlarmTime();
+        return alarmModel.getAlarmTime();
     }
 
     void AlarmActivatedPresenter::activate()
     {
-        return alarmModel->activate(true);
+        return alarmModel.activate(true);
     }
 
     void AlarmActivatedPresenter::deactivate()
     {
-        return alarmModel->activate(false);
+        return alarmModel.activate(false);
     }
 
     void AlarmActivatedPresenter::updateAlarmModel(AlarmModelReadyHandler callback)
     {
-        alarmModel->update(callback);
+        alarmModel.update(callback);
     }
 } // namespace app::popup

--- a/products/BellHybrid/apps/include/Application.hpp
+++ b/products/BellHybrid/apps/include/Application.hpp
@@ -1,9 +1,10 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include <ApplicationCommon.hpp>
+#include <common/models/AlarmModel.hpp>
 
 namespace app
 {
@@ -20,6 +21,8 @@ namespace app
                              uint32_t stackDepth                 = 4096,
                              sys::ServicePriority priority       = sys::ServicePriority::Idle);
 
+        sys::ReturnCodes InitHandler() override;
+
       protected:
         void attachPopups(const std::vector<gui::popup::ID> &popupsList) override;
         std::optional<gui::popup::Blueprint> popupBlueprintFallback(gui::popup::ID id) override;
@@ -28,6 +31,8 @@ namespace app
         void stopIdleTimer();
         void stopAllAudio();
         virtual void onStop();
+
+        std::unique_ptr<app::AlarmModel> alarmModel;
 
       private:
         sys::MessagePointer handleKBDKeyEvent(sys::Message *msgl) override;


### PR DESCRIPTION
**Description**

Alarm model was moved to the bell-specific
application class. By doing this, each application will
have access to its unique and private instance of the model.
Later, it can be propagated to the specific presenters etc.
The next step should be to use only the one instance
of the alarm model and propagate it to the each application.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
