### PR TITLE
[MOS-825] VoLTE steering according to IMSI

### DIFF
--- a/image/assets/lang/Deutsch.json
+++ b/image/assets/lang/Deutsch.json
@@ -469,7 +469,7 @@
   "app_settings_about": "Über Mudita Pure",
   "app_settings_title_languages": "Sprachauswahl",
   "app_settings_network_sim_cards": "SIM-Karten",
-  "app_settings_network_volte_not_available": "not available",
+  "app_settings_network_volte_not_available": "nicht verfügbar",
   "app_settings_network_active_card": "Aktiver Slot",
   "app_settings_network_unblock_card": "Entsperren Karte",
   "app_settings_network_not_connected": "keine Karte",

--- a/image/assets/lang/Espanol.json
+++ b/image/assets/lang/Espanol.json
@@ -469,7 +469,7 @@
   "app_settings_about": "Sobre Mudita Pure",
   "app_settings_title_languages": "Selección de idioma",
   "app_settings_network_sim_cards": "Tarjetas SIM",
-  "app_settings_network_volte_not_available": "not available",
+  "app_settings_network_volte_not_available": "no disponible",
   "app_settings_network_active_card": "Toma activa",
   "app_settings_network_unblock_card": "Desbloquear la tarjeta",
   "app_settings_network_not_connected": "sin tarjeta",

--- a/image/assets/lang/Francais.json
+++ b/image/assets/lang/Francais.json
@@ -437,7 +437,7 @@
   "app_settings_about": "À propos de Mudita Pure",
   "app_settings_title_languages": "Sélection de langue",
   "app_settings_network_sim_cards": "Cartes SIM",
-  "app_settings_network_volte_not_available": "not available",
+  "app_settings_network_volte_not_available": "non disponible",
   "app_settings_network_active_card": "Fente active",
   "app_settings_network_unblock_card": "Débloquer la carte",
   "app_settings_network_not_connected": "pas de carte",

--- a/image/assets/lang/Svenska.json
+++ b/image/assets/lang/Svenska.json
@@ -377,7 +377,7 @@
   "app_settings_about": "Om Mudita Pure",
   "app_settings_title_languages": "Språkval",
   "app_settings_network_sim_cards": "SIM-kort",
-  "app_settings_network_volte_not_available": "not available",
+  "app_settings_network_volte_not_available": "inte tillgängligt",
   "app_settings_network_active_card": "Aktivt slot",
   "app_settings_network_unblock_card": "Avblockera kort",
   "app_settings_network_not_connected": "inget kort",

--- a/module-apps/application-settings/windows/network/NetworkWindow.cpp
+++ b/module-apps/application-settings/windows/network/NetworkWindow.cpp
@@ -75,7 +75,7 @@ namespace gui
                     settingsApp->sendVolteChangeRequest(false);
                     break;
                 default:
-                    LOG_INFO("Skip request due unsettled VoLTE state");
+                    LOG_INFO("[VoLTE] skip request due to unsettled VoLTE state");
                     break;
                 }
                 return true;

--- a/module-services/service-cellular/service-cellular/VolteState.hpp
+++ b/module-services/service-cellular/service-cellular/VolteState.hpp
@@ -15,6 +15,6 @@ namespace cellular
             SwitchingToOn,
             Undefined
         } enablement   = Enablement::Undefined;
-        bool permitted = true;
+        bool permitted = false;
     };
 }

--- a/module-services/service-cellular/src/volte/ImsiParserUS.cpp
+++ b/module-services/service-cellular/src/volte/ImsiParserUS.cpp
@@ -23,12 +23,12 @@ namespace cellular::service
             mnc = imsi.substr(mccSize, mncSize);
         }
         catch (const std::out_of_range &e) {
-            LOG_ERROR("IMSI parsing error: %s", e.what());
+            LOG_ERROR("[VoLTE] IMSI parsing error: %s", e.what());
             return std::nullopt;
         }
 
         if (std::find(std::begin(usMcc), std::end(usMcc), mcc) == std::end(usMcc)) {
-            LOG_ERROR("Not US MCC.");
+            LOG_ERROR("[VoLTE] MCC not from USA");
             return std::nullopt;
         }
 

