### PR TITLE
[MOS-26] Add tethering info on status bar

### DIFF
--- a/image/assets/lang/Deutsch.json
+++ b/image/assets/lang/Deutsch.json
@@ -622,6 +622,7 @@
   "app_desktop_update_success": "MuditaOS wurde erfolgreich auf Version $VERSION aktualisiert.",
   "app_call_private_number": "Private Nummer",
   "app_call_ending_call": "Anruf wird beendet",
+  "statusbar_tethering": "TETHERING",
   "tethering": "Tethering",
   "tethering_turn_off_question": "Tethering ausschalten?",
   "tethering_enable_question": "<text>Sie sind mit dem Computer verbunden.<br />Tethering einschalten?<br /><text color='5'>(einige Funktionen können deaktiviert sein)</text></text>",

--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -595,6 +595,7 @@
   "app_desktop_update_success": "MuditaOS has been updated to ver. $VERSION succesfully.",
   "app_call_private_number": "Private number",
   "app_call_ending_call": "Disconnecting call",
+  "statusbar_tethering": "TETHERING",
   "tethering": "Tethering",
   "tethering_turn_off_question": "Turn tethering off?",
   "tethering_enable_question": "<text>You're connected to the computer.<br />Turn tethering on?<br /><text color='5'>(some functions may be disabled)</text></text>",

--- a/image/assets/lang/Espanol.json
+++ b/image/assets/lang/Espanol.json
@@ -623,6 +623,7 @@
   "app_desktop_update_success": "El SO de MuditaOS se ha actualizado a la ver. $VERSION correctamente.",
   "app_call_private_number": "Número privado",
   "app_call_ending_call": "Desconectando llamada",
+  "statusbar_tethering": "ANCLAJE DE RED",
   "tethering": "Anclaje de red",
   "tethering_turn_off_question": "¿Desactivar el anclaje de red?",
   "tethering_enable_question": "<text>Estás conectado al ordenador.<br />¿Activar el anclaje de red?<br /><text color='5'>(algunas funciones podrían desactivarse)</text></text>",

--- a/image/assets/lang/Francais.json
+++ b/image/assets/lang/Francais.json
@@ -590,6 +590,7 @@
   "app_desktop_update_success": "La mise à jour de MuditaOS à la version $VERSION a été effectuée avec succès.",
   "app_call_private_number": "Numéro privé",
   "app_call_ending_call": "Déconnexion de l'appel",
+  "statusbar_tethering": "MODE MODEM",
   "tethering": "Partage de connexion",
   "tethering_turn_off_question": "Voulez-vous désactiver le partage de connexion?",
   "tethering_enable_question": "<text>Vous êtes connecté à l'ordinateur.<br />Voulez-vous activer le partage de connexion?<br /><text color='5'>(certaines fonctions peuvent être désactivées)</text></text>",

--- a/image/assets/lang/Polski.json
+++ b/image/assets/lang/Polski.json
@@ -639,6 +639,7 @@
   "app_desktop_update_success": "System MuditaOS został pomyślnie zaktualizowany do wer. $VERSION.",
   "app_call_private_number": "Numer prywatny",
   "app_call_ending_call": "Kończenie połączenia",
+  "statusbar_tethering": "TETHERING",
   "tethering": "Tethering",
   "tethering_turn_off_question": "Wyłączyć tethering?",
   "tethering_enable_question": "<text>Połączono z komputerem.<br />Włączyć tethering?<br /><text color='5'>(Niektóre funkcje mogą być niedostępne)</text></text>",

--- a/image/assets/lang/Svenska.json
+++ b/image/assets/lang/Svenska.json
@@ -524,6 +524,7 @@
   "app_desktop_update_unpacking": "Packar upp",
   "app_call_private_number": "Dolt nummer",
   "app_call_ending_call": "Avslutar samtalet",
+  "statusbar_tethering": "INTERNETDELNING",
   "tethering": "Internetdelning",
   "tethering_turn_off_question": "Stänga av Internetdelning?",
   "tethering_enable_question": "<text>Du är ansluten till datorn.<br />Slå på Internetdelning?<br /><text color='9'>(vissa funktioner kan vara inaktiverade)</text></text>",

--- a/module-apps/application-desktop/include/application-desktop/ApplicationDesktop.hpp
+++ b/module-apps/application-desktop/include/application-desktop/ApplicationDesktop.hpp
@@ -65,7 +65,8 @@ namespace app
                      manager::actions::PhoneModeChanged,
                      manager::actions::BluetoothModeChanged,
                      manager::actions::NotificationsChanged,
