### PR TITLE
[MOS-259] Fix no calllog entries in DND mode

### DIFF
--- a/module-cellular/at/Commands.hpp
+++ b/module-cellular/at/Commands.hpp
@@ -55,6 +55,7 @@ namespace at
         CIMI, /// Its getting IMSI from selected SIM card
         QCMGR,
         ATH,       /// hangup
+        CHUP,      /// hangup all calls
         QHUP_BUSY, /// hangup all calls with busy reason
         ATA,       /// (doc): timeout should be possibly set up to 90s
         ATD,       /// setup call

--- a/module-cellular/at/src/ATFactory.cpp
+++ b/module-cellular/at/src/ATFactory.cpp
@@ -45,6 +45,7 @@ namespace at
             {AT::CIMI, std::make_shared<Cmd>("AT+CIMI")},
             {AT::QCMGR, std::make_shared<Cmd>("AT+QCMGR=", 180s)},
             {AT::ATH, std::make_shared<Cmd>("ATH", 100s)},
+            {AT::CHUP, std::make_shared<Cmd>("AT+CHUP", 100s)},
             {AT::QHUP_BUSY, std::make_shared<Cmd>("AT+QHUP=17", 100s)},
             {AT::ATA, std::make_shared<Cmd>("ATA", 100s)},
             {AT::ATD, std::make_shared<Cmd>("ATD", 6s)},

--- a/module-services/service-cellular/call/CallMachine.hpp
+++ b/module-services/service-cellular/call/CallMachine.hpp
@@ -38,6 +38,8 @@ namespace call
     {
         bool operator()(CallData &call)
         {
+            LOG_DEBUG("Called RING, status: %s",
+                      call.mode == sys::phone_modes::PhoneMode::Connected ? "true" : "false");
             return call.mode == sys::phone_modes::PhoneMode::Connected;
         }
     } constexpr RING;
@@ -116,6 +118,7 @@ namespace call
     {
         bool operator()(const call::event::CLIP &clip, Dependencies &di, CallData &call)
         {
+            LOG_DEBUG("Called ClipDND_OK!");
             return call.mode == sys::phone_modes::PhoneMode::DoNotDisturb &&
                    di.modem->areCallsFromFavouritesEnabled() && di.db->isNumberInFavourites(clip.number);
         }
@@ -125,6 +128,7 @@ namespace call
     {
         void operator()(const call::event::CLIP &clip, Dependencies &di, CallData &call)
         {
+            LOG_DEBUG("Called HandleClipDND!");
             handleClipCommon(di, clip, call);
             di.audio->play();
         }
@@ -134,6 +138,7 @@ namespace call
     {
         bool operator()(const call::event::CLIP &clip, Dependencies &di, CallData &call)
         {
+            LOG_DEBUG("Called ClipDND_NOK!");
             return call.mode == sys::phone_modes::PhoneMode::DoNotDisturb &&
                    not(di.modem->areCallsFromFavouritesEnabled() && di.db->isNumberInFavourites(clip.number));
         }
@@ -143,10 +148,16 @@ namespace call
     {
         void operator()(Dependencies &di, const call::event::CLIP &clip, CallData &call)
         {
-            setNumber(call, clip.number);
-            di.db->incrementNotAnsweredCallsNotification(call.record.phoneNumber);
-            di.db->endCall(call.record);
+            // the order here is crucial - rejecting by modem is first, because of how DND works -
+            // we have to reject incoming call ASAP.
             di.modem->rejectCall();
+            di.db->startCall(call.record);
+
+            LOG_DEBUG("Called HandleDND_Reject!");
+            setNumber(call, clip.number);
+            call.record.date = std::time(nullptr);
+            call.record.type = CallType::CT_MISSED;
+            di.db->endCall(call.record);
         }
     } constexpr HandleDND_Reject;
 
@@ -226,7 +237,7 @@ namespace call
             call.record.isRead = false;
             di.db->endCall(call.record);
             di.multicast->notifyCallEnded();
-            di.modem->hangupCall();
+            di.modem->rejectCall();
         }
     } constexpr HandleRejectCall;
 
@@ -239,7 +250,7 @@ namespace call
             call.record.isRead = false;
             di.db->endCall(call.record);
             di.multicast->notifyCallEnded();
-            di.modem->hangupCall();
+            di.modem->rejectCall();
         };
     } constexpr HandleMissedCall;
 
@@ -302,8 +313,9 @@ namespace call
                 "Idle"_s + boost::sml::event<evt::RING>[RING and not Tethering] / HandleRing = "RingDelay"_s,
 
                 "Idle"_s + boost::sml::event<evt::CLIP>[Tethering or ClipDND_NOK] / HandleDND_Reject = "Idle"_s,
