### PR TITLE
[BH-1618] Fix the wrong front light on the back action

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Fixed displayed device name when connected to Windows
+* Fixed the wrong front light on back action in alarms
 
 ### Added
 

--- a/products/BellHybrid/apps/application-bell-settings/models/alarm_settings/AlarmSettingsListItemProvider.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/models/alarm_settings/AlarmSettingsListItemProvider.cpp
@@ -97,10 +97,9 @@ namespace app::bell_settings
             }
         });
 
-        brightness->onEnter = [this]() {
-            auto brightness = settingsModel.getBrightness().getValue();
+        brightness->onEnter = [this, brightness]() {
             if (onFrontlightEnter) {
-                onFrontlightEnter(brightness);
+                onFrontlightEnter(brightness->value());
             }
         };
 

--- a/products/BellHybrid/apps/application-bell-settings/models/alarm_settings/PrewakeUpListItemProvider.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/models/alarm_settings/PrewakeUpListItemProvider.cpp
@@ -130,10 +130,9 @@ namespace app::bell_settings
             }
         });
 
-        brightness->onEnter = [this]() {
-            auto brightness = settingsModel.getBrightness().getValue();
+        brightness->onEnter = [this, brightness]() {
             if (onFrontlightEnter) {
-                onFrontlightEnter(brightness);
+                onFrontlightEnter(brightness->value());
             }
         };
 


### PR DESCRIPTION
If the user changes the front light intensity in
pre-wake up or main alarm and then going back
the front light value and intensity are the same.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
