### PR TITLE
[MOS-667] Fix loudspeaker switching

### DIFF
--- a/module-services/service-cellular/call/CallMachine.hpp
+++ b/module-services/service-cellular/call/CallMachine.hpp
@@ -307,9 +307,10 @@ namespace call
                 // outgoing call: Pure is Ringing (called from: handleCellularRingingMessage)
                 "Idle"_s + boost::sml::event<evt::StartCall> / HandleStartCall = "Starting"_s,
 
-                "Starting"_s + boost::sml::event<evt::Ended> / HandleEndCall      = "Idle"_s,
-                "Starting"_s + boost::sml::event<evt::Reject> / HandleEndCall     = "Idle"_s,
-                "Starting"_s + boost::sml::event<evt::Answer> / HandleStartedCall = "Ongoing"_s,
+                "Starting"_s + boost::sml::event<evt::AudioRequest> / HandleAudioRequest = "Starting"_s,
+                "Starting"_s + boost::sml::event<evt::Ended> / HandleEndCall             = "Idle"_s,
+                "Starting"_s + boost::sml::event<evt::Reject> / HandleEndCall            = "Idle"_s,
+                "Starting"_s + boost::sml::event<evt::Answer> / HandleStartedCall        = "Ongoing"_s,
 
                 "RingDelay"_s + boost::sml::event<evt::RingTimeout> / HandleRingTimeout = "Ringing"_s,
                 // here we do not need guard - RingDelay state is already guarded on entry

--- a/module-services/service-cellular/call/tests/test-CallMachine.cpp
+++ b/module-services/service-cellular/call/tests/test-CallMachine.cpp
@@ -434,3 +434,95 @@ TEST_CASE("test call in tethering")
     fakeit::Verify(Method(di.audio, play)).Exactly(0);
     fakeit::Verify(Method(di.api, rejectCall)).Exactly(1);
 }
+
+// --------------------------------------------
+// TEST LOUDSPEAKER SWITCHING IN STARTING STATE
+// --------------------------------------------
+
+TEST_CASE("test loudspeaker switching in starting state")
+{
+    using namespace boost::sml;
+    auto number  = utils::PhoneNumber("+48700800900");
+    auto di      = mocks::DIWrapper();
+    auto machine = std::make_unique<call::StateMachine>(di.get());
+
+    REQUIRE(machine->machine.process_event(call::event::StartCall{CallType::CT_OUTGOING, number.getView()}));
+    REQUIRE(machine->machine.is("Starting"_s));
+    REQUIRE(machine->machine.process_event(
+        call::event::AudioRequest{cellular::CallAudioEventRequest::EventType::LoudspeakerOn}));
+    fakeit::Verify(Method(di.audio, setLoudspeakerOn)).Exactly(1);
+
+    REQUIRE(machine->machine.process_event(
+        call::event::AudioRequest{cellular::CallAudioEventRequest::EventType::LoudspeakerOff}));
+    fakeit::Verify(Method(di.audio, setLoudspeakerOff)).Exactly(1);
+}
+
+// -----------------------------
+// TEST MUTING IN STARTING STATE
+// -----------------------------
+
+TEST_CASE("test muting in starting state")
+{
+    using namespace boost::sml;
+    auto number  = utils::PhoneNumber("+48700800900");
+    auto di      = mocks::DIWrapper();
+    auto machine = std::make_unique<call::StateMachine>(di.get());
+
+    REQUIRE(machine->machine.process_event(call::event::StartCall{CallType::CT_OUTGOING, number.getView()}));
+    REQUIRE(machine->machine.is("Starting"_s));
+    REQUIRE(
+        machine->machine.process_event(call::event::AudioRequest{cellular::CallAudioEventRequest::EventType::Mute}));
+    fakeit::Verify(Method(di.audio, muteCall)).Exactly(1);
+
+    REQUIRE(
+        machine->machine.process_event(call::event::AudioRequest{cellular::CallAudioEventRequest::EventType::Unmute}));
+    fakeit::Verify(Method(di.audio, unmuteCall)).Exactly(1);
+}
+
+// -------------------------------------------
+// TEST LOUDSPEAKER SWITCHING IN ONGOING STATE
+// -------------------------------------------
+
+TEST_CASE("test loudspeaker switching in ongoing state")
+{
+    using namespace boost::sml;
+    auto number  = utils::PhoneNumber("+48700800900");
+    auto di      = mocks::DIWrapper();
+    auto machine = std::make_unique<call::StateMachine>(di.get());
+
+    REQUIRE(machine->machine.process_event(call::event::StartCall{CallType::CT_OUTGOING, number.getView()}));
+    REQUIRE(machine->machine.is("Starting"_s));
+    REQUIRE(machine->machine.process_event(call::event::Answer{}));
+    REQUIRE(machine->machine.is("Ongoing"_s));
+    REQUIRE(machine->machine.process_event(
+        call::event::AudioRequest{cellular::CallAudioEventRequest::EventType::LoudspeakerOn}));
+    fakeit::Verify(Method(di.audio, setLoudspeakerOn)).Exactly(1);
+
+    REQUIRE(machine->machine.process_event(
+        call::event::AudioRequest{cellular::CallAudioEventRequest::EventType::LoudspeakerOff}));
+    fakeit::Verify(Method(di.audio, setLoudspeakerOff)).Exactly(1);
+}
+
+// ----------------------------
+// TEST MUTING IN ONGOING STATE
+// ----------------------------
+
+TEST_CASE("test muting in ongoing state")
+{
+    using namespace boost::sml;
+    auto number  = utils::PhoneNumber("+48700800900");
+    auto di      = mocks::DIWrapper();
+    auto machine = std::make_unique<call::StateMachine>(di.get());
+
+    REQUIRE(machine->machine.process_event(call::event::StartCall{CallType::CT_OUTGOING, number.getView()}));
+    REQUIRE(machine->machine.is("Starting"_s));
+    REQUIRE(machine->machine.process_event(call::event::Answer{}));
+    REQUIRE(machine->machine.is("Ongoing"_s));
+    REQUIRE(
+        machine->machine.process_event(call::event::AudioRequest{cellular::CallAudioEventRequest::EventType::Mute}));
+    fakeit::Verify(Method(di.audio, muteCall)).Exactly(1);
+
+    REQUIRE(
+        machine->machine.process_event(call::event::AudioRequest{cellular::CallAudioEventRequest::EventType::Unmute}));
+    fakeit::Verify(Method(di.audio, unmuteCall)).Exactly(1);
+}

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+* Fixed turning on loudspeaker before outgoing call is answered
 * Fixed PLAY label translation in German
 * Fixed USB connection/disconnection detection
 


### PR DESCRIPTION
Added missing state transition in call 
state machine, required to switch 
call sound to loudspeaker before 
the call has been answered or 
rejected.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