-                     manager::actions::AlarmClockStatusChanged}};
+                     manager::actions::AlarmClockStatusChanged,
+                     manager::actions::TetheringStateChanged}};
         }
     };
 

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -74,6 +74,7 @@ namespace gui
         appConfiguration.enable(status_bar::Indicator::SimCard);
         appConfiguration.enable(status_bar::Indicator::Bluetooth);
         appConfiguration.enable(status_bar::Indicator::AlarmClock);
+        appConfiguration.enable(status_bar::Indicator::Tethering);
         return appConfiguration;
     }
 

--- a/module-apps/apps-common/ApplicationCommon.cpp
+++ b/module-apps/apps-common/ApplicationCommon.cpp
@@ -27,6 +27,7 @@
 
 #include <popups/data/PhoneModeParams.hpp>
 #include <popups/data/BluetoothModeParams.hpp>
+#include <popups/data/TetheringParams.hpp>
 
 #if DEBUG_INPUT_EVENTS == 1
 #define debug_input_events(...) LOG_DEBUG(__VA_ARGS__)
@@ -116,6 +117,13 @@ namespace app
             if (params != nullptr) {
                 auto modeParams                  = static_cast<gui::PhoneModeParams *>(params.get());
                 this->statusIndicators.phoneMode = modeParams->getPhoneMode();
+            }
+            return actionHandled();
+        });
+        addActionReceiver(app::manager::actions::TetheringStateChanged, [this](auto &&params) {
+            if (params != nullptr) {
+                auto modeParams                       = static_cast<gui::TetheringParams *>(params.get());
+                this->statusIndicators.tetheringState = modeParams->getTetheringState();
             }
             return actionHandled();
         });

--- a/module-apps/apps-common/ApplicationCommon.hpp
+++ b/module-apps/apps-common/ApplicationCommon.hpp
@@ -125,6 +125,7 @@ namespace app
     {
       public:
         sys::phone_modes::PhoneMode phoneMode       = sys::phone_modes::PhoneMode::Uninitialized;
+        sys::phone_modes::Tethering tetheringState  = sys::phone_modes::Tethering::Off;
         sys::bluetooth::BluetoothMode bluetoothMode = sys::bluetooth::BluetoothMode::Disabled;
         bool alarmClockStatus                       = false;
     };

--- a/module-apps/apps-common/locks/windows/LockInputWindow.cpp
+++ b/module-apps/apps-common/locks/windows/LockInputWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "LockInputWindow.hpp"
@@ -113,6 +113,7 @@ namespace gui
         appConfiguration.enable(status_bar::Indicator::SimCard);
         appConfiguration.enable(status_bar::Indicator::Bluetooth);
         appConfiguration.enable(status_bar::Indicator::AlarmClock);
+        appConfiguration.enable(status_bar::Indicator::Tethering);
         return appConfiguration;
     }
 

--- a/module-apps/apps-common/popups/TetheringNotificationPopup.cpp
+++ b/module-apps/apps-common/popups/TetheringNotificationPopup.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TetheringNotificationPopup.hpp"
@@ -20,6 +20,7 @@ namespace gui
         appConfiguration.setIndicator(gui::status_bar::Indicator::Battery, true);
         appConfiguration.setIndicator(gui::status_bar::Indicator::SimCard, false);
         appConfiguration.setIndicator(gui::status_bar::Indicator::Signal, true);
+        appConfiguration.setIndicator(gui::status_bar::Indicator::Tethering, true);
         return appConfiguration;
     }
 } // namespace gui

--- a/module-apps/apps-common/popups/data/TetheringParams.hpp
+++ b/module-apps/apps-common/popups/data/TetheringParams.hpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "popups/Popups.hpp"
+
+#include <service-appmgr/Actions.hpp>
+#include <PhoneModes/Common.hpp>
+
+namespace gui
+{
+    class TetheringParams : public app::manager::actions::ActionParams
+    {
+      public:
+        explicit TetheringParams(sys::phone_modes::Tethering state) : tetheringState{state}
+        {}
+
+        [[nodiscard]] auto getTetheringState() const noexcept
+        {
+            return tetheringState;
+        }
+
+      private:
+        sys::phone_modes::Tethering tetheringState;
+    };
+} // namespace gui

