### PR TITLE
[MOS-424] Improvement of logger module

### DIFF
--- a/module-bsp/board/rt1051/os/_exit.cpp
+++ b/module-bsp/board/rt1051/os/_exit.cpp
@@ -44,7 +44,7 @@
 static void __attribute__((noreturn)) stop_system(void)
 {
     if (!isIRQ()) {
-        if (dumpLogs() != 1) {
+        if (shutdownFlushLogs() != 1) {
             LOG_ERROR("Cannot dump logs");
         }
         const auto err = purefs::subsystem::unmount_all();

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -49,25 +49,14 @@
 #define debug_input_events(...)
 #endif
 
-namespace
-{
-    constexpr auto loggerDelayMs   = 1000 * 60 * 5;
-    constexpr auto loggerTimerName = "Logger";
-} // namespace
-
 EventManagerCommon::EventManagerCommon(LogDumpFunction logDumpFunction, const std::string &name)
-    : sys::Service(name, "", stackDepth), loggerTimer{sys::TimerFactory::createPeriodicTimer(
-                                              this,
-                                              loggerTimerName,
-                                              std::chrono::milliseconds{loggerDelayMs},
-                                              [this](sys::Timer & /*timer*/) { dumpLogsToFile(); })},
-      logDumpFunction(logDumpFunction), settings(std::make_shared<settings::Settings>())
+    : sys::Service(name, "", stackDepth), logDumpFunction(std::move(logDumpFunction)),
+      settings(std::make_shared<settings::Settings>())
 {
     LOG_INFO("[%s] Initializing", name.c_str());
     alarmTimestamp = 0;
     alarmID        = 0;
     bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
-    loggerTimer.start();
 }
 
 EventManagerCommon::~EventManagerCommon()
@@ -277,7 +266,6 @@ int EventManagerCommon::dumpLogsToFile()
     if (logDumpFunction) {
         return logDumpFunction();
     }
-
     return 0;
 }
 

--- a/module-services/service-evtmgr/service-evtmgr/EventManagerCommon.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/EventManagerCommon.hpp
@@ -56,8 +56,6 @@ class EventManagerCommon : public sys::Service
     void processRTCFromTimestampRequest(time_t &newTime);
     void processTimezoneRequest(const std::string &timezone);
 
-    sys::TimerHandle loggerTimer;
-
     LogDumpFunction logDumpFunction;
 
     /// @return: < 0 - error occured during log flush

--- a/module-sys/SystemManager/SystemManagerCommon.cpp
+++ b/module-sys/SystemManager/SystemManagerCommon.cpp
@@ -10,7 +10,7 @@
 #include "thread.hpp"
 #include "ticks.hpp"
 #include "critical.hpp"
-#include <algorithm>
+#include "Logger.hpp"
 #include <service-evtmgr/KbdMessage.hpp>
 #include <service-evtmgr/BatteryMessages.hpp>
 #include <service-evtmgr/Constants.hpp>
@@ -33,6 +33,8 @@
 #include <service-db/DBServiceName.hpp>
 #include <module-gui/gui/Common.hpp>
 #include <service-eink/Common.hpp>
+
+#include <algorithm>
 
 const inline size_t systemManagerStack = 4096 * 2;
 
@@ -115,6 +117,8 @@ namespace sys
             this, "lowBatteryShutdownDelay", lowBatteryShutdownDelayTime, [this](sys::Timer &) {
                 CloseSystemHandler(CloseReason::LowBattery);
             });
+
+        Log::Logger::get().createTimer(this);
     }
 
     SystemManagerCommon::~SystemManagerCommon()

--- a/module-utils/log/CMakeLists.txt
+++ b/module-utils/log/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(log
         Logger.cpp
         log.cpp
         LoggerBuffer.cpp
+        LoggerWorker.cpp
         StringCircularBuffer.cpp
 )
 
