### PR TITLE
[MOS-74] Fix wrong tethering popup order

### DIFF
--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -7,6 +7,7 @@
 * Separated system volume from Bluetooth device volume for A2DP
 
 ### Fixed
+* Fixed wrong tethering popup order
 * Fixed crash during phone turn off
 * Fixed improper duration of the rejected outgoing call shown in calls log
 * Fixed Bluetooth volume control issues


### PR DESCRIPTION
<!-- Please describe your pull request here -->

After connecting to PC with locked phone there were pop-ups
of tethering and unlocking the screen in the wrong order.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
