### PR TITLE
[MOS-813] Emergency calling fixed

### DIFF
--- a/module-cellular/modem/mux/CellularMux.cpp
+++ b/module-cellular/modem/mux/CellularMux.cpp
@@ -215,7 +215,7 @@ CellularMux::ConfState CellularMux::baudDetectProcedure(uint16_t timeout_s)
     return ConfState::Failure;
 }
 
-CellularMux::ConfState CellularMux::confProcedure()
+CellularMux::ConfState CellularMux::confProcedure(bool disableRF)
 {
     LOG_DEBUG("Configuring modem...");
 
@@ -269,7 +269,7 @@ CellularMux::ConfState CellularMux::confProcedure()
         }
     }
 
-    if (!parser->cmd(at::AT::CFUN_DISABLE_TRANSMITTING)) {
+    if (disableRF && !parser->cmd(at::AT::CFUN_DISABLE_TRANSMITTING)) {
         return ConfState::Failure;
     }
 

--- a/module-cellular/modem/mux/CellularMux.h
+++ b/module-cellular/modem/mux/CellularMux.h
@@ -305,7 +305,7 @@ class CellularMux
 
     ConfState baudDetectOnce();
     ConfState baudDetectProcedure(uint16_t timeout_s = 30);
-    ConfState confProcedure();
+    ConfState confProcedure(bool disableRF);
     ConfState audioConfProcedure();
     ConfState startMultiplexer();
 

--- a/module-services/service-cellular/RequestFactory.cpp
+++ b/module-services/service-cellular/RequestFactory.cpp
@@ -81,8 +81,7 @@ namespace cellular
 
     std::unique_ptr<IRequest> RequestFactory::create()
     {
-        auto isRegisteredToNetwork = isConnectedToNetwork();
-        if (auto req = emergencyCheck(); req && isRegisteredToNetwork) {
+        if (auto req = emergencyCheck(); req) {
             return req;
         }
 
@@ -132,6 +131,7 @@ namespace cellular
         if (!simInserted) {
             return std::make_unique<RejectRequest>(RejectRequest::RejectReason::NoSim, request);
         }
+        auto isRegisteredToNetwork = isConnectedToNetwork();
         if (!isRegisteredToNetwork) {
             return std::make_unique<RejectRequest>(RejectRequest::RejectReason::NoNetworkConnection, request);
         }

--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -842,8 +842,15 @@ bool ServiceCellular::handle_power_down()
 
 bool ServiceCellular::handle_start_conf_procedure()
 {
+    auto simSelected = settings->getValue(settings::SystemProperties::activeSim, settings::SettingsScope::Global);
+    auto disableRF   = false;
+    if (simSelected.empty()) {
+        LOG_ERROR("No sim selected, disabling RF module.");
+        disableRF = true;
+    }
+
     // Start configuration procedure, if it's first run modem will be restarted
-    auto confRet = cmux->confProcedure();
+    auto confRet = cmux->confProcedure(disableRF);
     if (confRet == CellularMux::ConfState::Success) {
         priv->state->set(State::ST::AudioConfigurationProcedure);
         return true;

--- a/module-services/service-cellular/tests/unittest_request_factory.cpp
+++ b/module-services/service-cellular/tests/unittest_request_factory.cpp
@@ -51,14 +51,7 @@ TEST_CASE("Emergency handling")
         // no SIM and SIM emergency number / sim inserted
         {false, true, true, true, true, std::nullopt, typeid(CallRequest).name()},
         // no SIM and SIM emergency number / sim inserted / no network connection
-        {false,
-         true,
-         true,
-         true,
-         false,
-         RejectRequest::RejectReason::NoNetworkConnection,
-         typeid(RejectRequest).name(),
-         ""},
+        {true, true, true, true, false, std::nullopt, typeid(CallRequest).name()},
         // no SIM emergency number / sim inserted
         {false, false, true, true, true, std::nullopt, typeid(CallRequest).name()},
         // SIM emergency number / sim inserted


### PR DESCRIPTION
User is now able to make emergency call with no sim card inserted. RF functionality in modem is still disabled until sim card is selected by user.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [x] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
