### PR TITLE
[MOS-601] Disable debug timer in DisplayLightWindow

### DIFF
--- a/module-apps/application-settings/windows/display-keypad/DisplayLightWindow.hpp
+++ b/module-apps/application-settings/windows/display-keypad/DisplayLightWindow.hpp
@@ -22,7 +22,9 @@ namespace gui
       public:
         DisplayLightWindow(app::ApplicationCommon *app,
                            app::settingsInterface::ScreenLightSettings *screenLightSettings);
+#if DEVELOPER_SETTINGS_OPTIONS == 1
         ~DisplayLightWindow();
+#endif // DEVELOPER_SETTINGS_OPTIONS
 
       private:
         auto buildOptionsList() -> std::list<Option> override;
@@ -30,14 +32,19 @@ namespace gui
 
         void addBrightnessOption(std::list<Option> &);
         auto createBrightnessOption(int step) -> std::unique_ptr<SpinBoxOptionSettings>;
-        bool isDisplayLightSwitchOn                                = false;
-        bool isAutoLightSwitchOn                                   = false;
-        bsp::eink_frontlight::BrightnessPercentage brightnessValue = 0.0;
 
+#if DEVELOPER_SETTINGS_OPTIONS == 1
+        [[nodiscard]] auto onTimerTimeout(Item &self, sys::Timer &task) -> bool;
+#endif // DEVELOPER_SETTINGS_OPTIONS
+
+        bool isDisplayLightSwitchOn                                      = false;
+        bool isAutoLightSwitchOn                                         = false;
+        bsp::eink_frontlight::BrightnessPercentage brightnessValue       = 0.0;
         app::settingsInterface::ScreenLightSettings *screenLightSettings = nullptr;
         float ambientLight                                               = 0.0;
+#if DEVELOPER_SETTINGS_OPTIONS == 1
         sys::TimerHandle timerTask;
-        [[nodiscard]] auto onTimerTimeout(Item &self, sys::Timer &task) -> bool;
+#endif // DEVELOPER_SETTINGS_OPTIONS
         OptionWindowDestroyer rai_destroyer = OptionWindowDestroyer(*this);
     };
 } // namespace gui


### PR DESCRIPTION
**Description**

The timer is responsible for refreshing debug options which interferes
with navigation strings of other windows until it is stopped when window
is destroyed.

**Your checklist for this pull request**

Make sure that this PR:
- [x] Complies with our guidelines for contributions