### PR TITLE
[MOS-851] Remove factory reset screen from backup and restore

### DIFF
--- a/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
+++ b/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
@@ -47,7 +47,7 @@ namespace app::manager
             case sys::CloseReason::SystemBrownout:
             case sys::CloseReason::LowBattery:
                 return ActionRequest{senderName, app::manager::actions::SystemBrownout, nullptr};
-            case sys::CloseReason::RebootToRecovery:
+            case sys::CloseReason::FactoryReset:
                 return ActionRequest{senderName, app::manager::actions::DisplayFactoryResetInProgressScreen, nullptr};
             default:
                 return ActionRequest{senderName, app::manager::actions::DisplayLogoAtExit, nullptr};

--- a/module-sys/SystemManager/include/SystemManager/SystemManagerCommon.hpp
+++ b/module-sys/SystemManager/include/SystemManager/SystemManagerCommon.hpp
@@ -184,7 +184,7 @@ namespace sys
 
         void RebootHandler();
 
-        void RebootToRecoveryHandler(RecoveryReason recoveryReason);
+        void RebootToRecoveryHandler(CloseReason closeReason, RecoveryReason recoveryReason);
 
         void RebootToUsbMscModeHandler(State newState);
 
@@ -236,7 +236,6 @@ inline const char *c_str(sys::SystemManagerCommon::State state)
         return "RebootToRecovery";
     case sys::SystemManagerCommon::State::RebootToUsbMscMode:
         return "RebootToUsbMscModeUpdate";
-        break;
     case sys::SystemManagerCommon::State::ShutdownReady:
         return "ShutdownReady";
     }


### PR DESCRIPTION
Fix of the issue that factory reset screen
informing user of need to manually turn
on the phone to continue the process
was appearing also when restarting to
backup or restore.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
