### PR TITLE
[BH-1592] Prevent saving meditation settings when going back

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -80,9 +80,22 @@
         },
         {
             "type": "shell",
+            "label": "Build BellHybrid Disk Image (Linux)",
+            "command": "ninja",
+            "args": [
+                "BellHybrid-disk-img"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-BellHybrid-linux-Debug"
+            },
+            "group": "build",
+            "detail": "Build dir has to be configured with Cmake using Ninja",
+        },
+        {
+            "type": "shell",
             "label": "Configure and Build BellHybrid (Linux)",
             "group": "build",
-            "dependsOn": ["Configure BellHybrid (Linux)", "Build BellHybrid (Linux)"],
+            "dependsOn": ["Configure BellHybrid (Linux)", "Build BellHybrid (Linux)", "Build BellHybrid Disk Image (Linux)"],
             "dependsOrder": "sequence",
             "detail": "Configure cmake project and build with Ninja",
         },
@@ -162,9 +175,22 @@
         },
         {
             "type": "shell",
+            "label": "Build BellHybrid Disk Image (RT1051)",
+            "command": "ninja",
+            "args": [
+                "BellHybrid-disk-img"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-BellHybrid-rt1051-RelWithDebInfo"
+            },
+            "group": "build",
+            "detail": "Build dir has to be configured with Cmake using Ninja",
+        },
+        {
+            "type": "shell",
             "label": "Configure and Build BellHybrid (RT1051)",
             "group": "build",
-            "dependsOn": ["Configure BellHybrid (RT1051)", "Build BellHybrid (RT1051)"],
+            "dependsOn": ["Configure BellHybrid (RT1051)", "Build BellHybrid (RT1051)", "Build BellHybrid Disk Image (RT1051)"],
             "dependsOrder": "sequence",
             "detail": "Configure cmake project and build with Ninja",
         },

--- a/module-services/service-eink/ServiceEink.cpp
+++ b/module-services/service-eink/ServiceEink.cpp
@@ -430,7 +430,10 @@ namespace service::eink
 
     sys::MessagePointer ServiceEink::handleCancelRefreshMessage(sys::Message *request)
     {
+#if DEBUG_EINK_REFRESH == 1
         LOG_INFO("Refresh cancel");
+#endif
+
         if (einkDisplayState == EinkDisplayState::NeedRefresh)
             einkDisplayState = EinkDisplayState::Canceled;
         return sys::MessageNone{};

--- a/products/BellHybrid/apps/application-bell-meditation-timer/MeditationTimer.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/MeditationTimer.cpp
@@ -64,7 +64,7 @@ namespace app
         windowsFactory.attach(meditation::SettingsWindow::name,
                               [this](ApplicationCommon *app, const std::string &name) {
                                   auto presenter = std::make_unique<app::meditation::SettingsPresenter>(
-                                      app, *chimeIntervalModel, *chimeVolumeModel, *startDelayModel, *audioModel);
+                                      *chimeIntervalModel, *chimeVolumeModel, *startDelayModel, *audioModel);
                                   return std::make_unique<meditation::SettingsWindow>(app, std::move(presenter));
                               });
 

--- a/products/BellHybrid/apps/application-bell-meditation-timer/data/Contract.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/data/Contract.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -22,7 +22,7 @@ namespace app::meditation::contract
         virtual void loadData()                                                         = 0;
         virtual void saveData()                                                         = 0;
         virtual void eraseProviderData()                                                = 0;
-        virtual void handleEnter()                                                      = 0;
+        virtual void exitWithSave()                                                     = 0;
         virtual void exitWithoutSave()                                                  = 0;
     };
 

--- a/products/BellHybrid/apps/application-bell-meditation-timer/presenter/SettingsPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/presenter/SettingsPresenter.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -26,8 +26,7 @@ namespace app::meditation
     class SettingsPresenter : public contract::Presenter
     {
       public:
-        SettingsPresenter(app::ApplicationCommon *app,
-                          models::ChimeInterval &chimeIntervalModel,
+        SettingsPresenter(models::ChimeInterval &chimeIntervalModel,
                           models::ChimeVolume &chimeVolumeModel,
                           models::StartDelay &startDelayModel,
                           AbstractAudioModel &audioModel);
@@ -35,12 +34,11 @@ namespace app::meditation
         void saveData() override;
         auto getPagesProvider() const -> std::shared_ptr<gui::ListItemProvider> override;
         void eraseProviderData() override;
-        void handleEnter() override;
+        void exitWithSave() override;
         void exitWithoutSave() override;
 
       private:
         void stopSound();
-        ApplicationCommon *application{};
         models::ChimeInterval &chimeIntervalModel;
         models::ChimeVolume &chimeVolumeModel;
         models::StartDelay &startDelayModel;

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/SettingsWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/SettingsWindow.hpp
@@ -27,7 +27,10 @@ namespace app::meditation
         void rebuild() override;
 
       private:
+        void switchToExitWindow();
+
         gui::SideListView *sideListView{};
         std::unique_ptr<app::meditation::contract::Presenter> presenter;
+        bool isSaveNeeded{false};
     };
 } // namespace app::meditation


### PR DESCRIPTION
Main changes:
- When options are changed do not save the data right away.
- Move loading data from onBeforeShow to keep options after popup.
- Fix the back/close logic to avoid saving volume when back is long
  pressed.

Additional changes:
- added vscode tasks
- disabled refresh cancel log

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
