### PR TITLE
[MOS-783] Fix crash on entering SAR menu

### DIFF
--- a/module-apps/application-settings/ApplicationSettings.cpp
+++ b/module-apps/application-settings/ApplicationSettings.cpp
@@ -548,7 +548,9 @@ namespace app
             return std::make_unique<gui::CertificationWindow>(app);
         });
         windowsFactory.attach(gui::window::name::sar, [&](ApplicationCommon *app, const std::string &name) {
-            auto sarInfoRepository = std::make_unique<SARInfoRepository>("assets/certification_info", "sar.txt");
+            const auto path        = purefs::dir::getSystemDataDirPath() / "certification_info";
+            const auto filename    = "sar.txt";
+            auto sarInfoRepository = std::make_unique<SARInfoRepository>(path, filename);
             auto presenter         = std::make_unique<SARInfoWindowPresenter>(std::move(sarInfoRepository));
             return std::make_unique<gui::SARInfoWindow>(app, std::move(presenter));
         });

--- a/module-apps/application-settings/presenter/system/SARInfoWindowPresenter.cpp
+++ b/module-apps/application-settings/presenter/system/SARInfoWindowPresenter.cpp
@@ -1,7 +1,8 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SARInfoWindowPresenter.hpp"
+#include <log/log.hpp>
 
 SARInfoWindowPresenter::SARInfoWindowPresenter(std::unique_ptr<AbstractSARInfoRepository> &&sarInfoRepository)
     : sarInfoRepository{std::move(sarInfoRepository)}
@@ -9,5 +10,12 @@ SARInfoWindowPresenter::SARInfoWindowPresenter(std::unique_ptr<AbstractSARInfoRe
 
 std::string SARInfoWindowPresenter::getSarInfo()
 {
-    return sarInfoRepository->getSarInfoText();
+    try {
+        const auto sarInfoText = sarInfoRepository->getSarInfoText();
+        return sarInfoText;
+    }
+    catch (const std::runtime_error &e) {
+        LOG_ERROR("Failed to get SAR info text! Error: %s", e.what());
+        return "";
+    }
 }


### PR DESCRIPTION
Fix of the issue that entering SAR option
in menu resulted in crash of the phone
due to uncaught exception caused by
invalid path provided.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
