### PR TITLE
[MOS-591] Improve and unify vscode ide support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ doc/docs-gui/
 build-*/
 MuditaOS.log
 .vscode/ipch
-.vscode/tasks.json
+.vscode/.cortex-debug.*
 
 lib/
 

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -5,7 +5,10 @@
             "cStandard": "c11",
             "cppStandard": "c++17",
             "intelliSenseMode": "${default}",
-            "configurationProvider": "vector-of-bool.cmake-tools"
+            "configurationProvider": "ms-vscode.cpptools",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ]
         }
     ],
     "version": 4

--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -1,12 +1,12 @@
 buildType:
-  default: debug
+  default: Debug
   description: Build type
   choices:
-    debug:
+    Debug:
       short: Debug
       long: Build with debugging information
       buildType: Debug
-    relwithdebinfo:
+    RelWithDebInfo:
       short: Release with debug
       long: Build release with debug info version
       buildType: RelWithDebInfo
@@ -18,27 +18,23 @@ target:
     linux:
       short: Linux
       long: Build for Linux
-      target: linux
       settings:
         CMAKE_TOOLCHAIN_FILE: Target_Linux.cmake
     rt1051:
       short: RT1051
       long: Build for RT1051
-      target: rt1051
       settings:
         CMAKE_TOOLCHAIN_FILE: Target_RT1051.cmake
 
 product:
-  default: purephone
+  default: PurePhone
   description: Product
   choices:
-    purephone:
+    PurePhone:
       short: PurePhone
-      product: purephone
       settings:
         PRODUCT: PurePhone
-    bell:
+    BellHybrid:
       short: BellHybrid
-      product: bellhybrid
       settings:
         PRODUCT: BellHybrid

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,14 +1,17 @@
 {
     "version": "0.2.0",
     "configurations": [
+        
+        // Linux
+
         {
-            "name": "Linux Launch",
+            "name": "Launch PurePhone (Linux)",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/build-bell-linux-Debug/BellHybrid.elf",
+            "program": "${workspaceFolder}/build-PurePhone-linux-Debug/PurePhone.elf",
             "args": [],
-            "stopAtEntry": true,
-            "cwd": "${workspaceFolder}/build-bell-linux-Debug/",
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build-PurePhone-linux-Debug/",
             "environment": [],
             "externalConsole": false,
             "MIMode": "gdb",
@@ -18,82 +21,108 @@
                     "text": "-enable-pretty-printing",
                     "ignoreFailures": true
                 },
-                {
-                    "description": "disable SIGUSR1 logs",
-                    "text": "handle SIGUSR1 nostop noprint"
-                },
+                // {
+                //     "description": "disable SIGUSR1 logs",
+                //     "text": "handle SIGUSR1 nostop noprint"
+                // },
             ]
         },
+
         {
-            "name": "Linux Attach",
+            "name": "Launch BellHybrid (Linux)",
             "type": "cppdbg",
-            "request": "attach",
-            "program": "${workspaceFolder}/build-linux-Debug/PurePhone.elf",
+            "request": "launch",
+            "program": "${workspaceFolder}/build-BellHybrid-linux-Debug/BellHybrid.elf",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build-BellHybrid-linux-Debug/",
+            "environment": [],
+            "externalConsole": false,
             "MIMode": "gdb",
-            "processId": "${command:pickProcess}",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",
                     "text": "-enable-pretty-printing",
                     "ignoreFailures": true
                 },
-                {
-                    "description": "disable SIGUSR1 logs",
-                    "text": "handle SIGUSR1 nostop noprint"
-                },
+                // {
+                //     "description": "disable SIGUSR1 logs",
+                //     "text": "handle SIGUSR1 nostop noprint"
+                // }
             ]
         },
