### PR TITLE
[BH-1557] Change Harmony home screen font to bigger one

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -11,6 +11,9 @@
 * Fixed back button behavior in Relaxation
 
 ### Added
+#### Home Screen:
+* Font size increased
+
 #### PowerNap:
 * New circular progress bar 
 * Ringing bell image at the end of the Power Nap

--- a/module-apps/apps-common/widgets/BellBaseLayout.cpp
+++ b/module-apps/apps-common/widgets/BellBaseLayout.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BellBaseLayout.hpp"
@@ -84,7 +84,7 @@ namespace gui
         centerThreeBox->firstBox->setEdges(RectangleEdge::None);
         centerThreeBox->firstBox->activeItem = false;
 
-        leftArrow = new ImageBox(centerThreeBox->firstBox, 0, 0, 0, 0, new Image("bell_arrow_left_W_M"));
+        leftArrow = new ImageBox(centerThreeBox->firstBox, new Image("bell_arrow_left_W_M"));
         leftArrow->setAlignment(Alignment(Alignment::Horizontal::Right, Alignment::Vertical::Center));
         leftArrow->setMinimumSizeToFitImage();
         leftArrow->setVisible(true);
@@ -102,9 +102,8 @@ namespace gui
         centerThreeBox->lastBox->setEdges(RectangleEdge::None);
         centerThreeBox->lastBox->activeItem = false;
 
-        rightArrow = new ImageBox(centerThreeBox->lastBox, 0, 0, 0, 0, new Image("bell_arrow_right_W_M"));
+        rightArrow = new ImageBox(centerThreeBox->lastBox, new Image("bell_arrow_right_W_M"));
         rightArrow->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Center));
-        rightArrow->setMargins(Margins(0, 0, 0, 0));
         rightArrow->setMinimumSizeToFitImage();
         rightArrow->setVisible(true);
         rightArrow->setEdges(RectangleEdge::None);
@@ -123,7 +122,13 @@ namespace gui
     {
         setArrowVisible(BellBaseLayout::Arrow::Left, !minCondition);
         setArrowVisible(BellBaseLayout::Arrow::Right, !maxCondition);
-        centerThreeBox->firstBox->resizeItems();
-        centerThreeBox->lastBox->resizeItems();
+        if (centerThreeBox != nullptr) {
+            if (centerThreeBox->firstBox != nullptr) {
+                centerThreeBox->firstBox->resizeItems();
+            }
+            if (centerThreeBox->lastBox != nullptr) {
+                centerThreeBox->lastBox->resizeItems();
+            }
+        }
     }
 } // namespace gui

--- a/module-apps/apps-common/widgets/BellBaseLayout.hpp
+++ b/module-apps/apps-common/widgets/BellBaseLayout.hpp
@@ -12,8 +12,8 @@ namespace style::bell_base_layout
     constexpr inline auto h                   = style::window_height;
     constexpr inline auto first_layout_min_h  = 30U;
     constexpr inline auto outer_layouts_w     = 390U;
-    constexpr inline auto outer_layouts_h     = 102U;
-    constexpr inline auto outer_layout_margin = 39U;
+    constexpr inline auto outer_layouts_h     = 100U;
+    constexpr inline auto outer_layout_margin = 40U;
     constexpr inline auto center_layout_w     = 504U;
     constexpr inline auto center_layout_h     = h - 2 * outer_layout_margin - 2 * outer_layouts_h;
 

--- a/module-apps/apps-common/widgets/TimeSetFmtSpinner.hpp
+++ b/module-apps/apps-common/widgets/TimeSetFmtSpinner.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -75,7 +75,8 @@ namespace gui
             {style::window::font::verybiglight, {style::time_set_fmt_spinner::small_margin, 0, 0, 0}},
             {style::window::font::largelight, {style::time_set_fmt_spinner::small_margin, 0, 0, 0}},
             {style::window::font::supersizemelight, {style::time_set_fmt_spinner::big_margin, 0, 0, 0}},
