### PR TITLE
[BH-1566] Fix flac playback

### DIFF
--- a/products/BellHybrid/services/audio/ServiceAudio.cpp
+++ b/products/BellHybrid/services/audio/ServiceAudio.cpp
@@ -10,7 +10,9 @@
 
 namespace
 {
-    constexpr auto stackSize            = 1024 * 4;
+    // 4kB is too small because internally drflac_open() uses cache which by default has 4kB.
+    // Alternatively smaller DR_FLAC_BUFFER_SIZE could be defined.
+    constexpr auto stackSize            = 1024 * 8;
     constexpr auto defaultVolume        = "5";
     constexpr auto defaultSnoozeVolume  = "4";
     constexpr auto defaultBedtimeVolume = "6";


### PR DESCRIPTION
Increase stack size because internally drflac_open() uses cache which by default has 4kB.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
