### PR TITLE
[MOS-714] Fix passcode lock time discrepancy

### DIFF
--- a/module-apps/apps-common/locks/handlers/PhoneLockHandler.hpp
+++ b/module-apps/apps-common/locks/handlers/PhoneLockHandler.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -101,6 +101,7 @@ namespace locks
         void setNextUnlockAttemptLockTime(time_t time);
         void setNoLockTimeAttemptsLeft(unsigned int attemptsNumber);
         void increaseLockTime() noexcept;
+        void setNextUnlockAttemptFormattedTime() noexcept;
         void resetLockTime() noexcept;
         void broadcastLockTime() noexcept;
     };

--- a/module-apps/apps-common/locks/widgets/Lock.cpp
+++ b/module-apps/apps-common/locks/widgets/Lock.cpp
@@ -1,8 +1,7 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Lock.hpp"
-#include <log/log.hpp>
 
 namespace locks
 {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -8,6 +8,7 @@
 * Separated system volume from Bluetooth device volume for A2DP
 
 ### Fixed
+* Fixed passcode lock time discrepancy between lock screen and 'Wrong password' popup
 * Fixed cellular DMA errors
 * Fixed order of the services while closing system
 * Fixed crash of the E-ink service while restoring system data
@@ -22,6 +23,8 @@
 * Fixed PLAY label translation in German
 * Fixed USB connection/disconnection detection
 * Fixed memory leaks in APN settings
+
+### Added
 * Added basic MMS handling
 
 ## [1.3.0 2022-08-04]


### PR DESCRIPTION
Fix of the issue that passcode lock time
wasn't updating on 'Wrong passcode' popup,
what led to discrepancy of the time
between lock screen and the popup.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
