### PR TITLE
[MOS-350] Restored notifications about PIN changes

### DIFF
--- a/module-apps/ModuleApps.md
+++ b/module-apps/ModuleApps.md
@@ -120,6 +120,7 @@ With this, we can:
 
 **WARNING** In the MuditaOS a popup is a Window that can be shown any time on an action request.
 **NOTE** `attachPopups` should be most probably moved to `manifest` and popup enum just removed
+**NOTE** Pop-ups regarding SIM cards' presence/availability currently have some special logic regarding windows stack around them.
 
 Popups weren't designed as a part of the system, but rather step by step integrated into it. While there should be no issue with partially overflowing popups in the applications and UI, it would mean major source code refactoring and planning.
 

--- a/module-apps/apps-common/locks/handlers/SimLockHandler.cpp
+++ b/module-apps/apps-common/locks/handlers/SimLockHandler.cpp
@@ -176,7 +176,7 @@ namespace locks
         return sys::msgHandled();
     }
 
-    sys::MessagePointer SimLockHandler::handleSimAvailabilityMessage()
+    sys::MessagePointer SimLockHandler::handleSimPinLockStateMessage()
     {
         lock.lockState = Lock::LockState::Unlocked;
         simInfoAction();
@@ -207,7 +207,7 @@ namespace locks
         return sys::MessagePointer();
     }
 
-    sys::MessagePointer SimLockHandler::handleSimEnableRequest()
+    sys::MessagePointer SimLockHandler::handleSimPinLockEnableRequest()
     {
         setSimInputTypeAction(SimInputTypeAction::EnablePin);
 
@@ -218,7 +218,7 @@ namespace locks
         return sys::msgHandled();
     }
 
-    sys::MessagePointer SimLockHandler::handleSimDisableRequest()
+    sys::MessagePointer SimLockHandler::handleSimPinLockDisableRequest()
     {
         setSimInputTypeAction(SimInputTypeAction::DisablePin);
 

--- a/module-apps/apps-common/locks/handlers/SimLockHandler.hpp
+++ b/module-apps/apps-common/locks/handlers/SimLockHandler.hpp
@@ -59,14 +59,14 @@ namespace locks
         sys::MessagePointer handleSimPukRequest(unsigned int attempts);
         sys::MessagePointer handleSimPinChangeRequest();
         sys::MessagePointer handleSimPinChangeFailedRequest();
-        sys::MessagePointer handleSimEnableRequest();
-        sys::MessagePointer handleSimDisableRequest();
+        sys::MessagePointer handleSimPinLockEnableRequest();
+        sys::MessagePointer handleSimPinLockDisableRequest();
         sys::MessagePointer handleResetSimLockStateRequest();
         sys::MessagePointer handleSimBlockedRequest();
         sys::MessagePointer handleCMEErrorRequest(unsigned int errorCode);
         sys::MessagePointer handleSimUnlockedMessage();
         sys::MessagePointer handleSimPinChangedMessage();
-        sys::MessagePointer handleSimAvailabilityMessage();
+        sys::MessagePointer handleSimPinLockStateMessage();
         sys::MessagePointer handleSimReadyMessage();
         sys::MessagePointer handleSimNotInsertedMessage();
         sys::MessagePointer handleSimNotRespondingMessage();

--- a/module-apps/apps-common/popups/data/PopupRequestParams.hpp
+++ b/module-apps/apps-common/popups/data/PopupRequestParams.hpp
@@ -45,8 +45,9 @@ namespace gui
                                     locks::Lock lock,
                                     locks::SimInputTypeAction simInputTypeAction,
                                     unsigned int errorCode = 0)
-            : PopupRequestParams{popupId}, lock{std::move(lock)}, simInputTypeAction(simInputTypeAction),
-              errorCode(errorCode)
+            : PopupRequestParams(
+                  popupId, {popup::Disposition::Priority::Normal, popup::Disposition::WindowType::Popup, popupId}),
+              lock{std::move(lock)}, simInputTypeAction(simInputTypeAction), errorCode(errorCode)
         {}
 
         [[nodiscard]] auto getLock() const noexcept

