### PR TITLE
[MOS-836] Fix for selecting SIM during onboarding

### DIFF
--- a/module-apps/application-onboarding/ApplicationOnBoarding.cpp
+++ b/module-apps/application-onboarding/ApplicationOnBoarding.cpp
@@ -105,7 +105,9 @@ namespace app
         });
 
         connect(typeid(cellular::msg::notification::SimReady), [&](sys::Message *msg) {
-            if (getCurrentWindow()->getName() != gui::popup::window::sim_switching_window) {
+            auto selectedSIM = Store::GSM::get()->selected;
+            if (getCurrentWindow()->getName() != gui::popup::window::sim_switching_window &&
+                selectedSIM != Store::GSM::SelectedSIM::NONE) {
                 phoneLockSubject.setPhoneLock();
                 return sys::msgHandled();
             }


### PR DESCRIPTION
<!-- Please describe your pull request here -->

After inserting the SIM tray at the onboarding stage before selecting the slot - it is not possible to select the slot and activate the desired SIM card if it does not have a PIN enabled.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
