### PR TITLE
[MOS-810] Fixed call state timer termination

### DIFF
--- a/module-services/service-cellular/CellularServiceAPI.cpp
+++ b/module-services/service-cellular/CellularServiceAPI.cpp
@@ -47,13 +47,6 @@ bool CellularServiceAPI::HangupCall(sys::Service *serv)
     return true;
 }
 
-bool CellularServiceAPI::DismissCall(sys::Service *serv)
-{
-    auto msg = std::make_shared<cellular::DismissCallMessage>();
-    serv->bus.sendMulticast(std::move(msg), sys::BusChannel::ServiceCellularNotifications);
-    return true;
-}
-
 std::string CellularServiceAPI::GetIMSI(sys::Service *serv, bool getFullIMSINumber)
 {
 

--- a/module-services/service-cellular/call/CellularCall.cpp
+++ b/module-services/service-cellular/call/CellularCall.cpp
@@ -12,6 +12,7 @@
 
 namespace call
 {
+    Call::~Call() = default;
 
     Call::Call()
     {}
@@ -31,9 +32,6 @@ namespace call
                                                               std::make_unique<cellular::Api>(owner),
                                                               std::move(sentinel)});
     }
-
-    Call::~Call()
-    {}
 
     Call &Call::operator=(Call &&other) noexcept
     {

--- a/module-services/service-cellular/call/api/CallTimer.hpp
+++ b/module-services/service-cellular/call/api/CallTimer.hpp
@@ -19,6 +19,7 @@ namespace call::api
     struct TimerRing
     {
         virtual void start() = 0;
+        virtual ~TimerRing() = default;
     };
 }; // namespace call::api
 

--- a/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
+++ b/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
@@ -28,7 +28,6 @@ namespace CellularServiceAPI
 
     bool AnswerIncomingCall(sys::Service *serv);
     bool HangupCall(sys::Service *serv);
-    bool DismissCall(sys::Service *serv);
     /*
      * @brief Its calls sercive-cellular for selected SIM IMSI number.
      * @param serv pointer to caller service.

--- a/module-services/service-cellular/service-cellular/ServiceCellular.hpp
+++ b/module-services/service-cellular/service-cellular/ServiceCellular.hpp
@@ -302,7 +302,6 @@ class ServiceCellular : public sys::Service
 
     auto receiveSMS(std::string messageNumber) -> bool;
 
-    auto hangUpCall() -> bool;
     auto hangUpCallBusy() -> bool;
 
     auto tetheringTurnOffURC() -> bool;

--- a/module-services/service-cellular/src/ModemResetHandler.cpp
+++ b/module-services/service-cellular/src/ModemResetHandler.cpp
@@ -15,6 +15,7 @@ namespace cellular::service
         }
 
         procedureInProgress = ProcedureInProgress::SoftReset;
+        onAnyReset();
         onCellularStateSet(State::ST::PowerDownWaiting);
         return onSoftReset();
     }
@@ -27,6 +28,7 @@ namespace cellular::service
         }
 
         procedureInProgress = ProcedureInProgress::HardReset;
+        onAnyReset();
         onCellularStateSet(State::ST::PowerDownWaiting);
         onHardReset();
         return false;
@@ -40,6 +42,7 @@ namespace cellular::service
         }
 
         procedureInProgress = ProcedureInProgress::Reboot;
+        onAnyReset();
         onCellularStateSet(State::ST::PowerDownWaiting);
         onTurnModemOff();
         return false;
@@ -79,7 +82,6 @@ namespace cellular::service
     auto ModemResetHandler::handleSwitchToActive() -> bool
     {
         if (procedureInProgress == ProcedureInProgress::None) {
-
             return false;
         }
 
@@ -90,6 +92,8 @@ namespace cellular::service
 
     auto ModemResetHandler::performFunctionalityReset() -> bool
     {
+        onAnyReset();
+
         if (onFunctionalityReset) {
             return onFunctionalityReset();
         }

--- a/module-services/service-cellular/src/ModemResetHandler.hpp
+++ b/module-services/service-cellular/src/ModemResetHandler.hpp
@@ -54,6 +54,7 @@ namespace cellular::service
         std::function<bool()> onSoftReset;
         std::function<void()> onHardReset;
         std::function<bool()> onFunctionalityReset;
+        std::function<void()> onAnyReset;
 
       private:
         enum class ProcedureInProgress

--- a/module-services/service-cellular/src/ServiceCellularPriv.cpp
+++ b/module-services/service-cellular/src/ServiceCellularPriv.cpp
@@ -455,6 +455,8 @@ namespace cellular::internal
             }
             return succeed;
         };
+
+        modemResetHandler->onAnyReset = [this]() { owner->callStateTimer.stop(); };
     }
 
     void ServiceCellularPriv::initCSQHandler()

--- a/module-services/service-cellular/src/volte/VolteCapabilityHandler.cpp
+++ b/module-services/service-cellular/src/volte/VolteCapabilityHandler.cpp
@@ -3,7 +3,6 @@
 
 #include "VolteCapabilityHandler.hpp"
 #include <modem/BaseChannel.hpp>
-#include <modem/mux/CellularMux.h>
 #include <log/log.hpp>
 
 namespace cellular::service

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -43,6 +43,7 @@
 * Fixed looping on the SIM card selection screen
 * Fixed screen lock during onboarding
 * Fixed displayed device name when connected to Windows
+* Fixed redundant modem polling for call states
 
 ### Added
 * Added a popup for changing the SIM card


### PR DESCRIPTION
Fixed the problem that the call state polling
timer wasn't terminated in some cases, so the
modem command AT+CLCC had still been issued
until e.g. another call was made. In such cases,
this lead to inability for the modem to go to
a power-down state due to constant activity and
thus lead to battery power waste.

Additionally, fixed a hidden bug that TimerRing
hadn't got a virtual destructor.

Also thrown out some dead code.


Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added
