### PR TITLE
[MOS-600] Fix RF button hold leaves alarm ringing

### DIFF
--- a/module-apps/apps-common/popups/AlarmPopup.cpp
+++ b/module-apps/apps-common/popups/AlarmPopup.cpp
@@ -85,15 +85,13 @@ namespace gui
 
     bool AlarmPopup::onInput(const InputEvent &inputEvent)
     {
-        if (inputEvent.isShortRelease()) {
-            if (inputEvent.is(KeyCode::KEY_RF)) {
-                getPresenter()->stopAlarm();
-                return true;
-            }
-            else if (inputEvent.is(KeyCode::KEY_LF) && getPresenter()->haveSnoozedSkip()) {
-                getPresenter()->skipToNextSnooze();
-                return true;
-            }
+        if (inputEvent.isShortRelease(KeyCode::KEY_RF) || inputEvent.isLongRelease(KeyCode::KEY_RF)) {
+            getPresenter()->stopAlarm();
+            return true;
+        }
+        else if (inputEvent.isShortRelease(KeyCode::KEY_LF) && getPresenter()->haveSnoozedSkip()) {
+            getPresenter()->skipToNextSnooze();
+            return true;
         }
 
         return AppWindow::onInput(inputEvent);


### PR DESCRIPTION
**Description**

Fix of the issue that long press
of right function button causes
alarm popup window to close,
but alarm is still ringing.
The only way to turn it off was
to power off the phone.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
