### PR TITLE
[MOS-550] Disable deep partial refresh

### DIFF
--- a/module-services/service-eink/ServiceEink.cpp
+++ b/module-services/service-eink/ServiceEink.cpp
@@ -332,9 +332,11 @@ namespace service::eink
                 isRefreshRequired = false;
             }
             else {
-                refreshFrame = updateFrames.front();
-                refreshFrame.size.height =
-                    updateFrames.back().pos_y + updateFrames.back().size.height - updateFrames.front().pos_y;
+                if (refreshMode != hal::eink::EinkRefreshMode::REFRESH_DEEP) {
+                    refreshFrame = updateFrames.front();
+                    refreshFrame.size.height =
+                        updateFrames.back().pos_y + updateFrames.back().size.height - updateFrames.front().pos_y;
+                }
                 previousContext->insert(0, 0, ctx);
             }
         }


### PR DESCRIPTION
Always refresh the whole screen if deep refresh is required.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
