### PR TITLE
[MOS-421] Add state refresh when BT automatically turns off

### DIFF
--- a/module-apps/application-settings/models/bluetooth/BluetoothSettingsModel.cpp
+++ b/module-apps/application-settings/models/bluetooth/BluetoothSettingsModel.cpp
@@ -22,10 +22,15 @@ void BluetoothSettingsModel::requestStatus()
     service->bus.sendUnicast(std::make_shared<::message::bluetooth::RequestStatus>(), service::name::bluetooth);
 }
 
-void BluetoothSettingsModel::setStatus(const bool desiredBluetoothState, const bool desiredVisibility)
+void BluetoothSettingsModel::updateStatus(const bool desiredBluetoothState, const bool desiredVisibility)
 {
     status.state      = desiredBluetoothState ? BluetoothStatus::State::On : BluetoothStatus::State::Off;
     status.visibility = desiredVisibility;
+}
+
+void BluetoothSettingsModel::setStatus(const bool desiredBluetoothState, const bool desiredVisibility)
+{
+    updateStatus(desiredBluetoothState, desiredVisibility);
     message::bluetooth::SetStatus setStatus(status);
     service->bus.sendUnicast(std::make_shared<::message::bluetooth::SetStatus>(std::move(setStatus)),
                              service::name::bluetooth);

--- a/module-apps/application-settings/models/bluetooth/BluetoothSettingsModel.hpp
+++ b/module-apps/application-settings/models/bluetooth/BluetoothSettingsModel.hpp
@@ -18,6 +18,7 @@ class BluetoothSettingsModel
     explicit BluetoothSettingsModel(sys::Service *service);
 
     void requestStatus();
+    void updateStatus(bool desiredBluetoothState, bool desiredVisibility);
     void setStatus(bool desiredBluetoothState, bool desiredVisibility);
     void requestDeviceName();
     void setDeviceName(const UTF8 &deviceName);

--- a/module-apps/application-settings/windows/bluetooth/BluetoothWindow.cpp
+++ b/module-apps/application-settings/windows/bluetooth/BluetoothWindow.cpp
@@ -13,7 +13,7 @@ namespace gui
 
     BluetoothWindow::BluetoothWindow(app::ApplicationCommon *app,
                                      std::shared_ptr<BluetoothSettingsModel> bluetoothSettingsModel)
-        : BaseSettingsWindow(app, window::name::bluetooth), bluetoothSettingsModel(bluetoothSettingsModel)
+        : BaseSettingsWindow(app, window::name::bluetooth), bluetoothSettingsModel(std::move(bluetoothSettingsModel))
     {
         setTitle(utils::translate("app_settings_bluetooth_main"));
     }

--- a/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
+++ b/module-services/service-bluetooth/service-bluetooth/ServiceBluetooth.hpp
@@ -94,6 +94,7 @@ class ServiceBluetooth : public sys::Service
     void sendWorkerCommand(std::unique_ptr<bluetooth::event::Base> command);
 
     void handleTurnOff();
+    void handleTurnOn();
 
     std::shared_ptr<Mailbox<bluetooth::Command, QueueHandle_t, WorkerLock>> workerQueue;
     std::shared_ptr<bluetooth::SettingsHolder> settingsHolder;


### PR DESCRIPTION
**Description**

Added code to update BT power state
when it automatically turns off due
to inactivity.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
