### PR TITLE
[MOS-738] Fix receiving an empty SMS message

### DIFF
--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -8,6 +8,7 @@
 * Separated system volume from Bluetooth device volume for A2DP
 
 ### Fixed
+* Fixed receiving an empty SMS message
 * Fixed issue with inability to send SMS
 * Fixed mixed SMS messages
 * Fixed disappearing manual alarm and vibration volume setting in German


### PR DESCRIPTION
Checking how many parts the modem sent
and then catching an exception in case of an error.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
