### PR TITLE
[MOS-852] Fix autolock not working in UDM version

### DIFF
--- a/products/PurePhone/services/appmgr/ApplicationManager.cpp
+++ b/products/PurePhone/services/appmgr/ApplicationManager.cpp
@@ -156,7 +156,7 @@ namespace app::manager
 
         connect(typeid(PreventBlockingRequest), [this]([[maybe_unused]] sys::Message *msg) {
             if (!phoneLockHandler.isPhoneLocked()) {
-                autoLockTimer.stop();
+                autoLockTimer.start();
             }
             return std::make_shared<sys::ResponseMessage>();
         });
@@ -521,8 +521,9 @@ namespace app::manager
             autoLockTimer.stop();
             return;
         }
-        if (auto focusedApp = getFocusedApplication(); focusedApp == nullptr || focusedApp->preventsAutoLocking()) {
-            autoLockTimer.stop();
+        if (const auto focusedApp = getFocusedApplication();
+            (focusedApp == nullptr) || (focusedApp->preventsAutoLocking())) {
+            autoLockTimer.start();
             return;
         }
         if (phoneModeObserver->isTetheringOn()) {


### PR DESCRIPTION
Fix of the issue that in some cases phone
wouldn't lock automatically after given
timeout. This is not a proper fix,
rather a workaround, the whole autolock
mechanism should get refactored to
support testing via harness.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
