### PR TITLE
[MOS-421] Fix BT state first rendering off

### DIFF
--- a/module-apps/application-settings/windows/bluetooth/BluetoothWindow.cpp
+++ b/module-apps/application-settings/windows/bluetooth/BluetoothWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BluetoothWindow.hpp"
@@ -11,25 +11,20 @@
 namespace gui
 {
 
-    BluetoothWindow::BluetoothWindow(app::ApplicationCommon *app) : BaseSettingsWindow(app, window::name::bluetooth)
+    BluetoothWindow::BluetoothWindow(app::ApplicationCommon *app,
+                                     std::shared_ptr<BluetoothSettingsModel> bluetoothSettingsModel)
+        : BaseSettingsWindow(app, window::name::bluetooth), bluetoothSettingsModel(bluetoothSettingsModel)
     {
         setTitle(utils::translate("app_settings_bluetooth_main"));
-
-        bluetoothSettingsModel = std::make_unique<BluetoothSettingsModel>(application);
-        bluetoothSettingsModel->requestStatus();
     }
 
-    void BluetoothWindow::onBeforeShow(ShowMode /*mode*/, SwitchData *data)
+    void BluetoothWindow::onBeforeShow([[maybe_unused]] ShowMode mode, [[maybe_unused]] SwitchData *data)
     {
-        const auto newData = dynamic_cast<BluetoothStatusData *>(data);
-        if (newData != nullptr) {
-            if (const auto btState = newData->getState(); btState.has_value()) {
-                isBluetoothSwitchOn = btState.value();
-            }
-            if (const auto visibility = newData->getVisibility(); visibility.has_value()) {
-                isPhoneVisibilitySwitchOn = visibility.value();
-            }
-        }
+        const auto bluetoothStatus = bluetoothSettingsModel->getStatus();
+
+        isBluetoothSwitchOn       = bluetoothStatus.state == BluetoothStatus::State::On;
+        isPhoneVisibilitySwitchOn = bluetoothStatus.visibility;
+
         refreshOptionsList();
     }
 

--- a/module-apps/application-settings/windows/bluetooth/BluetoothWindow.hpp
+++ b/module-apps/application-settings/windows/bluetooth/BluetoothWindow.hpp
@@ -11,7 +11,7 @@ namespace gui
     class BluetoothWindow : public BaseSettingsWindow
     {
       public:
-        explicit BluetoothWindow(app::ApplicationCommon *app);
+        BluetoothWindow(app::ApplicationCommon *app, std::shared_ptr<BluetoothSettingsModel> bluetoothSettingsModel);
 
       private:
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
@@ -19,7 +19,7 @@ namespace gui
         void changeBluetoothState(bool &currentState);
         void changeVisibility(bool &currentVisibility);
 
-        std::unique_ptr<BluetoothSettingsModel> bluetoothSettingsModel;
+        std::shared_ptr<BluetoothSettingsModel> bluetoothSettingsModel;
         bool isBluetoothSwitchOn       = false;
         bool isPhoneVisibilitySwitchOn = false;
         OptionWindowDestroyer rai_destroyer = OptionWindowDestroyer(*this);


### PR DESCRIPTION
**Description**

Fix of the issue that after entering
bluetooth settings power state is shown
as off at first, even though bluetooth
is turned on.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
