### PR TITLE
[MOS-000] Bump binaries and add Bell target

### DIFF
--- a/cmake/modules/AddPackage.cmake
+++ b/cmake/modules/AddPackage.cmake
@@ -91,11 +91,15 @@ function(add_update_package SOURCE_TARGET)
     message("Adding '${SOURCE_TARGET}-UpdatePackage' target")
     if(ENABLE_SECURE_BOOT)
         add_custom_target(${SOURCE_TARGET}-UpdatePackage
-            DEPENDS ${UPDATE_PKG}.sig
+            DEPENDS
+                ${SOURCE_TARGET}-disk-img
+                ${UPDATE_PKG}.sig
         )
     else()
         add_custom_target(${SOURCE_TARGET}-UpdatePackage
-            DEPENDS ${UPDATE_PKG}
+            DEPENDS
+                ${SOURCE_TARGET}-disk-img
+                ${UPDATE_PKG}
         )
     endif()
 endfunction()

--- a/products/BellHybrid/BinaryAssetsVersions.cmake
+++ b/products/BellHybrid/BinaryAssetsVersions.cmake
@@ -5,5 +5,5 @@ if( NOT DEFINED ECOBOOT_BIN_VERSION)
 endif()
 
 if (NOT DEFINED RECOVERY_BIN_VERSION)
-    set(RECOVERY_BIN_VERSION 0.0.1 CACHE STRING "recovery binary version to download from recovery release page")
+    set(RECOVERY_BIN_VERSION 1.0.0 CACHE STRING "recovery binary version to download from recovery release page")
 endif()

--- a/products/BellHybrid/CMakeLists.txt
+++ b/products/BellHybrid/CMakeLists.txt
@@ -1,5 +1,11 @@
 add_executable(BellHybrid)
 
+add_custom_target(Bell ALL
+    DEPENDS
+        BellHybrid
+        BellHybrid.img
+        )
+
 target_link_directories(BellHybrid PRIVATE ${PROJECT_LIB_DIRECTORY})
 
 target_compile_definitions(BellHybrid

--- a/products/PurePhone/BinaryAssetsVersions.cmake
+++ b/products/PurePhone/BinaryAssetsVersions.cmake
@@ -1,9 +1,9 @@
 # This file sets versions of downloaded binaries for release packaging purposes
 
 if( NOT DEFINED ECOBOOT_BIN_VERSION)
-    set(ECOBOOT_BIN_VERSION 2.0.3 CACHE STRING "bootloader binary version to download from bootloader release page")
+    set(ECOBOOT_BIN_VERSION 2.0.0 CACHE STRING "bootloader binary version to download from bootloader release page")
 endif()
 
 if (NOT DEFINED RECOVERY_BIN_VERSION)
-    set(RECOVERY_BIN_VERSION 1.0.2 CACHE STRING "recovery binary version to download from recovery release page")
+    set(RECOVERY_BIN_VERSION 1.0.0 CACHE STRING "recovery binary version to download from recovery release page")
 endif()


### PR DESCRIPTION
Change binary assets versions for both
products, fixed missing dependencies
in Bell's CMake, added 'Bell' target
that automatically builds the
image.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
