### PR TITLE
[BH-1620] Fix pause deactivation by a deep press

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -5,12 +5,11 @@
 ### Fixed
 * Fixed displayed device name when connected to Windows
 * Fixed the wrong front light on back action in alarms
+* Fixed the pause deactivation by a deep press in relaxation
 
 ### Added
 
 ### Changed
-
-### Fixed
 
 ## [1.8.0 2022-12-14]
 

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.cpp
@@ -88,11 +88,6 @@ namespace gui
         presenter->onBeforeShow();
         updateTime();
 
-        if (mode == ShowMode::GUI_SHOW_RETURN && presenter->isPaused()) {
-            presenter->resume();
-            return;
-        }
-
         if (data && typeid(*data) == typeid(RelaxationSwitchData)) {
             auto *audioSwitchData = static_cast<RelaxationSwitchData *>(data);
             audioContext          = audioSwitchData->getAudioContext();


### PR DESCRIPTION
The deep press doesn't deactivate the pause
in a timer or loop mode.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
