### PR TITLE
[MOS-666] Fix disappearing setting bars in German

### DIFF
--- a/image/assets/lang/Deutsch.json
+++ b/image/assets/lang/Deutsch.json
@@ -417,6 +417,7 @@
   "app_settings_vibration": "Vibration",
   "app_settings_sound": "Ton",
   "app_settings_volume": "Lautstärke",
+  "app_settings_volume_focused": "Lautst.",
   "app_settings_call_ringtome": "Rufton",
   "app_settings_message_sound": "Nachrichtenton",
   "app_settings_notification_sound": "Benachrichtigungston",

--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -374,6 +374,7 @@
   "app_settings_vibration": "Vibration",
   "app_settings_sound": "Sound",
   "app_settings_volume": "Volume",
+  "app_settings_volume_focused": "Volume",
   "app_settings_call_ringtome": "Call ringtone",
   "app_settings_message_sound": "Message sound",
   "app_settings_notification_sound": "Notification sound",

--- a/image/assets/lang/Espanol.json
+++ b/image/assets/lang/Espanol.json
@@ -417,6 +417,7 @@
   "app_settings_vibration": "Vibración",
   "app_settings_sound": "Sonido",
   "app_settings_volume": "Volumen",
+  "app_settings_volume_focused": "Volumen",
   "app_settings_call_ringtome": "Tono de llamada",
   "app_settings_message_sound": "Sonido de mensajes",
   "app_settings_notification_sound": "Sonido de notificaciones",

--- a/image/assets/lang/Francais.json
+++ b/image/assets/lang/Francais.json
@@ -384,6 +384,7 @@
   "app_settings_vibration": "Vibration",
   "app_settings_sound": "Son",
   "app_settings_volume": "Volume",
+  "app_settings_volume_focused": "Volume",
   "app_settings_apps_alarm_clock_manual_volume": "Volume sonore manuel",
   "app_settings_call_ringtome": "Sonnerie d'appel",
   "app_settings_message_sound": "Son de messages",

--- a/image/assets/lang/Polski.json
+++ b/image/assets/lang/Polski.json
@@ -428,6 +428,7 @@
   "app_settings_vibration": "Wibracje",
   "app_settings_sound": "Dźwięk",
   "app_settings_volume": "Głośność",
+  "app_settings_volume_focused": "Głośność",
   "app_settings_call_ringtome": "Dźwięk dzwonka",
   "app_settings_message_sound": "Dźwięk wiadomości",
   "app_settings_notification_sound": "Dźwięk powiadomienia",

