### PR TITLE
[MOS-807] Fix MTP root path

### DIFF
--- a/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
@@ -51,7 +51,7 @@ namespace sdesktop::bluetooth
 class ServiceDesktop : public sys::Service
 {
   public:
-    ServiceDesktop();
+    explicit ServiceDesktop(const std::filesystem::path &mtpRootPath);
     ~ServiceDesktop() override;
 
     std::unique_ptr<WorkerDesktop> desktopWorker;
@@ -92,6 +92,7 @@ class ServiceDesktop : public sys::Service
     bool initialized                                         = false;
     bool isPlugEventUnhandled                                = false;
     bool isUsbConfigured                                     = false;
+    std::filesystem::path mtpRootPath;
 
     void generateDeviceUniqueId();
     auto getDeviceUniqueId() const -> std::string;

--- a/module-vfs/paths/filesystem_paths.cpp
+++ b/module-vfs/paths/filesystem_paths.cpp
@@ -11,12 +11,11 @@ namespace
     constexpr inline auto PATH_DB          = "db";
     constexpr inline auto PATH_LOGS        = "log";
     constexpr inline auto PATH_CRASH_DUMPS = "crash_dumps";
-    constexpr inline auto PATH_USER_MEDIA =
-        "media"; // TODO this won't work with our current non-hierarchical MTP implementation
-    constexpr inline auto PATH_TMP    = "temp";
-    constexpr inline auto PATH_ASSETS = "assets";
-    constexpr inline auto PATH_DATA   = "data";
-    constexpr inline auto PATH_VAR    = "var";
+    constexpr inline auto PATH_USER_MEDIA  = "media";
+    constexpr inline auto PATH_TMP         = "temp";
+    constexpr inline auto PATH_ASSETS      = "assets";
+    constexpr inline auto PATH_DATA        = "data";
+    constexpr inline auto PATH_VAR         = "var";
 } // namespace
 
 namespace purefs

--- a/products/BellHybrid/BellHybridMain.cpp
+++ b/products/BellHybrid/BellHybridMain.cpp
@@ -82,7 +82,7 @@ int main()
     systemServices.emplace_back(sys::CreatorFor<service::ServiceFileIndexer>(std::move(fileIndexerAudioPaths)));
     systemServices.emplace_back(sys::CreatorFor<ServiceDB>());
     systemServices.emplace_back(sys::CreatorFor<service::Audio>());
-    systemServices.emplace_back(sys::CreatorFor<ServiceDesktop>());
+    systemServices.emplace_back(sys::CreatorFor<ServiceDesktop>(purefs::dir::getUserMediaPath() / "app/relaxation"));
     systemServices.emplace_back(sys::CreatorFor<stm::ServiceTime>(std::make_shared<alarms::AlarmOperationsFactory>()));
     systemServices.emplace_back(sys::CreatorFor<service::eink::ServiceEink>(service::eink::ExitAction::None));
     systemServices.emplace_back(

--- a/products/BellHybrid/paths/Paths.cpp
+++ b/products/BellHybrid/paths/Paths.cpp
@@ -6,7 +6,7 @@
 
 std::filesystem::path paths::audio::user() noexcept
 {
-    return purefs::dir::getUserDiskPath() / "audio";
+    return purefs::dir::getUserMediaPath() / "app";
 }
 std::filesystem::path paths::audio::proprietary() noexcept
 {

--- a/products/PurePhone/PurePhoneMain.cpp
+++ b/products/PurePhone/PurePhoneMain.cpp
@@ -182,7 +182,7 @@ int main()
     systemServices.emplace_back(sys::CreatorFor<ServiceBluetooth>());
 #endif
 #ifdef ENABLE_SERVICE_DESKTOP
-    systemServices.emplace_back(sys::CreatorFor<ServiceDesktop>());
+    systemServices.emplace_back(sys::CreatorFor<ServiceDesktop>(purefs::dir::getUserMediaPath() / "app/music_player"));
 #endif
 #ifdef ENABLE_SERVICE_TIME
     systemServices.emplace_back(sys::CreatorFor<stm::ServiceTime>(std::make_shared<alarms::AlarmOperationsFactory>()));


### PR DESCRIPTION
Fixed MTP root paths for both Harmony and
Pure due to the MTP implementation
not supporting hierarchical directories.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
