### PR TITLE
[MOS-743] Workaround for audio config paths

### DIFF
--- a/image/user/data/equalizer/loudspeaker_routing.json
+++ b/image/user/data/equalizer/loudspeaker_routing.json
@@ -7,42 +7,42 @@
   "inputPath": 1,
   "outputPath": 2,
   "playbackPathGain": 0,
-  "playbackPathAtten": 5,
+  "playbackPathAtten": 2,
   "filterParams": [
     {
-      "filterType": "None",
-      "frequency": 100.2,
+      "filterType": "HighPass",
+      "frequency": 501.8,
       "samplerate": 16000,
       "Q": 0.701,
       "gain": 0
     },
     {
-      "filterType": "None",
-      "frequency": 17996.2,
+      "filterType": "Parametric",
+      "frequency": 2800,
       "samplerate": 16000,
-      "Q": 0.701,
-      "gain": 0
-    },
-    {
-      "filterType": "None",
-      "frequency": 13984.7,
-      "samplerate": 16000,
-      "Q": 0.701,
-      "gain": -10
-    },
-    {
-      "filterType": "None",
-      "frequency": 200.4,
-      "samplerate": 16000,
-      "Q": 0.701,
-      "gain": -10
-    },
-    {
-      "filterType": "None",
-      "frequency": 1496.7,
-      "samplerate": 16000,
-      "Q": 0.701,
+      "Q": 3,
       "gain": -4
+    },
+    {
+      "filterType": "Parametric",
+      "frequency": 4500,
+      "samplerate": 16000,
+      "Q": 3,
+      "gain": -6
+    },
+    {
+      "filterType": "Parametric",
+      "frequency": 7100,
+      "samplerate": 16000,
+      "Q": 3,
+      "gain": -3
+    },
+    {
+      "filterType": "Parametric",
+      "frequency": 2000.0,
+      "samplerate": 16000,
+      "Q": 2,
+      "gain": 6
     }
   ]
 }

