### PR TITLE
BH-1581 Prevent meditation settings reset with deep press

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+* Fixed resetting meditation settings with deep press.
+
 ### Added
 #### PowerNap:
 * New circular progress bar 

--- a/products/BellHybrid/apps/application-bell-meditation-timer/presenter/SettingsPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/presenter/SettingsPresenter.cpp
@@ -73,10 +73,14 @@ namespace app::meditation
                                      utils::translate("app_bell_meditation_chime_interval"),
                                      utils::translate("app_bell_meditation_chime_interval_bottom")};
 
+        chimeInterval->set_on_value_change_cb([this](const auto &val) { this->chimeIntervalModel.setValue(val); });
+
         auto startDelay = new list_items::StartDelay{list_items::StartDelay::spinner_type::range{0, 90, 10},
                                                      startDelayModel,
                                                      utils::translate("app_bell_meditation_start_delay"),
                                                      utils::translate("common_second_lower")};
+
+        startDelay->set_on_value_change_cb([this](const auto &val) { this->startDelayModel.setValue(val); });
 
         auto chimeVolume = new list_items::Numeric{list_items::Numeric::spinner_type::range{1, 10, 1},
                                                    chimeVolumeModel,


### PR DESCRIPTION
Set all settings values each time a value is changed instead of doing it after pressing enter and moving to the next settings page.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [X] Has changelog entry added

<!-- Thanks for your work ♥ -->
