### PR TITLE
[MOS-856] Add MTP path to DeviceInfo endpoint

### DIFF
--- a/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/JsonKeyNames.hpp
@@ -55,6 +55,7 @@ namespace sdesktop::endpoints::json
     inline constexpr auto updateFilePath         = "updateFilePath";
     inline constexpr auto backupFilePath         = "backupFilePath";
     inline constexpr auto syncFilePath           = "syncFilePath";
+    inline constexpr auto mtpPath                = "mtpPath";
     inline constexpr auto deviceToken            = "deviceToken";
 
     namespace updateprocess

--- a/module-vfs/paths/filesystem_paths.cpp
+++ b/module-vfs/paths/filesystem_paths.cpp
@@ -80,6 +80,14 @@ namespace purefs
         {
             return getSystemDiskPath() / PATH_VAR;
         }
+        std::filesystem::path getMusicPlayerPath() noexcept
+        {
+            return purefs::dir::getUserMediaPath() / "app/music_player";
+        }
+        std::filesystem::path getRelaxationPath() noexcept
+        {
+            return purefs::dir::getUserMediaPath() / "app/relaxation";
+        }
 
     } // namespace dir
 } // namespace purefs

--- a/module-vfs/paths/include/purefs/filesystem_paths.hpp
+++ b/module-vfs/paths/include/purefs/filesystem_paths.hpp
@@ -21,6 +21,9 @@ namespace purefs
         std::filesystem::path getAssetsDirPath() noexcept;
         std::filesystem::path getSystemDataDirPath() noexcept;
         std::filesystem::path getSystemVarDirPath() noexcept;
+        std::filesystem::path getMusicPlayerPath() noexcept;
+        std::filesystem::path getRelaxationPath() noexcept;
+
     } // namespace dir
 
     namespace file

--- a/products/BellHybrid/BellHybridMain.cpp
+++ b/products/BellHybrid/BellHybridMain.cpp
@@ -82,7 +82,7 @@ int main()
     systemServices.emplace_back(sys::CreatorFor<service::ServiceFileIndexer>(std::move(fileIndexerAudioPaths)));
     systemServices.emplace_back(sys::CreatorFor<ServiceDB>());
     systemServices.emplace_back(sys::CreatorFor<service::Audio>());
-    systemServices.emplace_back(sys::CreatorFor<ServiceDesktop>(purefs::dir::getUserMediaPath() / "app/relaxation"));
+    systemServices.emplace_back(sys::CreatorFor<ServiceDesktop>(purefs::dir::getRelaxationPath()));
     systemServices.emplace_back(sys::CreatorFor<stm::ServiceTime>(std::make_shared<alarms::AlarmOperationsFactory>()));
     systemServices.emplace_back(sys::CreatorFor<service::eink::ServiceEink>(service::eink::ExitAction::None));
     systemServices.emplace_back(

--- a/products/BellHybrid/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
+++ b/products/BellHybrid/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
@@ -61,7 +61,8 @@ namespace sdesktop::endpoints
               (purefs::dir::getTemporaryPath() / sdesktop::paths::recoveryStatusFilename).string()},
              {json::updateFilePath, (purefs::dir::getTemporaryPath() / sdesktop::paths::updateFilename).string()},
              {json::backupFilePath, (purefs::dir::getTemporaryPath() / sdesktop::paths::backupFilename).string()},
-             {json::syncFilePath, (purefs::dir::getTemporaryPath() / sdesktop::paths::syncFilename).string()}}));
+             {json::syncFilePath, (purefs::dir::getTemporaryPath() / sdesktop::paths::syncFilename).string()},
+             {json::mtpPath, purefs::dir::getRelaxationPath().string()}}));
 
         return http::Code::OK;
     }

--- a/products/PurePhone/PurePhoneMain.cpp
+++ b/products/PurePhone/PurePhoneMain.cpp
@@ -182,7 +182,7 @@ int main()
     systemServices.emplace_back(sys::CreatorFor<ServiceBluetooth>());
 #endif
 #ifdef ENABLE_SERVICE_DESKTOP
-    systemServices.emplace_back(sys::CreatorFor<ServiceDesktop>(purefs::dir::getUserMediaPath() / "app/music_player"));
+    systemServices.emplace_back(sys::CreatorFor<ServiceDesktop>(purefs::dir::getMusicPlayerPath()));
 #endif
 #ifdef ENABLE_SERVICE_TIME
     systemServices.emplace_back(sys::CreatorFor<stm::ServiceTime>(std::make_shared<alarms::AlarmOperationsFactory>()));

--- a/products/PurePhone/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
+++ b/products/PurePhone/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
@@ -62,6 +62,7 @@ namespace sdesktop::endpoints
              {json::updateFilePath, (purefs::dir::getTemporaryPath() / sdesktop::paths::updateFilename).string()},
              {json::backupFilePath, (purefs::dir::getTemporaryPath() / sdesktop::paths::backupFilename).string()},
              {json::syncFilePath, (purefs::dir::getTemporaryPath() / sdesktop::paths::syncFilename).string()},
+             {json::mtpPath, purefs::dir::getMusicPlayerPath().string()},
              {json::deviceToken, getDeviceToken()}}));
 
         return http::Code::OK;


### PR DESCRIPTION
Added MTP path for products to enable MC to use it instead of hardcoded paths

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [x] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
