### PR TITLE
[MOS-499] Improve lock screen power consumption

### DIFF
--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -213,9 +213,9 @@ namespace gui
 
     RefreshModes DesktopMainWindow::updateTime()
     {
-        auto ret = AppWindow::updateTime();
+        AppWindow::updateTime();
         clockDate->setTime(std::time(nullptr));
-        return ret;
+        return RefreshModes::GUI_REFRESH_FAST;
     }
 
     bool DesktopMainWindow::showInformationPopup(std::function<bool()> action, const std::string &notification)

--- a/module-apps/application-desktop/windows/DesktopMainWindow.hpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.hpp
@@ -22,8 +22,8 @@ namespace gui
     class DesktopMainWindow : public AppWindow
     {
       protected:
-        gui::ClockDateWidget *clockDate                                   = nullptr;
-        gui::ListView *notificationsList                                  = nullptr;
+        gui::ClockDateWidget *clockDate  = nullptr;
+        gui::ListView *notificationsList = nullptr;
         std::shared_ptr<gui::ActiveNotificationsListPresenter> notificationsListPresenter;
         std::shared_ptr<gui::NotificationsModel> notificationsModel;
 

--- a/module-apps/apps-common/ApplicationCommon.cpp
+++ b/module-apps/apps-common/ApplicationCommon.cpp
@@ -439,8 +439,10 @@ namespace app
     sys::MessagePointer ApplicationCommon::handleMinuteUpdated(sys::Message *msgl)
     {
         if (state == State::ACTIVE_FORGROUND) {
-            auto requestedRefreshMode = getCurrentWindow()->updateTime();
-            refreshWindow(requestedRefreshMode);
+            if (auto reqestedRefreshMode = getCurrentWindow()->updateTime();
+                reqestedRefreshMode != gui::RefreshModes::GUI_REFRESH_NONE) {
+                refreshWindow(reqestedRefreshMode);
+            }
         }
         return sys::msgHandled();
     }

--- a/module-apps/apps-common/popups/presenter/WallpaperPresenter.cpp
+++ b/module-apps/apps-common/popups/presenter/WallpaperPresenter.cpp
@@ -73,10 +73,6 @@ namespace gui
             }
             return true;
             break;
-        case WallpaperOption::Quote:
-            [[fallthrough]];
-        case WallpaperOption::Logo:
-            [[fallthrough]];
         default:
             return false;
             break;

--- a/module-bsp/board/rt1051/bsp/eink/EinkDisplay.cpp
+++ b/module-bsp/board/rt1051/bsp/eink/EinkDisplay.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "EinkDisplay.hpp"

--- a/module-services/service-evtmgr/battery/BatteryController.cpp
+++ b/module-services/service-evtmgr/battery/BatteryController.cpp
@@ -125,14 +125,17 @@ void sevm::battery::BatteryController::printCurrentState()
 }
 void sevm::battery::BatteryController::update()
 {
-    const auto soc           = Store::Battery::get().level;
-    const auto chargingState = Store::Battery::get().state;
+    const auto lastSoc   = Store::Battery::get().level;
+    const auto lastState = Store::Battery::get().state;
 
     updateSoC();
     Store::Battery::modify().state = transformChargingState(charger->getChargingStatus());
 
+    const auto currentSoc   = Store::Battery::get().level;
+    const auto currentState = Store::Battery::get().state;
+
     /// Send BatteryStatusChangeMessage only when battery SOC or charger state has changed
-    if (soc != Store::Battery::get().level || chargingState != Store::Battery::get().state) {
+    if (lastSoc != currentSoc || lastState != currentState) {
         auto message = std::make_shared<sevm::BatteryStatusChangeMessage>();
         service->bus.sendUnicast(std::move(message), service::name::evt_manager);
     }


### PR DESCRIPTION
Power on the e-ink only when it is needed e.g. fast or deep
refresh. This change should extend the battery life for a few hours.
Update battery percentage only when discharging.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
