### PR TITLE
[MOS-160] Fix broken text on SIM selection screen

### DIFF
--- a/image/assets/lang/Deutsch.json
+++ b/image/assets/lang/Deutsch.json
@@ -348,7 +348,7 @@
   "app_onboarding_start_configuration": "<text weight='light' size='46'><p>Hallo!</p></text><br></br><text weight='regular' size='27'>Konfigurieren wir gemeinsam Ihr <br></br> Mudita Pure.</text>",
   "app_onboarding_eula_license": "Lizenzvereinbarung (EULA)",
   "app_onboarding_select_sim": "Aktive SIM auswählen",
-  "app_onboarding_select_sim_description": "<text>Es kann immer nur eine SIM-Karte aktiv sein.<br></br>Sie können diese jetzt auswählen und bei Bedarf<br></br>in den Einstellungen wechseln.</text>",
+  "app_onboarding_select_sim_description": "<text>Es kann immer nur eine SIM-Karte<br></br>aktiv sein. Sie können diese<br></br>jetzt auswählen und bei Bedarf<br></br>in den Einstellungen wechseln.</text>",
   "app_onboarding_no_sim_selected_title": "SIM-Einrichtung",
   "app_onboarding_no_sim_selected_description": "<text>Keine SIM-Karte eingerichtet.<br></br>Richten Sie <br></br> SIM-Karten in den Einstellungen ein, um eine Verbindung zum Netzwerk herzustellen. </text>",
   "app_onboarding_title_configuration": "Konfiguration",

--- a/image/assets/lang/Francais.json
+++ b/image/assets/lang/Francais.json
@@ -317,7 +317,7 @@
   "app_onboarding_start_configuration": "<text weight='light' size='46'><p>Bonjour !</p></text><br></br><text weight='regular' size='27'>Configurons votre Mudita Pure.</text>",
   "app_onboarding_eula_license": "License agreement (EULA)",
   "app_onboarding_select_sim": "Choisissez la carte SIM active",
-  "app_onboarding_select_sim_description": "<text>Une seule carte SIM peut être active à la fois.<br></br>Vous pouvez la choisir maintenant et activer<br></br>les paramètres à tout moment.</text>",
+  "app_onboarding_select_sim_description": "<text>Une seule carte SIM peut être<br></br>active à la fois. Vous pouvez<br></br>la choisir maintenant et activer<br></br>les paramètres à tout moment.</text>",
   "app_onboarding_no_sim_selected_title": "Configuration SIM",
   "app_onboarding_no_sim_selected_description": "<text>No SIM card set up.<br></br>To connect to network, set up <br></br> SIM cards in Settings.</text>",
   "app_onboarding_title_configuration": "Configuration",

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -45,6 +45,7 @@
 * Fixed displayed device name when connected to Windows
 * Fixed redundant modem polling for call states
 * Fixed selecting SIM during onboarding
+* Fixed broken text on SIM selection screen during onboarding
 
 ### Added
 * Added a popup for changing the SIM card


### PR DESCRIPTION
<!-- Please describe your pull request here -->

During onboarding, the text displayed in French and German was truncated.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
