### PR TITLE
[BH-1588] Allow update from 1.6.0 to 1.7.0 and add two fixes

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -1,5 +1,18 @@
 # MuditaOS changelog - Harmony
 
+## Unreleased
+
+### Changed / Improved
+
+### Fixed
+
+* Fixed resetting meditation settings with deep press.
+
+### Added
+#### PowerNap:
+* New circular progress bar 
+* Ringing bell image at the end of the Power Nap
+
 ## [1.6.0 2022-06-14]
 
 ### Added

--- a/image/assets/lang/Deutsch.json
+++ b/image/assets/lang/Deutsch.json
@@ -699,6 +699,7 @@
   "app_bell_settings_factory_reset": "Zurücksetzen",
   "app_bell_settings_display_factory_reset_confirmation": "Zurücksetzen?",
   "app_bell_meditation_timer": "Meditation",
+  "app_bell_meditation_statistics": "Statistiken",
   "app_bell_meditation_chime_interval": "Intervallschall",
   "app_bell_meditation_progress": "Meditation",
   "app_bell_meditation_interval_none": "kein",

--- a/image/assets/lang/Espanol.json
+++ b/image/assets/lang/Espanol.json
@@ -699,6 +699,7 @@
   "app_bell_settings_factory_reset": "Restablecer",
   "app_bell_settings_display_factory_reset_confirmation": "<text>¿Restablecer la configuración?</text>",
   "app_bell_meditation_timer": "Meditación",
+  "app_bell_meditation_statistics": "Estadísticas",
   "app_bell_meditation_chime_interval": "Intervalo",
   "app_bell_meditation_progress": "Meditación",
   "app_bell_meditation_interval_none": "Ninguno",

--- a/image/assets/lang/Francais.json
+++ b/image/assets/lang/Francais.json
@@ -669,6 +669,7 @@
   "app_bell_settings_factory_reset": "Réinitialisation",
   "app_bell_settings_display_factory_reset_confirmation": "<text>Rétablir<br></br>la configuration ?</text>",
   "app_bell_meditation_timer": "Méditation",
+  "app_bell_meditation_statistics": "Statistiques",
   "app_bell_meditation_chime_interval": "gong intervalle",
   "app_bell_meditation_progress": "Méditation",
   "app_bell_meditation_interval_none": "Aucune",

--- a/products/BellHybrid/apps/application-bell-meditation-timer/presenter/SettingsPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/presenter/SettingsPresenter.cpp
@@ -73,10 +73,14 @@ namespace app::meditation
                                      utils::translate("app_bell_meditation_chime_interval"),
                                      utils::translate("app_bell_meditation_chime_interval_bottom")};
 
+        chimeInterval->set_on_value_change_cb([this](const auto &val) { this->chimeIntervalModel.setValue(val); });
+
         auto startDelay = new list_items::StartDelay{list_items::StartDelay::spinner_type::range{0, 90, 10},
                                                      startDelayModel,
                                                      utils::translate("app_bell_meditation_start_delay"),
                                                      utils::translate("common_second_lower")};
+
+        startDelay->set_on_value_change_cb([this](const auto &val) { this->startDelayModel.setValue(val); });
 
         auto chimeVolume = new list_items::Numeric{list_items::Numeric::spinner_type::range{1, 10, 1},
                                                    chimeVolumeModel,

--- a/tools/generate_update_image.sh
+++ b/tools/generate_update_image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #create update image
@@ -71,7 +71,6 @@ function linkInStageing(){
     ln -s ../../sysroot/sys/current/assets/fonts
     ln -s ../../sysroot/sys/current/assets/images
     ln -s ../../sysroot/sys/current/assets/lang
-    ln -s ../../sysroot/sys/current/assets/audio
     popd 1> /dev/null
 
     ln -s ../sysroot/sys/user


### PR DESCRIPTION
This PR makes possible to update to 1.7.0 from 1.6.0 but not from any of the previous versions. For it to work we have to change MC to force users to first update to 1.6.0 and only after that to update to 1.7.0.

It also includes the following fixes:
https://github.com/mudita/MuditaOS/pull/4104
https://github.com/mudita/MuditaOS/pull/4107

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [X] Has changelog entry added

<!-- Thanks for your work ♥ -->
