### PR TITLE
[MOS-827] Fix looping on the SIM card selection screen

### DIFF
--- a/module-apps/apps-common/locks/handlers/SimLockSubject.cpp
+++ b/module-apps/apps-common/locks/handlers/SimLockSubject.cpp
@@ -53,6 +53,6 @@ namespace locks
 
     void SimLockSubject::simSwitched()
     {
-        owner->bus.sendUnicast(std::make_shared<locks::SimSwitched>(), service::name::appmgr);
+        owner->bus.sendMulticast(std::make_shared<locks::SimSwitched>(), sys::BusChannel::PhoneLockChanges);
     }
 } // namespace locks

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -39,6 +39,7 @@
 * Fixed memory leaks in APN settings
 * Fixed windows flow regarding PUK requests after too many PIN mistakes
 * Fixed disappearing "confirm" button in PIN entering screen
+* Fixed looping on the SIM card selection screen
 
 ### Added
 * Added a popup for changing the SIM card


### PR DESCRIPTION
<!-- Please describe your pull request here -->

It was not possible to finish onboarding properly
when we selected a SIM card without an active PIN

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