-            {style::window::font::huge, {style::time_set_fmt_spinner::big_margin, 0, 0, 0}}};
+            {style::window::font::huge, {style::time_set_fmt_spinner::big_margin, 0, 0, 0}},
+            {style::window::font::gargantuan, {style::time_set_fmt_spinner::big_margin, 0, 0, 0}}};
         [[nodiscard]] auto getFmtMargins(const std::string &fmtFont) const noexcept -> Margins;
 
         auto onInput(const InputEvent &inputEvent) -> bool override;

--- a/module-apps/apps-common/widgets/TimeSetSpinner.hpp
+++ b/module-apps/apps-common/widgets/TimeSetSpinner.hpp
@@ -18,6 +18,8 @@ namespace style::time_set_spinner
 
     inline constexpr auto small_margin = 6U;
     inline constexpr auto big_margin   = 6U;
+    inline constexpr auto gargantuan_margin_left  = 14U;
+    inline constexpr auto gargantuan_margin_right = 7U;
 } // namespace style::time_set_spinner
 
 namespace gui
@@ -48,7 +50,8 @@ namespace gui
             {style::window::font::largelight, "alarm_colon_W_M"},
             {style::window::font::supersizeme, "alarm_colon_select_W_M"},
             {style::window::font::supersizemelight, "alarm_colon_select_W_M"},
-            {style::window::font::huge, "alarm_colon_clock_W_M"}};
+            {style::window::font::huge, "alarm_colon_clock_W_M"},
+            {style::window::font::gargantuan, "alarm_colon_clock_W_M"}};
 
         std::map<std::string, Margins> colonMarginsMap = {
             {style::window::font::verybiglight,
@@ -60,7 +63,12 @@ namespace gui
             {style::window::font::supersizemelight,
              {style::time_set_spinner::big_margin, 0, style::time_set_spinner::big_margin, 0}},
             {style::window::font::huge,
-             {style::time_set_spinner::big_margin, 0, style::time_set_spinner::big_margin, 0}}};
+             {style::time_set_spinner::big_margin, 0, style::time_set_spinner::big_margin, 0}},
+            {style::window::font::gargantuan,
+             {style::time_set_spinner::gargantuan_margin_left,
+              0,
+              style::time_set_spinner::gargantuan_margin_right,
+              0}}};
 
         U8IntegerSpinner *hour        = nullptr;
         ImageBox *colon              = nullptr;

--- a/module-gui/gui/core/FontInfo.cpp
+++ b/module-gui/gui/core/FontInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "FontInfo.hpp"
@@ -29,11 +29,11 @@ namespace gui
         memcpy(&smooth, data + offset, sizeof(uint16_t));
         offset += sizeof(uint16_t);
         // TODO additional space between characters????
-        memcpy(&char_spacing, data + offset, sizeof(uint16_t));
-        offset += sizeof(uint16_t);
+        memcpy(&char_spacing, data + offset, sizeof(int16_t));
+        offset += sizeof(int16_t);
         // TODO additional space between lines
-        memcpy(&line_spacing, data + offset, sizeof(uint16_t));
-        offset += sizeof(uint16_t);
+        memcpy(&line_spacing, data + offset, sizeof(int16_t));
+        offset += sizeof(int16_t);
         // distance in pixels between each line of text
         memcpy(&line_height, data + offset, sizeof(uint16_t));
         offset += sizeof(uint16_t);

--- a/module-gui/gui/core/FontInfo.hpp
+++ b/module-gui/gui/core/FontInfo.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -24,9 +24,9 @@ namespace gui
         // flag that informs if smoothing was turned on. 1 - smoothing was turned on.
         uint16_t smooth;
         // TODO additional space between characters????
-        uint16_t char_spacing;
+        int16_t char_spacing;
         // TODO additional space between lines
-        uint16_t line_spacing;
+        int16_t line_spacing;
         // distance in pixels between each line of text
         uint16_t line_height;
         // number of pixels from the absolute top of the line to the base of the characters