--- a/module-apps/apps-common/popups/lock-popups/PhoneLockInputWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/PhoneLockInputWindow.cpp
@@ -44,6 +44,7 @@ namespace gui
             appConfiguration.enable(status_bar::Indicator::SimCard);
             appConfiguration.enable(status_bar::Indicator::Bluetooth);
             appConfiguration.enable(status_bar::Indicator::AlarmClock);
+            appConfiguration.enable(status_bar::Indicator::Tethering);
         }
         else {
             appConfiguration.enable(status_bar::Indicator::Time);

--- a/module-apps/apps-common/popups/lock-popups/PhoneLockedInfoWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/PhoneLockedInfoWindow.cpp
@@ -101,6 +101,7 @@ status_bar::Configuration PhoneLockedInfoWindow::configureStatusBar(status_bar::
     appConfiguration.enable(status_bar::Indicator::Signal);
     appConfiguration.enable(status_bar::Indicator::Bluetooth);
     appConfiguration.enable(status_bar::Indicator::AlarmClock);
+    appConfiguration.enable(status_bar::Indicator::Tethering);
     return appConfiguration;
 }
 

--- a/module-apps/apps-common/popups/lock-popups/PhoneLockedWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/PhoneLockedWindow.cpp
@@ -150,6 +150,7 @@ namespace gui
         appConfiguration.disable(status_bar::Indicator::SimCard);
         appConfiguration.enable(status_bar::Indicator::Bluetooth);
         appConfiguration.enable(status_bar::Indicator::AlarmClock);
+        appConfiguration.enable(status_bar::Indicator::Tethering);
 
         return appConfiguration;
     }

--- a/module-apps/apps-common/windows/AppWindow.cpp
+++ b/module-apps/apps-common/windows/AppWindow.cpp
@@ -134,6 +134,15 @@ namespace gui
         applyToStatusBar(std::move(fn));
     }
 
+    bool AppWindow::updateTethering(const sys::phone_modes::Tethering state)
+    {
+        if (statusBar == nullptr) {
+            return false;
+        }
+
+        return statusBar->updateTetheringState(state);
+    }
+
     bool AppWindow::preventsAutoLocking() const noexcept
     {
         return preventsAutoLock;

--- a/module-apps/apps-common/windows/AppWindow.hpp
+++ b/module-apps/apps-common/windows/AppWindow.hpp
@@ -72,6 +72,7 @@ namespace gui
         bool updateSignalStrength();
         bool updateNetworkAccessTechnology();
         void updatePhoneMode(sys::phone_modes::PhoneMode mode);
+        bool updateTethering(const sys::phone_modes::Tethering state);
         [[nodiscard]] bool preventsAutoLocking() const noexcept;
         virtual RefreshModes updateTime();
 

--- a/module-gui/gui/widgets/CMakeLists.txt
+++ b/module-gui/gui/widgets/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources( ${PROJECT_NAME}
         "${CMAKE_CURRENT_LIST_DIR}/status-bar/SignalStrengthText.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/status-bar/NetworkAccessTechnology.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/status-bar/PhoneMode.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/status-bar/Tethering.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/status-bar/Time.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/status-bar/Lock.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/Style.cpp"

--- a/module-gui/gui/widgets/StatusBar.hpp
+++ b/module-gui/gui/widgets/StatusBar.hpp
@@ -27,6 +27,7 @@ namespace gui
         class SIM;
         class Time;
         class Lock;
+        class Tethering;
     } // namespace status_bar
 } // namespace gui
 
@@ -48,6 +49,7 @@ namespace gui::status_bar
         NetworkAccessTechnology, /// NAT (eg 3G, 4G, LTE)
         PhoneMode,               /// phone mode
         AlarmClock,              /// alarm clock active
+        Tethering,               /// tethering status
     };
 
     using Indicators          = std::vector<Indicator>;
@@ -87,6 +89,10 @@ namespace gui::status_bar
         /// @param alarmClockStatus desired alarm clock status
         void setAlarmClockStatus(bool alarmClockStatus);
 
+        /// Set tethering state
+        /// @param tetheringState desired tethering state
+        void setTetheringState(sys::phone_modes::Tethering tetheringState);
+
         /// Set a configuration modifier to the specified indicator
         /// @param indicator indicator type
         /// @param config desired indicator's configuration
@@ -103,6 +109,10 @@ namespace gui::status_bar
         /// Get the Alarm Clock status configuration
         /// @return alarm clock status
         [[nodiscard]] auto getAlarmClockStatus() const noexcept -> bool;
