### PR TITLE
[MOS-613] Fix keyboard doesn't respond

### DIFF
--- a/module-bsp/board/rt1051/drivers/RT1051DriverI2C.cpp
+++ b/module-bsp/board/rt1051/drivers/RT1051DriverI2C.cpp
@@ -3,10 +3,54 @@
 
 #include "RT1051DriverI2C.hpp"
 #include <log/log.hpp>
-#include "../board.h"
+#include "board.h"
 
 namespace drivers
 {
+    namespace
+    {
+        ssize_t translateErrorCode(const status_t errorStatus)
+        {
+            I2CErrorCodes code;
+
+            switch (errorStatus) {
+            case kStatus_LPI2C_Busy:
+                code = I2CErrorCodes::busy;
+                break;
+            case kStatus_LPI2C_Idle:
+                code = I2CErrorCodes::idle;
+                break;
+            case kStatus_LPI2C_Nak:
+                code = I2CErrorCodes::nak;
+                break;
+            case kStatus_LPI2C_FifoError:
+                code = I2CErrorCodes::fifo;
+                break;
+            case kStatus_LPI2C_BitError:
+                code = I2CErrorCodes::bit;
+                break;
+            case kStatus_LPI2C_ArbitrationLost:
+                code = I2CErrorCodes::arbitrationLost;
+                break;
+            case kStatus_LPI2C_PinLowTimeout:
+                code = I2CErrorCodes::pinLowTimeout;
+                break;
+            case kStatus_LPI2C_NoTransferInProgress:
+                code = I2CErrorCodes::noTransferInProgress;
+                break;
+            case kStatus_LPI2C_DmaRequestFail:
+                code = I2CErrorCodes::dmaRequestFail;
+                break;
+            case kStatus_LPI2C_Timeout:
+                code = I2CErrorCodes::timeout;
+                break;
+            default:
+                code = I2CErrorCodes::unknown;
+                break;
+            }
+            return static_cast<ssize_t>(code);
+        }
+    } // namespace
 
     RT1051DriverI2C::RT1051DriverI2C(const I2CInstances inst, const DriverI2CParams &params) : DriverI2C(params, inst)
     {
@@ -64,7 +108,7 @@ namespace drivers
         auto ret = BOARD_LPI2C_Send(
             base, addr.deviceAddress, addr.subAddress, addr.subAddressSize, const_cast<uint8_t *>(txBuff), size);
         if (ret != kStatus_Success) {
-            return -1; // TODO:M.P: fix me
+            return translateErrorCode(ret);
         }
         else {
             return size;
@@ -76,7 +120,7 @@ namespace drivers
         cpp_freertos::LockGuard lock(mutex);
         auto ret = BOARD_LPI2C_Receive(base, addr.deviceAddress, addr.subAddress, addr.subAddressSize, rxBuff, size);
         if (ret != kStatus_Success) {
-            return -1; // TODO:M.P: fix me
+            return translateErrorCode(ret);
         }
         else {
             return size;
@@ -104,7 +148,7 @@ namespace drivers
         ret |= BOARD_LPI2C_Send(base, addr.deviceAddress, addr.subAddress, addr.subAddressSize, (uint8_t *)&rx, size);
 
         if (ret != kStatus_Success) {
-            return -1; // TODO:M.P: fix me
+            return translateErrorCode(ret);
         }
         else {
             return size;

--- a/module-bsp/board/rt1051/drivers/RT1051DriverI2C.hpp
+++ b/module-bsp/board/rt1051/drivers/RT1051DriverI2C.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #ifndef PUREPHONE_RT1051DRIVERI2C_HPP
@@ -6,8 +6,8 @@
 
 #include "drivers/i2c/DriverI2C.hpp"
 
-#include "../fsl_drivers/fsl_common.h"
-#include "../fsl_drivers/fsl_lpi2c.h"
+#include <fsl_common.h>
+#include <fsl_lpi2c.h>
 #include "board/clock_config.h"
 
 #include "mutex.hpp"

--- a/module-bsp/drivers/i2c/DriverI2C.hpp
+++ b/module-bsp/drivers/i2c/DriverI2C.hpp
@@ -19,6 +19,21 @@ namespace drivers
         COUNT
     };
 
+    enum class I2CErrorCodes : std::int8_t
+    {
+        busy                 = 0,
+        idle                 = -1,
+        nak                  = -2,
+        fifo                 = -3,
+        bit                  = -4,
+        arbitrationLost      = -5,
+        pinLowTimeout        = -6,
+        noTransferInProgress = -7,
+        dmaRequestFail       = -8,
+        timeout              = -9,
+        unknown              = -10
+    };
+
     struct DriverI2CParams
     {
         uint32_t baudrate;


### PR DESCRIPTION
Now the keyboard driver is checking the result of i2c
transmission and we get an error code if something fails.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [ ] Has documentation updated

<!-- Thanks for your work ♥ -->
