### PR TITLE
[CP-1448] Add storage info to device info endpoint

### DIFF
--- a/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
@@ -11,9 +11,9 @@ namespace sdesktop::endpoints::json
     inline constexpr auto sim                 = "sim";
     inline constexpr auto trayState           = "trayState";
     inline constexpr auto signalStrength      = "signalStrength";
-    inline constexpr auto fsTotal             = "fsTotal";
-    inline constexpr auto fsFreePercent       = "fsFreePercent";
-    inline constexpr auto fsFree              = "fsFree";
+    inline constexpr auto deviceSpaceTotal    = "deviceSpaceTotal";
+    inline constexpr auto systemReservedSpace = "systemReservedSpace";
+    inline constexpr auto usedUserSpace       = "usedUserSpace";
     inline constexpr auto gitRevision         = "gitRevision";
     inline constexpr auto gitBranch           = "gitBranch";
     inline constexpr auto gitTag              = "gitTag";

--- a/module-services/service-desktop/endpoints/include/endpoints/deviceInfo/DeviceInfoEndpointCommon.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/deviceInfo/DeviceInfoEndpointCommon.hpp
@@ -31,8 +31,6 @@ namespace sdesktop::endpoints
         auto getStorageStats(const std::string &path) -> std::tuple<long, long>;
         auto getStorageInfo() -> std::tuple<long, long, long>;
 
-        static constexpr auto OS_RESERVED_SPACE_IN_MB = (1024LU);
-
         explicit DeviceInfoEndpointCommon(sys::Service *ownerServicePtr) : Endpoint(ownerServicePtr)
         {
             debugName = "DeviceInfoEndpoint";

--- a/products/BellHybrid/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
+++ b/products/BellHybrid/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
@@ -22,14 +22,14 @@ namespace sdesktop::endpoints
 
     auto DeviceInfoEndpoint::getDeviceInfo(Context &context) -> http::Code
     {
-        auto [totalMbytes, freeUserMbytes, freePercent] = getStorageInfo();
+        auto [totalDeviceSpaceMiB, reservedSystemSpaceMiB, usedUserSpaceMiB] = getStorageInfo();
 
         context.setResponseBody(
             json11::Json::object({{json::batteryLevel, std::to_string(Store::Battery::get().level)},
                                   {json::batteryState, std::to_string(static_cast<int>(Store::Battery::get().state))},
-                                  {json::fsTotal, std::to_string(totalMbytes)},
-                                  {json::fsFree, std::to_string(freeUserMbytes)},
-                                  {json::fsFreePercent, std::to_string(freePercent)},
+                                  {json::deviceSpaceTotal, std::to_string(totalDeviceSpaceMiB)},
+                                  {json::systemReservedSpace, std::to_string(reservedSystemSpaceMiB)},
+                                  {json::usedUserSpace, std::to_string(usedUserSpaceMiB)},
                                   {json::gitRevision, (std::string)(GIT_REV)},
                                   {json::gitBranch, (std::string)GIT_BRANCH},
                                   {json::currentRTCTime, std::to_string(static_cast<uint32_t>(std::time(nullptr)))},

--- a/products/PurePhone/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
+++ b/products/PurePhone/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
@@ -37,7 +37,7 @@ namespace sdesktop::endpoints
 
     auto DeviceInfoEndpoint::getDeviceInfo(Context &context) -> http::Code
     {
-        auto [totalMbytes, freeUserMbytes, freePercent] = getStorageInfo();
+        auto [totalDeviceSpaceMiB, reservedSystemSpaceMiB, usedUserSpaceMiB] = getStorageInfo();
 
         context.setResponseBody(json11::Json::object(
             {{json::batteryLevel, std::to_string(Store::Battery::get().level)},
@@ -49,9 +49,9 @@ namespace sdesktop::endpoints
               std::to_string(static_cast<int>(Store::GSM::get()->getNetwork().accessTechnology))},
              {json::networkStatus, std::to_string(static_cast<int>(Store::GSM::get()->getNetwork().status))},
              {json::networkOperatorName, Store::GSM::get()->getNetworkOperatorName()},
-             {json::fsTotal, std::to_string(totalMbytes)},
-             {json::fsFree, std::to_string(freeUserMbytes)},
-             {json::fsFreePercent, std::to_string(freePercent)},
+             {json::deviceSpaceTotal, std::to_string(totalDeviceSpaceMiB)},
+             {json::systemReservedSpace, std::to_string(reservedSystemSpaceMiB)},
+             {json::usedUserSpace, std::to_string(usedUserSpaceMiB)},
              {json::gitRevision, std::string(GIT_REV)},
              {json::gitBranch, std::string(GIT_BRANCH)},
              {json::currentRTCTime, std::to_string(static_cast<uint32_t>(std::time(nullptr)))},

--- a/test/pytest/service-desktop/test_device_info.py
+++ b/test/pytest/service-desktop/test_device_info.py
@@ -18,9 +18,9 @@ def test_get_device_information(harness):
     assert ret.diag_info["accessTechnology"] in ['0', '2', '3', '4', '5', '6', '7', '255']
     assert 0 <= int(ret.diag_info["networkStatus"]) < 7
     assert ret.diag_info["networkOperatorName"] is not None
-    assert 0 < int(ret.diag_info["fsTotal"]) < 16000
-    assert 0 < int(ret.diag_info["fsFree"]) < 16000
-    assert 0 < int(ret.diag_info["fsFreePercent"]) <= 100
+    assert int(ret.diag_info["deviceSpaceTotal"]) == 14945
+    assert int(ret.diag_info["systemReservedSpace"]) == 2042
+    assert 0 < int(ret.diag_info["usedUserSpace"]) <= 12903
     assert re.match(r"^(\d|[a-z]){8,40}$", ret.diag_info["gitRevision"])
     assert ret.diag_info["gitBranch"] is not None
     assert int(ret.diag_info["currentRTCTime"]) > 1641991996


### PR DESCRIPTION
**Description**

<!-- Please describe your pull request here -->
DeviceInfo endpoint now contains information such as:
`deviceSpaceTotal` - total storage space on the device
`systemReservedSpace` - storage space on the device
reserved for the OS
`usedUserSpace` - storage space on the device used
for user files on the user partition

Documentation: https://appnroll.atlassian.net/wiki/spaces/CP/pages/957055183/Device+Info+endpoint+1#Get-Device-Information

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
