### PR TITLE
[MOS-201] Fix notes paste option

### DIFF
--- a/module-apps/application-notes/windows/NotesOptions.cpp
+++ b/module-apps/application-notes/windows/NotesOptions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "NotesOptions.hpp"
@@ -101,16 +101,20 @@ namespace app::notes
                 return true;
             },
             options);
-        addOption(
-            {"common_text_paste"},
-            [application, textWidget](gui::Item &item) {
-                if (textWidget != nullptr) {
-                    textWidget->addText(Clipboard::getInstance().paste(), gui::AdditionType::perBlock);
-                }
-                application->returnToPreviousWindow();
-                return true;
-            },
-            options);
+
+        if (Clipboard::getInstance().gotData()) {
+            addOption(
+                {"common_text_paste"},
+                [application, textWidget](gui::Item &item) {
+                    if (textWidget != nullptr) {
+                        textWidget->addText(Clipboard::getInstance().paste(), gui::AdditionType::perBlock);
+                    }
+                    application->returnToPreviousWindow();
+                    return true;
+                },
+                options);
+        }
+
         return options;
     }
 } // namespace app::notes

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -47,6 +47,7 @@
 * Fixed selecting SIM during onboarding
 * Fixed broken text in French and German on SIM selection screen during onboarding
 * Fixed broken text in Spanish on the PIN input screen
+* Fixed notes paste option showing for empty clipboard
 
 ### Added
 * Added a popup for changing the SIM card


### PR DESCRIPTION
Check clipboard content before showing
paste option.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
