### PR TITLE
[MOS-820] Fix crashes caused by plugging the charger.

### DIFF
--- a/module-bsp/board/linux/usb_cdc/usb_cdc.cpp
+++ b/module-bsp/board/linux/usb_cdc/usb_cdc.cpp
@@ -29,6 +29,10 @@
 #define LOG_FATAL(...)
 #define LOG_CUSTOM(loggerLevel, ...)
 #endif
+namespace
+{
+    xTaskHandle taskHandleReceive;
+}
 namespace bsp
 {
     int fd;
@@ -148,6 +152,8 @@ namespace bsp
     {
         LOG_INFO("usbDeinit removing file %s", ptsFileName);
         std::remove(ptsFileName);
+        if (taskHandleReceive)
+            vTaskDelete(taskHandleReceive);
     }
 
     void usbReinit(const std::string &)
@@ -202,7 +208,6 @@ namespace bsp
         cfsetospeed(&newtio, SERIAL_BAUDRATE);
         tcsetattr(fd, TCSANOW, &newtio);
 
-        xTaskHandle taskHandleReceive;
         USBReceiveQueue = initParams.queueHandle;
         USBIrqQueue     = initParams.irqQueueHandle;
 


### PR DESCRIPTION
Fix for the linux simulator crashes caused by connecting/disconnecting charger.

The deleting of the USBLinuxReceive task has been added in the USB stack de-initialization process to avoid creating multiple instances during next initializations.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
