### PR TITLE
[BH-1612] Show battery 100% on 24h vert. face with date

### DIFF
--- a/module-apps/apps-common/widgets/TimeSetSpinner.hpp
+++ b/module-apps/apps-common/widgets/TimeSetSpinner.hpp
@@ -16,6 +16,7 @@ namespace style::time_set_spinner
         inline constexpr auto size = 6U;
     } // namespace focus
 
+    inline constexpr auto very_small_margin       = 3U;
     inline constexpr auto small_margin = 6U;
     inline constexpr auto big_margin   = 6U;
     inline constexpr auto gargantuan_margin_left  = 14U;
@@ -56,9 +57,9 @@ namespace gui
 
         std::map<std::string, Margins> colonMarginsMap = {
             {style::window::font::verybiglight,
-             {style::time_set_spinner::small_margin, 0, style::time_set_spinner::small_margin, 0}},
+             {style::time_set_spinner::very_small_margin, 0, style::time_set_spinner::very_small_margin, 0}},
             {style::window::font::veryverybiglight,
-             {style::time_set_spinner::small_margin, 0, style::time_set_spinner::small_margin, 0}},
+             {style::time_set_spinner::very_small_margin, 0, style::time_set_spinner::very_small_margin, 0}},
             {style::window::font::largelight,
              {style::time_set_spinner::small_margin, 0, style::time_set_spinner::small_margin, 0}},
             {style::window::font::supersizeme,

--- a/products/BellHybrid/CMakeLists.txt
+++ b/products/BellHybrid/CMakeLists.txt
@@ -115,14 +115,14 @@ download_asset_release_json(json-common-target
                             ${CMAKE_CURRENT_SOURCE_DIR}/assets/assets_common.json
                             ${CMAKE_BINARY_DIR}/sysroot/sys/current/
                             MuditaOSPublicAssets
-                            0.0.14
+                            0.0.15
                             ${MUDITA_CACHE_DIR}
     )
 download_asset_release_json(json-community-target
                             ${CMAKE_CURRENT_SOURCE_DIR}/assets/assets_community.json
                             ${CMAKE_BINARY_DIR}/sysroot/sys/current/
                             MuditaOSPublicAssets
-                            0.0.14
+                            0.0.15
                             ${MUDITA_CACHE_DIR}
     )
 download_asset_json(json-rt1051-target

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningLoopWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningLoopWindow.cpp
@@ -60,7 +60,7 @@ namespace
 
     gui::BellBattery *createBattery(gui::VBox *parent)
     {
-        auto battery = new gui::BellBattery(parent);
+        auto battery = new gui::BellBattery(parent, gui::BatteryWidthMode::Fixed);
         battery->setMinimumSize(gui::battery::battery_widget_w, gui::battery::battery_widget_h);
         battery->setEdges(gui::RectangleEdge::None);
         battery->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center));

--- a/products/BellHybrid/apps/common/include/common/layouts/HomeScreenLayoutVerticalWithDate.hpp
+++ b/products/BellHybrid/apps/common/include/common/layouts/HomeScreenLayoutVerticalWithDate.hpp
@@ -23,7 +23,7 @@ namespace gui
         void setTimeFormat(utils::time::Locale::TimeFormat fmt) override;
 
       private:
-        void setBatteryLevelState(const Store::Battery &batteryContext) override;
+        bool isBatteryVisibilityAllowed(const Store::Battery &batteryContext) override;
         bool isAlarmTimeVisibilityAllowed() override;
 
         TextFixedSize *ampm = nullptr;

--- a/products/BellHybrid/apps/common/include/common/widgets/BellBattery.hpp
+++ b/products/BellHybrid/apps/common/include/common/widgets/BellBattery.hpp
@@ -14,7 +14,7 @@ namespace gui
     namespace battery
     {
         constexpr auto font_small         = style::window::font::largelight;
-        constexpr auto image_right_margin = 10U;
+        constexpr auto image_right_margin = 5U;
         constexpr auto percent_h          = 102U;
         constexpr auto percent_w          = 106U;
         constexpr auto battery_widget_h   = 64U;
@@ -28,10 +28,16 @@ namespace gui
         Hide  // Never show percentage
     };
 
+    enum class BatteryWidthMode
+    {
+        Fixed,
+        FitToContent
+    };
+
     class BellBattery : public gui::HBox
     {
       public:
-        BellBattery(Item *parent);
+        BellBattery(Item *parent, BatteryWidthMode widthMode);
         void setFont(const UTF8 &fontName);
         void update(units::SOC soc, bool isCharging);
         void setBatteryPercentMode(BatteryPercentMode mode);
@@ -42,5 +48,6 @@ namespace gui
         BatteryPercentMode batteryPercentMode = BatteryPercentMode::Show;
         Text *percentText                     = nullptr;
         Image *img                            = nullptr;
+        BatteryWidthMode widthMode            = BatteryWidthMode::Fixed;
     };
 } // namespace gui

