### PR TITLE
[MOS-159] Fix broken text on the PIN input screen

### DIFF
--- a/image/assets/lang/Espanol.json
+++ b/image/assets/lang/Espanol.json
@@ -256,7 +256,7 @@
   "app_desktop_info_mmi_result_success": "Correcto",
   "app_desktop_info_mmi_result_failed": "Error",
   "sim_header_setup": "<text>Configuración de <token>$SIM</token></text>",
-  "sim_enter_pin_unlock": "<text>Introduce el código PIN para configurar <br></br> la tarjeta <token>$PINTYPE</token>:</text>",
+  "sim_enter_pin_unlock": "<text>Introduce el código PIN<br></br>para configurar la tarjeta <token>$PINTYPE</token>:</text>",
   "sim_enter_enter_current": "<text>Introduce el código PIN actual:</text>",
   "sim_change_pin": "Cambiar código PIN",
   "sim_enter_new_pin": "Introduce el nuevo código PIN:",

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -45,7 +45,8 @@
 * Fixed displayed device name when connected to Windows
 * Fixed redundant modem polling for call states
 * Fixed selecting SIM during onboarding
-* Fixed broken text on SIM selection screen during onboarding
+* Fixed broken text in French and German on SIM selection screen during onboarding
+* Fixed broken text in Spanish on the PIN input screen
 
 ### Added
 * Added a popup for changing the SIM card


### PR DESCRIPTION
<!-- Please describe your pull request here -->

On the PIN entry screen,
the text displayed in Spanish was truncated.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
