### PR TITLE
[MOS-758] Fixed locked password wallpaper behavior

### DIFF
--- a/module-apps/apps-common/popups/presenter/WallpaperPresenter.cpp
+++ b/module-apps/apps-common/popups/presenter/WallpaperPresenter.cpp
@@ -66,17 +66,13 @@ namespace gui
 
     bool WallpaperPresenter::updateWallpaper()
     {
-        switch (selectedOption) {
-        case WallpaperOption::Clock:
+        if (selectedOption == WallpaperOption::Clock || clockWallpaperForced) {
             if (clockWallpaper) {
                 clockWallpaper->updateTime();
             }
             return true;
-            break;
-        default:
-            return false;
-            break;
         }
+        return false;
     }
 
     void WallpaperPresenter::forceClockWallpaper()

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -8,6 +8,7 @@
 * Separated system volume from Bluetooth device volume for A2DP
 
 ### Fixed
+* Fixed wrong time displayed on password locked screen with 'Quotes' or 'Logo' wallpaper
 * Fixed issue with inability to send SMS
 * Fixed mixed SMS messages
 * Fixed disappearing manual alarm and vibration volume setting in German


### PR DESCRIPTION
Fix of the issue that when quotes or logo
wallpapers were selected, clock displayed
after entering wrong password thrice
always showed 0:00.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
