### PR TITLE
[MOS-660] Fix disappearing button in PIN entering screen

### DIFF
--- a/module-apps/apps-common/locks/widgets/SimLockBox.cpp
+++ b/module-apps/apps-common/locks/widgets/SimLockBox.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SimLockBox.hpp"
@@ -64,7 +64,7 @@ namespace gui
         }
 
         LockWindow->setImage("sim_128px_W_G");
-        LockWindow->setNavBarWidgetsActive(false, false, true);
+        LockWindow->setNavBarWidgetsActive(false, LockWindow->lock->canVerify(), true);
     }
 
     void SimLockBox::setVisibleStateInputInvalid(InputErrorType type, unsigned int value)

--- a/module-apps/apps-common/popups/lock-popups/SimLockInputWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/SimLockInputWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SimLockInputWindow.hpp"
@@ -43,6 +43,7 @@ namespace gui
         if (lock->isState(locks::Lock::LockState::ErrorOccurred)) {
             lockBox->setVisibleStateError(errorCode);
         }
+        application->refreshWindow(gui::RefreshModes::GUI_REFRESH_DEEP);
     }
 
     status_bar::Configuration SimLockInputWindow::configureStatusBar(status_bar::Configuration appConfiguration)

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -38,6 +38,7 @@
 * Fixed USB connection/disconnection detection
 * Fixed memory leaks in APN settings
 * Fixed windows flow regarding PUK requests after too many PIN mistakes
+* Fixed disappearing "confirm" button in PIN entering screen
 
 ### Added
 * Added tethering information on the status bar


### PR DESCRIPTION
<!-- Please describe your pull request here -->

When we returned from the SOS screen to the PIN entry screen, the "confirm" button disappeared.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
