### PR TITLE
[MOS-92] Fix continuing music playback after BT disconnection

### DIFF
--- a/module-apps/application-music-player/include/application-music-player/ApplicationMusicPlayer.hpp
+++ b/module-apps/application-music-player/include/application-music-player/ApplicationMusicPlayer.hpp
@@ -6,7 +6,6 @@
 #include <Application.hpp>
 #include <Audio/decoder/Decoder.hpp>
 #include <purefs/filesystem_paths.hpp>
-#include <atomic>
 
 namespace gui
 {

--- a/module-audio/Audio/AudioCommon.cpp
+++ b/module-audio/Audio/AudioCommon.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AudioCommon.hpp"
@@ -12,7 +12,7 @@ namespace audio
 {
     audio::RetCode GetDeviceError(AudioDevice::RetCode retCode)
     {
-        if (retCode == AudioDevice::RetCode::Success) {
+        if (retCode != AudioDevice::RetCode::Failure) {
             return RetCode::Success;
         }
 

--- a/module-audio/Audio/AudioDevice.hpp
+++ b/module-audio/Audio/AudioDevice.hpp
@@ -22,7 +22,8 @@ namespace audio
         enum class RetCode
         {
             Success = 0,
-            Failure
+            Failure,
+            Disconnected
         };
 
         enum class Type

--- a/module-audio/Audio/Operation/PlaybackOperation.cpp
+++ b/module-audio/Audio/Operation/PlaybackOperation.cpp
@@ -15,10 +15,9 @@ namespace audio
 {
 
     using namespace AudioServiceMessage;
-    using namespace utils;
 
     PlaybackOperation::PlaybackOperation(const char *file, const audio::PlaybackType &playbackType, Callback callback)
-        : Operation(callback, playbackType), dec(nullptr)
+        : Operation(std::move(callback), playbackType), dec(nullptr)
     {
         // order defines priority
         AddProfile(Profile::Type::PlaybackHeadphones, playbackType, false);
@@ -157,7 +156,7 @@ namespace audio
 
     audio::RetCode PlaybackOperation::SendEvent(std::shared_ptr<Event> evt)
     {
-        auto isAvailable = evt->getDeviceState() == Event::DeviceState::Connected ? true : false;
+        const auto isAvailable = evt->getDeviceState() == Event::DeviceState::Connected;
         switch (evt->getType()) {
         case EventType::JackState:
             SetProfileAvailability({Profile::Type::PlaybackHeadphones}, isAvailable);

--- a/module-audio/Audio/Operation/PlaybackOperation.hpp
+++ b/module-audio/Audio/Operation/PlaybackOperation.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -7,7 +7,6 @@
 #include "Audio/Stream.hpp"
 #include "Audio/Endpoint.hpp"
 #include "Audio/decoder/DecoderWorker.hpp"
-#include "Audio/StreamQueuedEventsListener.hpp"
 #include "Audio/decoder/Decoder.hpp"
 
 #include <chrono>

--- a/module-audio/Audio/Operation/RecorderOperation.cpp
+++ b/module-audio/Audio/Operation/RecorderOperation.cpp
@@ -1,23 +1,18 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "RecorderOperation.hpp"
 
-#include "Audio/AudioDevice.hpp"
 #include "Audio/encoder/Encoder.hpp"
 #include "Audio/Profiles/Profile.hpp"
-#include "Audio/Profiles/ProfileRecordingHeadphones.hpp"
-#include "Audio/Profiles/ProfileRecordingOnBoardMic.hpp"
 #include "Audio/AudioCommon.hpp"
 
 #include <log/log.hpp>
 #include "FreeRTOS.h"
-#include "task.h"
 
 namespace audio
 {
     using namespace AudioServiceMessage;
-    using namespace utils;
 
 #define PERF_STATS_ON 0
 

--- a/module-audio/Audio/Operation/RecorderOperation.hpp
+++ b/module-audio/Audio/Operation/RecorderOperation.hpp
@@ -1,11 +1,10 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include "Operation.hpp"
 #include <Audio/encoder/Encoder.hpp>
-#include <Audio/AudioDevice.hpp>
 
 namespace audio
 {

--- a/module-audio/Audio/decoder/DecoderWorker.cpp
+++ b/module-audio/Audio/decoder/DecoderWorker.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DecoderWorker.hpp"
@@ -10,7 +10,7 @@ audio::DecoderWorker::DecoderWorker(audio::AbstractStream *audioStreamOut,
                                     EndOfFileCallback endOfFileCallback,
                                     ChannelMode mode)
     : sys::Worker(DecoderWorker::workerName, DecoderWorker::workerPriority, stackDepth), audioStreamOut(audioStreamOut),
-      decoder(decoder), endOfFileCallback(endOfFileCallback),
+      decoder(decoder), endOfFileCallback(std::move(endOfFileCallback)),
       bufferSize(audioStreamOut->getInputTraits().blockSize / sizeof(BufferInternalType)), channelMode(mode)
 {}
 

--- a/module-bluetooth/Bluetooth/audio/BluetoothAudioDevice.hpp
+++ b/module-bluetooth/Bluetooth/audio/BluetoothAudioDevice.hpp
@@ -60,8 +60,10 @@ namespace bluetooth
         auto getTraits() const -> Traits override;
         auto getSourceFormat() -> ::audio::AudioFormat override;
 
-        audio::AudioDevice::RetCode Pause() override;
+        audio::AudioDevice::RetCode Start() override;
+        audio::AudioDevice::RetCode Stop() override;
         audio::AudioDevice::RetCode Resume() override;
+        audio::AudioDevice::RetCode Pause() override;
     };
 
     class CVSDAudioDevice : public BluetoothAudioDevice

--- a/module-bluetooth/Bluetooth/interface/profiles/A2DP/A2DP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/A2DP/A2DP.cpp
@@ -480,7 +480,7 @@ namespace bluetooth
 
             AVRCP::playInfo.status = AVRCP_PLAYBACK_STATUS_PLAYING;
             if (AVRCP::mediaTracker.avrcp_cid != 0u) {
-                avrcp_target_set_playback_status(AVRCP::mediaTracker.avrcp_cid, AVRCP_PLAYBACK_STATUS_PLAYING);
+                avrcp_target_set_playback_status(AVRCP::mediaTracker.avrcp_cid, AVRCP::playInfo.status);
             }
             startTimer(&AVRCP::mediaTracker);
             LOG_INFO(
@@ -504,7 +504,7 @@ namespace bluetooth
 
             AVRCP::playInfo.status = AVRCP_PLAYBACK_STATUS_PAUSED;
             if (AVRCP::mediaTracker.avrcp_cid != 0u) {
-                avrcp_target_set_playback_status(AVRCP::mediaTracker.avrcp_cid, AVRCP_PLAYBACK_STATUS_PAUSED);
+                avrcp_target_set_playback_status(AVRCP::mediaTracker.avrcp_cid, AVRCP::playInfo.status);
             }
             LOG_INFO(
                 "A2DP Source: Stream paused: a2dp_cid [expected 0x%02x, received 0x%02x], local_seid [expected %d, "
@@ -562,13 +562,13 @@ namespace bluetooth
         if (isConnected) {
             disconnect();
         }
-        LOG_INFO("Starting playback");
+        LOG_INFO("Connecting A2DP profile");
         a2dp_source_establish_stream(device.address, &AVRCP::mediaTracker.a2dp_cid);
     }
 
     void A2DP::A2DPImpl::disconnect()
     {
-        LOG_INFO("Stopping playback");
+        LOG_INFO("Disonnecting A2DP profile");
         a2dp_source_disconnect(AVRCP::mediaTracker.a2dp_cid);
         auto &busProxy = const_cast<sys::Service *>(ownerService)->bus;
         busProxy.sendUnicast(std::make_shared<message::bluetooth::DisconnectResult>(device), service::name::bluetooth);
@@ -612,7 +612,7 @@ namespace bluetooth
     }
     void A2DP::A2DPImpl::deInit()
     {
-        LOG_DEBUG("[A2DP] deinit");
+        LOG_DEBUG("Deinitializing A2DP profile");
 
         sdp_unregister_service(a2dpSdpRecordHandle);
         sdp_unregister_service(avrcpControllerSdpRecordHandle);

--- a/module-bluetooth/Bluetooth/interface/profiles/A2DP/AVRCP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/A2DP/AVRCP.cpp
@@ -57,6 +57,8 @@ namespace bluetooth
                                           AVRCP_SUBUNIT_TYPE_AUDIO,
                                           static_cast<const std::uint8_t *>(AVRCP::subunitInfo),
                                           sizeof(AVRCP::subunitInfo));
+
+            avrcp_target_set_playback_status(AVRCP::mediaTracker.avrcp_cid, AVRCP::playInfo.status);
             return;
 
         case AVRCP_SUBEVENT_CONNECTION_RELEASED:

--- a/module-bluetooth/Bluetooth/interface/profiles/A2DP/AVRCP.hpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/A2DP/AVRCP.hpp
@@ -33,7 +33,7 @@ namespace bluetooth
         {
             uint8_t track_id[8];
             uint32_t song_length_ms;
-            avrcp_playback_status_t status;
+            avrcp_playback_status_t status = AVRCP_PLAYBACK_STATUS_STOPPED;
             uint32_t song_position_ms; // 0xFFFFFFFF if not supported
         };
 

--- a/module-services/service-audio/include/service-audio/ServiceAudio.hpp
+++ b/module-services/service-audio/include/service-audio/ServiceAudio.hpp
@@ -8,8 +8,6 @@
 
 #include <Audio/Audio.hpp>
 #include <Audio/AudioMux.hpp>
-#include <MessageType.hpp>
-#include <service-db/DBServiceAPI.hpp>
 #include <service-db/DBServiceName.hpp>
 #include <service-db/QueryMessage.hpp>
 #include <Service/Service.hpp>
@@ -127,8 +125,8 @@ class ServiceAudio : public sys::Service
     auto handleA2DPVolumeChangedOnBluetoothDevice(sys::Message *msgl) -> sys::MessagePointer;
     auto handleHSPVolumeChangedOnBluetoothDevice(sys::Message *msgl) -> sys::MessagePointer;
     auto handleHFPVolumeChangedOnBluetoothDevice(sys::Message *msgl) -> sys::MessagePointer;
-    auto handleA2DPAudioPause() -> sys::MessagePointer;
-    auto handleA2DPAudioStart() -> sys::MessagePointer;
+    auto handleMultimediaAudioPause() -> sys::MessagePointer;
+    auto handleMultimediaAudioStart() -> sys::MessagePointer;
 };
 
 namespace sys

--- a/module-services/service-db/include/service-db/Settings.hpp
+++ b/module-services/service-db/include/service-db/Settings.hpp
@@ -7,14 +7,11 @@
 #include "SettingsScope.hpp"
 #include "SettingsProxy.hpp"
 
-#include <cstdint>
 #include <functional>
 #include <list>
 #include <map>
 #include <memory>
 #include <optional>
-#include <string>
-#include <exception>
 
 namespace settings
 {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -7,6 +7,7 @@
 * Separated system volume from Bluetooth device volume for A2DP
 
 ### Fixed
+* Fixed music player behaviour when connecting/disconnecting audio devices
 * Fixed dropping the call during the DND mode
 * Fixed wrong tethering popup order
 * Fixed crash during phone turn off


### PR DESCRIPTION
Fix of the issue that after disconnecting
BT A2DP device during music playback
and reconnecting it without leaving
music player app the sound was not
audible anywhere.
Additionally unified behaviour of music
playback on connection/disconnection
of audio devices.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
