### PR TITLE
[BH-1531] Remove redundant arrows when alarm is ringing

### DIFF
--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
@@ -116,11 +116,13 @@ namespace gui
         case app::home_screen::ViewState::AlarmRinging:
             alarm->setAlarmStatus(AlarmSetSpinner::Status::RINGING);
             setHeaderViewMode(HeaderViewMode::AlarmIcon);
+            alarm->setEditMode(EditMode::Browse);
             removeTextDescription();
             break;
         case app::home_screen::ViewState::AlarmRingingDeactivatedWait:
             alarm->setAlarmStatus(AlarmSetSpinner::Status::DEACTIVATED);
             setHeaderViewMode(HeaderViewMode::AlarmIcon);
+            alarm->setEditMode(EditMode::Browse);
             break;
         case app::home_screen::ViewState::AlarmSnoozedWait:
             setHeaderViewMode(HeaderViewMode::SnoozeIcon);
@@ -128,6 +130,7 @@ namespace gui
             break;
         case app::home_screen::ViewState::AlarmSnoozed:
             setHeaderViewMode(HeaderViewMode::SnoozeIconAndTime);
+            alarm->setEditMode(EditMode::Browse);
             removeTextDescription();
             break;
         }


### PR DESCRIPTION
Remove redundant arrows when alarm is ringing

**Description**

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [X] Has unit tests if possible.
- [X] Has documentation updated

<!-- Thanks for your work ♥ -->
