### PR TITLE
[MOS-823] Update 'misc' submodule reference

### DIFF
--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -11,6 +11,7 @@
 * Fixed music files extension case sensitivity
 * Fixed MTP issues
 * Rebuilt SIM cards window
+* Added option to provide custom GDB to crash analysis script
 
 ### Fixed
 * Fixed incorrect total CPU usage in logs


### PR DESCRIPTION
Added a possibility to use a custom GDB for crash analysis.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added
