### PR TITLE
[MOS-635] Bump updater version for Pure

### DIFF
--- a/products/PurePhone/BinaryAssetsVersions.cmake
+++ b/products/PurePhone/BinaryAssetsVersions.cmake
@@ -5,5 +5,5 @@ if( NOT DEFINED ECOBOOT_BIN_VERSION)
 endif()
 
 if (NOT DEFINED UPDATER_BIN_VERSION)
-    set(UPDATER_BIN_VERSION 1.5.0 CACHE STRING "updater binary version to download from updater release page")
+    set(UPDATER_BIN_VERSION 1.5.2 CACHE STRING "updater binary version to download from updater release page")
 endif()


### PR DESCRIPTION
**Description**

Changed downloaded version of updater,
1.5.2 allows to downgrade MuditaOS.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