-                "Idle"_s + boost::sml::event<evt::CLIP>[ClipConnected] / HandleClipWithoutRing       = "HaveId"_s,
-                "Idle"_s + boost::sml::event<evt::CLIP>[ClipDND_OK] / HandleClipDND                  = "HaveId"_s,
+
+                "Idle"_s + boost::sml::event<evt::CLIP>[ClipConnected] / HandleClipWithoutRing = "HaveId"_s,
+                "Idle"_s + boost::sml::event<evt::CLIP>[ClipDND_OK] / HandleClipDND            = "HaveId"_s,
                 // outgoing call: Pure is Ringing (called from: handleCellularRingingMessage)
                 "Idle"_s + boost::sml::event<evt::StartCall> / HandleStartCall = "Starting"_s,
 

--- a/module-services/service-cellular/call/CellularCall.cpp
+++ b/module-services/service-cellular/call/CellularCall.cpp
@@ -50,6 +50,10 @@ namespace call
         if (machine == nullptr) {
             return false;
         };
+        // triggering the sentinel here is necessary to speed up the state machine processing,
+        // as the DND mode is based on quick hangup when the call arrives - thus we can hear some
+        // calling signal if the hangup wasn't fast enough
+        machine->di.sentinel->HoldMinimumFrequency(bsp::CpuFrequencyMHz::Level_6);
         return machine->machine.process_event(ring);
     }
 

--- a/module-services/service-cellular/call/api/CallDB.cpp
+++ b/module-services/service-cellular/call/api/CallDB.cpp
@@ -10,14 +10,6 @@
 CallDB::CallDB(sys::Service *s) : owner(s)
 {}
 
-void CallDB::incrementNotAnsweredCallsNotification(const utils::PhoneNumber::View &number)
-{
-    DBServiceAPI::GetQuery(
-        owner,
-        db::Interface::Name::Notifications,
-        std::make_unique<db::query::notifications::Increment>(NotificationsRecord::Key::Calls, number));
-}
-
 void CallDB::startCall(CalllogRecord &rec)
 {
     if (rec.ID == DB_ID_NONE) {

--- a/module-services/service-cellular/call/api/CallDB.hpp
+++ b/module-services/service-cellular/call/api/CallDB.hpp
@@ -20,8 +20,6 @@ namespace call::api
     class DB
     {
       public:
-        virtual void incrementNotAnsweredCallsNotification(const utils::PhoneNumber::View &number) = 0;
-        // overrides record data
         virtual void startCall(CalllogRecord &rec)                                = 0;
         virtual void endCall(const CalllogRecord &rec)                            = 0;
         virtual bool isNumberInFavourites(const utils::PhoneNumber::View &number) = 0;
@@ -36,8 +34,6 @@ class CallDB : public call::api::DB
 
   public:
     explicit CallDB(sys::Service *);
-
-    void incrementNotAnsweredCallsNotification(const utils::PhoneNumber::View &number) override;
     void startCall(CalllogRecord &rec) override;
     void endCall(const CalllogRecord &rec) override;
     bool isNumberInFavourites(const utils::PhoneNumber::View &number) override;

--- a/module-services/service-cellular/call/api/ModemCallApi.cpp
+++ b/module-services/service-cellular/call/api/ModemCallApi.cpp
@@ -38,7 +38,11 @@ namespace cellular
 
     bool Api::rejectCall()
     {
-        return hangupCall();
+        if (cmux == nullptr) {
+            throw std::runtime_error("call api not initialized");
+        }
+        auto channel = cmux->get(CellularMux::Channel::Commands);
+        return channel != nullptr && channel->cmd(at::AT::CHUP);
     }
 
     bool Api::areCallsFromFavouritesEnabled()

--- a/products/PurePhone/services/db/ServiceDB.cpp
+++ b/products/PurePhone/services/db/ServiceDB.cpp
@@ -172,7 +172,6 @@ sys::MessagePointer ServiceDB::DataReceivedHandler(sys::DataMessage *msgl, sys::
         auto record           = std::make_unique<std::vector<CalllogRecord>>();
         msg->record.ID        = DB_ID_NONE;
         auto ret              = calllogRecordInterface->Add(msg->record);
-        LOG_INFO("HERE! ADD! SUCCESS? %s", ret ? "SUCCESS" : "FAIL");
         if (ret) {
             // return the newly added record
             msg->record = calllogRecordInterface->GetByID(calllogRecordInterface->GetLastID());

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -7,6 +7,7 @@
 * Separated system volume from Bluetooth device volume for A2DP
 
 ### Fixed
+* Fixed not adding call log entries in Do Not Disturb mode.
 * Fixed improper duration of the rejected outgoing call shown in calls log
 * Fixed Bluetooth volume control issues
 * Fixed turning on loudspeaker before outgoing call is answered


### PR DESCRIPTION
**Description**

Fixed no calllog entries in DND mode, which were caused
by not starting the call in DB interface, so no entry was created.

Moreover, small optimizing of the DND handling.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible.
- [x] Has documentation updated

<!-- Thanks for your work ♥ -->
