### PR TITLE
[CP-1666] DeviceInfo request should return "SerialNumber" for Harmony

### DIFF
--- a/products/BellHybrid/services/desktop/endpoints/include/endpoints/deviceInfo/DeviceInfoEndpoint.hpp
+++ b/products/BellHybrid/services/desktop/endpoints/include/endpoints/deviceInfo/DeviceInfoEndpoint.hpp
@@ -14,6 +14,7 @@ namespace sdesktop::endpoints
         explicit DeviceInfoEndpoint(sys::Service *ownerServicePtr) : DeviceInfoEndpointCommon(ownerServicePtr)
         {}
 
+        auto getSerialNumber() -> std::string;
         auto getDeviceInfo(Context &context) -> http::Code override;
     };
 


### PR DESCRIPTION
Add reading serial number from emmc partition
Add serial number to body response for deviceInfo endpoint for Harmony

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
