### PR TITLE
[MOS-640] Change windows flow in SIM settings

### DIFF
--- a/module-apps/application-settings/include/application-settings/ApplicationSettings.hpp
+++ b/module-apps/application-settings/include/application-settings/ApplicationSettings.hpp
@@ -144,6 +144,8 @@ namespace app
 
         void createUserInterface() override;
         void destroyUserInterface() override;
+        void returnToPreviousWindow() override;
+
         void setSim(Store::GSM::SIM sim) override;
         void updateSim() override;
         Store::GSM::SIM getSim() override;

--- a/module-apps/apps-common/ApplicationCommon.cpp
+++ b/module-apps/apps-common/ApplicationCommon.cpp
@@ -921,7 +921,7 @@ namespace app
             return;
         }
         if (windowsStack().pop(newWindow)) {
-            LOG_INFO("Get back to window!");
+            LOG_INFO("Requested window %s is previous one - get back to it", newWindow.c_str());
             return;
         }
         LOG_INFO("Create window for stack: %s", newWindow.c_str());
@@ -953,6 +953,16 @@ namespace app
             return window == windowName;
         }
         LOG_ERROR("no window: %s", windowName.c_str());
+        return false;
+    }
+
+    bool ApplicationCommon::isPreviousWindow(const std::string &windowName) const noexcept
+    {
+        if (const auto &previousWindowName = getPreviousWindow(); previousWindowName != std::nullopt) {
+            return previousWindowName == windowName;
+        }
+
+        LOG_WARN("no previous window");
         return false;
     }
 

--- a/module-apps/apps-common/ApplicationCommon.hpp
+++ b/module-apps/apps-common/ApplicationCommon.hpp
@@ -266,9 +266,7 @@ namespace app
             switchWindow(windowName, gui::ShowMode::GUI_SHOW_INIT, std::move(data));
         };
 
-        /// Method used to go back to desired window by using the index difference on stack value
-        /// @param ignoredWindowsNumber: defines how many windows will be skipped while going back on stack
-        [[deprecated]] void returnToPreviousWindow();
+        [[deprecated]] virtual void returnToPreviousWindow();
 
         /// Find and pop window from stack by window name
         void popWindow(const std::string &window);
@@ -387,6 +385,7 @@ namespace app
         gui::AppWindow *getCurrentWindow();
         /// @ingrup AppWindowStack
         bool isCurrentWindow(const std::string &windowName) const noexcept;
+        bool isPreviousWindow(const std::string &windowName) const noexcept;
 
         /// @ingrup AppWindowStack
         gui::AppWindow *getWindow(const std::string &name);

--- a/module-apps/apps-common/popups/lock-popups/SimInfoWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/SimInfoWindow.cpp
@@ -6,6 +6,8 @@
 #include <locks/data/LockData.hpp>
 #include <i18n/i18n.hpp>
 
+#include <application-settings/ApplicationSettings.hpp>
+
 using namespace gui;
 
 SimInfoWindow::SimInfoWindow(app::ApplicationCommon *app, const std::string &name) : WindowWithTimer(app, name)
@@ -31,8 +33,8 @@ void SimInfoWindow::onBeforeShow(ShowMode mode, SwitchData *data)
     WindowWithTimer::onBeforeShow(mode, data);
 
     if (auto infoData = dynamic_cast<locks::SimLockData *>(data)) {
-
-        switch (infoData->getSimInputTypeAction()) {
+        action_ = infoData->getSimInputTypeAction();
+        switch (action_.value()) {
         case locks::SimInputTypeAction::UnlockWithPuk:
         case locks::SimInputTypeAction::ChangePin:
             setTitle(utils::translate("sim_change_pin"));

--- a/module-apps/apps-common/popups/lock-popups/SimInfoWindow.hpp
+++ b/module-apps/apps-common/popups/lock-popups/SimInfoWindow.hpp
@@ -6,6 +6,7 @@
 #include <popups/WindowWithTimer.hpp>
 #include <Text.hpp>
 #include <gui/widgets/Icon.hpp>
+#include <locks/data/LockData.hpp>
 
 namespace gui
 {
@@ -19,5 +20,13 @@ namespace gui
         void buildInterface() override;
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
         status_bar::Configuration configureStatusBar(status_bar::Configuration appConfiguration) override;
+
+        locks::SimInputTypeAction getAction() const
+        {
+            return action_.value();
+        }
+
+      private:
+        std::optional<locks::SimInputTypeAction> action_;
     };
 } /* namespace gui */

--- a/module-apps/apps-common/popups/lock-popups/SimLockInputWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/SimLockInputWindow.cpp
@@ -7,6 +7,8 @@
 #include <locks/widgets/SimLockBox.hpp>
 #include <locks/widgets/LockHash.hpp>
 
+#include <application-settings/ApplicationSettings.hpp>
+
 #include <service-appmgr/Controller.hpp>
 #include <popups/data/PopupRequestParams.hpp>
 
@@ -88,7 +90,13 @@ namespace gui
                 lock->consumeState();
             }
             application->getSimLockSubject().resetSimLockState();
-            application->returnToPreviousWindow();
+            if (auto *settingsApp = dynamic_cast<app::ApplicationSettings *>(application);
+                settingsApp && settingsApp->isPreviousWindow(gui::window::name::sim_pin_settings)) {
+                settingsApp->switchWindow(gui::window::name::sim_cards);
+            }
+            else {
+                application->returnToPreviousWindow();
+            }
             return true;
         }
         else if (inputEvent.is(KeyCode::KEY_PND)) {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -6,6 +6,7 @@
 * Added Polish translation to a calendar title
 * Changed USB logging
 * Separated system volume from Bluetooth device volume for A2DP
+* Made windows flow in SIM cards settings more robust
 
 ### Fixed
 * Fixed receiving an empty SMS message


### PR DESCRIPTION
Made SIM cards settings windows switching more robust. Is as a prerequisite for MOS-641.

- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added
