### PR TITLE
[MOS-801] Fix memory handling around NetworkWindow

### DIFF
--- a/module-apps/application-settings/windows/network/NetworkWindow.hpp
+++ b/module-apps/application-settings/windows/network/NetworkWindow.hpp
@@ -18,6 +18,8 @@ namespace gui
         auto buildOptionsList() -> std::list<Option> override;
         app::settingsInterface::OperatorsSettings *operatorsSettings;
 
+        OptionWindowDestroyer rai_destroyer = OptionWindowDestroyer(*this);
+
       public:
         NetworkWindow(app::ApplicationCommon *app, app::settingsInterface::OperatorsSettings *operatorsSettings);
 


### PR DESCRIPTION
Added the missing window destroyer.

Make sure that this PR:
    - Complies with our guidelines for contributions
    - Has unit tests if possible
    - Has documentation updated
    - Has changelog entry added
^
------ none applicable here
