### PR TITLE
[MOS-753] SIM reinsertion case in SIM Settings

### DIFF
--- a/module-apps/application-settings/ApplicationSettings.cpp
+++ b/module-apps/application-settings/ApplicationSettings.cpp
@@ -589,7 +589,8 @@ namespace app
 
         // despite "import_contacts" has auto-lock prevented, it's included here in previousWindowBackingToSimCards for
         // simplicity
-        if (currentWindowName == phone_lock_window && previousWindowBackingToSimCards) {
+        if ((currentWindowName == phone_lock_window || currentWindowName == sim_unlock_window) &&
+            previousWindowBackingToSimCards) {
             switchWindow(sim_cards);
             return;
         }


### PR DESCRIPTION
Handling the case when the user during PIN changing or turning the PIN on/off puts the SIM tray out and shortly after back in. In such a case, the Settings application now goes to the 'SIM cards' window
instead of 'PIN settings'.

- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added (I think it's not needed as it's a patch for MOS-640 which added an appropriate entry)