--- a/module-services/service-cellular/src/volte/VolteAllowedUSList.cpp
+++ b/module-services/service-cellular/src/volte/VolteAllowedUSList.cpp
@@ -25,11 +25,11 @@ namespace cellular::service
 
     auto VolteAllowedUSList::isVolteAllowed(const OperatorInfo &operatorInfo) -> bool
     {
-        LOG_INFO("Trying to find MCC: %s, MNC: %s", operatorInfo.MCC.c_str(), operatorInfo.MNC.c_str());
+        LOG_INFO("[VoLTE] trying to find MCC: %s, MNC: %s", operatorInfo.MCC.c_str(), operatorInfo.MNC.c_str());
 
         if (std::find(std::begin(allowedOperators), std::end(allowedOperators), operatorInfo) ==
             std::end(allowedOperators)) {
-            LOG_ERROR("Unable to find. VoLTE not allowed.");
+            LOG_ERROR("[VoLTE] unable to find MCC+MNC on list - VoLTE not allowed");
             return false;
         }
         return true;

--- a/module-services/service-cellular/src/volte/VolteCapabilityHandler.hpp
+++ b/module-services/service-cellular/src/volte/VolteCapabilityHandler.hpp
@@ -8,13 +8,6 @@
 #include "VolteAllowedListInterface.hpp"
 
 #include <memory>
-#include <vector>
-
-namespace at
-{
-    class Result;
-    class BaseChannel;
-} // namespace at
 
 namespace cellular::service
 {
@@ -24,20 +17,14 @@ namespace cellular::service
         VolteCapabilityHandler(std::unique_ptr<ImsiParserInteface> imsiParser,
                                std::unique_ptr<VolteAllowedListInterface> allowedList,
                                std::unique_ptr<VolteCapabilityCellularInterface> cellularInterface);
-        /** Set AT command channel
-         * \param channel channel (or nullptr to block communication):
-         */
-        void setChannel(at::BaseChannel *channel);
         /** Check if it is a possibility to enable VoLTE on current operator
          * @return true when VoLTE is allowed, false when not
          */
-        auto isVolteAllowed() -> bool;
+        auto isVolteAllowed(at::BaseChannel &channel) -> bool;
 
       private:
         std::unique_ptr<ImsiParserInteface> imsiParser;
         std::unique_ptr<VolteAllowedListInterface> allowedList;
         std::unique_ptr<VolteCapabilityCellularInterface> cellularInterface;
-
-        auto isCellularInterfaceReady() -> bool;
     };
 } // namespace cellular::service

--- a/module-services/service-cellular/src/volte/VolteCapabilityHandlerCellular.cpp
+++ b/module-services/service-cellular/src/volte/VolteCapabilityHandlerCellular.cpp
@@ -3,24 +3,15 @@
 
 #include "VolteCapabilityHandlerCellular.hpp"
 #include <modem/mux/CellularMux.h>
