### PR TITLE
[MOS-648] Fix USB connection/disconnection detection

### DIFF
--- a/module-bsp/board/linux/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/linux/hal/battery_charger/BatteryCharger.cpp
@@ -39,6 +39,7 @@ namespace hal::battery
         Voltage getBatteryVoltage() const final;
         std::optional<SOC> getSOC() const final;
         ChargingStatus getChargingStatus() const final;
+        ChargerPresence getChargerPresence() const final;
 
       private:
         void worker();
@@ -93,6 +94,11 @@ namespace hal::battery
         else {
             return ChargingStatus::Discharging;
         }
+    }
+    AbstractBatteryCharger::ChargerPresence BatteryCharger::getChargerPresence() const
+    {
+        return isPlugged ? AbstractBatteryCharger::ChargerPresence::PluggedIn
+                         : AbstractBatteryCharger::ChargerPresence::Unplugged;
     }
 
     void BatteryCharger::worker()

--- a/module-bsp/board/rt1051/bellpx/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/rt1051/bellpx/hal/battery_charger/BatteryCharger.cpp
@@ -58,6 +58,7 @@ namespace hal::battery
         Voltage getBatteryVoltage() const final;
         std::optional<SOC> getSOC() const final;
         ChargingStatus getChargingStatus() const final;
+        ChargerPresence getChargerPresence() const final;
 
         static BatteryWorkerQueue &getWorkerQueueHandle();
 
@@ -179,6 +180,13 @@ namespace hal::battery
             return ChargingStatus::PluggedNotCharging;
         }
     }
+
+    AbstractBatteryCharger::ChargerPresence BellBatteryCharger::getChargerPresence() const
+    {
+        return getChargingStatus() == ChargingStatus::Discharging ? AbstractBatteryCharger::ChargerPresence::Unplugged
+                                                                  : AbstractBatteryCharger::ChargerPresence::PluggedIn;
+    }
+
     std::optional<AbstractBatteryCharger::SOC> BellBatteryCharger::fetchBatterySOC() const
     {
         if (const auto soc = fuel_gauge.get_battery_soc(); const auto scaled_soc = scale_soc(*soc)) {

--- a/module-bsp/board/rt1051/puretx/bsp/battery_charger/battery_charger.cpp
+++ b/module-bsp/board/rt1051/puretx/bsp/battery_charger/battery_charger.cpp
@@ -941,4 +941,14 @@ namespace bsp::battery_charger
         LOG_INFO("\tAvgCurrent: %dmA", getAvgCurrent());
         LOG_INFO("\tRawSoC: %d%%", getBatteryLevel().value());
     }
+
+    bool isChargerPlugged()
+    {
+        const auto chargerStatus = chargerRead(Registers::CHG_INT_OK);
+        if (chargerStatus.first != kStatus_Success) {
+            LOG_ERROR("failed to read charger status");
+            return false;
+        }
+        return chargerStatus.second & static_cast<std::uint8_t>(CHG_INT::CHGIN_I);
+    }
 } // namespace bsp::battery_charger

--- a/module-bsp/board/rt1051/puretx/bsp/battery_charger/battery_charger.hpp
+++ b/module-bsp/board/rt1051/puretx/bsp/battery_charger/battery_charger.hpp
@@ -92,4 +92,6 @@ namespace bsp::battery_charger
 
     bool checkConfigurationFile(std::ifstream &file);
 
+    bool isChargerPlugged();
+
 } // namespace bsp::battery_charger

--- a/module-bsp/board/rt1051/puretx/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/rt1051/puretx/hal/battery_charger/BatteryCharger.cpp
@@ -85,6 +85,7 @@ namespace hal::battery
         Voltage getBatteryVoltage() const final;
         std::optional<SOC> getSOC() const final;
         ChargingStatus getChargingStatus() const final;
+        ChargerPresence getChargerPresence() const final;
 
         static BatteryWorkerQueue &getWorkerQueueHandle();
 
@@ -172,6 +173,11 @@ namespace hal::battery
     AbstractBatteryCharger::ChargingStatus PureBatteryCharger::getChargingStatus() const
     {
         return transformChargingState(bsp::battery_charger::getChargeStatus());
+    }
+    AbstractBatteryCharger::ChargerPresence PureBatteryCharger::getChargerPresence() const
+    {
+        return bsp::battery_charger::isChargerPlugged() ? AbstractBatteryCharger::ChargerPresence::PluggedIn
+                                                        : AbstractBatteryCharger::ChargerPresence::Unplugged;
     }
     PureBatteryCharger::BatteryWorkerQueue &PureBatteryCharger::getWorkerQueueHandle()
     {

--- a/module-bsp/hal/include/hal/battery_charger/AbstractBatteryCharger.hpp
+++ b/module-bsp/hal/include/hal/battery_charger/AbstractBatteryCharger.hpp
@@ -33,6 +33,13 @@ namespace hal::battery
             Brownout
         };
 
+        enum class ChargerPresence
+        {
+            Undefined,
+            PluggedIn,
+            Unplugged
+        };
+
         struct Factory
         {
             static std::unique_ptr<AbstractBatteryCharger> create(xQueueHandle);
@@ -43,6 +50,7 @@ namespace hal::battery
         virtual Voltage getBatteryVoltage() const        = 0;
         virtual std::optional<SOC> getSOC() const        = 0;
         virtual ChargingStatus getChargingStatus() const = 0;
+        virtual ChargerPresence getChargerPresence() const = 0;
 
         static_assert(sizeof(Events) == sizeof(std::uint8_t),
                       "All events processed by event manager ought to have size of std::uint8_t");

--- a/module-services/service-evtmgr/battery/BatteryController.hpp
+++ b/module-services/service-evtmgr/battery/BatteryController.hpp
@@ -19,6 +19,7 @@ namespace sevm::battery
     {
       public:
         using Events = hal::battery::AbstractBatteryCharger::Events;
+        using ChargerPresence = hal::battery::AbstractBatteryCharger::ChargerPresence;
         explicit BatteryController(sys::Service *service, xQueueHandle notificationChannel);
 
         void poll();
@@ -30,10 +31,11 @@ namespace sevm::battery
         void update();
         void updateSoC();
         void printCurrentState();
-        void checkPlugState();
+        void checkChargerPresence();
         sys::Service *service{nullptr};
         std::unique_ptr<hal::battery::AbstractBatteryCharger> charger;
         BatteryBrownoutDetector brownoutDetector;
         BatteryState batteryState;
+        ChargerPresence chargerPresence{ChargerPresence::Undefined};
     };
 }; // namespace sevm::battery

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Fixed PLAY label translation in German
+* Fixed USB connection/disconnection detection
 
 ## [1.3.0 2022-08-04]
 


### PR DESCRIPTION
If there were errors while charging the battery,
e.g. too high temperature, the detection of USB
connection/disconnection failed.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [x] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
