### PR TITLE
[MOS-373] Fixed missing timezone window

### DIFF
--- a/module-apps/application-settings/windows/system/DateAndTimeMainWindow.cpp
+++ b/module-apps/application-settings/windows/system/DateAndTimeMainWindow.cpp
@@ -52,6 +52,10 @@ namespace gui
                 application->bus.sendUnicast(
                     std::make_shared<stm::message::SetAutomaticDateAndTimeRequest>(automaticDateAndTimeIsOn),
                     service::name::service_time);
+                if (!automaticDateAndTimeIsOn) {
+                    application->switchWindow(window::name::change_time_zone, nullptr);
+                    return true;
+                }
                 refreshOptionsList();
                 return true;
             },


### PR DESCRIPTION
Fixed missing timezone window, which should be displayed after Automatic date and time setting is set to disabled. MOS-181 is also fixed by this commit.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [x] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