--- a/module-audio/Audio/Profiles/ProfilePlaybackHeadphones.hpp
+++ b/module-audio/Audio/Profiles/ProfilePlaybackHeadphones.hpp
@@ -14,7 +14,7 @@ namespace audio
             : Profile(
                   "Playback Headphones",
                   Type::PlaybackHeadphones,
-                  purefs::dir::getUserDiskPath() / "data/equalizer/headphones_playback.json",
+                  purefs::dir::getCurrentOSPath() / "user/data/equalizer/headphones_playback.json",
                   audio::codec::Configuration{
                       .sampleRate_Hz = 0,
                       .bitWidth      = 16,

--- a/module-audio/Audio/Profiles/ProfilePlaybackLoudspeaker.hpp
+++ b/module-audio/Audio/Profiles/ProfilePlaybackLoudspeaker.hpp
@@ -15,7 +15,7 @@ namespace audio
             : Profile(
                   "Playback Loudspeaker",
                   Type::PlaybackLoudspeaker,
-                  purefs::dir::getUserDiskPath() / "data/equalizer/loudspeaker_playback.json",
+                  purefs::dir::getCurrentOSPath() / "user/data/equalizer/loudspeaker_playback.json",
                   audio::codec::Configuration{
                       .sampleRate_Hz     = 0,
                       .bitWidth          = 16,

--- a/module-audio/Audio/Profiles/ProfileRoutingEarspeaker.hpp
+++ b/module-audio/Audio/Profiles/ProfileRoutingEarspeaker.hpp
@@ -14,7 +14,7 @@ namespace audio
             : Profile(
                   "Routing Earspeaker",
                   Type::RoutingEarspeaker,
-                  purefs::dir::getUserDiskPath() / "data/equalizer/earspeaker_routing.json",
+                  purefs::dir::getCurrentOSPath() / "user/data/equalizer/earspeaker_routing.json",
                   audio::codec::Configuration{
                       .sampleRate_Hz = 16000,
                       .bitWidth      = 16,

--- a/module-audio/Audio/Profiles/ProfileRoutingHeadphones.hpp
+++ b/module-audio/Audio/Profiles/ProfileRoutingHeadphones.hpp
@@ -14,7 +14,7 @@ namespace audio
             : Profile(
                   "Routing Headset",
                   Type::RoutingHeadphones,
-                  purefs::dir::getUserDiskPath() / "data/equalizer/headphones_routing.json",
+                  purefs::dir::getCurrentOSPath() / "user/data/equalizer/headphones_routing.json",
                   audio::codec::Configuration{
                       .sampleRate_Hz = 16000,
                       .bitWidth      = 16,

--- a/module-audio/Audio/Profiles/ProfileRoutingLoudspeaker.hpp
+++ b/module-audio/Audio/Profiles/ProfileRoutingLoudspeaker.hpp
@@ -13,31 +13,33 @@ namespace audio
 
       public:
         ProfileRoutingLoudspeaker(Volume volume, Gain gain)
-            : Profile(
-                  "Routing Speakerphone",
-                  Type::RoutingLoudspeaker,
-                  purefs::dir::getUserDiskPath() / "data/equalizer/loudspeaker_routing.json",
-                  audio::codec::Configuration{
-                      .sampleRate_Hz = sampleRate,
-                      .bitWidth      = 16,
-                      .flags =
-                          static_cast<uint32_t>(audio::codec::Flags::InputLeft) | // microphone use left audio channel
-                          static_cast<uint32_t>(audio::codec::Flags::OutputMono),
-                      .outputVolume      = 1,
-                      .inputGain         = 0,
-                      .playbackPathGain  = 0,
-                      .playbackPathAtten = 5,
-                      .inputPath         = audio::codec::InputPath::Microphone,
-                      .outputPath        = audio::codec::OutputPath::Loudspeaker,
-                      .filterCoefficients =
-                          {qfilter_CalculateCoeffs(audio::equalizer::FilterType::None, 307.3f, sampleRate, 0.701f, 0),
-                           qfilter_CalculateCoeffs(audio::equalizer::FilterType::None, 5080.1f, sampleRate, 0.847f, 0),
-                           qfilter_CalculateCoeffs(
-                               audio::equalizer::FilterType::None, 15975.7f, sampleRate, 0.701f, -10),
-                           qfilter_CalculateCoeffs(audio::equalizer::FilterType::None, 200.4f, sampleRate, 0.701f, -10),
-                           qfilter_CalculateCoeffs(
-                               audio::equalizer::FilterType::None, 1496.7f, sampleRate, 0.701f, -4)}},
-                  AudioDevice::Type::Audiocodec)
+            : Profile("Routing Speakerphone",
+                      Type::RoutingLoudspeaker,
+                      purefs::dir::getCurrentOSPath() / "user/data/equalizer/loudspeaker_routing.json",
+                      audio::codec::Configuration{
+                          .sampleRate_Hz = sampleRate,
+                          .bitWidth      = 16,
+                          .flags         = static_cast<uint32_t>(
+                                       audio::codec::Flags::InputLeft) | // microphone use left audio channel
+                                   static_cast<uint32_t>(audio::codec::Flags::OutputMono),
+                          .outputVolume      = 1,
+                          .inputGain         = 0,
+                          .playbackPathGain  = 0,
+                          .playbackPathAtten = 2,
+                          .inputPath         = audio::codec::InputPath::Microphone,
+                          .outputPath        = audio::codec::OutputPath::Loudspeaker,
+                          .filterCoefficients =
+                              {qfilter_CalculateCoeffs(
+                                   audio::equalizer::FilterType::HighPass, 501.8f, sampleRate, 0.701f, 0),
+                               qfilter_CalculateCoeffs(
+                                   audio::equalizer::FilterType::Parametric, 2800.f, sampleRate, 3.f, -4),
+                               qfilter_CalculateCoeffs(
+                                   audio::equalizer::FilterType::Parametric, 4500.f, sampleRate, 3.f, -6),
+                               qfilter_CalculateCoeffs(
+                                   audio::equalizer::FilterType::Parametric, 7100.f, sampleRate, 3.f, -3),
+                               qfilter_CalculateCoeffs(
+                                   audio::equalizer::FilterType::Parametric, 2000.f, sampleRate, 2.f, 6)}},
+                      AudioDevice::Type::Audiocodec)
         {
             audioConfiguration.sampleRate_Hz = sampleRate;
             audioConfiguration.outputVolume  = static_cast<float>(volume);


### PR DESCRIPTION
Workaround for the issue that updater
places audio config JSON files in
wrong location. This should be
removed after the updater is fixed.
Additionally update of loudspeaker
routing config.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
