### PR TITLE
[MOS-792] Added VoLTE setting in db

### DIFF
--- a/image/user/db/settings_v2_002.sql
+++ b/image/user/db/settings_v2_002.sql
@@ -45,7 +45,8 @@ INSERT OR IGNORE INTO settings_tab (path, value) VALUES
     ('gs_current_timezone_rules', ''),
     ('\ServiceTime\\gs_automatic_date_and_time_is_on', '1'),
     ('\ServiceEink\\display_inverted_mode', '0'),
-    ('display_lock_screen_deep_refresh_rate', '30');
+    ('display_lock_screen_deep_refresh_rate', '30'),
+    ('cl_volte_enabled', '0');
 
 
 

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -251,6 +251,11 @@ sys::ReturnCodes ServiceCellular::InitHandler()
             settings::Cellular::currentUID, std::to_string(static_cast<int>(uid)), settings::SettingsScope::Global);
     };
 
+    auto rawVolteSetting = settings->getValue(settings::Cellular::volteEnabled, settings::SettingsScope::Global);
+    if (rawVolteSetting.empty()) {
+        settings->setValue(settings::Cellular::volteEnabled, "0", settings::SettingsScope::Global);
+    }
+
     cpuSentinel = std::make_shared<sys::CpuSentinel>(serviceName, this);
 
     ongoingCall =
@@ -595,6 +600,23 @@ void ServiceCellular::registerMessageHandlers()
         return std::make_shared<cellular::IsCallActiveResponse>(ongoingCall && ongoingCall->active());
     });
 
+    connect(typeid(cellular::GetVolteStateRequest), [&](sys::Message *request) -> sys::MessagePointer {
+        return std::make_shared<cellular::GetVolteStateResponse>(priv->volteHandler->getVolteState());
+    });
+
+    connect(typeid(cellular::SwitchVolteOnOffRequest), [&](sys::Message *request) -> sys::MessagePointer {
+        auto message = static_cast<cellular::SwitchVolteOnOffRequest *>(request);
+        auto channel = cmux->get(CellularMux::Channel::Commands);
+        settings->setValue(
+            settings::Cellular::volteEnabled, message->enable ? "1" : "0", settings::SettingsScope::Global);
+        if (not priv->volteHandler->switchVolte(*channel, message->enable)) {
+            auto notification = std::make_shared<cellular::VolteStateNotification>(priv->volteHandler->getVolteState());
+            bus.sendMulticast(std::move(notification), sys::BusChannel::ServiceCellularNotifications);
+            priv->modemResetHandler->performHardReset();
+        }
+        return sys::MessageNone{};
+    });
+
     handle_CellularGetChannelMessage();
 }
 
@@ -870,12 +892,11 @@ bool ServiceCellular::handle_cellular_priv_init()
     priv->simContacts->setChannel(channel);
     priv->imeiGetHandler->setChannel(channel);
 
-#if ENABLE_VOLTE == 1
-    constexpr bool enableVolte = true;
-#else
-    constexpr bool enableVolte = false;
-#endif
     bool needReset = false;
+
+    auto enableVolte =
+        settings->getValue(settings::Cellular::volteEnabled, settings::SettingsScope::Global) == "1" ? true : false;
+    ;
     try {
         needReset = !priv->tetheringHandler->configure() || !priv->volteHandler->switchVolte(*channel, enableVolte);
     }

--- a/module-services/service-cellular/service-cellular/CellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/CellularMessage.hpp
@@ -5,6 +5,7 @@
 
 #include "SignalStrength.hpp"
 #include <service-cellular/State.hpp>
+#include <service-cellular/VolteState.hpp>
 
 #include <modem/mux/CellularMux.h>
 #include <PhoneNumber.hpp>
@@ -1055,4 +1056,28 @@ namespace cellular
         const bool active = false;
     };
 
+    class GetVolteStateRequest : public sys::DataMessage
+    {};
+
+    struct GetVolteStateResponse : public sys::ResponseMessage
+    {
+        VolteState volteState;
+        explicit GetVolteStateResponse(VolteState volteState) : volteState(volteState)
+        {}
+    };
+
+    struct VolteStateNotification : public sys::DataMessage
+    {
+        VolteState volteState;
+        explicit VolteStateNotification(VolteState volteState)
+            : sys::DataMessage(MessageType::MessageTypeUninitialized), volteState(volteState)
+        {}
+    };
+
+    struct SwitchVolteOnOffRequest : public sys::DataMessage
+    {
+        bool enable = false;
+        SwitchVolteOnOffRequest(bool enable) : DataMessage(MessageType::MessageTypeUninitialized), enable(enable)
+        {}
+    };
 } // namespace cellular

--- a/module-services/service-cellular/service-cellular/VolteState.hpp
+++ b/module-services/service-cellular/service-cellular/VolteState.hpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+namespace cellular
+{
+
+    enum class VolteState
+    {
+        On,
+        Off,
+        SwitchingToOff,
+        SwitchingToOn,
+        Undefined
+    };
+}

--- a/module-services/service-cellular/src/VolteHandler.hpp
+++ b/module-services/service-cellular/src/VolteHandler.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <service-cellular/VolteState.hpp>
 #include <module-cellular/at/ATFactory.hpp>
 #include <module-cellular/at/response.hpp>
 #include <module-utils/utility/Utils.hpp>
@@ -35,7 +36,7 @@ namespace cellular::service
     template <typename CmuxChannel, typename ModemResponseParser>
     struct VolteHandler : private NonCopyable
     {
-        bool switchVolte(CmuxChannel &channel, bool enable) const
+        bool switchVolte(CmuxChannel &channel, bool enable)
         {
             ModemResponseParser const parser;
 
@@ -77,9 +78,18 @@ namespace cellular::service
                     throw std::runtime_error("[VoLTE] failed to " + std::string(enable ? "enable" : "disable") +
                                              " IMS");
                 }
+                volteState = enable ? cellular::VolteState::SwitchingToOn : cellular::VolteState::SwitchingToOff;
+            }
+            else {
+                volteState = enable ? cellular::VolteState::On : cellular::VolteState::Off;
             }
 
             return alreadyConfigured;
+        }
+
+        auto getVolteState() -> cellular::VolteState
+        {
+            return volteState;
         }
 
       private:
@@ -87,5 +97,6 @@ namespace cellular::service
         {
             return std::to_string(magic_enum::enum_integer(imsState));
         }
+        cellular::VolteState volteState = cellular::VolteState::Undefined;
     };
 } // namespace cellular::service

--- a/module-services/service-db/agents/settings/SystemSettings.hpp
+++ b/module-services/service-db/agents/settings/SystemSettings.hpp
@@ -48,6 +48,7 @@ namespace settings
         constexpr inline auto apn_list    = "cl_apn_list";
         constexpr inline auto offlineMode = "cl_offline_mode";
         constexpr inline auto currentUID  = "cl_current_uid";
+        constexpr inline auto volteEnabled = "cl_volte_enabled";
     } // namespace Cellular
 
     namespace Battery

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -41,6 +41,7 @@
 * Added tethering information on the status bar
 * Added basic MMS handling
 * Added run-time statistics for tasks
+* Added VoLTE state in settings database
 
 ## [1.3.0 2022-08-04]
 


### PR DESCRIPTION
VoLTE enabled/disabled state is now stored in settings database. VoLTE is enabled or disabled to mach setting during modem initialisation.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [x] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
