### PR TITLE
[MOS-665] Fix incorrect outgoing call duration

### DIFF
--- a/module-services/service-cellular/call/api/CallTimer.cpp
+++ b/module-services/service-cellular/call/api/CallTimer.cpp
@@ -2,7 +2,6 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CallTimer.hpp"
-#include <Timers/TimerFactory.hpp>
 
 CallTimer::CallTimer(sys::TimerHandle handle) : handle(std::move(handle))
 {}
@@ -20,7 +19,8 @@ void CallTimer::stop()
 
 time_t CallTimer::duration()
 {
-    return std::time(nullptr) - startActiveTime;
+    const auto timeElapsed = std::time(nullptr) - startActiveTime;
+    return handle.isActive() ? timeElapsed : 0;
 }
 
 TimerRing::TimerRing(sys::TimerHandle handle) : handle(std::move(handle))

--- a/module-services/service-cellular/call/api/CallTimer.hpp
+++ b/module-services/service-cellular/call/api/CallTimer.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <memory>
 #include <Timers/TimerHandle.hpp>
 
 namespace call::api
@@ -26,7 +25,7 @@ namespace call::api
 class CallTimer : public call::api::Timer
 {
     sys::TimerHandle handle;
-    std::time_t startActiveTime{};
+    std::time_t startActiveTime{0};
 
   public:
     explicit CallTimer(sys::TimerHandle handle);

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+* Fixed improper duration of the rejected outgoing call shown in calls log
 * Fixed turning on loudspeaker before outgoing call is answered
 * Fixed PLAY label translation in German
 * Fixed USB connection/disconnection detection


### PR DESCRIPTION
Fix of the issue that cancelled or rejected
outgoing call had improper duration in
calllog.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
