### PR TITLE
[MOS-210] Avoid blocking of key handling, artificially generate Release

### DIFF
--- a/module-services/service-evtmgr/service-evtmgr/WorkerEventCommon.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/WorkerEventCommon.hpp
@@ -69,6 +69,7 @@ class WorkerEventCommon : public sys::Worker
     void updateResourcesAfterCpuFrequencyChange(bsp::CpuFrequencyMHz newFrequency);
     bool initEventQueues();
     bool initCommonHardwareComponents();
+    void sendKeyUnicast(RawKey const &key);
 
     /**
      * @brief list of keys with long press enabled. First item is key code, second is long press time.


### PR DESCRIPTION
**Description**

In rare cases when corresponding Press and Release key events were not generated the logic prevented other keys from being handled. Handling of other keys is no longer blocked.

In addition to the above Release event is artificially generated. This ensures that key presses are not ignored if there were no real Release event. Typically this may occur when keys are pressed fast one after another. A side effect is that when a key was pressed while other one was already pressed then both of them are handled by the UI which prevents e.g. letters from being ignored while writing.

**Your checklist for this pull request**

Make sure that this PR:
- [x] Complies with our guidelines for contributions