+#include <module-cellular/modem/BaseChannel.hpp>
 
 namespace cellular::service
 {
-    void VolteCapabilityCellular::setChannel(at::BaseChannel *channel)
+    auto VolteCapabilityCellular::getImsi(at::BaseChannel &channel) -> std::optional<std::string>
     {
-        this->channel = channel;
-    }
-
-    auto VolteCapabilityCellular::getImsi() -> std::optional<std::string>
-    {
-        if (channel == nullptr) {
-            LOG_ERROR("No channel provided. Request ignored");
-            return std::nullopt;
-        }
-
-        auto result = channel->cmd(at::AT::CIMI);
+        auto result = channel.cmd(at::AT::CIMI);
         if (not result) {
-            LOG_ERROR("Failed to read IMSI, disable VoLTE.");
+            LOG_ERROR("[VoLTE] failed to read IMSI - will disable VoLTE");
             return std::nullopt;
         }
 

--- a/module-services/service-cellular/src/volte/VolteCapabilityHandlerCellular.hpp
+++ b/module-services/service-cellular/src/volte/VolteCapabilityHandlerCellular.hpp
@@ -10,20 +10,13 @@
 
 namespace at
 {
-    class Result;
     class BaseChannel;
 } // namespace at
 
 namespace cellular::service
 {
-
-    class VolteCapabilityCellular : public VolteCapabilityCellularInterface
+    struct VolteCapabilityCellular : VolteCapabilityCellularInterface
     {
-      public:
-        void setChannel(at::BaseChannel *channel) final;
-        auto getImsi() -> std::optional<std::string> final;
-
-      private:
-        at::BaseChannel *channel = nullptr;
+        auto getImsi(at::BaseChannel &) -> std::optional<std::string> final;
     };
 } // namespace cellular::service

--- a/module-services/service-cellular/src/volte/VolteCapabiltyHandlerCellularInterface.hpp
+++ b/module-services/service-cellular/src/volte/VolteCapabiltyHandlerCellularInterface.hpp
@@ -8,18 +8,15 @@
 
 namespace at
 {
-    class Result;
     class BaseChannel;
-} // namespace at
+}
 
 namespace cellular::service
 {
-
     class VolteCapabilityCellularInterface
     {
       public:
         virtual ~VolteCapabilityCellularInterface()          = default;
-        virtual void setChannel(at::BaseChannel *channel)    = 0;
-        virtual auto getImsi() -> std::optional<std::string> = 0;
+        virtual auto getImsi(at::BaseChannel &) -> std::optional<std::string> = 0;
     };
 } // namespace cellular::service

--- a/module-services/service-cellular/tests/unittest_volteCapabilityHandler.cpp
+++ b/module-services/service-cellular/tests/unittest_volteCapabilityHandler.cpp
@@ -7,9 +7,42 @@
 #include <module-services/service-cellular/src/volte/ImsiParserUS.hpp>
 #include <module-services/service-cellular/src/volte/VolteAllowedUSList.hpp>
 #include <module-services/service-cellular/src/volte/VolteCapabiltyHandlerCellularInterface.hpp>
+#include <module-cellular/modem/BaseChannel.hpp>
 
 TEST_CASE("VoLTE Capability handler")
 {
+    struct BaseChannelStub final : at::BaseChannel
+    {
+        virtual ~BaseChannelStub() = default;
+
+        virtual auto cmd(const std::string &, std::chrono::milliseconds = at::default_timeout, size_t = 0) -> at::Result
+        {
+            return at::Result{};
+        }
+        virtual auto cmd(const at::AT &) -> at::Result
+        {
+            return at::Result{};
+        }
+        virtual auto cmd(const at::Cmd &) -> at::Result
+        {
+            return at::Result{};
+        }
+        virtual void cmdLog(std::string, const at::Result &, std::chrono::milliseconds)
+        {}
+        virtual void cmdInit()
+        {}
+        virtual void cmdSend(std::string)
+        {}
+        virtual size_t cmdReceive(std::uint8_t *, std::chrono::milliseconds)
+        {
+            return 0;
+        }
+        virtual void cmdPost()
+        {}
+    };
+
+    static BaseChannelStub baseChannelStub;
+
     SECTION("ImsiParserUS success - US IMSI")
     {
         using namespace cellular::service;
@@ -86,9 +119,7 @@ TEST_CASE("VoLTE Capability handler")
 
     class MockTMobileUS : public cellular::service::VolteCapabilityCellularInterface
     {
-        void setChannel(at::BaseChannel *channel)
-        {}
-        auto getImsi() -> std::optional<std::string>
+        auto getImsi(at::BaseChannel &) -> std::optional<std::string> override
         {
             return "310120123456789";
         }
@@ -100,15 +131,13 @@ TEST_CASE("VoLTE Capability handler")
         VolteCapabilityHandler handler{std::make_unique<ImsiParserUS>(),
                                        std::make_unique<VolteAllowedUSList>(),
                                        std::make_unique<MockTMobileUS>()};
-        auto result = handler.isVolteAllowed();
+        auto result = handler.isVolteAllowed(baseChannelStub);
         REQUIRE(result == true);
     }
 
     class MockNonTMobileUS : public cellular::service::VolteCapabilityCellularInterface
     {
-        void setChannel(at::BaseChannel *channel)
-        {}
-        auto getImsi() -> std::optional<std::string>
+        auto getImsi(at::BaseChannel &) -> std::optional<std::string>
         {
             return "310999123456789";
         }
@@ -120,15 +149,13 @@ TEST_CASE("VoLTE Capability handler")
         VolteCapabilityHandler handler{std::make_unique<ImsiParserUS>(),
                                        std::make_unique<VolteAllowedUSList>(),
                                        std::make_unique<MockNonTMobileUS>()};
-        auto result = handler.isVolteAllowed();
+        auto result = handler.isVolteAllowed(baseChannelStub);
         REQUIRE(result == false);
     }
 
     class MockFailedToGetImsi : public cellular::service::VolteCapabilityCellularInterface
     {
-        void setChannel(at::BaseChannel *channel)
-        {}
-        auto getImsi() -> std::optional<std::string>
+        auto getImsi(at::BaseChannel &) -> std::optional<std::string>
         {
             return std::nullopt;
         }
@@ -140,7 +167,7 @@ TEST_CASE("VoLTE Capability handler")
         VolteCapabilityHandler handler{std::make_unique<ImsiParserUS>(),
                                        std::make_unique<VolteAllowedUSList>(),
                                        std::make_unique<MockFailedToGetImsi>()};
-        auto result = handler.isVolteAllowed();
+        auto result = handler.isVolteAllowed(baseChannelStub);
         REQUIRE(result == false);
     }
 }

--- a/module-services/service-cellular/tests/unittest_volteHandler.cpp
+++ b/module-services/service-cellular/tests/unittest_volteHandler.cpp
@@ -113,7 +113,7 @@ TEST_CASE("VoLTE handler test")
 
         VolteHandler<CommandSequentialChannel, DummyModemResponseParser> handler;
 
-        REQUIRE_THROWS_WITH(handler.switchVolte(channel, true), Catch::Contains("voice domain"));
+        REQUIRE_THROWS_WITH(handler.switchVolte(channel, true, true), Catch::Contains("voice domain"));
     }
 
     SECTION("ThrowsAboutMbnAutoselectFailure_When_TryingToEnableVolte_And_AutoselectCommandRespondsNOK")
@@ -127,7 +127,7 @@ TEST_CASE("VoLTE handler test")
 
         VolteHandler<CommandSequentialChannel, DummyModemResponseParser> handler;
 
-        REQUIRE_THROWS_WITH(handler.switchVolte(channel, true), Catch::Contains("MBN"));
+        REQUIRE_THROWS_WITH(handler.switchVolte(channel, true, true), Catch::Contains("MBN"));
     }
 
     SECTION("ThrowsAboutImsCheckingFailure_When_TryingToEnableVolte_And_ImsConfigurationQueryRespondsNOK")
