### PR TITLE
[BH-1621] Fix UI design regression in pre-wake up

### DIFF
--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -673,7 +673,7 @@
   "app_bell_settings_alarm_settings_volume": "Main alarm volume",
   "app_bell_settings_alarm_settings_light": "Main alarm light",
   "app_bell_settings_alarm_settings_prewake_up": "Pre-wake up",
-  "app_bell_settings_alarm_settings_prewake_up_chime_top_description": "Pre-wake up",
+  "app_bell_settings_alarm_settings_prewake_up_chime_top_description": "Pre-wake up chime",
   "app_bell_settings_alarm_settings_prewake_up_chime_bottom_description": "before the alarm",
   "app_bell_settings_alarm_settings_prewake_up_chime_tone": "Pre-wake up chime tone",
   "app_bell_settings_alarm_settings_prewake_up_chime_volume": "Pre-wake up chime volume",

--- a/products/BellHybrid/alarms/src/actions/FrontlightAction.cpp
+++ b/products/BellHybrid/alarms/src/actions/FrontlightAction.cpp
@@ -99,7 +99,6 @@ namespace alarms
     bool FrontlightAction::execute()
     {
         std::string settingString;
-        std::string prewakeupString;
 
         switch (settingsDependency) {
         case SettingsDependency::AlarmClock:
@@ -112,10 +111,9 @@ namespace alarms
             }
             break;
         case SettingsDependency::Prewakeup:
-            prewakeupString = settings.getValue(bell::settings::PrewakeUp::duration, settings::SettingsScope::Global);
             settingString =
                 settings.getValue(bell::settings::PrewakeUp::lightDuration, settings::SettingsScope::Global);
-            if (settingString == std::string(prewakeupFrontlightOFF) || prewakeupString == std::string(prewakeupOFF)) {
+            if (settingString == std::string(prewakeupFrontlightOFF)) {
                 return true;
             }
             break;

--- a/products/BellHybrid/alarms/src/actions/FrontlightAction.hpp
+++ b/products/BellHybrid/alarms/src/actions/FrontlightAction.hpp
@@ -36,7 +36,6 @@ namespace alarms
       private:
         static constexpr std::string_view alarmFrontlightOFF     = "0";
         static constexpr std::string_view prewakeupFrontlightOFF = "0";
-        static constexpr std::string_view prewakeupOFF           = "0";
 
         sys::Service &service;
         SettingsDependency settingsDependency;

--- a/products/BellHybrid/apps/application-bell-settings/models/alarm_settings/PrewakeUpListItemProvider.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/models/alarm_settings/PrewakeUpListItemProvider.cpp
@@ -39,7 +39,8 @@ namespace app::bell_settings
 
         chimeDuration->onProceed = [chimeDuration, this]() {
             if (chimeDuration->value() == 0) {
-                this->onExit();
+                constexpr auto lightDurationListIndex = 3U;
+                list->rebuildList(gui::listview::RebuildType::OnOffset, lightDurationListIndex);
                 return true;
             }
             return false;


### PR DESCRIPTION
Due to changed UI the user couldn't turn off
chime and turn on the front light. Now the user
is able to do it.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
