### PR TITLE
[CP-1665] Adding an information about device colour to USB descriptor

### DIFF
--- a/doc/os_api/usb_device_descriptor/device_colour.md
+++ b/doc/os_api/usb_device_descriptor/device_colour.md
@@ -1,0 +1,12 @@
+# Device colour
+
+Device colour is added as metadata about the device to the USB descriptor.
+The colour of the device is coded in **bcdDevice** field.
+Each device colour has assigned a value:
+```
+none  - 0x0111
+black - 0x0112
+gray  - 0x0113
+``` 
+*none* - is used when the information about device colour is not available for the device or is different than specified.
+

--- a/doc/os_api/usb_device_descriptor/usb_device_descriptor.md
+++ b/doc/os_api/usb_device_descriptor/usb_device_descriptor.md
@@ -1,0 +1,4 @@
+# USB Device Description
+
+Detailed information about **USB Device Description** can be found under the following link: 
+https://www.keil.com/pack/doc/mw/USB/html/_u_s_b__device__descriptor.html

--- a/module-bsp/bsp/usb/usb.hpp
+++ b/module-bsp/bsp/usb/usb.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -36,6 +36,7 @@ namespace bsp
         xQueueHandle queueHandle;
         xQueueHandle irqQueueHandle;
         std::string serialNumber;
+        std::uint16_t deviceVersion;
         std::string rootPath;
     };
 
@@ -44,7 +45,7 @@ namespace bsp
     int usbCDCSend(std::string *sendMsg);
     int usbCDCSendRaw(const char *dataPtr, size_t dataLen);
     void usbDeinit();
-    void usbReinit(const std::string& rootPath);
+    void usbReinit(const std::string &rootPath);
     void usbSuspend();
     void usbHandleDataReceived();
 

--- a/module-services/service-desktop/CMakeLists.txt
+++ b/module-services/service-desktop/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
         DesktopEvent.cpp
         DeveloperModeMessage.cpp
         DesktopMessages.cpp
+        DeviceColour.cpp
         OutboxNotifications.cpp
         ServiceDesktop.cpp
         WorkerDesktop.cpp
@@ -27,6 +28,7 @@ target_sources(
         include/service-desktop/DesktopEvent.hpp
         include/service-desktop/DesktopMessages.hpp
         include/service-desktop/DeveloperModeMessage.hpp
+        include/service-desktop/DeviceColour.hpp
         include/service-desktop/Outbox.hpp
         include/service-desktop/OutboxNotifications.hpp
         include/service-desktop/ServiceDesktop.hpp

--- a/module-services/service-desktop/DeviceColour.cpp
+++ b/module-services/service-desktop/DeviceColour.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <service-desktop/DeviceColour.hpp>
+#include <map>
+#include <cstdio>
+namespace
+{
+    constexpr auto NONE = "none";
+    const std::map<std::string, std::uint16_t> colour_to_version_map{
+        {NONE, 0x0111}, {"black", 0x0112}, {"gray", 0x0113}};
+
+} // namespace
+
+namespace device_colour
+{
+    std::uint16_t getColourVersion(const std::string &colour)
+    {
+        auto it = colour_to_version_map.find(colour);
+        if (it == colour_to_version_map.end()) {
+            return colour_to_version_map.at(NONE);
+        }
+        return colour_to_version_map.at(colour);
+    }
+} // namespace device_colour

--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -192,13 +192,15 @@ auto ServiceDesktop::usbWorkerInit() -> sys::ReturnCodes
         return sys::ReturnCodes::Success;
     }
     auto serialNumber = getSerialNumber();
+    auto caseColour   = getCaseColour();
 
-    LOG_DEBUG("usbWorkerInit Serial Number: %s", serialNumber.c_str());
+    LOG_DEBUG("usbWorkerInit Serial Number: %s, Case Colour: %s", serialNumber.c_str(), caseColour.c_str());
 
     desktopWorker = std::make_unique<WorkerDesktop>(this,
                                                     std::bind(&ServiceDesktop::restartConnectionActiveTimer, this),
                                                     *usbSecurityModel,
                                                     serialNumber,
+                                                    caseColour,
                                                     purefs::dir::getUserDiskPath() / "music");
 
     initialized =

--- a/module-services/service-desktop/WorkerDesktop.hpp
+++ b/module-services/service-desktop/WorkerDesktop.hpp
@@ -23,6 +23,7 @@ class WorkerDesktop : public sys::Worker
                   std::function<void()> messageProcessedCallback,
                   const sdesktop::USBSecurityModel &securityModel,
                   const std::string &serialNumber,
+                  const std::string &caseColour,
                   const std::string &rootPath);
 
     virtual bool init(std::list<sys::WorkerQueueInfo> queues) override;
@@ -51,6 +52,7 @@ class WorkerDesktop : public sys::Worker
     xQueueHandle irqQueue;
     const sdesktop::USBSecurityModel &securityModel;
     const std::string serialNumber;
+    const std::string caseColour;
     std::string rootPath;
     sys::Service *ownerService = nullptr;
     sdesktop::endpoints::StateMachine parser;

--- a/module-services/service-desktop/include/service-desktop/DeviceColour.hpp
+++ b/module-services/service-desktop/include/service-desktop/DeviceColour.hpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <string>
+
+namespace device_colour
+{
+    std::uint16_t getColourVersion(const std::string &colour);
+
+} // namespace device_colour


### PR DESCRIPTION
Getting information about device colour and changing it to number. 
Pass information about device colour to usb_stack. 
Set a bcdDevice with the corresponding value.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
