### PR TITLE
[MOS-558] Fix wrong nav. bar state after exit from custom repeat window

### DIFF
--- a/module-apps/application-alarm-clock/widgets/AlarmRRuleOptionsItem.cpp
+++ b/module-apps/application-alarm-clock/widgets/AlarmRRuleOptionsItem.cpp
@@ -56,7 +56,9 @@ namespace gui
         onLoadCallback = [&]([[maybe_unused]] std::shared_ptr<AlarmEventRecord> alarm) {
             checkCustomOption(getPresenter()->getDescription());
             optionSpinner->setCurrentValue(getPresenter()->getDescription());
-            this->navBarRestoreFromTemporaryMode();
+            if (app::alarmClock::AlarmRRulePresenter::RRuleOptions::Never == getPresenter()->getOption())
+                this->navBarRestoreFromTemporaryMode();
+
         };
     }
 
@@ -73,6 +75,13 @@ namespace gui
 
     void AlarmRRuleOptionsItem::checkCustomOption(const std::string &selectedOption)
     {
+        if (rRuleOptions.back().second != "Custom")
+            if (const auto days = getPresenter()->getCustomDays();
+                std::none_of(days.cbegin(), days.cend(), [](const auto &day) { return day.second; })) {
+                rRuleOptions.back().second = "Custom";
+                printOptions();
+            }
+
         for (auto const &option : rRuleOptions) {
             if (selectedOption.empty() || option.second == selectedOption) {
                 return;

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -107,6 +107,7 @@
 * Fixed the order in which contacts are displayed in the list.
 * Fixed incorrect navigation text in onboarding for timezone and date time.
 * Fixed wrong time displayed on password locked screen with 'Quotes' or 'Logo' wallpaper.
+* Fixed wrong navigation bar state after exit from custom repeat window
 
 
 ## [1.3.0 2022-08-04]


### PR DESCRIPTION
The additional navigation bar restore has been added to have proper state after exit from custom repeat window. The restoration of the repeat option spinner labels has been added after uncheck of all options.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
