### PR TITLE
[MOS-790] Workaround for ext4 booting

### DIFF
--- a/board/linux/libiosyscalls/src/iosyscalls-internal.hpp
+++ b/board/linux/libiosyscalls/src/iosyscalls-internal.hpp
@@ -2,7 +2,6 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
-#include <stddef.h>
 #include <stdio.h>
 #include <purefs/vfs_subsystem.hpp>
 

--- a/board/linux/libiosyscalls/src/iosyscalls.cpp
+++ b/board/linux/libiosyscalls/src/iosyscalls.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "iosyscalls-internal.hpp"
@@ -81,7 +81,7 @@ namespace vfsn::linux::internal
 
     const char *npath_translate(const char *inpath, char *buffer)
     {
-        auto inputPath = std::string(inpath);
+        const auto inputPath = std::string(inpath);
 
         for (auto path = IMAGE_PATHS; *path != 0; ++path) {
             if (std::strstr(inpath, *path) == inpath) {
@@ -98,7 +98,16 @@ namespace vfsn::linux::internal
                     outpath += inputPath;
                 }
                 else if (*inpath == '/') {
-                    outpath = sysroot + inputPath;
+                    constexpr auto os_path    = "/sys/os";
+                    const auto os_path_length = strlen(os_path);
+                    if (std::strncmp(inpath, os_path, os_path_length) == 0) {
+                        outpath = sysroot;
+                        outpath += "/sys";
+                        outpath += inputPath.substr(os_path_length);
+                    }
+                    else {
+                        outpath = sysroot + inputPath;
+                    }
                 }
                 else {
                     outpath = sysroot;

--- a/module-vfs/paths/filesystem_paths.cpp
+++ b/module-vfs/paths/filesystem_paths.cpp
@@ -7,6 +7,7 @@ namespace
 {
     constexpr inline auto PATH_SYS         = "/sys";
     constexpr inline auto PATH_CONF        = "/mfgconf";
+    constexpr inline auto PATH_OS          = "os";
     constexpr inline auto PATH_USER        = "user";
     constexpr inline auto PATH_CURRENT     = "current";
     constexpr inline auto PATH_PREVIOUS    = "previous";
@@ -30,7 +31,7 @@ namespace purefs
     {
         std::filesystem::path getRootDiskPath() noexcept
         {
-            return std::filesystem::path{eMMC_disk};
+            return std::filesystem::path{eMMC_disk} / PATH_OS;
         }
 
         std::filesystem::path getMfgConfPath() noexcept
@@ -45,27 +46,27 @@ namespace purefs
 
         std::filesystem::path getCurrentOSPath() noexcept
         {
-            return std::filesystem::path{eMMC_disk} / PATH_CURRENT;
+            return getRootDiskPath() / PATH_CURRENT;
         }
 
         std::filesystem::path getPreviousOSPath() noexcept
         {
-            return std::filesystem::path{eMMC_disk} / PATH_PREVIOUS;
+            return getRootDiskPath() / PATH_PREVIOUS;
         }
 
         std::filesystem::path getUpdatesOSPath() noexcept
         {
-            return std::filesystem::path{eMMC_disk} / PATH_USER / PATH_UPDATES;
+            return getUserDiskPath() / PATH_UPDATES;
         }
 
         std::filesystem::path getTemporaryPath() noexcept
         {
-            return std::filesystem::path{eMMC_disk} / PATH_USER / PATH_TMP;
+            return getUserDiskPath() / PATH_TMP;
         }
 
         std::filesystem::path getBackupOSPath() noexcept
         {
-            return std::filesystem::path{eMMC_disk} / PATH_USER / PATH_BACKUP;
+            return getUserDiskPath() / PATH_BACKUP;
         }
 
         std::filesystem::path getFactoryOSPath() noexcept

--- a/module-vfs/src/purefs/vfs_subsystem.cpp
+++ b/module-vfs/src/purefs/vfs_subsystem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <purefs/fs/filesystem.hpp>
@@ -21,8 +21,8 @@ namespace purefs::subsystem
     {
         constexpr auto default_blkdev_name      = "emmc0";
         constexpr auto default_nvrom_name       = "nvrom0";
-        constexpr auto fat_part_code            = 0x0b;
-        constexpr auto lfs_part_code            = 0x9e;
+        constexpr auto fat_part_code            = 0x0B;
+        constexpr auto lfs_part_code            = 0x9E;
         constexpr auto linux_part_code          = 0x83;
         constexpr auto layout_part_count        = 3;
         constexpr auto boot_part_index          = 0;
@@ -180,7 +180,7 @@ namespace purefs::subsystem
         }
         const auto parts = disk->partitions(default_blkdev_name);
         if (parts.size() != layout_part_count) {
-            LOG_FATAL("Unknown partitions layout part size is %u", unsigned(parts.size()));
+            LOG_FATAL("Unknown partitions layout part size is %u", (unsigned)(parts.size()));
             return -EIO;
         }
         const auto &boot_part = parts[boot_part_index];
@@ -189,12 +189,16 @@ namespace purefs::subsystem
             LOG_FATAL("First partition is not bootable");
             return -EIO;
         }
-        if (boot_part.type != fat_part_code) {
-            LOG_FATAL("Invalid boot partition type expected code: %i current code: %i", fat_part_code, boot_part.type);
+        if ((boot_part.type != fat_part_code) && (boot_part.type != linux_part_code)) {
+            LOG_FATAL("Invalid boot partition type expected code: %02X or %02X current code: %02X",
+                      fat_part_code,
+                      linux_part_code,
+                      boot_part.type);
             return -EIO;
         }
-        if ((user_part.type != lfs_part_code) && (user_part.type != linux_part_code)) {
-            LOG_FATAL("Invalid user partition type expected code: %i current code: %i", lfs_part_code, user_part.type);
+        if (user_part.type != linux_part_code) {
+            LOG_FATAL(
+                "Invalid user partition type expected code: %02X current code: %02X", linux_part_code, user_part.type);
             return -EIO;
         }
         auto vfs = g_fs_core.lock();
@@ -203,7 +207,7 @@ namespace purefs::subsystem
             return -EIO;
         }
         auto err =
-            vfs->mount(boot_part.name, purefs::dir::getRootDiskPath().string(), "vfat", fs::mount_flags::read_only);
+            vfs->mount(boot_part.name, purefs::dir::getRootDiskPath().string(), "auto", fs::mount_flags::read_only);
         if (err) {
             return err;
         }


### PR DESCRIPTION
Workaround required to make MuditaOS
able to boot from ext4-formatted OS
partition.
Previously OS partition was mounted
on /sys and user partition on
/sys/user. This worked
when two separate FS drivers
(FATFS and lwext4) were used.
Changing OS partition to ext4
created an ambiguity whether
/sys/user is user's partition
mountpoint or folder 'user'
on OS partition. This
workaround still may create
ambiguities, so the issue
should be fixed in one of
the further releases by
completely removing 'sys'
prefix.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
