### PR TITLE
[CP-563] Return correct threadID after adding new message

### DIFF
--- a/module-db/Interface/SMSRecord.cpp
+++ b/module-db/Interface/SMSRecord.cpp
@@ -409,8 +409,9 @@ std::unique_ptr<db::QueryResult> SMSRecordInterface::addQuery(const std::shared_
     auto record           = localQuery->record;
     const auto result     = Add(record);
     if (result) {
-        record.ID = GetLastID();
+        record = GetByID(GetLastID());
     }
+
     auto response = std::make_unique<db::query::SMSAddResult>(record, result);
     response->setRequestQuery(query);
     response->setRecordID(record.ID);

--- a/test/pytest/service-desktop/test_messages.py
+++ b/test/pytest/service-desktop/test_messages.py
@@ -89,6 +89,8 @@ def test_add_and_delete_message(harness):
     result, message_record = messages_tester.add_message(message_number, message_body)
     assert result, "Failed to add message!"
     assert message_record["messageBody"] == message_body, "Message body corrupted!"
+    assert message_record["messageID"] > 0, "Message ID not correct!"
+    assert message_record["threadID"] > 0, "Thread ID not correct!"
 
     result, received_messages_records_count = messages_tester.get_messages_count()
     assert result, "Failed to get messages count!"


### PR DESCRIPTION
**Description**

After adding a new message via Messages EP API,
threadID field was always 0, which was incorrect.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
