### PR TITLE
[MOS-821] Adjust VoLTE GUI basing on operator

### DIFF
--- a/image/assets/lang/Deutsch.json
+++ b/image/assets/lang/Deutsch.json
@@ -469,6 +469,7 @@
   "app_settings_about": "Über Mudita Pure",
   "app_settings_title_languages": "Sprachauswahl",
   "app_settings_network_sim_cards": "SIM-Karten",
+  "app_settings_network_volte_not_available": "not available",
   "app_settings_network_active_card": "Aktiver Slot",
   "app_settings_network_unblock_card": "Entsperren Karte",
   "app_settings_network_not_connected": "keine Karte",

--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -426,6 +426,7 @@
   "app_settings_about": "About Mudita Pure",
   "app_settings_title_languages": "Language selection",
   "app_settings_network_sim_cards": "SIM cards",
+  "app_settings_network_volte_not_available": "not available",
   "app_settings_network_active_card": "Active slot",
   "app_settings_network_unblock_card": "Unblock card",
   "app_settings_network_not_connected": "no card",

--- a/image/assets/lang/Espanol.json
+++ b/image/assets/lang/Espanol.json
@@ -469,6 +469,7 @@
   "app_settings_about": "Sobre Mudita Pure",
   "app_settings_title_languages": "Selección de idioma",
   "app_settings_network_sim_cards": "Tarjetas SIM",
+  "app_settings_network_volte_not_available": "not available",
   "app_settings_network_active_card": "Toma activa",
   "app_settings_network_unblock_card": "Desbloquear la tarjeta",
   "app_settings_network_not_connected": "sin tarjeta",

--- a/image/assets/lang/Francais.json
+++ b/image/assets/lang/Francais.json
@@ -437,6 +437,7 @@
   "app_settings_about": "À propos de Mudita Pure",
   "app_settings_title_languages": "Sélection de langue",
   "app_settings_network_sim_cards": "Cartes SIM",
+  "app_settings_network_volte_not_available": "not available",
   "app_settings_network_active_card": "Fente active",
   "app_settings_network_unblock_card": "Débloquer la carte",
   "app_settings_network_not_connected": "pas de carte",

--- a/image/assets/lang/Polski.json
+++ b/image/assets/lang/Polski.json
@@ -480,6 +480,7 @@
   "app_settings_about": "O Mudita Pure",
   "app_settings_title_languages": "Wybór języka",
   "app_settings_network_sim_cards": "Karty SIM",
+  "app_settings_network_volte_not_available": "niedostępne",
   "app_settings_network_active_card": "Aktywny slot",
   "app_settings_network_unblock_card": "Odblokuj kartę",
   "app_settings_network_not_connected": "brak karty",

--- a/image/assets/lang/Svenska.json
+++ b/image/assets/lang/Svenska.json
@@ -377,6 +377,7 @@
   "app_settings_about": "Om Mudita Pure",
   "app_settings_title_languages": "Språkval",
   "app_settings_network_sim_cards": "SIM-kort",
+  "app_settings_network_volte_not_available": "not available",
   "app_settings_network_active_card": "Aktivt slot",
   "app_settings_network_unblock_card": "Avblockera kort",
   "app_settings_network_not_connected": "inget kort",

--- a/module-apps/application-settings/include/application-settings/ApplicationSettings.hpp
+++ b/module-apps/application-settings/include/application-settings/ApplicationSettings.hpp
@@ -205,7 +205,7 @@ namespace app
         bool callsFromFavorites                                        = false;
         int connectionFrequency                                        = 0;
         bool flightModeOn                                              = true;
-        cellular::VolteState volteState{cellular::VolteState::Undefined};
+        cellular::VolteState volteState;
         std::shared_ptr<BluetoothSettingsModel> bluetoothSettingsModel = nullptr;
     };
 

--- a/module-services/service-cellular/service-cellular/VolteState.hpp
+++ b/module-services/service-cellular/service-cellular/VolteState.hpp
@@ -5,12 +5,16 @@
 
 namespace cellular
 {
-    enum class VolteState
+    struct VolteState
     {
-        On,
-        Off,
-        SwitchingToOff,
-        SwitchingToOn,
-        Undefined
+        enum class Enablement
+        {
+            On,
+            Off,
+            SwitchingToOff,
+            SwitchingToOn,
+            Undefined
+        } enablement   = Enablement::Undefined;
+        bool permitted = true;
     };
 }

--- a/module-services/service-cellular/src/VolteHandler.hpp
+++ b/module-services/service-cellular/src/VolteHandler.hpp
@@ -90,15 +90,17 @@ namespace cellular::service
                                              " IMS");
                 }
 
-                volteState = enable ? cellular::VolteState::SwitchingToOn : cellular::VolteState::SwitchingToOff;
+                volteState.enablement = enable ? cellular::VolteState::Enablement::SwitchingToOn
+                                               : cellular::VolteState::Enablement::SwitchingToOff;
                 isFirstRunAfterSwitch = false;
             }
             else {
-                if (volteState == cellular::VolteState::SwitchingToOn ||
-                    volteState == cellular::VolteState::SwitchingToOff) {
+                if (volteState.enablement == cellular::VolteState::Enablement::SwitchingToOn ||
+                    volteState.enablement == cellular::VolteState::Enablement::SwitchingToOff) {
                     isFirstRunAfterSwitch = true;
                 }
-                volteState = enable ? cellular::VolteState::On : cellular::VolteState::Off;
+                volteState.enablement =
+                    enable ? cellular::VolteState::Enablement::On : cellular::VolteState::Enablement::Off;
             }
 
             return alreadyConfigured;
@@ -161,7 +163,7 @@ namespace cellular::service
             return std::to_string(magic_enum::enum_integer(imsState));
         }
 
-        cellular::VolteState volteState = cellular::VolteState::Undefined;
+        cellular::VolteState volteState;
         bool isFirstRunAfterSwitch      = false;
     };
 } // namespace cellular::service


### PR DESCRIPTION
When VoLTE isn't permitted for the current SIM
card's operator, display information only.
Otherwise, display a switch.

Make sure that this PR:
- [x] Complies with our guidelines for contributions


After this change, the code still works as previously - VoLTE availability isn't restricted yet and the whole thing, including translations, will be ready when connected together to form the whole MOS-815.