### PR TITLE
[MOS-676] Fix destroying wrong sentinels

### DIFF
--- a/module-sys/SystemManager/GovernorSentinelOperations.cpp
+++ b/module-sys/SystemManager/GovernorSentinelOperations.cpp
@@ -17,7 +17,9 @@ namespace sys
             auto sentinelWeakPointer = (*sentinel)->GetSentinel();
             // remove expired ptrs
             if (sentinelWeakPointer.expired()) {
-                sentinels.erase(sentinel.base());
+                // shift iterator to point on the correct successor,
+                // without std::next it removes (sentinel - 1) element
+                sentinels.erase(std::next(sentinel).base());
                 continue;
             }
             // call foo on sentinel

--- a/module-sys/SystemManager/tests/unittest_CpuSentinelsGovernor.cpp
+++ b/module-sys/SystemManager/tests/unittest_CpuSentinelsGovernor.cpp
@@ -119,6 +119,43 @@ TEST_CASE("GovernorSentinelsVector - single sentinel add and remove")
     REQUIRE(container.empty());
 }
 
+TEST_CASE("GovernorSentinelsVector - a few removed in the middle")
+{
+    using namespace sys;
+    size_t count          = 0;
+    constexpr size_t size = 10;
+    GovernorSentinelsVector container;
+    std::vector<std::shared_ptr<CpuSentinel>> sentinels;
+    std::vector<std::string> sentinelName;
+
+    governed_callback foo = [&](const GovernorSentinel &s) { return false; };
+
+    for (size_t i = 0; i < size; ++i) {
+        sentinelName.push_back("test_" + std::to_string(i));
+        sentinels.push_back(std::make_shared<CpuSentinel>(sentinelName[i], nullptr));
+        container.push_back(std::make_unique<GovernorSentinel>(sentinels[i]));
+    }
+
+    // Remove sentinel in the middle
+    sentinels.erase(sentinels.begin() + 2);
+    sentinelName.erase(sentinelName.begin() + 2);
+
+    // Remove sentinel in the middle
+    sentinels.erase(sentinels.begin() + 6);
+    sentinelName.erase(sentinelName.begin() + 6);
+
+    for_each_governed_sentinel(container, foo);
+
+    auto countSentinels = sentinels.size();
+    for (size_t i = 0; i < countSentinels; ++i) {
+        auto cont = container[i]->GetSentinel();
+        if (not cont.expired()) {
+            count++;
+        }
+    }
+    REQUIRE(count == countSentinels);
+}
+
 TEST_CASE("GovernorSentinelsVector - multiple sentinels add and remove")
 {
     using namespace sys;

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -7,6 +7,7 @@
 * Separated system volume from Bluetooth device volume for A2DP
 
 ### Fixed
+* Fixed removing wrong sentinels
 * Fixed music player behaviour when connecting/disconnecting audio devices
 * Fixed dropping the call during the DND mode
 * Fixed wrong tethering popup order


### PR DESCRIPTION
If the service is closed the governor removes connected
sentinel. The base iterator refers to the element that is next
in the reversed list. Adding std::next the iterator points to
the correct element.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