+
+        // RT1051
+
         {
-            "name": "Debug (rt1051)",
-            "type": "gdb",
-            "gdbpath": "arm-none-eabi-gdb",
-            "request": "attach",
-            "target": ":2331",
-            "remote": true,
-            "cwd": "${workspaceRoot}",
-            "valuesFormatting": "parseText",
-            "executable": "${workspaceFolder}/build-rt1051-Debug/PurePhone.elf",
-            "autorun": [
-                "eval \"monitor exec SetRTTAddr %p\", &_SEGGER_RTT",
+            "name": "Launch PurePhone (RT1051)",
+            "type": "cortex-debug",
+            "request": "launch",
+            "executable": "${workspaceFolder}/build-PurePhone-rt1051-RelWithDebInfo/PurePhone.elf",
+            "servertype": "jlink",
+            "serverpath": "JLinkGDBServerCLExe",
+            "cwd": "${workspaceFolder}",
+            "gdbPath": "arm-none-eabi-gdb",
+            // "debuggerArgs": ["-x", "${workspaceFolder}/.gdbinit-1051"],
+            // "serverArgs": ["-strict", "-ir", "-singlerun", "-speed", "25000"],
+            // "runToEntryPoint": "main",
+            // "runToMain": true,
+            "preLaunchCommands": [],
+            "postLaunchCommands": [],
+            "interface": "swd",
+            "device": "MCIMXRT1051",
+            "jlinkscript": "${workspaceFolder}/evkbimxrt1050_sdram_init.jlinkscript",
+            "rtos": "FreeRTOS",
+            "overrideLaunchCommands": [
+                // "source .gdb_macros",
+                // "handle SIGUSR1 nostop noprint",
+                // "maint set internal-warning quit no",
+                // "maint set internal-warning corefile no",
+                // "set pagination off",
+                // "set python print-stack full",
+                // "target remote localhost:2331",
+                // "source tools/gdb_crash_extend.py",
+                // "source tools/misc/puregdb/puregdb.py",
                 "monitor reset 0",
                 "monitor halt",
                 "monitor memU32 0x401BC000 = 128;",
                 "load",
+                "eval \"monitor exec SetRTTAddr %p\", &_SEGGER_RTT",
                 "info threads",
                 "thread 2",
-                "b ResetISR",
-                "b main",
-                "b HardFault_Handler",
-                "b MemManage_Handler",
-                "b BusFault_Handler",
-                "b UsageFault_Handler",
+                "tb main",
+                // "b HardFault_Handler",
+                // "b _exit",
+                // "b abort",
+                // "b WDOG1_IRQHandler",
+                // "b RTWDOG_IRQHandler",
+                // "b IntDefaultHandler",
             ]
         },
+
         {
-            "name": "RelWithDebug (rt1051)",
-            "type": "gdb",
-            "gdbpath": "arm-none-eabi-gdb",
-            "request": "attach",
-            "target": ":2331",
-            "remote": true,
-            "cwd": "${workspaceRoot}",
-            "valuesFormatting": "parseText",
-            "executable": "${workspaceFolder}/build-rt1051-RelWithDebInfo/PurePhone.elf",
-            "autorun": [
-                "eval \"monitor exec SetRTTAddr %p\", &_SEGGER_RTT",
+            "name": "Launch BellHybrid (RT1051)",
+            "type": "cortex-debug",
+            "request": "launch",
+            "executable": "${workspaceFolder}/build-BellHybrid-rt1051-RelWithDebInfo/BellHybrid.elf",
+            "servertype": "jlink",
+            "serverpath": "JLinkGDBServerCLExe",
+            "cwd": "${workspaceFolder}",
+            "gdbPath": "arm-none-eabi-gdb",
+            "interface": "swd",
+            "device": "MCIMXRT1051",
+            "jlinkscript": "${workspaceFolder}/evkbimxrt1050_sdram_init_T6.jlinkscript",
+            "rtos": "FreeRTOS",
+            "overrideLaunchCommands": [
                 "monitor reset 0",
                 "monitor halt",
                 "monitor memU32 0x401BC000 = 128;",
                 "load",
+                "eval \"monitor exec SetRTTAddr %p\", &_SEGGER_RTT",
                 "info threads",
                 "thread 2",
-                "b ResetISR",
-                "b main",
-                "b HardFault_Handler",
-                "b MemManage_Handler",
-                "b BusFault_Handler",
-                "b UsageFault_Handler",
+                "tb main",
             ]
-        }
+        },
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "cmake.configureSettings": {
         "COLOR_OUTPUT": "OFF"
     },
-    "testMate.cpp.test.executables": "build-purephone-linux-Debug/{googletest,catch2}-*",
+    "testMate.cpp.test.executables": "build-PurePhone-linux-Debug/{googletest,catch2}-*",
     "files.associations": {
         "*.inc": "cpp",
         "*.tcc": "cpp",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,186 @@
+{
+    "version":"2.0.0",
+    "tasks": [
+
+        // Linux
+
+        {
+            "type": "shell",
+            "label": "Configure PurePhone (Linux)",
+            "command": "./configure.sh",
+            "args": [
+                "pure",
+                "linux",
+                "Debug",
+                "-G",
+                "Ninja"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "detail": "Run cmake configure script",
+        },
+        {
+            "type": "shell",
+            "label": "Build PurePhone (Linux)",
+            "command": "ninja",
+            "args": [
+                "-j`nproc`",
+                "Pure"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-PurePhone-linux-Debug"
+            },
+            "group": {
+                "kind": "build",
+                //"isDefault": true
+            },
+            "detail": "Build dir has to be configured with Cmake using Ninja",
+        },
+        {
+            "type": "shell",
+            "label": "Configure and Build PurePhone (Linux)",
+            "group": "build",
+            "dependsOn": ["Configure PurePhone (Linux)", "Build PurePhone (Linux)"],
+            "dependsOrder": "sequence",
+            "detail": "Configure cmake project and build with Ninja",
+        },
+
+        {
+            "type": "shell",
+            "label": "Configure BellHybrid (Linux)",
+            "command": "./configure.sh",
+            "args": [
+                "bell",
+                "linux",
+                "Debug",
+                "-G",
+                "Ninja"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "detail": "Run cmake configure script",
+        },
+        {
+            "type": "shell",
+            "label": "Build BellHybrid (Linux)",
+            "command": "ninja",
+            "args": [
+                "-j`nproc`",
+                "BellHybrid"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-BellHybrid-linux-Debug"
+            },
+            "group": "build",
+            "detail": "Build dir has to be configured with Cmake using Ninja",
+        },
+        {
+            "type": "shell",
+            "label": "Configure and Build BellHybrid (Linux)",
+            "group": "build",
+            "dependsOn": ["Configure BellHybrid (Linux)", "Build BellHybrid (Linux)"],
+            "dependsOrder": "sequence",
+            "detail": "Configure cmake project and build with Ninja",
+        },
+
+        // RT1051
+
+        {
+            "type": "shell",
+            "label": "Configure PurePhone (RT1051)",
+            "command": "./configure.sh",
+            "args": [
+                "pure",
+                "rt1051",
+                "RelWithDebInfo",
+                "-G",
+                "Ninja"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "detail": "Run cmake configure script",
+        },
+        {
+            "type": "shell",
+            "label": "Build PurePhone (RT1051)",
+            "command": "ninja",
+            "args": [
+                "-j`nproc`",
+                "Pure"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-PurePhone-rt1051-RelWithDebInfo"
+            },
+            "group": "build",
+            "detail": "Build dir has to be configured with Cmake using Ninja",
+        },
+        {
+            "type": "shell",
+            "label": "Configure and Build PurePhone (RT1051)",
+            "group": "build",
+            "dependsOn": ["Configure PurePhone (RT1051)", "Build PurePhone (RT1051)"],
+            "dependsOrder": "sequence",
+            "detail": "Configure cmake project and build with Ninja",
+        },
+
+        {
+            "type": "shell",
+            "label": "Configure BellHybrid (RT1051)",
+            "command": "./configure.sh",
+            "args": [
+                "bell",
+                "rt1051",
+                "RelWithDebInfo",
+                "-G",
+                "Ninja"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "detail": "Run cmake configure script",
+        },
+        {
+            "type": "shell",
+            "label": "Build BellHybrid (RT1051)",
+            "command": "ninja",
+            "args": [
+                "-j`nproc`",
+                "BellHybrid"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-BellHybrid-rt1051-RelWithDebInfo"
+            },
+            "group": "build",
+            "detail": "Build dir has to be configured with Cmake using Ninja",
+        },
+        {
+            "type": "shell",
+            "label": "Configure and Build BellHybrid (RT1051)",
+            "group": "build",
+            "dependsOn": ["Configure BellHybrid (RT1051)", "Build BellHybrid (RT1051)"],
+            "dependsOrder": "sequence",
+            "detail": "Configure cmake project and build with Ninja",
+        },
+
+        // {
+        //     "type": "shell",
+        //     "label": "Run JLink Server for PurePhone (RT1051)",
+        //     //"command": "if ps -C JLinkGDBServerCLExe -o comm= 2>/dev/null | grep -x JLinkGDBServerC >/dev/null 2>&1; then echo \"JLinkGDBServerCLExe is already running\"; else ./StartJLinkServer.sh; fi",
+        //     "command": "./StartJLinkServer.sh",
+        //     "args": [
+        //     ],
+        //     "options": {
+        //         "cwd": "${workspaceFolder}"
+        //     },
+        //     "group": "build", // TEST, this is technically incorrect
+        //     "detail": "Run JLink Server for PurePhone required for debugging",
+        // },
+    ]
+}


### PR DESCRIPTION
**Description**

Make cmake build paths for the cmake extension the same as the ones used when building from command line and consistent with added tasks.

Add configure (cmake) and build (ninja) tasks.

Add/fix/improve launch configurations (for rt1051 [cortex-debug](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug) extension is required).

Fix cpp properties to allow vscode finding headers and symbols.

Side note. There is a bug in `arm-none-eabi-gdb` 10 and 11 preventing comfortable debugging of muditaos with and without vscode (internal error in `bt` or `info stack`). Switching to `arm-none-eabi-gdb` 12.1 solves this issue. `gdb-multiarch` 12.0.9 works as well.

![vscode](https://user-images.githubusercontent.com/1226951/179398024-9c5f8583-cfc8-42e1-b73c-360977cf1f3e.png)

**Your checklist for this pull request**

Make sure that this PR:
- [x] Complies with our guidelines for contributions