--- a/module-apps/apps-common/popups/lock-popups/SimInfoWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/SimInfoWindow.cpp
@@ -33,8 +33,7 @@ void SimInfoWindow::onBeforeShow(ShowMode mode, SwitchData *data)
     WindowWithTimer::onBeforeShow(mode, data);
 
     if (auto infoData = dynamic_cast<locks::SimLockData *>(data)) {
-        action_ = infoData->getSimInputTypeAction();
-        switch (action_.value()) {
+        switch (infoData->getSimInputTypeAction()) {
         case locks::SimInputTypeAction::UnlockWithPuk:
         case locks::SimInputTypeAction::ChangePin:
             setTitle(utils::translate("sim_change_pin"));

--- a/module-apps/apps-common/popups/lock-popups/SimInfoWindow.hpp
+++ b/module-apps/apps-common/popups/lock-popups/SimInfoWindow.hpp
@@ -6,7 +6,6 @@
 #include <popups/WindowWithTimer.hpp>
 #include <Text.hpp>
 #include <gui/widgets/Icon.hpp>
-#include <locks/data/LockData.hpp>
 
 namespace gui
 {
@@ -20,13 +19,5 @@ namespace gui
         void buildInterface() override;
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
         status_bar::Configuration configureStatusBar(status_bar::Configuration appConfiguration) override;
-
-        locks::SimInputTypeAction getAction() const
-        {
-            return action_.value();
-        }
-
-      private:
-        std::optional<locks::SimInputTypeAction> action_;
     };
 } /* namespace gui */

--- a/module-apps/apps-common/popups/lock-popups/SimLockInputWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/SimLockInputWindow.cpp
@@ -90,13 +90,7 @@ namespace gui
                 lock->consumeState();
             }
             application->getSimLockSubject().resetSimLockState();
-            if (auto *settingsApp = dynamic_cast<app::ApplicationSettings *>(application);
-                settingsApp && settingsApp->isPreviousWindow(gui::window::name::sim_pin_settings)) {
-                settingsApp->switchWindow(gui::window::name::sim_cards);
-            }
-            else {
-                application->returnToPreviousWindow();
-            }
+            application->returnToPreviousWindow();
             return true;
         }
         else if (inputEvent.is(KeyCode::KEY_PND)) {

--- a/products/PurePhone/services/appmgr/ApplicationManager.cpp
+++ b/products/PurePhone/services/appmgr/ApplicationManager.cpp
@@ -275,22 +275,24 @@ namespace app::manager
                         return simLockHandler.handleSimPinChangeFailedRequest();
                     }
                 });
-        connect(typeid(locks::EnableSimPin),
-                [&](sys::Message *request) -> sys::MessagePointer { return simLockHandler.handleSimEnableRequest(); });
-        connect(typeid(locks::DisableSimPin),
-                [&](sys::Message *request) -> sys::MessagePointer { return simLockHandler.handleSimDisableRequest(); });
+        connect(typeid(locks::EnableSimPin), [&](sys::Message *request) -> sys::MessagePointer {
+            return simLockHandler.handleSimPinLockEnableRequest();
+        });
+        connect(typeid(locks::DisableSimPin), [&](sys::Message *request) -> sys::MessagePointer {
+            return simLockHandler.handleSimPinLockDisableRequest();
+        });
         connect(typeid(cellular::msg::request::sim::SetPinLock::Response),
                 [&](sys::Message *request) -> sys::MessagePointer {
                     auto data = static_cast<cellular::msg::request::sim::SetPinLock::Response *>(request);
                     if (data->retCode) {
-                        return simLockHandler.handleSimAvailabilityMessage();
+                        return simLockHandler.handleSimPinLockStateMessage();
                     }
                     else {
                         if (data->lock == cellular::api::SimLockState::Enabled) {
-                            return simLockHandler.handleSimEnableRequest();
+                            return simLockHandler.handleSimPinLockEnableRequest();
                         }
                         else {
-                            return simLockHandler.handleSimDisableRequest();
+                            return simLockHandler.handleSimPinLockDisableRequest();
                         }
                     }
                 });


### PR DESCRIPTION
Made SimInfo pop-ups completely omitted when
going back to windows.

Fixed the SimUnlockInputRequestParams's
constructor.

Done a bit of refactor in the places of
interest, e.g. naming clarification.


Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has documentation updated