+
+        /// Get the tethering state configuration
+        /// @return tethering state
+        [[nodiscard]] auto getTetheringState() const noexcept -> sys::phone_modes::Tethering;
 
         /// Check if the specified indicator is enabled
         /// @param indicator indicator to be checked
@@ -129,6 +139,7 @@ namespace gui::status_bar
             {Indicator::SimCard, false},
             {Indicator::NetworkAccessTechnology, false},
             {Indicator::AlarmClock, false},
+            {Indicator::Tethering, false},
         };
 
         /// Phone mode
@@ -139,6 +150,9 @@ namespace gui::status_bar
 
         /// Alarm Clock status
         bool mAlarmClockStatus = false;
+
+        /// Tethering state
+        sys::phone_modes::Tethering mTetheringState = sys::phone_modes::Tethering::Off;
 
         /// Indicator modifiers:
         IndicatorsModifiers indicatorsModifiers;
@@ -192,6 +206,9 @@ namespace gui::status_bar
         /// Update NAT widget state depending on the current configuration
         bool updateNetworkAccessTechnology();
 
+        /// Update tethering widget state depending on the current configuration
+        bool updateTetheringState(const sys::phone_modes::Tethering state);
+
         /// Accepts GuiVisitor to update the status bar
         void accept(GuiVisitor &visitor) override;
 
@@ -236,6 +253,13 @@ namespace gui::status_bar
         /// @param enabled true to show false to hide the widget
         void showNetworkAccessTechnology(bool enabled);
 
+        /// Show/hide tethering state widget
+        /// @param enabled true to show false to hide the widget
+        void showTethering(bool enabled);
+
+        /// Show/hide phone mode or tethering widget
+        void showPhoneModeOrTethering(bool phoneModeEnabled, bool tetheringEnabled);
+
         /// Sets the status of the specified indicator on the Status bar
         /// @param indicator indicator id
         /// @param enabled enable or disable the specified indicator
@@ -272,6 +296,9 @@ namespace gui::status_bar
 
         /// Pointer to widget with battery status
         BatteryBase *battery = nullptr;
+
+        /// Pointer to widget with tethering state
+        Tethering *tethering = nullptr;
 
         /// Pointer to the left horizontal box
         HBox *leftBox = nullptr;

--- a/module-gui/gui/widgets/status-bar/SignalStrengthBar.cpp
+++ b/module-gui/gui/widgets/status-bar/SignalStrengthBar.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SignalStrengthBar.hpp"
@@ -47,7 +47,9 @@ namespace gui::status_bar
         setMinimumSize(img->getWidth(), style::status_bar::height);
     }
 
