### PR TITLE
[BH-1536] Remove unneeded compilation flags

### DIFF
--- a/module-bsp/CMakeLists.txt
+++ b/module-bsp/CMakeLists.txt
@@ -38,8 +38,6 @@ target_compile_options(${PROJECT_NAME}
     -Wno-missing-field-initializers
     -Wno-unused-function
     -Wno-switch
-    -Wno-implicit-fallthrough
-    -Wno-unused-variable
 
     # C only flags
     $<$<COMPILE_LANGUAGE:C>:-Wno-old-style-declaration>

--- a/module-bsp/board/rt1051/CMakeLists.txt
+++ b/module-bsp/board/rt1051/CMakeLists.txt
@@ -67,8 +67,6 @@ target_include_directories(module-bsp
 
 set_source_files_properties(
 	eMMC/fsl_mmc.c PROPERTIES COMPILE_FLAGS -Wno-unused-function
-	common/i2c.c PROPERTIES COMPILE_FLAGS -Wno-unused-function
-    bsp/rtc/rtc.cpp PROPERTIES COMPILE_FLAGS "-Wno-unused-value -Wno-error=unused-value"
 )
 
 target_compile_definitions(module-bsp PUBLIC USB_STACK_FREERTOS)

--- a/module-bsp/board/rt1051/bellpx/bsp/audio/AW8898driver.cpp
+++ b/module-bsp/board/rt1051/bellpx/bsp/audio/AW8898driver.cpp
@@ -518,7 +518,6 @@ namespace bsp::audio::AW8898
 
     void HAL_Delay(std::uint32_t count)
     {
-        extern std::uint32_t SystemCoreClock;
         vTaskDelay(pdMS_TO_TICKS(count));
     }
 

--- a/module-bsp/board/rt1051/bellpx/bsp/switches/switches.cpp
+++ b/module-bsp/board/rt1051/bellpx/bsp/switches/switches.cpp
@@ -159,8 +159,7 @@ namespace bsp::bell_switches
 
     void debounceTimerCallback(TimerHandle_t timerHandle)
     {
-        auto timerState                     = static_cast<DebounceTimerState *>(pvTimerGetTimerID(timerHandle));
-        BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+        auto timerState = static_cast<DebounceTimerState *>(pvTimerGetTimerID(timerHandle));
         xTimerStop(timerState->timer, 0);
 
         auto currentState = timerState->gpio->ReadPin(static_cast<uint32_t>(timerState->pin)) ? KeyEvents::Released
@@ -191,8 +190,7 @@ namespace bsp::bell_switches
 
     void debounceTimerCenterClickCallback(TimerHandle_t timerHandle)
     {
-        auto timerState                     = static_cast<DebounceTimerState *>(pvTimerGetTimerID(timerHandle));
-        BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+        auto timerState = static_cast<DebounceTimerState *>(pvTimerGetTimerID(timerHandle));
         xTimerStop(timerState->timer, 0);
 
         if (qHandleIrq != nullptr) {
@@ -317,7 +315,6 @@ namespace bsp::bell_switches
             return;
         }
         DebounceTimerState &debounceTimerState = debounceTimers.at(timerId);
-        auto temp                              = &debounceTimerState;
         debounceTimerState.gpio->DisableInterrupt(1U << static_cast<uint32_t>(debounceTimerState.pin));
         debounceTimerState.lastState = debounceTimerState.gpio->ReadPin(static_cast<uint32_t>(debounceTimerState.pin))
                                            ? KeyEvents::Released
@@ -374,7 +371,6 @@ namespace bsp::bell_switches
         gpio_sw->DisableInterrupt(1 << static_cast<uint32_t>(BoardDefinitions::BELL_SWITCHES_RIGHT));
         gpio_sw->DisableInterrupt(1 << static_cast<uint32_t>(BoardDefinitions::BELL_SWITCHES_LATCH));
     }
-
 
     std::vector<KeyEvent> getKeyEvents(NotificationSource notification)
     {

--- a/module-bsp/board/rt1051/bsp/rtc/rtc.cpp
+++ b/module-bsp/board/rt1051/bsp/rtc/rtc.cpp
@@ -238,7 +238,8 @@ namespace bsp::rtc
     {
         std::uint32_t secondsToMinute = 60 - (timestamp % 60);
 
-        struct tm date;
+        struct tm date
+        {};
         getCurrentDateTime(&date);
 
         return setAlarmInSecondsFromNow(secondsToMinute);

--- a/module-bsp/board/rt1051/puretx/bsp/battery_charger/battery_charger.cpp
+++ b/module-bsp/board/rt1051/puretx/bsp/battery_charger/battery_charger.cpp
@@ -544,7 +544,7 @@ namespace bsp::battery_charger
 
         // Short time to synchronize after configuration
         vTaskDelay(pdMS_TO_TICKS(100));
-        StateOfCharge level = getBatteryLevel();
+        getBatteryLevel();
 
         clearAllChargerIRQs();
         clearFuelGuageIRQ(static_cast<std::uint16_t>(batteryINTBSource::all));

--- a/module-bsp/devices/power/CW2015.cpp
+++ b/module-bsp/devices/power/CW2015.cpp
@@ -50,7 +50,6 @@ namespace bsp::devices::power
         constexpr auto micro_to_milli_ratio    = 1000;
         constexpr auto adc_conversion_constant = 305;
 
-        uint8_t volt_h, volt_l;
         uint32_t ADMin = 0, ADMax = 0, ADResult = 0;
 
         /// Filter data using median
@@ -278,19 +277,18 @@ namespace bsp::devices::power
         BATTINFO profile{};
         RetCodes ret_code{RetCodes::Ok};
 
-        const auto result = std::all_of(
-            profile.cbegin(), profile.cend(), [this, ret_code, reg = BATTINFO::ADDRESS](const auto &e) mutable {
-                const auto result = read(reg++);
-                if (not result) {
-                    ret_code = RetCodes::CommunicationError;
-                    return false;
-                }
-                if (*result != e) {
-                    ret_code = RetCodes::ProfileInvalid;
-                    return false;
-                }
-                return true;
-            });
+        std::all_of(profile.cbegin(), profile.cend(), [this, ret_code, reg = BATTINFO::ADDRESS](const auto &e) mutable {
+            const auto result = read(reg++);
+            if (not result) {
+                ret_code = RetCodes::CommunicationError;
+                return false;
+            }
+            if (*result != e) {
+                ret_code = RetCodes::ProfileInvalid;
+                return false;
+            }
+            return true;
+        });
 
         return ret_code;
     }


### PR DESCRIPTION
**Description**

Removed `-Wno-unused-variable` from
module-bsp.
Fixed issues that were reported after
removing it.
Removed unneeded compile flags from
rt1051 cmake file.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
