### PR TITLE
[MOS-91] Fix cellular DMA errors

### DIFF
--- a/module-bsp/board/rt1051/bsp/cellular/rt1051_cellular.cpp
+++ b/module-bsp/board/rt1051/bsp/cellular/rt1051_cellular.cpp
@@ -230,6 +230,11 @@ namespace bsp
                 if (!LPUART_IsEDMATxBusy(&uartDmaHandle)) {
                     break;
                 }
+                else if (i == maxTXCheckRetires - 1) {
+                    LOG_ERROR("Cellular Uart error: EDMA is busy");
+                    LPUART_TransferAbortSendEDMA(CELLULAR_UART_BASE, &uartDmaHandle);
+                    return -1;
+                }
             }
         }
 
@@ -249,6 +254,7 @@ namespace bsp
 
         if (status != kStatus_Success) {
             LOG_ERROR("Cellular: TX Failed! , status: %d", static_cast<int>(status));
+            LPUART_TransferAbortSendEDMA(CELLULAR_UART_BASE, &uartDmaHandle);
             disableTx();
             return -1;
         }
@@ -258,6 +264,7 @@ namespace bsp
 
         if (ulNotificationValue == 0) {
             LOG_ERROR("Cellular Uart error: TX Transmission timeout");
+            LPUART_TransferAbortSendEDMA(CELLULAR_UART_BASE, &uartDmaHandle);
             disableTx();
             return -1;
         }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -7,6 +7,7 @@
 * Separated system volume from Bluetooth device volume for A2DP
 
 ### Fixed
+* Fixed cellular DMA errors
 * Fixed order of the services while closing system
 * Fixed crash of the E-ink service while restoring system data
 * Fixed removing wrong sentinels


### PR DESCRIPTION
<!-- Please describe your pull request here -->

Fix "DMA is busy" errors when booting the GSM modem
at the stage of finding the appropriate baudrate.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