--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
@@ -69,7 +69,7 @@ namespace gui
         statusBox->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
         statusBox->setVisible(true);
 
-        battery = new BellBattery(statusBox);
+        battery = new BellBattery(statusBox, gui::BatteryWidthMode::FitToContent);
         battery->setMaximumSize(battery::battery_widget_w, battery::battery_widget_h);
         battery->setEdges(RectangleEdge::None);
         battery->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));

--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutVerticalWithDate.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutVerticalWithDate.cpp
@@ -108,18 +108,9 @@ namespace gui
         }
     }
 
-    void HomeScreenLayoutVerticalWithDate::setBatteryLevelState(const Store::Battery &batteryContext)
+    bool HomeScreenLayoutVerticalWithDate::isBatteryVisibilityAllowed(const Store::Battery &batteryContext)
     {
-        // In 24h mode battery indicator is lower so 100% is too long to be displayed
-        if (!ampm->visible) {
-            const auto percentMode = batteryContext.level < 100 ? BatteryPercentMode::Show : BatteryPercentMode::Hide;
-            battery->setBatteryPercentMode(percentMode);
-        }
-        else
-            battery->setBatteryPercentMode(BatteryPercentMode::Show);
-        battery->update(batteryContext.level, isBatteryCharging(batteryContext.state));
-        battery->setVisible(true);
-        battery->informContentChanged();
+        return true;
     }
 
     bool HomeScreenLayoutVerticalWithDate::isAlarmTimeVisibilityAllowed()

--- a/products/BellHybrid/apps/common/src/widgets/BellBattery.cpp
+++ b/products/BellHybrid/apps/common/src/widgets/BellBattery.cpp
@@ -20,7 +20,7 @@ namespace
 
 namespace gui
 {
-    BellBattery::BellBattery(Item *parent) : HBox(parent)
+    BellBattery::BellBattery(Item *parent, BatteryWidthMode widthMode) : HBox(parent), widthMode(widthMode)
     {
         img = new Image(this, battery_low, gui::ImageTypeSpecifier::W_M);
         img->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Center));
@@ -33,8 +33,8 @@ namespace gui
         percentText->setEditMode(EditMode::Browse);
         percentText->activeItem = false;
         percentText->drawUnderline(false);
-        percentText->setVisible(false);
         percentText->setText("000%");
+        percentText->setVisible(false);
     }
 
     void BellBattery::setFont(const UTF8 &fontName)
@@ -50,8 +50,10 @@ namespace gui
         }
 
         const auto text = UTF8(std::to_string(soc) + "%");
-        // Without this the text is not set properly if percentText was hidden
-        percentText->setMinimumWidthToFitText(text);
+        if (widthMode == BatteryWidthMode::FitToContent) {
+            // Without this the text is not set properly if percentText was hidden
+            percentText->setMinimumWidthToFitText(text);
+        }
         percentText->setText(text);
 
         if (isCharging) {
@@ -76,7 +78,9 @@ namespace gui
             percentText->setVisible(false);
         }
 
-        setWidthsToFitContent();
+        if (widthMode == BatteryWidthMode::FitToContent) {
+            setWidthsToFitContent();
+        }
         img->informContentChanged();
     }
 

--- a/products/BellHybrid/apps/common/src/widgets/LayoutVertical.cpp
+++ b/products/BellHybrid/apps/common/src/widgets/LayoutVertical.cpp
@@ -70,7 +70,7 @@ namespace gui
         alarmMainTime->setAlignment(Alignment(Alignment::Horizontal::Right, Alignment::Vertical::Center));
         alarmMainTime->setVisible(false);
 
-        battery = new BellBattery(nullptr);
+        battery = new BellBattery(nullptr, gui::BatteryWidthMode::Fixed);
         battery->setMinimumSize(battery::battery_widget_w, battery::battery_widget_h);
         battery->setEdges(RectangleEdge::None);
         battery->setVisible(true);


### PR DESCRIPTION
Decrease space between colon and digits in TimeSetSpinner for smaller fonts.
Decrease main vertical time width.
Use battery icon with smaller width.
Decrease space between battery icon and percentage.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
