### PR TITLE
[MOS-668] Modify USB notifications logging

### DIFF
--- a/module-services/service-desktop/WorkerDesktop.cpp
+++ b/module-services/service-desktop/WorkerDesktop.cpp
@@ -202,20 +202,21 @@ bool WorkerDesktop::handleIrqQueueMessage(std::shared_ptr<sys::WorkerQueue> &que
         return false;
     }
 
-    LOG_DEBUG("USB status: %s", magic_enum::enum_name(notification).data());
-
     if (notification == bsp::USBDeviceStatus::Connected) {
+        LOG_DEBUG("USB status: Connected");
         ownerService->bus.sendMulticast(std::make_shared<sdesktop::usb::USBConnected>(),
                                         sys::BusChannel::USBNotifications);
         usbStatus = bsp::USBDeviceStatus::Connected;
     }
     else if (notification == bsp::USBDeviceStatus::Configured) {
         if (usbStatus == bsp::USBDeviceStatus::Connected) {
+            LOG_DEBUG("USB status: First configuration");
             ownerService->bus.sendUnicast(
                 std::make_shared<sdesktop::usb::USBConfigured>(sdesktop::usb::USBConfigurationType::firstConfiguration),
                 service::name::service_desktop);
         }
         else {
+            LOG_DEBUG("USB status: Reconfiguration");
             ownerService->bus.sendUnicast(
                 std::make_shared<sdesktop::usb::USBConfigured>(sdesktop::usb::USBConfigurationType::reconfiguration),
                 service::name::service_desktop);
@@ -223,6 +224,7 @@ bool WorkerDesktop::handleIrqQueueMessage(std::shared_ptr<sys::WorkerQueue> &que
         usbStatus = bsp::USBDeviceStatus::Configured;
     }
     else if (notification == bsp::USBDeviceStatus::Disconnected) {
+        LOG_DEBUG("USB status: Disconnected");
         ownerService->bus.sendMulticast(std::make_shared<sdesktop::usb::USBDisconnected>(),
                                         sys::BusChannel::USBNotifications);
         usbStatus = bsp::USBDeviceStatus::Disconnected;
@@ -231,6 +233,7 @@ bool WorkerDesktop::handleIrqQueueMessage(std::shared_ptr<sys::WorkerQueue> &que
         bsp::usbHandleDataReceived();
     }
     else if (notification == bsp::USBDeviceStatus::Reset) {
+        LOG_DEBUG("USB status: Reset");
         if (usbStatus == bsp::USBDeviceStatus::Configured) {
             reset();
         }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed / Improved
+* Changed USB logging
+
 ### Fixed
 * Fixed improper duration of the rejected outgoing call shown in calls log
 * Fixed turning on loudspeaker before outgoing call is answered


### PR DESCRIPTION
Modified USB notifications logging so no logs are being created
when USB data is received, thus logs are not overloaded and are
smaller

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
