### PR TITLE
[MOS-737] Fix for adding a country code prefix to existing contact

### DIFF
--- a/module-db/Interface/ContactRecord.hpp
+++ b/module-db/Interface/ContactRecord.hpp
@@ -289,7 +289,10 @@ class ContactRecordInterface : public RecordInterface<ContactRecord, ContactReco
         -> const std::unique_ptr<db::QueryResult>;
 
     auto addTemporaryContactForNumber(const ContactRecord::Number &number) -> std::optional<ContactRecord>;
-    auto getNumbersIDs(std::uint32_t contactID, const ContactRecord &contact) -> std::vector<std::uint32_t>;
+    auto getNumbersIDs(std::uint32_t contactID,
+                       const ContactRecord &contact,
+                       utils::PhoneNumber::Match matchLevel = utils::PhoneNumber::Match::POSSIBLE)
+        -> std::vector<std::uint32_t>;
     auto addNumbers(std::uint32_t contactID, const std::vector<ContactRecord::Number> &numbers)
         -> std::optional<std::string>;
     auto addOrUpdateName(std::uint32_t contactID, std::uint32_t nameID, const ContactRecord &contact)

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -41,6 +41,7 @@
 * Fixed windows flow regarding PUK requests after too many PIN mistakes
 * Fixed disappearing "confirm" button in PIN entering screen
 * Fixed looping on the SIM card selection screen
+* Fixed adding country code prefix to existing contact
 
 ### Added
 * Added a popup for changing the SIM card


### PR DESCRIPTION
Adding or removing code country from contact's number creates a new number record. Old number, which was connected witch contact previously, is removed from the numbers table to avoid miss match numbers. Changing country code only creates new number records, without removing old ones. Old ones are temporary number from now.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
