### PR TITLE
[MOS-558] Fix wrong navigation bar state after exit from custom repeat window.

### DIFF
--- a/module-apps/application-alarm-clock/widgets/AlarmRRuleOptionsItem.cpp
+++ b/module-apps/application-alarm-clock/widgets/AlarmRRuleOptionsItem.cpp
@@ -56,6 +56,7 @@ namespace gui
         onLoadCallback = [&]([[maybe_unused]] std::shared_ptr<AlarmEventRecord> alarm) {
             checkCustomOption(getPresenter()->getDescription());
             optionSpinner->setCurrentValue(getPresenter()->getDescription());
+            this->navBarRestoreFromTemporaryMode();
         };
     }
 


### PR DESCRIPTION
The additional navigation bar restore has been added to have proper state after exit from custom repeat window. No object did it before.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
