### PR TITLE
[MOS-689] Rename getPrevWindow() for consistency

### DIFF
--- a/module-apps/apps-common/ApplicationCommon.cpp
+++ b/module-apps/apps-common/ApplicationCommon.cpp
@@ -927,7 +927,7 @@ namespace app
         windowsStack().push(newWindow, windowsFactory.build(this, newWindow), d);
     }
 
-    std::optional<std::string> ApplicationCommon::getPrevWindow(uint32_t count) const
+    std::optional<std::string> ApplicationCommon::getPreviousWindow(uint32_t count) const
     {
         return windowsStack().get(count);
     }

--- a/module-apps/apps-common/ApplicationCommon.hpp
+++ b/module-apps/apps-common/ApplicationCommon.hpp
@@ -377,7 +377,7 @@ namespace app
         void pushWindow(const std::string &newWindow, const gui::popup::Disposition &d = gui::popup::WindowDisposition);
         /// getter for previous window name
         /// @ingrup AppWindowStack
-        std::optional<std::string> getPrevWindow(uint32_t count = 1) const;
+        std::optional<std::string> getPreviousWindow(uint32_t count = 1) const;
         /// clears windows stack
         /// @ingrup AppWindowStack
         void cleanPrevWindw();

--- a/products/BellHybrid/apps/application-bell-onboarding/ApplicationBellOnBoarding.cpp
+++ b/products/BellHybrid/apps/application-bell-onboarding/ApplicationBellOnBoarding.cpp
@@ -206,7 +206,7 @@ namespace app
 
         auto selectedWindowCondition =
             getCurrentWindow()->getName() == gui::window::name::informationOnBoardingWindow &&
-            msg->getWindowName() == *getPrevWindow() &&
+            msg->getWindowName() == *getPreviousWindow() &&
             msg->getSenderWindowName() == gui::window::name::informationOnBoardingWindow;
 
         if (selectedWindowCondition && informationState == OnBoarding::InformationStates::DeepClickWarningInfo) {
@@ -238,7 +238,7 @@ namespace app
                      inputEvent.isKeyRelease(gui::KeyCode::KEY_LEFT)) {
                 informationState = OnBoarding::InformationStates::DeepClickWarningInfo;
                 if (getCurrentWindow()->getName() == gui::window::name::informationOnBoardingWindow) {
-                    displayInformation(*getPrevWindow());
+                    displayInformation(*getPreviousWindow());
                 }
                 else {
                     displayInformation(getCurrentWindow()->getName());
@@ -248,7 +248,7 @@ namespace app
                 if (informationState == OnBoarding::InformationStates::DeepClickWarningInfo) {
                     informationPromptTimer.stop();
                     informationState = OnBoarding::InformationStates::DeepClickCorrectionInfo;
-                    displayInformation(*getPrevWindow());
+                    displayInformation(*getPreviousWindow());
                 }
                 else {
                     informationState = OnBoarding::InformationStates::RotateInfo;
@@ -260,13 +260,13 @@ namespace app
                 switch (informationState) {
                 case OnBoarding::InformationStates::DeepClickCorrectionInfo:
                     if (inputEvent.isKeyRelease(gui::KeyCode::KEY_ENTER)) {
-                        switchWindow(*getPrevWindow());
+                        switchWindow(*getPreviousWindow());
                         return true;
                     }
                     break;
                 case OnBoarding::InformationStates::LightClickInfo:
                     if (inputEvent.isKeyRelease(gui::KeyCode::KEY_ENTER)) {
-                        switchWindow(*getPrevWindow());
+                        switchWindow(*getPreviousWindow());
                         return true;
                     }
                     break;
@@ -274,7 +274,7 @@ namespace app
                     if (inputEvent.isKeyRelease(gui::KeyCode::KEY_UP) ||
                         inputEvent.isKeyRelease(gui::KeyCode::KEY_DOWN) ||
                         inputEvent.isKeyRelease(gui::KeyCode::KEY_ENTER)) {
-                        switchWindow(*getPrevWindow());
+                        switchWindow(*getPreviousWindow());
                         return true;
                     }
                     break;


### PR DESCRIPTION
Now it's consistent with getCurrentWindow().

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible - N/A
- [x] Has documentation updated - N/A
- [x] Has changelog entry added - N/A