--- a/module-apps/application-settings/widgets/SpinBoxOptionSettings.cpp
+++ b/module-apps/application-settings/widgets/SpinBoxOptionSettings.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SpinBoxOptionSettings.hpp"
@@ -7,22 +7,29 @@
 
 namespace gui
 {
-    SpinBoxOptionSettings::SpinBoxOptionSettings(UTF8 text,
+    SpinBoxOptionSettings::SpinBoxOptionSettings(const UTF8 &text,
+                                                 const UTF8 &textFocused,
                                                  std::uint8_t value,
                                                  std::uint8_t maxValue,
-                                                 std::function<bool(uint8_t)> updateCallback,
+                                                 std::function<bool(std::uint8_t)> updateCallback,
                                                  std::function<void(const UTF8 &text)> navBarTemporaryMode,
                                                  std::function<void()> navBarRestoreFromTemporaryMode,
                                                  bool indent)
         : updateCallback(std::move(updateCallback)), navBarTemporaryMode(std::move(navBarTemporaryMode)),
           navBarRestoreFromTemporaryMode(std::move(navBarRestoreFromTemporaryMode)), maxValue(maxValue), value(value),
-          text(text), indent(indent)
+          text(text), textFocused(textFocused), indent(indent)
     {}
 
     auto SpinBoxOptionSettings::build() const -> ListItem *
     {
-        auto spinBox = new SpinBox(
-            nullptr, text, updateCallback, maxValue, value, navBarTemporaryMode, navBarRestoreFromTemporaryMode);
+        auto spinBox = new SpinBox(nullptr,
+                                   text,
+                                   textFocused,
+                                   updateCallback,
+                                   maxValue,
+                                   value,
+                                   navBarTemporaryMode,
+                                   navBarRestoreFromTemporaryMode);
 
         auto optionItem = new gui::ListItem();
         optionItem->setMinimumSize(style::window::default_body_width, style::window::label::big_h);

--- a/module-apps/application-settings/widgets/SpinBoxOptionSettings.hpp
+++ b/module-apps/application-settings/widgets/SpinBoxOptionSettings.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -10,10 +10,11 @@ namespace gui
     class SpinBoxOptionSettings : public option::Base
     {
       public:
-        SpinBoxOptionSettings(UTF8 text,
-                              uint8_t value,
-                              uint8_t maxValue,
-                              std::function<bool(uint8_t)> updateCallback,
+        SpinBoxOptionSettings(const UTF8 &text,
+                              const UTF8 &textFocused,
+                              std::uint8_t value,
+                              std::uint8_t maxValue,
+                              std::function<bool(std::uint8_t)> updateCallback,
                               std::function<void(const UTF8 &text)> navBarTemporaryMode,
                               std::function<void()> navBarRestoreFromTemporaryMode,
                               bool indent = false);
@@ -27,6 +28,7 @@ namespace gui
         std::uint8_t maxValue;
         std::uint8_t value;
         UTF8 text;
+        UTF8 textFocused;
         bool indent = false;
     };
 } // namespace gui

--- a/module-apps/application-settings/windows/apps/AlarmClockWindow.cpp
+++ b/module-apps/application-settings/windows/apps/AlarmClockWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlarmClockWindow.hpp"
@@ -31,10 +31,12 @@ namespace gui
                                      [&]() { switchManualVolumeState(); });
 
         if (mManualVolumeEnabled) {
+            constexpr auto maxVolumeLevel = 10;
             optionList.emplace_back(std::make_unique<gui::SpinBoxOptionSettings>(
                 utils::translate("app_settings_volume"),
+                utils::translate("app_settings_volume_focused"),
                 mAudioModel->getVolume(),
-                std::ceil(10.0),
+                maxVolumeLevel,
                 [&](uint8_t value) {
                     setVolume(value);
                     return true;

--- a/module-apps/application-settings/windows/apps/PhoneWindow.cpp
+++ b/module-apps/application-settings/windows/apps/PhoneWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhoneWindow.hpp"
@@ -28,10 +28,12 @@ namespace gui
 
 #if DEVELOPER_SETTINGS_OPTIONS == 1
         if (mVibrationsEnabled) {
+            constexpr auto maxVibrationLevel = 10;
             optionList.emplace_back(std::make_unique<gui::SpinBoxOptionSettings>(
                 utils::translate("app_settings_volume"),
+                utils::translate("app_settings_volume_focused"),
                 mAudioModel->getVibrationLevel(),
-                10,
+                maxVibrationLevel,
                 [&](uint8_t value) {
                     mAudioModel->setVibrationLevel(value);
                     return true;

--- a/module-apps/application-settings/windows/display-keypad/DisplayLightWindow.cpp
+++ b/module-apps/application-settings/windows/display-keypad/DisplayLightWindow.cpp
@@ -119,6 +119,7 @@ namespace gui
 
         auto spinner = std::make_unique<gui::SpinBoxOptionSettings>(
             utils::translate("app_settings_display_light_brightness"),
+            utils::translate("app_settings_display_light_brightness"),
             std::ceil(brightnessValue / brightnessStep),
             std::ceil(screen_light_control::ManualModeParameters::MAX_BRIGHTNESS / brightnessStep),
             setBrightness,

--- a/module-apps/apps-common/widgets/SpinBox.cpp
+++ b/module-apps/apps-common/widgets/SpinBox.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SpinBox.hpp"
@@ -14,9 +14,10 @@ namespace gui
 {
     SpinBox::SpinBox(Item *parent,
                      const std::string &title,
+                     const std::string &titleFocused,
                      UpdateCallback updateCallback,
-                     uint8_t maxValue,
-                     uint8_t startValue,
+                     std::uint8_t maxValue,
+                     std::uint8_t startValue,
                      std::function<void(const UTF8 &text)> navBarTemporaryMode,
                      std::function<void()> navBarRestoreFromTemporaryMode)
         : HBox(parent, style::window::default_left_margin), updateBarCallback(std::move(updateCallback)),
@@ -33,25 +34,31 @@ namespace gui
         rightArrow = addArrow(this, "arrow_right_20px_W_M", Alignment::Horizontal::Right, false);
         bar        = addBarGraph(this, maxValue, startValue);
 
-        focusChangedCallback = [this](Item &item) {
-            leftArrow->setVisible(item.focus);
-            rightArrow->setVisible(item.focus);
-            resizeItems();
-
+        focusChangedCallback = [=](Item &item) {
             if (item.focus) {
+                titleLabel->setMinimumWidthToFitText(titleFocused);
+                titleLabel->setText(titleFocused);
+                leftArrow->setVisible(true);
+                rightArrow->setVisible(true);
                 if (this->navBarTemporaryMode) {
                     this->navBarTemporaryMode("");
                 }
             }
             else {
+                leftArrow->setVisible(false);
+                rightArrow->setVisible(false);
+                titleLabel->setMinimumWidthToFitText(title);
+                titleLabel->setText(title);
                 if (this->navBarRestoreFromTemporaryMode) {
                     this->navBarRestoreFromTemporaryMode();
                 }
             }
+
+            resizeItems();
             return true;
         };
 
-        inputCallback = [this](gui::Item &item, const gui::InputEvent &event) {
+        inputCallback = [this]([[maybe_unused]] gui::Item &item, const gui::InputEvent &event) {
             auto ret = false;
             if (!event.isShortRelease()) {
                 return false;
@@ -101,7 +108,7 @@ namespace gui
         return title;
     }
 
-    HBarGraph *SpinBox::addBarGraph(Item *parent, uint8_t maxValue, uint8_t startValue)
+    HBarGraph *SpinBox::addBarGraph(Item *parent, std::uint8_t maxValue, std::uint8_t startValue)
     {
         auto barGraph = new HBarGraph(parent, 0, 0, maxValue);
         barGraph->setMaximumWidth(style::window::default_body_width);

--- a/module-apps/apps-common/widgets/SpinBox.hpp
+++ b/module-apps/apps-common/widgets/SpinBox.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -12,10 +12,11 @@ namespace gui
     class SpinBox : public HBox
     {
       public:
-        using UpdateCallback = std::function<bool(uint8_t)>;
+        using UpdateCallback = std::function<bool(std::uint8_t)>;
 
         SpinBox(Item *parent,
                 const std::string &title,
+                const std::string &titleFocused,
                 UpdateCallback updateCallback,
                 std::uint8_t maxValue,
                 std::uint8_t startValue,
@@ -25,13 +26,13 @@ namespace gui
       private:
         auto addArrow(Item *parent, const std::string &arrowName, Alignment::Horizontal aligment, bool visible)
             -> Image *;
-        auto addBarGraph(Item *parent, uint8_t maxValue, uint8_t startValue) -> HBarGraph *;
+        auto addBarGraph(Item *parent, std::uint8_t maxValue, std::uint8_t startValue) -> HBarGraph *;
         auto addTitle(Item *parent, const std::string &text) -> Text *;
 
-        HBarGraph *bar;
-        Text *titleLabel;
-        Image *leftArrow;
-        Image *rightArrow;
+        HBarGraph *bar    = nullptr;
+        Text *titleLabel  = nullptr;
+        Image *leftArrow  = nullptr;
+        Image *rightArrow = nullptr;
         UpdateCallback updateBarCallback;
         std::function<void(const UTF8 &text)> navBarTemporaryMode = nullptr;
         std::function<void()> navBarRestoreFromTemporaryMode      = nullptr;

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -8,6 +8,7 @@
 * Separated system volume from Bluetooth device volume for A2DP
 
 ### Fixed
+* Fixed disappearing manual alarm and vibration volume setting in German
 * Fixed the accessibility of user files by MTP
 * Fixed SIM card pop-ups not showing
 * Fixed lost bytes in logs


### PR DESCRIPTION
Fix of the issue that with German language
selected manual volume setting bar and
vibration volume setting bar would
disappear when focused.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
