### PR TITLE
[MOS-569] Fix incorrect navtext in onboarding for time zone and date time

### DIFF
--- a/module-apps/application-onboarding/windows/OnBoardingDateAndTimeWindow.cpp
+++ b/module-apps/application-onboarding/windows/OnBoardingDateAndTimeWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "OnBoardingDateAndTimeWindow.hpp"
@@ -28,10 +28,6 @@ namespace app::onBoarding
     {
         DateAndTimeMainWindow::onBeforeShow(mode, data);
         header->navigationIndicatorAdd(new gui::header::IceAction(), gui::header::BoxSelection::Left);
-
-        navBar->setText(gui::nav_bar::Side::Center, utils::translate(style::strings::common::save));
-        navBar->setText(gui::nav_bar::Side::Left, utils::translate(style::strings::common::Switch));
-        navBar->setText(gui::nav_bar::Side::Right, utils::translate(style::strings::common::back));
     }
 
     bool OnBoardingDateAndTimeWindow::onInput(const gui::InputEvent &inputEvent)


### PR DESCRIPTION
**Description**

The label 'SWITCH' remains visible instead of the original 'SELECT' whenever
exiting Change time zone' or 'Change date and time' sub-menus. The state returns
to normal when highlighting other options for the  'Date and time' screen.

**Your checklist for this pull request**

Make sure that this PR:
- [x] Complies with our guidelines for contributions