@@ -17,10 +18,12 @@ target_include_directories(log PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(log
     PRIVATE
         utility
+        purefs-paths
     PUBLIC
         module-os
         log-api
         utils-rotator    
+        sys-service
 )
 
 if (${ENABLE_TESTS})

--- a/module-utils/log/LoggerBuffer.hpp
+++ b/module-utils/log/LoggerBuffer.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -8,11 +8,12 @@
 class LoggerBuffer : public StringCircularBuffer
 {
   public:
-    using StringCircularBuffer::StringCircularBuffer;
+    explicit LoggerBuffer(size_t size) : StringCircularBuffer(size)
+    {}
 
-    [[nodiscard]] std::pair<bool, std::string> get() override;
-    void put(const std::string &logMsg) override;
-    void put(std::string &&logMsg) override;
+    [[nodiscard]] std::pair<bool, std::string> get();
+    void put(const std::string &logMsg);
+    void put(std::string &&logMsg);
 
     static constexpr auto lostBytesMessage = "bytes was lost.";
 

--- a/module-utils/log/LoggerBufferContainer.hpp
+++ b/module-utils/log/LoggerBufferContainer.hpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "LoggerBuffer.hpp"
+
+class LoggerBufferContainer
+{
+  public:
+    LoggerBufferContainer()
+        : currentIndex{0}, buffer{LoggerBuffer(circularBufferSize), LoggerBuffer(circularBufferSize)},
+          currentBuffer{buffer}, flushBuffer{buffer}
+    {}
+
+    LoggerBuffer *getFlushBuffer()
+    {
+        return flushBuffer;
+    }
+
+    LoggerBuffer *getCurrentBuffer()
+    {
+        return currentBuffer;
+    }
+
+    constexpr size_t getCircularBufferSize()
+    {
+        return circularBufferSize;
+    }
+
+    void nextBuffer()
+    {
+        ++currentIndex;
+        flushBuffer = currentBuffer;
+        currentIndex %= numberOfBuffers;
+        currentBuffer = &buffer[currentIndex];
+    }
+
+    size_t getCurrentIndex()
+    {
+        return currentIndex;
+    }
+
+  private:
+    static constexpr size_t circularBufferSize = 1024;
+    static constexpr size_t numberOfBuffers    = 2;
+
+    size_t currentIndex;
+    LoggerBuffer buffer[numberOfBuffers];
+    LoggerBuffer *currentBuffer;
+    LoggerBuffer *flushBuffer;
+};

--- a/module-utils/log/LoggerWorker.cpp
+++ b/module-utils/log/LoggerWorker.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "LoggerWorker.hpp"
+#include "Logger.hpp"
+#include <log/log.hpp>
+#include <magic_enum.hpp>
+#include <purefs/filesystem_paths.hpp>
+
+namespace Log
+{
+    LoggerWorker::LoggerWorker(const std::string name) : Worker(name, priority)
+    {}
+
+    void LoggerWorker::notify(Signal command)
+    {
+        if (auto queue = getQueueByName(SignalQueueName); !queue->Overwrite(&command)) {
+            LOG_ERROR("Unable to overwrite the command in the commands queue.");
+        }
+    }
+
+    bool LoggerWorker::handleMessage(std::uint32_t queueID)
+    {
+        if (const auto queue = queues[queueID]; queue->GetQueueName() == SignalQueueName) {
+            if (sys::WorkerCommand command; queue->Dequeue(&command, 0)) {
+                handleCommand(static_cast<Signal>(command.command));
+            }
+        }
+        return true;
+    }
+
+    void LoggerWorker::handleCommand(Signal command)
+    {
+        switch (command) {
+        case Signal::DumpFilledBuffer:
+        case Signal::DumpIntervalBuffer:
+        case Signal::DumpDiagnostic:
+            LOG_INFO("Received signal: %s", magic_enum::enum_name(command).data());
+            Log::Logger::get().dumpToFile(purefs::dir::getLogsPath() / LOG_FILE_NAME);
+            break;
+        default:
+            LOG_ERROR("Command not valid: %d", static_cast<int>(command));
+        }
+    }
+
+} // namespace Log

--- a/module-utils/log/LoggerWorker.hpp
+++ b/module-utils/log/LoggerWorker.hpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <Service/Worker.hpp>
+
+namespace Log
+{
+    static constexpr auto workerName = "LoggerWorker";
+
+    class LoggerWorker : public sys::Worker
+    {
+      public:
+        enum class Signal
+        {
+            DumpFilledBuffer,
+            DumpIntervalBuffer,
+            DumpDiagnostic
+        };
+
+        static constexpr auto SignalQueueName   = "LoggerSignal";
+        static constexpr auto SignalSize        = sizeof(Signal);
+        static constexpr auto SignalQueueLenght = 1;
+
+        explicit LoggerWorker(const std::string name);
+        void notify(Signal command);
+        bool handleMessage(std::uint32_t queueID) override;
+        void handleCommand(Signal command);
+
+      private:
+        static constexpr auto priority = static_cast<UBaseType_t>(sys::ServicePriority::Idle);
+    };
+
+} // namespace Log

--- a/module-utils/log/StringCircularBuffer.hpp
+++ b/module-utils/log/StringCircularBuffer.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -11,7 +11,6 @@ class StringCircularBuffer
   public:
     explicit StringCircularBuffer(size_t size) : buffer(std::make_unique<std::string[]>(size)), capacity(size)
     {}
-    virtual ~StringCircularBuffer() = default;
     [[nodiscard]] size_t getCapacity() const noexcept
     {
         return capacity;
@@ -29,8 +28,8 @@ class StringCircularBuffer
     {
         return full;
     }
-    virtual void put(const std::string &item);
-    virtual void put(std::string &&item);
+    void put(const std::string &item);
+    void put(std::string &&item);
     void reset();
 
   private:

--- a/module-utils/log/board/rt1051/log_rt1051.cpp
+++ b/module-utils/log/board/rt1051/log_rt1051.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <board.h>
@@ -27,7 +27,7 @@ namespace Log
 
         loggerBufferCurrentPos += vsnprintf(&loggerBuffer[loggerBufferCurrentPos], loggerBufferSizeLeft(), fmt, args);
         logToDevice(Device::DEFAULT, loggerBuffer, loggerBufferCurrentPos);
-        circularBuffer.put(std::string(loggerBuffer, loggerBufferCurrentPos));
+        buffer.getCurrentBuffer()->put(std::string(loggerBuffer, loggerBufferCurrentPos));
     }
 
     void Logger::logToDevice(Device device, std::string_view logMsg, size_t length)

--- a/module-utils/log/doc/logging_engine.md
+++ b/module-utils/log/doc/logging_engine.md
@@ -21,14 +21,21 @@ to a proper device (`SEGGER_RTT`, `console output`, `SYSTEMVIEW`)
 and at the same time to put them to a `circular buffer`.
 
 `Circular buffer` has a limited size which sometimes results in losing some logs.
-
 In such a case, proper `lost message info` is added to `msg` received from the buffer.
+
+However, it should not happen because the logger has a worker and 2 logger buffers. When
+the buffer is full the logger switch buffer and sends message to the worker to dump logs.
 
 ## Dumping to a file
 
-Logs from `Circular buffer` are dumped to a file named `MuditaOS.log` every 10 sec by `EventManagerCommon` timer.
+Logs from `Circular buffer` are dumped to a file named `MuditaOS.log` when:
+- `Circular buffer` is full
+- every 15 minutes from last dump
+- download diagnostic from the phone
+- system shutdown
 
-Current max log file size is 50 MB (after reaching this size no more logs are dumped).
+Current max log file size is 15MB. After reaching this size the `Rotator` save file and add
+extension at the end of file extension eg. `MuditaOS.log.1`. Then create the new file.
 
 Logs can be accessed using `mount_user_lfs_partition.py` script from `tools` directory.
 Additionally, `test/get_os_log.py` script allows getting a log file from a running phone.
@@ -37,5 +44,3 @@ Additionally, `test/get_os_log.py` script allows getting a log file from a runni
 
 There are a series of useful system logging capabilities defined in:
 `module-utils/log/api/log/debug.hpp`
-
-Please see doxygen documentation for each parameter.

--- a/module-utils/log/logdump/include/logdump/logdump.h
+++ b/module-utils/log/logdump/include/logdump/logdump.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -10,7 +10,8 @@ extern "C"
     /// @return: < 0 - error occurred during log flush
     /// @return:   0 - log flush did not happen
     /// @return:   1 - log flush successful
-    int dumpLogs();
+    int diagnosticDumpLogs();
+    int shutdownFlushLogs();
 
 #ifdef __cplusplus
 }

--- a/module-utils/log/logdump/logdump.cpp
+++ b/module-utils/log/logdump/logdump.cpp
@@ -1,11 +1,17 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <logdump/logdump.h>
-#include <purefs/filesystem_paths.hpp>
 #include <Logger.hpp>
 
-int dumpLogs()
+using namespace Log;
+
+int diagnosticDumpLogs()
 {
-    return Log::Logger::get().dumpToFile(purefs::dir::getLogsPath() / LOG_FILE_NAME);
+    return Logger::get().diagnosticDump();
+}
+
+int shutdownFlushLogs()
+{
+    return Logger::get().flushLogs();
 }

--- a/module-utils/log/tests/test_logDumps.cpp
+++ b/module-utils/log/tests/test_logDumps.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include <log/Logger.hpp>
+#include <log/LoggerBufferContainer.hpp>
 
 namespace
 {
@@ -113,4 +114,24 @@ TEST_CASE("Test if log files rotate")
 
     // Clean-up the environment
     std::filesystem::remove_all(logsDir);
+}
+
+TEST_CASE("Test if choose proper buffer")
+{
+    LoggerBufferContainer buffer;
+
+    size_t bufferIndex = buffer.getCurrentIndex();
+    REQUIRE(bufferIndex == 0);
+
+    buffer.nextBuffer();
+    bufferIndex = buffer.getCurrentIndex();
+    REQUIRE(bufferIndex == 1);
+
+    buffer.nextBuffer();
+    bufferIndex = buffer.getCurrentIndex();
+    REQUIRE(bufferIndex == 0);
+
+    buffer.nextBuffer();
+    bufferIndex = buffer.getCurrentIndex();
+    REQUIRE(bufferIndex == 1);
 }

--- a/products/BellHybrid/BellHybridMain.cpp
+++ b/products/BellHybrid/BellHybridMain.cpp
@@ -91,7 +91,7 @@ int main()
     }
 
     std::vector<std::unique_ptr<sys::BaseServiceCreator>> systemServices;