@@ -142,7 +142,7 @@ TEST_CASE("VoLTE handler test")
 
         VolteHandler<CommandSequentialChannel, DummyModemResponseParser> handler;
 
-        REQUIRE_THROWS_WITH(handler.switchVolte(channel, true), Catch::Contains("IMS"));
+        REQUIRE_THROWS_WITH(handler.switchVolte(channel, true, true), Catch::Contains("IMS"));
     }
 
     SECTION("ThrowsAboutImsCheckingFailure_When_TryingToEnableVolte_And_CantParseImsConfigurationQuery")
@@ -157,7 +157,7 @@ TEST_CASE("VoLTE handler test")
 
         VolteHandler<CommandSequentialChannel, QcfgImsThrowingParser> handler;
 
-        REQUIRE_THROWS_WITH(handler.switchVolte(channel, true), Catch::Contains("IMS"));
+        REQUIRE_THROWS_WITH(handler.switchVolte(channel, true, true), Catch::Contains("IMS"));
     }
 
     SECTION("ReturnsOk_When_TryingToEnableVolte_And_AlreadyEnabled")
@@ -172,7 +172,7 @@ TEST_CASE("VoLTE handler test")
 
         VolteHandler<CommandSequentialChannel, QcfgImsDummyParser<true>> handler;
 
