### PR TITLE
[MOS-664] PLAY label translation fix

### DIFF
--- a/image/assets/lang/Deutsch.json
+++ b/image/assets/lang/Deutsch.json
@@ -31,7 +31,7 @@
   "common_stop": "STOPPEN",
   "common_resume": "FORTFAHREN",
   "common_pause": "PAUSIEREN",
-  "common_play": "SPIEL",
+  "common_play": "ABSPIELEN",
   "common_retry": "NOCHMAL VERSUCHEN",
   "common_abort": "ABBRECHEN",
   "common_connect": "VERBINDEN",

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -1,5 +1,10 @@
 # MuditaOS changelog - PurePhone
 
+## Unreleased
+
+### Fixed
+* Fixed PLAY label translation in German
+
 ## [1.3.0 2022-08-04]
 
 ### Added


### PR DESCRIPTION
Improved translation of PLAY label
in German.

![Screenshot from 2022-08-12 13-04-44](https://user-images.githubusercontent.com/88655668/184341972-7faca007-af00-4075-b2e4-bafe5bccdfa7.png)

https://github.com/mudita/MuditaOS/issues/4022

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [x] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
