### PR TITLE
[MOS-741] Fix crashes during the cellular frame processing

### DIFF
--- a/module-cellular/modem/mux/CellularMuxFrame.h
+++ b/module-cellular/modem/mux/CellularMuxFrame.h
@@ -134,8 +134,17 @@ class CellularMuxFrame
             else { // long length
                 Length = static_cast<uint16_t>(serData[3] >> 1) + (static_cast<uint16_t>(serData[3]) << 7);
             }
-            if (serData[3] == 0xFF) // ugly hack for Quectel misimplementation of the standard
-                Length = myLen - 6;
+            if (serData[3] == 0xFF) { // ugly hack for Quectel misimplementation of the standard
+                if (myLen < 6) {
+                    LOG_ERROR("The size of the hacked frame is less than 6 bytes. Dropping...");
+                    Address     = 0;
+                    Control     = 0;
+                    frameStatus = EmptyFrame;
+                    return;
+                }
+                else
+                    Length = myLen - 6;
+            }
 
             data.clear();
             data.insert(data.begin(),


### PR DESCRIPTION
Added an additional condition that checks the size of the hacked frame to avoid processing an incorrect sized frame.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
