### PR TITLE
MOS-586-crash-of-pure-simulator-while-navigating-into-settings-phone-modes

### DIFF
--- a/module-apps/application-settings/windows/phone-modes/PhoneModesWindow.cpp
+++ b/module-apps/application-settings/windows/phone-modes/PhoneModesWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhoneModesWindow.hpp"
@@ -24,10 +24,14 @@ namespace gui
         auto selectedPhoneModeIndex = static_cast<unsigned int>(phoneModeSettings->getCurrentPhoneMode());
 
         modifiedModesStrings = initialModesStrings;
-        modifiedModesStrings[selectedPhoneModeIndex] =
-            "<text><b>" + modifiedModesStrings[selectedPhoneModeIndex] + " </b></text>";
-
-        refreshOptions(modesOptList(), selectedPhoneModeIndex);
+        if (selectedPhoneModeIndex < modifiedModesStrings.size()) {
+            modifiedModesStrings[selectedPhoneModeIndex] =
+                "<text><b>" + modifiedModesStrings[selectedPhoneModeIndex] + " </b></text>";
+            refreshOptions(modesOptList(), selectedPhoneModeIndex);
+        }
+        else {
+            refreshOptions(modesOptList());
+        }
     }
 
     auto PhoneModesWindow::modesOptList() -> std::list<gui::Option>


### PR DESCRIPTION
**Description**

Pure in simulator crashes with ASAN error when phone mode is uninitialized and user navigates into Settings -> Phone Modes.
Fix out of bounds memory access when selected phone mode is Uninitialized.

**Your checklist for this pull request**

Make sure that this PR:
- [X] Complies with our guidelines for contributions