### PR TITLE
[MOS-769] Make a destructor virtual

### DIFF
--- a/module-apps/apps-common/WindowsPopupFilter.hpp
+++ b/module-apps/apps-common/WindowsPopupFilter.hpp
@@ -22,9 +22,12 @@ namespace gui::popup
     {
       private:
         std::list<std::function<bool(const gui::PopupRequestParams &)>> appDependentFilter;
+        /// non-owning pointer to existing stack - @see attachWindowsStack()
         app::WindowsStack *stack = nullptr;
 
       public:
+        virtual ~Filter() = default;
+
         void attachWindowsStack(app::WindowsStack *stack);
         void addAppDependentFilter(std::function<bool(const gui::PopupRequestParams &)> f);
         virtual bool isPermitted(const gui::PopupRequestParams &params) const;


### PR DESCRIPTION
Make Make gui::popup::Filter's destructor
virtual because it has a virtual method.

Additionally, added a documenting comment.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has documentation updated