### PR TITLE
MOS-839 Fix crashes occuring after a few VoLTE toggles

### DIFF
--- a/module-services/service-cellular/call/CellularCall.cpp
+++ b/module-services/service-cellular/call/CellularCall.cpp
@@ -28,7 +28,7 @@ namespace call
                                                               std::make_unique<CallDB>(owner),
                                                               std::make_unique<CallTimer>(std::move(timer)),
                                                               std::make_unique<TimerRing>(std::move(timerRing)),
-                                                              std::make_unique<cellular::Api>(owner, cmux),
+                                                              std::make_unique<cellular::Api>(owner),
                                                               std::move(sentinel)});
     }
 

--- a/module-services/service-cellular/call/api/ModemCallApi.hpp
+++ b/module-services/service-cellular/call/api/ModemCallApi.hpp
@@ -6,6 +6,11 @@
 #include "PhoneModes/PhoneMode.hpp"
 #include "PhoneModes/Tethering.hpp"
 
+namespace at
+{
+    enum class AT;
+}
+
 class CellularMux;
 class ServiceCellular;
 
@@ -30,11 +35,12 @@ namespace cellular
     {
       private:
         ServiceCellular *cellular = nullptr;
-        CellularMux *cmux         = nullptr;
+
+        bool handleEvent(at::AT modemCommand);
 
       public:
         Api() = default;
-        Api(ServiceCellular *cellular, CellularMux *);
+        Api(ServiceCellular *cellular);
 
         bool answerIncomingCall() override;
         bool hangupCall() override;


### PR DESCRIPTION
Those were occuring after calls which were preceded by a few VoLTE on/off toggles.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