-        REQUIRE(handler.switchVolte(channel, true));
+        REQUIRE(handler.switchVolte(channel, true, true));
     }
 
     SECTION("ReturnsOk_When_TryingToDisableVolte_And_AlreadyDisabled")
@@ -183,7 +183,7 @@ TEST_CASE("VoLTE handler test")
 
         VolteHandler<CommandSequentialChannel, QcfgImsDummyParser<true>> handler;
 
-        REQUIRE(handler.switchVolte(channel, false));
+        REQUIRE(handler.switchVolte(channel, true, false));
     }
 
     SECTION("ReturnsFalse_When_TryingToDisableVolte_And_WasEnabledBefore")
@@ -197,7 +197,7 @@ TEST_CASE("VoLTE handler test")
 
         VolteHandler<CommandSequentialChannel, QcfgImsDummyParser<false>> handler;
 
-        REQUIRE_FALSE(handler.switchVolte(channel, false));
+        REQUIRE_FALSE(handler.switchVolte(channel, true, false));
     }
 
     SECTION("ReturnsFalse_When_TryingToEnableVolte_And_WasEnabledBefore")
@@ -211,7 +211,7 @@ TEST_CASE("VoLTE handler test")
 
         VolteHandler<CommandSequentialChannel, QcfgImsDummyParser<false>> handler;
 
-        REQUIRE_FALSE(handler.switchVolte(channel, false));
+        REQUIRE_FALSE(handler.switchVolte(channel, true, false));
     }
 
     SECTION("ThrowsAboutImsFailure_When_DisablingVolte_And_ImsSteeringCommandFailed")
@@ -225,7 +225,8 @@ TEST_CASE("VoLTE handler test")
 
         VolteHandler<CommandSequentialChannel, QcfgImsDummyParser<false>> handler;
 
-        REQUIRE_THROWS_WITH(handler.switchVolte(channel, false), Catch::Contains("fail") && Catch::Contains("IMS"));
+        REQUIRE_THROWS_WITH(handler.switchVolte(channel, true, false),
+                            Catch::Contains("fail") && Catch::Contains("IMS"));
     }
 
     SECTION("ThrowsAboutImsFailure_When_EnablingVolte_And_ImsSteeringCommandFailed")
@@ -241,6 +242,7 @@ TEST_CASE("VoLTE handler test")
 
         VolteHandler<CommandSequentialChannel, QcfgImsDummyParser<false>> handler;
 
-        REQUIRE_THROWS_WITH(handler.switchVolte(channel, true), Catch::Contains("fail") && Catch::Contains("IMS"));
+        REQUIRE_THROWS_WITH(handler.switchVolte(channel, true, true),
+                            Catch::Contains("fail") && Catch::Contains("IMS"));
     }
 }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -12,6 +12,7 @@
 * Fixed MTP issues
 * Rebuilt SIM cards window
 * Added option to provide custom GDB to crash analysis script
+* Made VoLTE available for proven cellular network(s) only
 
 ### Fixed
 * Fixed incorrect total CPU usage in logs


### PR DESCRIPTION
Steering the GUI and the modem according to
whether VoLTE is permitted for the active
SIM card's operator. This is done based on
the SIM card's IMSI string.

Additionally, made logging more consistent.

Co-authored by Kuba Kleczkowski.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [x] Has changelog entry added
