### PR TITLE
[MOS-831] Fix screen lock during onboarding

### DIFF
--- a/module-apps/application-onboarding/ApplicationOnBoarding.cpp
+++ b/module-apps/application-onboarding/ApplicationOnBoarding.cpp
@@ -60,7 +60,7 @@ namespace app
             return retMsg;
         }
 
-        return sys::msgNotHandled();
+        return handleAsyncResponse(resp);
     }
 
     sys::ReturnCodes ApplicationOnBoarding::InitHandler()

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -42,6 +42,7 @@
 * Fixed disappearing "confirm" button in PIN entering screen
 * Fixed looping on the SIM card selection screen
 * Fixed adding country code prefix to existing contact
+* Fixed screen lock during onboarding
 
 ### Added
 * Added a popup for changing the SIM card


### PR DESCRIPTION
<!-- Please describe your pull request here -->

When the user locked the screen during onboarding, the lock screen appeared but without the current time and date.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