-    systemServices.emplace_back(sys::CreatorFor<EventManager>([]() { return dumpLogs(); }));
+    systemServices.emplace_back(sys::CreatorFor<EventManager>([]() { return diagnosticDumpLogs(); }));
     systemServices.emplace_back(sys::CreatorFor<service::ServiceFileIndexer>(std::move(fileIndexerAudioPaths)));
     systemServices.emplace_back(sys::CreatorFor<ServiceDB>());
     systemServices.emplace_back(sys::CreatorFor<service::Audio>());
@@ -145,7 +145,7 @@ int main()
         [&platform] {
             try {
                 LOG_DEBUG("System deinit");
-                if (dumpLogs() != 1) {
+                if (shutdownFlushLogs() != 1) {
                     LOG_ERROR("Cannot dump logs");
                 }
                 platform->deinit();

--- a/products/PurePhone/PurePhoneMain.cpp
+++ b/products/PurePhone/PurePhoneMain.cpp
@@ -158,7 +158,7 @@ int main()
 
     std::vector<std::unique_ptr<sys::BaseServiceCreator>> systemServices;
 #ifdef ENABLE_SERVICE_EVTMGR
-    systemServices.emplace_back(sys::CreatorFor<EventManager>([]() { return dumpLogs(); }));
+    systemServices.emplace_back(sys::CreatorFor<EventManager>([]() { return diagnosticDumpLogs(); }));
 #endif
 #ifdef ENABLE_SERVICE_FILEINDEXER
     systemServices.emplace_back(sys::CreatorFor<service::ServiceFileIndexer>(std::move(fileIndexerAudioPaths)));
@@ -284,7 +284,7 @@ int main()
         [&platform] {
             try {
                 LOG_DEBUG("System deinit");
-                if (dumpLogs() != 1) {
+                if (shutdownFlushLogs() != 1) {
                     LOG_ERROR("Cannot dump logs");
                 }
                 platform->deinit();

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -8,6 +8,7 @@
 * Separated system volume from Bluetooth device volume for A2DP
 
 ### Fixed
+* Fixed lost bytes in logs
 * Fixed passcode lock time discrepancy between lock screen and 'Wrong password' popup
 * Fixed cellular DMA errors
 * Fixed order of the services while closing system


### PR DESCRIPTION
Due to losing bytes the logger has a worker
which is responsible for dumping logs to
the file. The logger also has its own timer
to dump logs every 15 minutes. EventManager
is not responsible for interval dumping logs
now.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [x] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
