### PR TITLE
[MOS-395] Fix issue with inability to send SMS

### DIFF
--- a/module-services/service-cellular/src/ServiceCellularPriv.cpp
+++ b/module-services/service-cellular/src/ServiceCellularPriv.cpp
@@ -294,6 +294,8 @@ namespace cellular::internal
             if (!checkSmsCenter(*channel)) {
                 LOG_ERROR("SMS center check failed");
             }
+            // Perform soft reset because sometimes the modem is not able to send next messages
+            modemResetHandler->performSoftReset();
         }
 
         DBServiceAPI::GetQuery(

--- a/module-utils/phonenumber/PhoneNumber.cpp
+++ b/module-utils/phonenumber/PhoneNumber.cpp
@@ -30,7 +30,9 @@ PhoneNumber::PhoneNumber(const std::string &phoneNumber, country::Id defaultCoun
     : countryCode(defaultCountryCode)
 {
     auto &util = *phn_util::GetInstance();
-    util.ParseAndKeepRawInput(phoneNumber, country::getAlpha2Code(countryCode), &pbNumber);
+    auto number = phoneNumber;
+    number.erase(std::remove_if(number.begin(), number.end(), PhoneNumber::CharacterToRemove), number.end());
+    util.ParseAndKeepRawInput(number, country::getAlpha2Code(countryCode), &pbNumber);
 
     // determine real country code from number
     std::string regionCode;
@@ -38,7 +40,7 @@ PhoneNumber::PhoneNumber(const std::string &phoneNumber, country::Id defaultCoun
     countryCode = country::getIdByAlpha2Code(regionCode);
 
     // create view representation
-    viewSelf = makeView(phoneNumber);
+    viewSelf = makeView(number);
 }
 
 PhoneNumber::PhoneNumber(const View &numberView)
@@ -82,6 +84,9 @@ PhoneNumber::PhoneNumber(const std::string &phoneNumber, const std::string &e164
     auto &util = *phn_util::GetInstance();
     std::string regionCode;
 
+    auto number = phoneNumber;
+    number.erase(std::remove_if(number.begin(), number.end(), PhoneNumber::CharacterToRemove), number.end());
+
     // non empty E164 format: match numbers, throw on error
     if (e164number.size() > 0) {
         // parse E164 number
@@ -102,18 +107,18 @@ PhoneNumber::PhoneNumber(const std::string &phoneNumber, const std::string &e164
 
         // use region code to parse number originally entered by the user
         // keep raw input in order to be able to use original format in formatting
-        if (util.ParseAndKeepRawInput(phoneNumber, regionCode, &pbNumber) != errCode::NO_PARSING_ERROR) {
-            throw PhoneNumber::Error(phoneNumber, "Can't parse phone number");
+        if (util.ParseAndKeepRawInput(number, regionCode, &pbNumber) != errCode::NO_PARSING_ERROR) {
+            throw PhoneNumber::Error(number, "Can't parse phone number");
         }
 
         // check if numbers match
         if (util.IsNumberMatch(pbNumberE164, pbNumber) != phn_util::EXACT_MATCH) {
-            throw PhoneNumber::Error(phoneNumber, "Can't match number with E164 format");
+            throw PhoneNumber::Error(number, "Can't match number with E164 format");
         }
     }
     // empty E164: use entered number
     else {
-        util.ParseAndKeepRawInput(phoneNumber, country::getAlpha2Code(countryCode), &pbNumber);
+        util.ParseAndKeepRawInput(number, country::getAlpha2Code(countryCode), &pbNumber);
 
         // determine real country code from number
         util.GetRegionCodeForNumber(pbNumber, &regionCode);
@@ -121,7 +126,7 @@ PhoneNumber::PhoneNumber(const std::string &phoneNumber, const std::string &e164
     }
 
     // create view representation
-    viewSelf = makeView(phoneNumber);
+    viewSelf = makeView(number);
 }
 
 bool PhoneNumber::isValid() const
@@ -142,6 +147,20 @@ std::string PhoneNumber::getFormatted() const
 std::string PhoneNumber::toE164() const
 {
     return viewSelf.getE164();
+}
+
+bool PhoneNumber::CharacterToRemove(char c)
+{
+    // According to Quectel_EC25&EC21_AT_Commands_Manual_V1.3.pdf p.91
+    switch (c) {
+    case '(':
+    case ')':
+    case '-':
+    case ' ':
+        return true;
+    default:
+        return false;
+    }
 }
 
 PhoneNumber::Match PhoneNumber::match(const PhoneNumber &other) const

--- a/module-utils/phonenumber/PhoneNumber.hpp
+++ b/module-utils/phonenumber/PhoneNumber.hpp
@@ -339,6 +339,14 @@ namespace utils
                                country::Id defaultCountryCode = country::defaultCountry);
 
         /**
+         * @brief Check whether character must be removed
+         *
+         * @param c - a character to check
+         * @return true is character is on the list
+         */
+        static bool CharacterToRemove(char c);
+
+        /**
          * @brief Create instance of View directly from the E164 format.
          *
          * @param inputNumber - a string represenation of a number to create View from

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -9,6 +9,7 @@
 * Implemented partial refresh of the display
 
 ### Fixed
+* Fixed issue with inability to send SMS
 * Fixed mixed SMS messages
 * Fixed disappearing manual alarm and vibration volume setting in German
 * Fixed SIM card pop-ups not showing


### PR DESCRIPTION
Get rid of unnecessary separators which can be
problematic for cellular modem. Add modem soft
reset if send SMS message will fail.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
