### PR TITLE
[MOS-770] Fixed VoLTE setting switch

### DIFF
--- a/image/user/db/settings_v2_002-devel.sql
+++ b/image/user/db/settings_v2_002-devel.sql
@@ -32,6 +32,7 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('\ServiceBluetooth\\bt_bonded_devices', ''),
     ('battery_critical_level', '10'),
     ('cl_offline_mode', '1'),
+    ('cl_volte_on', '0'),
     ('msg_only_mode_connection_frequency', '15'),
     ('off_notifications_when_locked', '0'),
     ('off_calls_from_favorites', '0'),

--- a/image/user/db/settings_v2_002.sql
+++ b/image/user/db/settings_v2_002.sql
@@ -33,6 +33,7 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('battery_critical_level', '10'),
     ('cl_offline_mode', '1'),
     ('cl_current_uid', '0'),
+    ('cl_volte_on', '0'),
     ('msg_only_mode_connection_frequency', '15'),
     ('off_notifications_when_locked', '0'),
     ('off_calls_from_favorites', '0'),

--- a/module-apps/application-settings/ApplicationSettings.cpp
+++ b/module-apps/application-settings/ApplicationSettings.cpp
@@ -317,6 +317,14 @@ namespace app
             return handleAudioStop(notification);
         });
 
+        try {
+            voLteStateOn =
+                !!std::stoul(settings->getValue(::settings::Cellular::volte_on, ::settings::SettingsScope::Global));
+        }
+        catch (std::exception const &exc) {
+            LOG_ERROR("[VoLTE] checking on/off state failed: %s; left as default FALSE", exc.what());
+        }
+
         createUserInterface();
 
         settings->registerValueChange(settings::operators_on,
@@ -650,6 +658,9 @@ namespace app
     {
         if (!value.empty()) {
             voLteStateOn = utils::getNumericValue<bool>(value);
+        }
+        else {
+            LOG_ERROR("[VoLTE] empty state setting string!");
         }
     }
 

--- a/module-services/service-cellular/NetworkSettings.cpp
+++ b/module-services/service-cellular/NetworkSettings.cpp
@@ -269,24 +269,6 @@ at::Result::Code NetworkSettings::setIMSState(at::response::qcfg_ims::IMSState s
     return resp.code;
 }
 
-std::optional<std::pair<at::response::qcfg_ims::IMSState, at::response::qcfg_ims::VoLTEIMSState>> NetworkSettings::
-    getIMSState()
-{
-    std::vector<std::string> operatorNames;
-    auto channel = cellularService.cmux->get(CellularMux::Channel::Commands);
-    if (channel) {
-
-        at::Cmd buildCmd = at::factory(at::AT::QCFG_IMS);
-        auto resp        = channel->cmd(buildCmd);
-        std::pair<at::response::qcfg_ims::IMSState, at::response::qcfg_ims::VoLTEIMSState> ret;
-        if ((resp.code == at::Result::Code::OK) && (at::response::parseQCFG_IMS(resp, ret))) {
-            return ret;
-        }
-    }
-
-    return std::nullopt;
-}
-
 at::Result::Code NetworkSettings::setVoLTEState(VoLTEState state)
 {
     /**
@@ -336,7 +318,7 @@ VoLTEState NetworkSettings::getVoLTEConfigurationState()
      * about whether the VoLTE actually works in the selected network
      *
      */
-    if (auto state = getIMSState(); state) {
+    if (auto state = cellularService.getIMSState(); state) {
         /// check disable in any other state VoLTE is likely
         return state->first == at::response::qcfg_ims::IMSState::Disable ? VoLTEState::Off : VoLTEState::On;
     }

--- a/module-services/service-cellular/NetworkSettings.hpp
+++ b/module-services/service-cellular/NetworkSettings.hpp
@@ -73,7 +73,6 @@ class NetworkSettings
     bool setOperator(at::response::cops::CopsMode mode, at::response::cops::NameFormat format, const std::string &name);
 
     at::Result::Code setIMSState(at::response::qcfg_ims::IMSState state);
-    std::optional<std::pair<at::response::qcfg_ims::IMSState, at::response::qcfg_ims::VoLTEIMSState>> getIMSState();
 
     std::string printVoLTEDebug();
 

--- a/module-services/service-cellular/service-cellular/ServiceCellular.hpp
+++ b/module-services/service-cellular/service-cellular/ServiceCellular.hpp
@@ -95,6 +95,7 @@ class ServiceCellular : public sys::Service
      */
     bool getIMSI(std::string &destination, bool fullNumber = false);
     std::vector<std::string> getNetworkInfo();
+    std::optional<std::pair<at::response::qcfg_ims::IMSState, at::response::qcfg_ims::VoLTEIMSState>> getIMSState();
 
     auto areCallsFromFavouritesEnabled() -> bool;
 


### PR DESCRIPTION
Added the setting to the database generation scripts. Fixed the setting's underlying handling.
Enhanced and tidied up VoLTE logging.

Make sure that this PR:
- [x] Complies with our guidelines for contributions