### PR TITLE
[MOS-514] Fix crash on entering PIN settings

### DIFF
--- a/module-services/service-cellular/src/SimCard.cpp
+++ b/module-services/service-cellular/src/SimCard.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SimCard.hpp"
@@ -43,7 +43,7 @@ namespace cellular
     {
         bool SimCard::ready() const
         {
-            return channel;
+            return channel != nullptr;
         }
 
         bool SimCard::initialized() const
@@ -322,6 +322,11 @@ namespace cellular
 
         std::optional<at::SimInsertedStatus> SimCard::readSimCardInsertStatus()
         {
+            if (not ready()) {
+                LOG_ERROR("SIM not ready yet.");
+                return std::nullopt;
+            }
+
             auto command  = at::cmd::QSIMSTAT(at::cmd::Modifier::Get);
             auto response = channel->cmd(command);
             auto result   = command.parseQSIMSTAT(response);


### PR DESCRIPTION
**Description**

Fix of the issue that entering 'PIN settings'
window before SIM card was ready caused
the crash of the system.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
