### PR TITLE
[MOS-662][MOS-301] Fix Eink shutdown while restoring data

### DIFF
--- a/module-services/service-eink/ServiceEink.cpp
+++ b/module-services/service-eink/ServiceEink.cpp
@@ -111,6 +111,8 @@ namespace service::eink
 
     sys::ReturnCodes ServiceEink::DeinitHandler()
     {
+        // Eink must be turn on before wiping out the display
+        display->powerOn();
         if (exitAction == ExitAction::WipeOut) {
             display->wipeOut();
         }

--- a/module-sys/SystemManager/SystemManagerCommon.cpp
+++ b/module-sys/SystemManager/SystemManagerCommon.cpp
@@ -67,11 +67,12 @@ namespace sys
     {
         namespace restore
         {
-            static constexpr std::array whitelist = {service::name::service_desktop,
-                                                     service::name::evt_manager,
-                                                     service::name::eink,
-                                                     service::name::appmgr,
-                                                     service::name::cellular};
+            static constexpr std::array whitelist = {
+                service::name::service_desktop, // Handle restore procedure
+                service::name::evt_manager, // Workaround for charging battery after shutting down and turn on the phone
+                service::name::appmgr,
+                service::name::cellular,
+            };
         }
 
         namespace regularClose
@@ -704,7 +705,10 @@ namespace sys
 
         // We are going to remove services in reversed order of creation
         CriticalSection::Enter();
-        std::reverse(servicesList.begin(), servicesList.end());
+        if (not serviceListReversed) {
+            std::reverse(servicesList.begin(), servicesList.end());
+            serviceListReversed = true;
+        }
         CriticalSection::Exit();
 
         InitiateSystemCloseSequence(closeReason);
@@ -741,10 +745,12 @@ namespace sys
     void SystemManagerCommon::RestoreSystemHandler()
     {
         LOG_INFO("Entering restore system state");
-
         // We are going to remove services in reversed order of creation
         CriticalSection::Enter();
-        std::reverse(servicesList.begin(), servicesList.end());
+        if (not serviceListReversed) {
+            std::reverse(servicesList.begin(), servicesList.end());
+            serviceListReversed = true;
+        }
         CriticalSection::Exit();
 
         DestroyServices(sys::state::restore::whitelist);

--- a/module-sys/SystemManager/include/SystemManager/SystemManagerCommon.hpp
+++ b/module-sys/SystemManager/include/SystemManager/SystemManagerCommon.hpp
@@ -193,6 +193,7 @@ namespace sys
         void UpdateResourcesAfterCpuFrequencyChange(bsp::CpuFrequencyMHz newFrequency);
 
         bool cpuStatisticsTimerInit{false};
+        bool serviceListReversed{false};
 
         CloseReason closeReason{CloseReason::RegularPowerDown};
         UpdateReason updateReason{UpdateReason::Update};

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -7,6 +7,8 @@
 * Separated system volume from Bluetooth device volume for A2DP
 
 ### Fixed
+* Fixed order of the services while closing system
+* Fixed crash of the E-ink service while restoring system data
 * Fixed removing wrong sentinels
 * Fixed music player behaviour when connecting/disconnecting audio devices
 * Fixed dropping the call during the DND mode


### PR DESCRIPTION
While restoring data the timer can turn off power of eink to
save the power. To avoid this situation we need to power on
the eink before wiping out the display. The restore procedure
also performs reversing servises list to close. In this case
we do it twice so the order is wrong.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