--- a/module-gui/gui/widgets/Style.hpp
+++ b/module-gui/gui/widgets/Style.hpp
@@ -58,6 +58,7 @@ namespace style
         inline constexpr auto default_rect_yaps            = 10U;
         namespace font
         {
+            inline constexpr auto gargantuan       = "gargantuan";
             inline constexpr auto colossal         = "colossal";
             inline constexpr auto huge             = "huge";
             inline constexpr auto supersizeme      = "supersizeme";

--- a/products/BellHybrid/CMakeLists.txt
+++ b/products/BellHybrid/CMakeLists.txt
@@ -115,14 +115,14 @@ download_asset_release_json(json-common-target
                             ${CMAKE_CURRENT_SOURCE_DIR}/assets/assets_common.json
                             ${CMAKE_BINARY_DIR}/sysroot/sys/current/
                             MuditaOSPublicAssets
-                            0.0.11
+                            0.0.12
                             ${MUDITA_CACHE_DIR}
     )
 download_asset_release_json(json-community-target
                             ${CMAKE_CURRENT_SOURCE_DIR}/assets/assets_community.json
                             ${CMAKE_BINARY_DIR}/sysroot/sys/current/
                             MuditaOSPublicAssets
-                            0.0.11
+                            0.0.12
                             ${MUDITA_CACHE_DIR}
     )
 download_asset_json(json-rt1051-target

--- a/products/BellHybrid/apps/common/include/common/data/BellMainStyle.hpp
+++ b/products/BellHybrid/apps/common/include/common/data/BellMainStyle.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -11,7 +11,7 @@ namespace bellMainStyle
     {
         namespace time
         {
-            inline constexpr auto font = style::window::font::huge;
+            inline constexpr auto font = style::window::font::gargantuan;
         } // namespace time
 
         namespace alarmSetSpinner

--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
@@ -52,10 +52,9 @@ namespace gui
 
         time = new TimeSetFmtSpinner(this->centerBox);
         time->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::h);
-        time->setFont(bellMainStyle::mainWindow::time::font);
+        time->setFont(mainWindow::time::font);
         time->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
         time->setEditMode(EditMode::Browse);
-        time->setFont(mainWindow::time::font);
         time->activeItem = false;
 
         statusBox = new DuoHBox(this->lastBox, 0, 0, 0, 0);

--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassicWithAmPm.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassicWithAmPm.cpp
@@ -23,7 +23,7 @@ namespace gui
 
         fmt = new TextFixedSize(nullptr, 0, 0, 0, 0);
         fmt->setMaximumSize(style::homescreen_classic::bottom_box_w, style::homescreen_classic::bottom_box_h);
-        fmt->setFont(mainWindow::bottomDescription::font_small);
+        fmt->setFont(mainWindow::bottomDescription::font_normal);
         fmt->setEdges(RectangleEdge::None);
         fmt->activeItem = false;
         fmt->drawUnderline(false);

--- a/products/BellHybrid/assets/assets_proprietary.json
+++ b/products/BellHybrid/assets/assets_proprietary.json
@@ -35,6 +35,11 @@
             "output": "assets/fonts/gt_pressura/gt_pressura_light_200.mpf"
         },
         {
+            "name": "./fonts/bell/gt_pressura_regular_220_altered.mpf",
+            "ref": "5df11a03b9b9b5b9ff4cb99d09091670f5a6361d",
+            "output": "assets/fonts/gt_pressura/gt_pressura_regular_220_altered.mpf"
+        },
+        {
             "name": "./fonts/common/gt_pressura_light_30.mpf",
             "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
             "output": "assets/fonts/gt_pressura/gt_pressura_light_30.mpf"


### PR DESCRIPTION
Changes:
- Increase home screen font size to 220 regular (with altered char spacing, line spacing and baseline).
- Decrease the size of colon.
- Increase the size of AM/PM to normal on the home screen with AM/PM.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [X] Has changelog entry added

<!-- Thanks for your work ♥ -->
