### PR TITLE
[BH-1590] Light press ends the Power Nap

### DIFF
--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
@@ -100,8 +100,7 @@ namespace gui
     {
         if (inputEvent.isShortRelease()) {
             const auto key = mapKey(inputEvent.getKeyCode());
-            if (presenter->isNapFinished() &&
-                (key == KeyMap::LightPress || key == KeyMap::DeepPressDown || key == KeyMap::DeepPressUp)) {
+            if (presenter->isNapFinished() && key == KeyMap::LightPress) {
                 presenter->endNap();
                 return true;
             }


### PR DESCRIPTION
The deep press doesn't have any effect on the power nap application. 
At the end of the power nap, the deep press change only alarm mode.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