-    void SignalStrengthBar::update(const Store::SignalStrength &signal, const Store::Network::Status &status)
+    void SignalStrengthBar::update(const Store::SignalStrength &signal,
+                                   const Store::Network::Status &status,
+                                   const Store::Tethering &tethering)
     {
         try {
             if (img == nullptr) {
@@ -55,7 +57,10 @@ namespace gui::status_bar
                 return;
             }
 
-            if (status == Store::Network::Status::RegisteredRoaming) {
+            if (tethering == Store::Tethering::On) {
+                img->set(signal_none, style::status_bar::imageTypeSpecifier);
+            }
+            else if (status == Store::Network::Status::RegisteredRoaming) {
                 img->set(signalMapRoaming.at(signal.rssiBar), style::status_bar::imageTypeSpecifier);
             }
             else if (status == Store::Network::Status::RegisteredHomeNetwork) {

--- a/module-gui/gui/widgets/status-bar/SignalStrengthBar.hpp
+++ b/module-gui/gui/widgets/status-bar/SignalStrengthBar.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -15,7 +15,9 @@ namespace gui::status_bar
     {
       public:
         SignalStrengthBar(Item *parent, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
-        void update(const Store::SignalStrength &signal, const Store::Network::Status &status) override;
+        void update(const Store::SignalStrength &signal,
+                    const Store::Network::Status &status,
+                    const Store::Tethering &tethering) override;
 
       private:
         Image *img = nullptr;

--- a/module-gui/gui/widgets/status-bar/SignalStrengthBase.hpp
+++ b/module-gui/gui/widgets/status-bar/SignalStrengthBase.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -13,6 +13,8 @@ namespace gui::status_bar
     {
       public:
         SignalStrengthBase(Item *parent, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
-        virtual void update(const Store::SignalStrength &signal, const Store::Network::Status &status) = 0;
+        virtual void update(const Store::SignalStrength &signal,
+                            const Store::Network::Status &status,
+                            const Store::Tethering &tethering) = 0;
     };
 } // namespace gui::status_bar

--- a/module-gui/gui/widgets/status-bar/SignalStrengthText.cpp
+++ b/module-gui/gui/widgets/status-bar/SignalStrengthText.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SignalStrengthText.hpp"
@@ -23,7 +23,8 @@ namespace gui::status_bar
     }
 
     void SignalStrengthText::update(const Store::SignalStrength &signal,
-                                    [[maybe_unused]] const Store::Network::Status &status)
+                                    [[maybe_unused]] const Store::Network::Status &status,
+                                    [[maybe_unused]] const Store::Tethering &tethering)
     {
         label->setText(utils::to_string(signal.rssidBm) + " dBm");
     }

--- a/module-gui/gui/widgets/status-bar/SignalStrengthText.hpp
+++ b/module-gui/gui/widgets/status-bar/SignalStrengthText.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -17,7 +17,8 @@ namespace gui::status_bar
       public:
         SignalStrengthText(Item *parent, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
         void update(const Store::SignalStrength &signal,
-                    [[maybe_unused]] const Store::Network::Status &status) override;
+                    [[maybe_unused]] const Store::Network::Status &status,
+                    [[maybe_unused]] const Store::Tethering &tethering) override;
 
       private:
         Label *label = nullptr;

--- a/module-gui/gui/widgets/status-bar/Style.hpp
+++ b/module-gui/gui/widgets/status-bar/Style.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -35,6 +35,11 @@ namespace style::status_bar
         inline constexpr auto maxX = 157u;
         inline constexpr auto font = style::window::font::verysmall;
     }; // namespace phonemode
+    namespace tethering
+    {
+        inline constexpr auto maxX = 180u;
+        inline constexpr auto font = style::window::font::verysmall;
+    }; // namespace tethering
     namespace signal
     {
         inline constexpr auto font = style::window::font::verysmall;

--- a/module-gui/gui/widgets/status-bar/Tethering.cpp
+++ b/module-gui/gui/widgets/status-bar/Tethering.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "Tethering.hpp"
+
+#include <log/log.hpp>
+#include <i18n/i18n.hpp>
+
+#include "Item.hpp"
+#include "Style.hpp"
+
+namespace gui::status_bar
+{
+    Tethering::Tethering(Item *parent, std::uint32_t x, std::uint32_t y, std::uint32_t w, std::uint32_t h)
+        : StatusBarWidgetBase(parent, x, y, w, h)
+    {
+        setEdges(RectangleEdge::None);
+        setFont(style::status_bar::tethering::font);
+        setTextEllipsisType(TextEllipsis::Right);
+        setText(utils::translate("statusbar_tethering"));
+        setAlignment(gui::Alignment(gui::Alignment::Horizontal::Left, gui::Alignment::Vertical::Center));
+    }
+} // namespace gui::status_bar

--- a/module-gui/gui/widgets/status-bar/Tethering.hpp
+++ b/module-gui/gui/widgets/status-bar/Tethering.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "StatusBarWidgetBase.hpp"
+#include <Label.hpp>
+#include <gui/widgets/StatusBar.hpp>
+
+namespace gui::status_bar
+{
+    /// widget drawn on the status bar showing current tethering state:
+    class Tethering : public StatusBarWidgetBase<Label>
+    {
+
+      public:
+        /// Phone mode widget class constructor
+        /// @param parent parent item pointer
+        /// @param x widget x position
+        /// @param y widget y position
+        /// @param w widget width
+        /// @param h widget height
+        Tethering(Item *parent, std::uint32_t x, std::uint32_t y, std::uint32_t w, std::uint32_t h);
+    };
+
+} // namespace gui::status_bar

--- a/module-services/service-appmgr/include/service-appmgr/Actions.hpp
+++ b/module-services/service-appmgr/include/service-appmgr/Actions.hpp
@@ -55,6 +55,7 @@ namespace app::manager
             SMSRejectedByOfflineNotification,
             CallRejectedByOfflineNotification,
             PhoneModeChanged,
+            TetheringStateChanged,
             BluetoothModeChanged,
             AlarmClockStatusChanged,
             NotificationsChanged,

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -319,9 +319,11 @@ void ServiceCellular::registerMessageHandlers()
     });
     phoneModeObserver->subscribe([&](sys::phone_modes::Tethering tethering) {
         if (tethering == sys::phone_modes::Tethering::On) {
+            Store::GSM::get()->setTethering(Store::Tethering::On);
             priv->tetheringHandler->enable();
         }
         else {
+            Store::GSM::get()->setTethering(Store::Tethering::Off);
             priv->tetheringHandler->disable();
         }
         if (ongoingCall != nullptr) {

--- a/module-utils/EventStore/EventStore.cpp
+++ b/module-utils/EventStore/EventStore.cpp
@@ -90,4 +90,14 @@ namespace Store
         cpp_freertos::LockGuard lock(mutex);
         return networkOperatorName;
     }
+    void GSM::setTethering(const Tethering &tethering)
+    {
+        cpp_freertos::LockGuard lock(mutex);
+        this->tethering = tethering;
+    }
+    Tethering GSM::getTethering() const
+    {
+        cpp_freertos::LockGuard lock(mutex);
+        return tethering;
+    }
 }; // namespace Store

--- a/module-utils/EventStore/EventStore.hpp
+++ b/module-utils/EventStore/EventStore.hpp
@@ -74,6 +74,12 @@ namespace Store
         RssiBar rssiBar = RssiBar::zero;
     };
 
+    enum class Tethering
+    {
+        Off,
+        On
+    };
+
     struct Network
     {
         enum class Status
@@ -116,6 +122,7 @@ namespace Store
         SignalStrength signalStrength;
         Network network;
         std::string networkOperatorName;
+        Tethering tethering;
 
         static cpp_freertos::MutexStandard mutex;
 
@@ -154,11 +161,14 @@ namespace Store
         void setSignalStrength(const SignalStrength &signalStrength);
         SignalStrength getSignalStrength() const;
 
-        void setNetwork(const Network &signalStrength);
+        void setNetwork(const Network &network);
         Network getNetwork() const;
 
         void setNetworkOperatorName(const std::string &newNetworkOperatorName);
         std::string getNetworkOperatorName() const;
+
+        void setTethering(const Tethering &tethering);
+        Tethering getTethering() const;
 
         static GSM *get();
     };

--- a/products/PurePhone/apps/Application.cpp
+++ b/products/PurePhone/apps/Application.cpp
@@ -32,6 +32,7 @@ namespace app
         window->updateSignalStrength();
         window->updateNetworkAccessTechnology();
         window->updatePhoneMode(statusIndicators.phoneMode);
+        window->updateTethering(statusIndicators.tetheringState);
     }
 
     void Application::attachPopups(const std::vector<gui::popup::ID> &popupsList)

--- a/products/PurePhone/services/appmgr/RunAppsInBackground.cpp
+++ b/products/PurePhone/services/appmgr/RunAppsInBackground.cpp
@@ -13,6 +13,8 @@ namespace app::manager
             if (auto app = getApplication(name); app != nullptr) {
                 StatusIndicators statusIndicators;
                 statusIndicators.phoneMode        = phoneModeObserver->getCurrentPhoneMode();
+                statusIndicators.tetheringState   = phoneModeObserver->isTetheringOn() ? sys::phone_modes::Tethering::On
+                                                                                       : sys::phone_modes::Tethering::Off;
                 statusIndicators.bluetoothMode    = bluetoothMode;
                 statusIndicators.alarmClockStatus = alarmClockStatus;
                 app->runInBackground(statusIndicators, this);

--- a/products/PurePhone/services/appmgr/include/appmgr/ApplicationManager.hpp
+++ b/products/PurePhone/services/appmgr/include/appmgr/ApplicationManager.hpp
@@ -30,6 +30,7 @@ namespace app::manager
         void changeBluetoothMode(const ApplicationHandle *app);
         void changeAlarmClockStatus(const ApplicationHandle *app);
         void handleTetheringChanged(sys::phone_modes::Tethering tethering);
+        void changeTetheringState(const sys::phone_modes::Tethering state, const ApplicationHandle *app);
         void handleSnoozeCountChange(unsigned snoozeCount);
         void processKeypadBacklightState(bsp::keypad_backlight::State keypadLightState);
         void registerMessageHandlers() override;

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -35,6 +35,7 @@
 * Fixed windows flow regarding PUK requests after too many PIN mistakes
 
 ### Added
+* Added tethering information on the status bar
 * Added basic MMS handling
 
 ## [1.3.0 2022-08-04]


### PR DESCRIPTION
<!-- Please describe your pull request here -->

When tethering is on, info appears in the status bar and network coverage indicates "no connection"

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
