### PR TITLE
[CP-1484] Add new mechanism for data synchronization between MOS and MC

### DIFF
--- a/module-services/service-db/DBServiceAPI.cpp
+++ b/module-services/service-db/DBServiceAPI.cpp
@@ -275,6 +275,20 @@ auto DBServiceAPI::DBBackup(sys::Service *serv, std::string backupPath) -> bool
     return false;
 }
 
+auto DBServiceAPI::DBPrepareSyncPackage(sys::Service *serv, const std::string &syncPackagePath) -> bool
+{
+    LOG_INFO("DBPrepareSyncPackage %s", syncPackagePath.c_str());
+
+    auto msg = std::make_shared<DBServiceMessageSyncPackage>(MessageType::DBSyncPackage, syncPackagePath);
+
+    auto ret = serv->bus.sendUnicastSync(std::move(msg), service::name::db, DefaultTimeoutInMs);
+    if (auto retMsg = dynamic_cast<DBServiceResponseMessage *>(ret.second.get()); retMsg) {
+        return retMsg->retCode;
+    }
+    LOG_ERROR("DBPrepareSyncPackage error, return code: %s", c_str(ret.first));
+    return false;
+}
+
 bool DBServiceAPI::AddSMS(sys::Service *serv, const SMSRecord &record, std::unique_ptr<db::QueryListener> &&listener)
 {
     auto query = std::make_unique<db::query::SMSAdd>(record);

--- a/module-services/service-db/include/service-db/DBServiceAPI.hpp
+++ b/module-services/service-db/include/service-db/DBServiceAPI.hpp
@@ -109,6 +109,7 @@ class DBServiceAPI
     [[deprecated]] static auto CalllogUpdate(sys::Service *serv, const CalllogRecord &rec) -> bool;
 
     static auto DBBackup(sys::Service *serv, std::string backupPath) -> bool;
+    static auto DBPrepareSyncPackage(sys::Service *serv, const std::string &syncPackagePath) -> bool;
 
     static auto IsContactInFavourites(sys::Service *serv, const utils::PhoneNumber::View &numberView) -> bool;
     /**

--- a/module-services/service-db/include/service-db/DBServiceMessage.hpp
+++ b/module-services/service-db/include/service-db/DBServiceMessage.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -15,6 +15,13 @@ class DBServiceMessageBackup : public DBMessage
   public:
     DBServiceMessageBackup(MessageType messageType, std::string backupPath);
     std::string backupPath;
+};
+
+class DBServiceMessageSyncPackage : public DBMessage
+{
+  public:
+    DBServiceMessageSyncPackage(MessageType messageType, const std::string &syncPackagePath);
+    std::string syncPackagePath;
 };
 
 class DBServiceResponseMessage : public DBResponseMessage

--- a/module-services/service-db/messages/DBServiceMessage.cpp
+++ b/module-services/service-db/messages/DBServiceMessage.cpp
@@ -1,10 +1,14 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <service-db/DBServiceMessage.hpp>
 
 DBServiceMessageBackup::DBServiceMessageBackup(MessageType messageType, std::string backupPath)
     : DBMessage(messageType), backupPath(backupPath)
+{}
+
+DBServiceMessageSyncPackage::DBServiceMessageSyncPackage(MessageType messageType, const std::string &syncPackagePath)
+    : DBMessage(messageType), syncPackagePath(syncPackagePath)
 {}
 
 DBServiceResponseMessage::DBServiceResponseMessage(uint32_t retCode, uint32_t count, MessageType respTo)

--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -46,6 +46,7 @@ sys::ReturnCodes ServiceDesktop::InitHandler()
     connectHandler<message::bluetooth::ResponseVisibleDevices>();
     connectHandler<sdesktop::developerMode::DeveloperModeRequest>();
     connectHandler<sdesktop::BackupMessage>();
+    connectHandler<sdesktop::SyncMessage>();
     connectHandler<sdesktop::RestoreMessage>();
     connectHandler<sdesktop::FactoryMessage>();
     connectHandler<sdesktop::usb::USBConfigured>();
@@ -101,20 +102,39 @@ std::string ServiceDesktop::prepareBackupFilename()
     return std::string(backupFileName.data());
 }
 
+std::string ServiceDesktop::prepareSyncFilename()
+{
+    const std::size_t maxFileNameSize = 64;
+    std::array<char, maxFileNameSize> syncFileName{};
+    std::time_t now;
+    std::time(&now);
+    std::strftime(syncFileName.data(), syncFileName.size(), "%FT%OH%OM%OSZ", std::localtime(&now));
+
+    return std::string(syncFileName.data());
+}
+
 void ServiceDesktop::prepareBackupData()
 {
-    backupRestoreStatus.operation     = BackupRestore::Operation::Backup;
-    backupRestoreStatus.taskId        = prepareBackupFilename();
-    backupRestoreStatus.state         = BackupRestore::OperationState::Stopped;
-    backupRestoreStatus.backupTempDir = purefs::dir::getTemporaryPath() / backupRestoreStatus.taskId;
+    backupSyncRestoreStatus.operation     = BackupSyncRestore::Operation::Backup;
+    backupSyncRestoreStatus.taskId        = prepareBackupFilename();
+    backupSyncRestoreStatus.state         = BackupSyncRestore::OperationState::Stopped;
+    backupSyncRestoreStatus.backupTempDir = purefs::dir::getTemporaryPath() / backupSyncRestoreStatus.taskId;
+}
+
+void ServiceDesktop::prepareSyncData()
+{
+    backupSyncRestoreStatus.operation     = BackupSyncRestore::Operation::Sync;
+    backupSyncRestoreStatus.taskId        = prepareSyncFilename();
+    backupSyncRestoreStatus.state         = BackupSyncRestore::OperationState::Stopped;
+    backupSyncRestoreStatus.backupTempDir = purefs::dir::getTemporaryPath() / backupSyncRestoreStatus.taskId;
 }
 
 void ServiceDesktop::prepareRestoreData(const std::filesystem::path &restoreLocation)
 {
-    backupRestoreStatus.operation = BackupRestore::Operation::Restore;
-    backupRestoreStatus.taskId    = restoreLocation.filename();
-    backupRestoreStatus.state     = BackupRestore::OperationState::Stopped;
-    backupRestoreStatus.location  = purefs::dir::getBackupOSPath() / backupRestoreStatus.taskId;
+    backupSyncRestoreStatus.operation = BackupSyncRestore::Operation::Restore;
+    backupSyncRestoreStatus.taskId    = restoreLocation.filename();
+    backupSyncRestoreStatus.state     = BackupSyncRestore::OperationState::Stopped;
+    backupSyncRestoreStatus.location  = purefs::dir::getBackupOSPath() / backupSyncRestoreStatus.taskId;
 }
 
 auto ServiceDesktop::requestLogsFlush() -> void
@@ -313,17 +333,37 @@ auto ServiceDesktop::handle(sdesktop::developerMode::DeveloperModeRequest *msg) 
 
 auto ServiceDesktop::handle(sdesktop::BackupMessage * /*msg*/) -> std::shared_ptr<sys::Message>
 {
-    backupRestoreStatus.state          = BackupRestore::OperationState::Running;
-    backupRestoreStatus.completionCode = BackupRestore::BackupUserFiles(this, backupRestoreStatus.backupTempDir);
-    backupRestoreStatus.location       = backupRestoreStatus.taskId;
+    backupSyncRestoreStatus.state = BackupSyncRestore::OperationState::Running;
+    backupSyncRestoreStatus.completionCode =
+        BackupSyncRestore::BackupUserFiles(this, backupSyncRestoreStatus.backupTempDir);
+    backupSyncRestoreStatus.location = backupSyncRestoreStatus.taskId;
 
-    if (backupRestoreStatus.completionCode == BackupRestore::CompletionCode::Success) {
+    if (backupSyncRestoreStatus.completionCode == BackupSyncRestore::CompletionCode::Success) {
         LOG_INFO("Backup finished");
-        backupRestoreStatus.state = BackupRestore::OperationState::Finished;
+        backupSyncRestoreStatus.state = BackupSyncRestore::OperationState::Finished;
     }
     else {
         LOG_ERROR("Backup failed");
-        backupRestoreStatus.state = BackupRestore::OperationState::Error;
+        backupSyncRestoreStatus.state = BackupSyncRestore::OperationState::Error;
+    }
+
+    return sys::MessageNone{};
+}
+
+auto ServiceDesktop::handle(sdesktop::SyncMessage * /*msg*/) -> std::shared_ptr<sys::Message>
+{
+    backupSyncRestoreStatus.state = BackupSyncRestore::OperationState::Running;
+    backupSyncRestoreStatus.completionCode =
+        BackupSyncRestore::PrepareSyncPackage(this, backupSyncRestoreStatus.backupTempDir);
+    backupSyncRestoreStatus.location = backupSyncRestoreStatus.taskId;
+
+    if (backupSyncRestoreStatus.completionCode == BackupSyncRestore::CompletionCode::Success) {
+        LOG_INFO("Sync package preparation finished");
+        backupSyncRestoreStatus.state = BackupSyncRestore::OperationState::Finished;
+    }
+    else {
+        LOG_ERROR("Sync package preparation failed");
+        backupSyncRestoreStatus.state = BackupSyncRestore::OperationState::Error;
     }
 
     return sys::MessageNone{};
@@ -331,17 +371,18 @@ auto ServiceDesktop::handle(sdesktop::BackupMessage * /*msg*/) -> std::shared_pt
 
 auto ServiceDesktop::handle(sdesktop::RestoreMessage * /*msg*/) -> std::shared_ptr<sys::Message>
 {
-    backupRestoreStatus.state          = BackupRestore::OperationState::Running;
-    backupRestoreStatus.completionCode = BackupRestore::RestoreUserFiles(this, backupRestoreStatus.location);
+    backupSyncRestoreStatus.state = BackupSyncRestore::OperationState::Running;
+    backupSyncRestoreStatus.completionCode =
+        BackupSyncRestore::RestoreUserFiles(this, backupSyncRestoreStatus.location);
 
-    if (backupRestoreStatus.completionCode == BackupRestore::CompletionCode::Success) {
+    if (backupSyncRestoreStatus.completionCode == BackupSyncRestore::CompletionCode::Success) {
         LOG_DEBUG("Restore finished");
-        backupRestoreStatus.state = BackupRestore::OperationState::Finished;
+        backupSyncRestoreStatus.state = BackupSyncRestore::OperationState::Finished;
         sys::SystemManagerCommon::Reboot(this);
     }
     else {
         LOG_ERROR("Restore failed");
-        backupRestoreStatus.state = BackupRestore::OperationState::Error;
+        backupSyncRestoreStatus.state = BackupSyncRestore::OperationState::Error;
     }
 
     return sys::MessageNone{};

--- a/module-services/service-desktop/endpoints/backup/BackupHelper.cpp
+++ b/module-services/service-desktop/endpoints/backup/BackupHelper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <endpoints/Context.hpp>
@@ -19,11 +19,17 @@ namespace sdesktop::endpoints
 
     auto BackupHelper::processGet(Context &context) -> ProcessResult
     {
+        if (context.getBody()[json::messages::category].string_value() == json::messages::categorySync) {
+            return checkSyncState(context);
+        }
         return checkState(context);
     }
 
     auto BackupHelper::processPost(Context &context) -> ProcessResult
     {
+        if (context.getBody()[json::messages::category].string_value() == json::messages::categorySync) {
+            return executeSyncRequest(context);
+        }
         return executeRequest(context);
     }
 
@@ -31,7 +37,7 @@ namespace sdesktop::endpoints
     {
         auto ownerServicePtr = static_cast<ServiceDesktop *>(owner);
 
-        if (ownerServicePtr->getBackupRestoreStatus().state == BackupRestore::OperationState::Running) {
+        if (ownerServicePtr->getBackupSyncRestoreStatus().state == BackupSyncRestore::OperationState::Running) {
             LOG_DEBUG("Backup already running");
             // a backup is already running, don't start a second task
             context.setResponseStatus(http::Code::NotAcceptable);
@@ -46,7 +52,7 @@ namespace sdesktop::endpoints
                                              service::name::service_desktop);
 
             // return new generated backup info
-            context.setResponseBody(ownerServicePtr->getBackupRestoreStatus());
+            context.setResponseBody(ownerServicePtr->getBackupSyncRestoreStatus());
         }
 
         putToSendQueue(context.createSimpleResponse());
@@ -59,15 +65,75 @@ namespace sdesktop::endpoints
         auto ownerServicePtr = static_cast<ServiceDesktop *>(owner);
 
         if (context.getBody()[json::taskId].is_string()) {
-            if (ownerServicePtr->getBackupRestoreStatus().taskId == context.getBody()[json::taskId].string_value()) {
-                if (ownerServicePtr->getBackupRestoreStatus().state == BackupRestore::OperationState::Finished) {
+            if (ownerServicePtr->getBackupSyncRestoreStatus().taskId ==
+                context.getBody()[json::taskId].string_value()) {
+                if (ownerServicePtr->getBackupSyncRestoreStatus().state ==
+                    BackupSyncRestore::OperationState::Finished) {
                     context.setResponseStatus(http::Code::SeeOther);
                 }
                 else {
                     context.setResponseStatus(http::Code::OK);
                 }
 
-                context.setResponseBody(ownerServicePtr->getBackupRestoreStatus());
+                context.setResponseBody(ownerServicePtr->getBackupSyncRestoreStatus());
+            }
+            else {
+                context.setResponseStatus(http::Code::NotFound);
+            }
+        }
+        else {
+            LOG_DEBUG("Backup task not found");
+            context.setResponseStatus(http::Code::BadRequest);
+        }
+
+        LOG_DEBUG("Responding");
+        putToSendQueue(context.createSimpleResponse());
+
+        return {sent::yes, std::nullopt};
+    }
+
+    auto BackupHelper::executeSyncRequest(Context &context) -> ProcessResult
+    {
+        auto ownerServicePtr = static_cast<ServiceDesktop *>(owner);
+
+        if (ownerServicePtr->getBackupSyncRestoreStatus().state == BackupSyncRestore::OperationState::Running) {
+            LOG_DEBUG("Sync already running");
+            // a sync package preparation is already running, don't start a second task
+            context.setResponseStatus(http::Code::NotAcceptable);
+        }
+        else {
+            LOG_DEBUG("Starting a sync package preparation");
+            // initialize new sync information
+            ownerServicePtr->prepareSyncData();
+
+            // start the sync package preparation process in the background
+            ownerServicePtr->bus.sendUnicast(std::make_shared<sdesktop::SyncMessage>(), service::name::service_desktop);
+
+            // return new generated sync package info
+            context.setResponseBody(ownerServicePtr->getBackupSyncRestoreStatus());
+        }
+
+        putToSendQueue(context.createSimpleResponse());
+
+        return {sent::yes, std::nullopt};
+    }
+
+    auto BackupHelper::checkSyncState(Context &context) -> ProcessResult
+    {
+        auto ownerServicePtr = static_cast<ServiceDesktop *>(owner);
+
+        if (context.getBody()[json::taskId].is_string()) {
+            if (ownerServicePtr->getBackupSyncRestoreStatus().taskId ==
+                context.getBody()[json::taskId].string_value()) {
+                if (ownerServicePtr->getBackupSyncRestoreStatus().state ==
+                    BackupSyncRestore::OperationState::Finished) {
+                    context.setResponseStatus(http::Code::SeeOther);
+                }
+                else {
+                    context.setResponseStatus(http::Code::OK);
+                }
+
+                context.setResponseBody(ownerServicePtr->getBackupSyncRestoreStatus());
             }
             else {
                 context.setResponseStatus(http::Code::NotFound);

--- a/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
@@ -25,34 +25,35 @@ namespace sdesktop::endpoints::json
     inline constexpr auto networkOperatorName = "networkOperatorName";
     inline constexpr auto accessTechnology    = "accessTechnology";
 
-    inline constexpr auto update         = "update";
-    inline constexpr auto updateInfo     = "updateInfo";
-    inline constexpr auto updateError    = "updateError";
-    inline constexpr auto errorCode      = "errorCode";
-    inline constexpr auto statusCode     = "statusCode";
-    inline constexpr auto updateHistory  = "updateHistory";
-    inline constexpr auto usbMscMode     = "usbMscMode";
-    inline constexpr auto versionString  = "string";
-    inline constexpr auto fileExists     = "fileExists";
-    inline constexpr auto boot           = "boot";
-    inline constexpr auto version        = "version";
-    inline constexpr auto taskId         = "id";
-    inline constexpr auto state          = "state";
-    inline constexpr auto success        = "success";
-    inline constexpr auto reboot         = "reboot";
-    inline constexpr auto rebootMode     = "rebootMode";
-    inline constexpr auto request        = "request";
-    inline constexpr auto restore        = "restore";
-    inline constexpr auto finished       = "finished";
-    inline constexpr auto pending        = "pending";
-    inline constexpr auto location       = "location";
-    inline constexpr auto reason         = "reason";
-    inline constexpr auto serialNumber   = "serialNumber";
-    inline constexpr auto caseColour     = "caseColour";
-    inline constexpr auto fileList       = "fileList";
-    inline constexpr auto files          = "files";
-    inline constexpr auto backupLocation = "backupLocation";
-    inline constexpr auto deviceToken    = "deviceToken";
+    inline constexpr auto update              = "update";
+    inline constexpr auto updateInfo          = "updateInfo";
+    inline constexpr auto updateError         = "updateError";
+    inline constexpr auto errorCode           = "errorCode";
+    inline constexpr auto statusCode          = "statusCode";
+    inline constexpr auto updateHistory       = "updateHistory";
+    inline constexpr auto usbMscMode          = "usbMscMode";
+    inline constexpr auto versionString       = "string";
+    inline constexpr auto fileExists          = "fileExists";
+    inline constexpr auto boot                = "boot";
+    inline constexpr auto version             = "version";
+    inline constexpr auto taskId              = "id";
+    inline constexpr auto state               = "state";
+    inline constexpr auto success             = "success";
+    inline constexpr auto reboot              = "reboot";
+    inline constexpr auto rebootMode          = "rebootMode";
+    inline constexpr auto request             = "request";
+    inline constexpr auto restore             = "restore";
+    inline constexpr auto finished            = "finished";
+    inline constexpr auto pending             = "pending";
+    inline constexpr auto location            = "location";
+    inline constexpr auto reason              = "reason";
+    inline constexpr auto serialNumber        = "serialNumber";
+    inline constexpr auto caseColour          = "caseColour";
+    inline constexpr auto fileList            = "fileList";
+    inline constexpr auto files               = "files";
+    inline constexpr auto backupLocation      = "backupLocation";
+    inline constexpr auto syncPackageLocation = "syncPackageLocation";
+    inline constexpr auto deviceToken         = "deviceToken";
 
     namespace updateprocess
     {
@@ -71,6 +72,8 @@ namespace sdesktop::endpoints::json
         inline constexpr auto categoryMessage  = "message";
         inline constexpr auto categoryThread   = "thread";
         inline constexpr auto categoryTemplate = "template";
+        inline constexpr auto categoryBackup   = "backup";
+        inline constexpr auto categorySync     = "sync";
 
         inline constexpr auto limit              = "limit";
         inline constexpr auto offset             = "offset";

--- a/module-services/service-desktop/endpoints/include/endpoints/backup/BackupHelper.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/backup/BackupHelper.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -19,5 +19,7 @@ namespace sdesktop::endpoints
       private:
         auto executeRequest(Context &context) -> ProcessResult;
         auto checkState(Context &context) -> ProcessResult;
+        auto executeSyncRequest(Context &context) -> ProcessResult;
+        auto checkSyncState(Context &context) -> ProcessResult;
     };
 } // namespace sdesktop::endpoints

--- a/module-services/service-desktop/endpoints/restore/RestoreHelper.cpp
+++ b/module-services/service-desktop/endpoints/restore/RestoreHelper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <endpoints/Context.hpp>
@@ -31,9 +31,9 @@ namespace sdesktop::endpoints
         auto ownerService = static_cast<ServiceDesktop *>(owner);
 
         if (context.getBody()[json::taskId].is_string()) {
-            if (ownerService->getBackupRestoreStatus().taskId == context.getBody()[json::taskId].string_value()) {
+            if (ownerService->getBackupSyncRestoreStatus().taskId == context.getBody()[json::taskId].string_value()) {
                 context.setResponseStatus(http::Code::OK);
-                context.setResponseBody(ownerService->getBackupRestoreStatus());
+                context.setResponseBody(ownerService->getBackupSyncRestoreStatus());
             }
             else {
                 return {sent::no, ResponseContext{.status = http::Code::NotFound}};
@@ -46,7 +46,7 @@ namespace sdesktop::endpoints
 
                 return {sent::no, ResponseContext{.status = http::Code::BadRequest}};
             }
-            auto filesList = json11::Json::object{{json::files, BackupRestore::GetBackupFiles()}};
+            auto filesList = json11::Json::object{{json::files, BackupSyncRestore::GetBackupFiles()}};
             context.setResponseBody(filesList);
         }
 
@@ -61,7 +61,7 @@ namespace sdesktop::endpoints
         auto ownerService = static_cast<ServiceDesktop *>(owner);
 
         if (context.getBody()[json::restore].is_string()) {
-            if (ownerService->getBackupRestoreStatus().state == BackupRestore::OperationState::Running) {
+            if (ownerService->getBackupSyncRestoreStatus().state == BackupSyncRestore::OperationState::Running) {
                 LOG_WARN("Restore is running, try again later");
 
                 return {sent::no, ResponseContext{.status = http::Code::NotAcceptable}};
@@ -88,7 +88,7 @@ namespace sdesktop::endpoints
                                               service::name::service_desktop);
 
                 // return new generated restore info
-                context.setResponseBody(ownerService->getBackupRestoreStatus());
+                context.setResponseBody(ownerService->getBackupSyncRestoreStatus());
             }
         }
         else {

--- a/module-services/service-desktop/include/service-desktop/BackupRestore.hpp
+++ b/module-services/service-desktop/include/service-desktop/BackupRestore.hpp
@@ -13,12 +13,13 @@ namespace sys
     class Service;
 } // namespace sys
 
-class BackupRestore
+class BackupSyncRestore
 {
   public:
     enum class Operation
     {
         Backup,
+        Sync,
         Restore
     };
 
@@ -102,13 +103,17 @@ class BackupRestore
     };
 
     static CompletionCode BackupUserFiles(sys::Service *ownerService, std::filesystem::path &path);
+    static CompletionCode PrepareSyncPackage(sys::Service *ownerService, std::filesystem::path &path);
     static CompletionCode RestoreUserFiles(sys::Service *ownerService, const std::filesystem::path &path);
     static json11::Json GetBackupFiles();
 
   private:
     static bool RemoveBackupDir(const std::filesystem::path &path);
     static bool CreateBackupDir(const std::filesystem::path &path);
+    static bool RemoveSyncDir(const std::filesystem::path &path);
+    static bool CreateSyncDir(const std::filesystem::path &path);
     static bool PackUserFiles(const std::filesystem::path &path);
+    static bool PackSyncFiles(const std::filesystem::path &path);
     static bool UnpackBackupFile(const std::filesystem::path &path);
     static std::string ReadVersionFromJsonFile(const std::filesystem::path &jsonFilePath);
     static bool CheckBackupVersion(const std::filesystem::path &extractedBackup);

--- a/module-services/service-desktop/include/service-desktop/DesktopMessages.hpp
+++ b/module-services/service-desktop/include/service-desktop/DesktopMessages.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -18,6 +18,14 @@ namespace sdesktop
         BackupMessage() : sys::DataMessage(MessageType::Backup)
         {}
         ~BackupMessage() override = default;
+    };
+
+    class SyncMessage : public sys::DataMessage
+    {
+      public:
+        SyncMessage() : sys::DataMessage(MessageType::Sync)
+        {}
+        ~SyncMessage() override = default;
     };
 
     class RestoreMessage : public sys::DataMessage

--- a/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
@@ -55,7 +55,7 @@ class ServiceDesktop : public sys::Service
     ~ServiceDesktop() override;
 
     std::unique_ptr<WorkerDesktop> desktopWorker;
-    BackupRestore::OperationStatus backupRestoreStatus;
+    BackupSyncRestore::OperationStatus backupSyncRestoreStatus;
 
     sys::ReturnCodes InitHandler() override;
     sys::ReturnCodes DeinitHandler() override;
@@ -63,11 +63,13 @@ class ServiceDesktop : public sys::Service
     sys::MessagePointer DataReceivedHandler(sys::DataMessage *msg, sys::ResponseMessage *resp) override;
 
     std::string prepareBackupFilename();
+    std::string prepareSyncFilename();
     void prepareBackupData();
+    void prepareSyncData();
     void prepareRestoreData(const std::filesystem::path &restoreLocation);
-    const BackupRestore::OperationStatus getBackupRestoreStatus()
+    const BackupSyncRestore::OperationStatus getBackupSyncRestoreStatus()
     {
-        return backupRestoreStatus;
+        return backupSyncRestoreStatus;
     }
     const sdesktop::USBSecurityModel *getSecurity()
     {
@@ -120,6 +122,7 @@ class ServiceDesktop : public sys::Service
     [[nodiscard]] auto handle(message::bluetooth::ResponseVisibleDevices *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(sdesktop::developerMode::DeveloperModeRequest *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(sdesktop::BackupMessage *msg) -> std::shared_ptr<sys::Message>;
+    [[nodiscard]] auto handle(sdesktop::SyncMessage *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(sdesktop::RestoreMessage *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(sdesktop::FactoryMessage *msg) -> std::shared_ptr<sys::Message>;
     [[nodiscard]] auto handle(sdesktop::usb::USBConfigured *msg) -> std::shared_ptr<sys::Message>;

--- a/module-vfs/paths/filesystem_paths.cpp
+++ b/module-vfs/paths/filesystem_paths.cpp
@@ -13,6 +13,7 @@ namespace
     constexpr auto PATH_UPDATES      = "updates";
     constexpr auto PATH_TMP          = "tmp";
     constexpr auto PATH_BACKUP       = "backup";
+    constexpr inline auto PATH_SYNC  = "sync";
     constexpr auto PATH_FACTORY      = "factory";
     constexpr auto PATH_LOGS         = "logs";
     constexpr auto PATH_CRASH_DUMPS  = "crash_dumps";
@@ -68,6 +69,11 @@ namespace purefs
         std::filesystem::path getBackupOSPath() noexcept
         {
             return std::filesystem::path{eMMC_disk} / PATH_USER / PATH_BACKUP;
+        }
+
+        std::filesystem::path getSyncPackagePath() noexcept
+        {
+            return getUserDiskPath() / PATH_SYNC;
         }
 
         std::filesystem::path getFactoryOSPath() noexcept

--- a/module-vfs/paths/include/purefs/filesystem_paths.hpp
+++ b/module-vfs/paths/include/purefs/filesystem_paths.hpp
@@ -19,6 +19,7 @@ namespace purefs
         std::filesystem::path getUpdatesOSPath() noexcept;
         std::filesystem::path getTemporaryPath() noexcept;
         std::filesystem::path getBackupOSPath() noexcept;
+        std::filesystem::path getSyncPackagePath() noexcept;
         std::filesystem::path getFactoryOSPath() noexcept;
         std::filesystem::path getLogsPath() noexcept;
         std::filesystem::path getCrashDumpsPath() noexcept;

--- a/products/PurePhone/services/db/ServiceDB.cpp
+++ b/products/PurePhone/services/db/ServiceDB.cpp
@@ -205,6 +205,13 @@ sys::MessagePointer ServiceDB::DataReceivedHandler(sys::DataMessage *msgl, sys::
         responseMsg = std::make_shared<DBServiceResponseMessage>(ret);
     } break;
 
+    case MessageType::DBSyncPackage: {
+        auto time   = utils::time::Scoped("DBSyncPackage");
+        auto msg    = static_cast<DBServiceMessageSyncPackage *>(msgl);
+        auto ret    = StoreIntoSyncPackage({msg->syncPackagePath});
+        responseMsg = std::make_shared<DBServiceResponseMessage>(ret);
+    } break;
+
     default:
         break;
     }
@@ -318,6 +325,21 @@ bool ServiceDB::StoreIntoBackup(const std::filesystem::path &backupPath)
             }
             break;
         }
+    }
+
+    return true;
+}
+
+bool ServiceDB::StoreIntoSyncPackage(const std::filesystem::path &syncPackagePath)
+{
+    if (!contactsDB->storeIntoFile(syncPackagePath / std::filesystem::path(contactsDB->getName()).filename())) {
+        LOG_ERROR("Store contactsDB in sync package failed");
+        return false;
+    }
+
+    if (!smsDB->storeIntoFile(syncPackagePath / std::filesystem::path(smsDB->getName()).filename())) {
+        LOG_ERROR("Store smsDB in sync package failed");
+        return false;
     }
 
     return true;

--- a/products/PurePhone/services/db/include/db/ServiceDB.hpp
+++ b/products/PurePhone/services/db/include/db/ServiceDB.hpp
@@ -43,6 +43,7 @@ class ServiceDB : public ServiceDBCommon
     ~ServiceDB() override;
 
     bool StoreIntoBackup(const std::filesystem::path &backupPath);
+    bool StoreIntoSyncPackage(const std::filesystem::path &syncPackagePath);
 
   private:
     std::unique_ptr<EventsDB> eventsDB;

--- a/products/PurePhone/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
+++ b/products/PurePhone/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
@@ -59,6 +59,7 @@ namespace sdesktop::endpoints
              {json::serialNumber, getSerialNumber()},
              {json::caseColour, getCaseColour()},
              {json::backupLocation, purefs::dir::getBackupOSPath().string()},
+             {json::syncPackageLocation, purefs::dir::getSyncPackagePath().string()},
              {json::deviceToken, getDeviceToken()}}));
 
         return http::Code::OK;

--- a/source/MessageType.hpp
+++ b/source/MessageType.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -17,6 +17,7 @@ enum class MessageType
 
     DBServiceNotification, ///< Common service-db notification message.
     DBServiceBackup,
+    DBSyncPackage,
 
     DBSettingsGet,    ///< get current settings from database
     DBSettingsUpdate, ///< update settings
@@ -116,6 +117,7 @@ enum class MessageType
     // service-desktop  messages
     UpdateOS,
     Backup,
+    Sync,
     Restore,
     Factory,
     DeveloperModeRequest,


### PR DESCRIPTION
<!-- Please describe your pull request here -->
This mechanism is similar to the current backup implementation but is stripped of irrelevant data that is not required by the MC to perform data synchronization.
Documentation: https://appnroll.atlassian.net/wiki/spaces/CP/pages/1727627287/Backup+Endpoint+API+4#Synchronization
**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [x] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
