### PR TITLE
[BH-1482] Fixed missing relaxation entries

### DIFF
--- a/products/BellHybrid/alarms/src/AlarmSoundPaths.cpp
+++ b/products/BellHybrid/alarms/src/AlarmSoundPaths.cpp
@@ -34,7 +34,7 @@ namespace alarms::paths
 
     std::filesystem::path getBackgroundSoundsDir() noexcept
     {
-        return purefs::dir::getCurrentOSPath() / "assets/audio/bg_sounds";
+        return purefs::dir::getCurrentOSPath() / "assets/audio/bell/bg_sounds";
     }
 
     std::filesystem::path getMeditationSoundsDir() noexcept


### PR DESCRIPTION
This PR adds a cherry-picked commit. The original description:

Fixed missing relaxation entries by temporarily
replacing background sounds asset path.
1.6.0 update doesn't replace the old audio assets with the new ones. As a result we have temporarily two identical copies placed under different paths. This issue should be fixed with the proper migration mechanism that we currently lack.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
