### PR TITLE
[BH-1574][BH-1614] Fix the bedside lamp and brightness in the alarm 

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -30,6 +30,7 @@
 * Add loop mode
 
 ### Fixed
+* Brightness calculation for alarms
 
 #### Home Screen:
 * Centering of battery indicator.

--- a/module-services/service-evtmgr/screen-light-control/ScreenLightControlParameters.hpp
+++ b/module-services/service-evtmgr/screen-light-control/ScreenLightControlParameters.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -8,6 +8,14 @@
 
 namespace screen_light_control
 {
+    // Sender which send light request
+    enum class Sender
+    {
+        Other,
+        AlarmPrewakeup,
+        Alarm
+    };
+
     /// Modes in which front light can operate
     enum class ScreenLightMode
     {

--- a/module-services/service-evtmgr/service-evtmgr/ScreenLightControlMessage.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/ScreenLightControlMessage.hpp
@@ -11,37 +11,18 @@
 
 namespace sevm
 {
-    class ScreenLightSettingsControlMessage : public sys::DataMessage
-    {
-        const screen_light_control::Action action;
-        std::optional<screen_light_control::Parameters> params;
-
-      public:
-        explicit ScreenLightSettingsControlMessage(
-            screen_light_control::Action act, std::optional<screen_light_control::Parameters> params = std::nullopt)
-            : sys::DataMessage(MessageType::ScreenLightControlAction), action(act), params{std::move(params)}
-        {}
-
-        [[nodiscard]] auto getAction() const noexcept -> screen_light_control::Action
-        {
-            return action;
-        }
-
-        [[nodiscard]] auto getParams() const noexcept -> const std::optional<screen_light_control::Parameters> &
-        {
-            return params;
-        }
-    };
-
     class ScreenLightControlMessage : public sys::DataMessage
     {
         const screen_light_control::Action action;
         std::optional<screen_light_control::Parameters> params;
+        const screen_light_control::Sender sender;
 
       public:
         explicit ScreenLightControlMessage(screen_light_control::Action act,
-                                           std::optional<screen_light_control::Parameters> params = std::nullopt)
-            : sys::DataMessage(MessageType::ScreenLightControlAction), action(act), params{std::move(params)}
+                                           std::optional<screen_light_control::Parameters> params = std::nullopt,
+                                           screen_light_control::Sender sender = screen_light_control::Sender::Other)
+            : sys::DataMessage(MessageType::ScreenLightControlAction),
+              action(act), params{std::move(params)}, sender{sender}
         {}
 
         [[nodiscard]] auto getAction() const noexcept -> screen_light_control::Action
@@ -52,6 +33,11 @@ namespace sevm
         [[nodiscard]] auto getParams() const noexcept -> const std::optional<screen_light_control::Parameters> &
         {
             return params;
+        }
+
+        [[nodiscard]] auto getSender() const noexcept -> screen_light_control::Sender
+        {
+            return sender;
         }
     };
 

--- a/products/BellHybrid/apps/application-bell-settings/models/FrontlightModel.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/models/FrontlightModel.cpp
@@ -35,17 +35,17 @@ namespace app::bell_settings
     }
     void FrontlightModel::setStatus(bool onOff)
     {
-        app->bus.sendUnicast(std::make_shared<sevm::ScreenLightSettingsControlMessage>(
+        app->bus.sendUnicast(std::make_shared<sevm::ScreenLightControlMessage>(
                                  onOff ? screen_light_control::Action::turnOn : screen_light_control::Action::turnOff),
                              service::name::evt_manager);
     }
     void FrontlightModel::setMode(screen_light_control::ScreenLightMode mode)
     {
-        app->bus.sendUnicast(std::make_shared<sevm::ScreenLightSettingsControlMessage>(
-                                 mode == screen_light_control::ScreenLightMode::Automatic
-                                     ? screen_light_control::Action::enableAutomaticMode
-                                     : screen_light_control::Action::disableAutomaticMode),
-                             service::name::evt_manager);
+        app->bus.sendUnicast(
+            std::make_shared<sevm::ScreenLightControlMessage>(mode == screen_light_control::ScreenLightMode::Automatic
+                                                                  ? screen_light_control::Action::enableAutomaticMode
+                                                                  : screen_light_control::Action::disableAutomaticMode),
+            service::name::evt_manager);
     }
     void FrontlightModel::setBrightness(frontlight_utils::Brightness value)
     {

--- a/products/BellHybrid/apps/application-bell-settings/models/alarm_settings/AlarmSettingsModel.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/models/alarm_settings/AlarmSettingsModel.cpp
@@ -50,13 +50,13 @@ namespace app::bell_settings
 
     void AlarmFrontlightModel::setValue(frontlight_utils::Brightness value)
     {
-        const auto valStr = std::to_string(value);
+        const auto valStr = std::to_string(frontlight_utils::fixedValToPercentage(value));
         settings.setValue(bell::settings::Alarm::brightness, valStr, settings::SettingsScope::Global);
     }
 
     frontlight_utils::Brightness AlarmFrontlightModel::getValue() const
     {
         const auto str = settings.getValue(bell::settings::Alarm::brightness, settings::SettingsScope::Global);
-        return std::stoi(str);
+        return frontlight_utils::percentageToFixedVal(std::stoi(str));
     }
 } // namespace app::bell_settings

--- a/products/BellHybrid/services/evtmgr/EventManager.cpp
+++ b/products/BellHybrid/services/evtmgr/EventManager.cpp
@@ -87,17 +87,11 @@ void EventManager::initProductEvents()
 {
     backlightHandler.init();
 
-    connect(typeid(sevm::ScreenLightSettingsControlMessage), [&](sys::Message *msgl) {
-        auto *m           = static_cast<sevm::ScreenLightSettingsControlMessage *>(msgl);
-        const auto params = m->getParams();
-        backlightHandler.processScreenRequest(m->getAction(), params.value_or(screen_light_control::Parameters()));
-        return sys::msgHandled();
-    });
-
     connect(typeid(sevm::ScreenLightControlMessage), [&](sys::Message *msgl) {
         auto *m           = static_cast<sevm::ScreenLightControlMessage *>(msgl);
         const auto params = m->getParams();
-        backlightHandler.screenRequest(m->getAction(), params.value_or(screen_light_control::Parameters()));
+        backlightHandler.processRequest(
+            m->getAction(), params.value_or(screen_light_control::Parameters()), m->getSender());
         return sys::msgHandled();
     });
 

--- a/products/BellHybrid/services/evtmgr/backlight-handler/BacklightHandler.cpp
+++ b/products/BellHybrid/services/evtmgr/backlight-handler/BacklightHandler.cpp
@@ -101,10 +101,25 @@ namespace backlight
         backlightType = type;
     }
 
-    void Handler::screenRequest(screen_light_control::Action action, const screen_light_control::Parameters &params)
+    void Handler::processRequest(screen_light_control::Action action,
+                                 const screen_light_control::Parameters &params,
+                                 screen_light_control::Sender sender)
     {
-        if (backlightType == Type::Frontlight) {
+        switch (sender) {
+        case screen_light_control::Sender::AlarmPrewakeup:
+        case screen_light_control::Sender::Alarm:
+            switch (action) {
+            case screen_light_control::Action::turnOff:
+                backlightType = Type::Frontlight;
+                break;
+            default:
+                break;
+            }
             processScreenRequest(action, params);
+            break;
+        default:
+            processScreenRequest(action, params);
+            break;
         }
     }
 

--- a/products/BellHybrid/services/evtmgr/include/evtmgr/backlight-handler/BacklightHandler.hpp
+++ b/products/BellHybrid/services/evtmgr/include/evtmgr/backlight-handler/BacklightHandler.hpp
@@ -33,13 +33,15 @@ namespace backlight
       public:
         Handler(std::shared_ptr<settings::Settings> settings, sys::Service *parent);
 
-        void init() override;
-
         void handleKeyPressed(int key = 0);
 
         void handleScreenLight(Type type);
 
-        void screenRequest(screen_light_control::Action action, const screen_light_control::Parameters &params);
+        void processRequest(screen_light_control::Action action,
+                            const screen_light_control::Parameters &params,
+                            screen_light_control::Sender sender);
+
+        void init() override;
 
         void processScreenRequest(screen_light_control::Action action,
                                   const screen_light_control::Parameters &params) override;


### PR DESCRIPTION
Now the bedside lamp has lower priority
than the pre-wake up and main alarm. It means
that the front light will be changed according
to alarm settings.

Fix front light brightness calculation for
pre-wake up and main alarm.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
