### PR TITLE
[CP-1413] Windows displays wrong name of connected device

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+* Fixed displayed device name when connected to Windows
+
 ### Added
 
 #### Home Screen:

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -42,6 +42,7 @@
 * Fixed disappearing "confirm" button in PIN entering screen
 * Fixed looping on the SIM card selection screen
 * Fixed screen lock during onboarding
+* Fixed displayed device name when connected to Windows
 
 ### Added
 * Added a popup for changing the SIM card


### PR DESCRIPTION
Changes in usb_stack

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
