### PR TITLE
[MOS-593] Fix backup issues with DB

### DIFF
--- a/module-services/service-db/DBServiceAPI.cpp
+++ b/module-services/service-db/DBServiceAPI.cpp
@@ -268,8 +268,8 @@ auto DBServiceAPI::DBBackup(sys::Service *serv, std::string backupPath) -> bool
         std::make_shared<DBServiceMessageBackup>(MessageType::DBServiceBackup, backupPath);
 
     auto ret = serv->bus.sendUnicastSync(msg, service::name::db, DefaultTimeoutInMs);
-    if (ret.first == sys::ReturnCodes::Success) {
-        return true;
+    if (auto retMsg = dynamic_cast<DBServiceResponseMessage *>(ret.second.get()); retMsg) {
+        return retMsg->retCode;
     }
     LOG_ERROR("DBBackup error, return code: %s", c_str(ret.first));
     return false;


### PR DESCRIPTION
**Description**

<!-- Please describe your pull request here -->
Backup had some issues when filesystem was not clearly closed.
After that, sqlite was not commiting the transaction while
doing VACUUM INTO query, which caused fail on the next
query. Fixed by commiting the transaction when there's
any ongoing one during backup.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
