### PR TITLE
[MOS-855] Fix restore from legacy backup

### DIFF
--- a/module-db/tests/ContactsRecord_tests.cpp
+++ b/module-db/tests/ContactsRecord_tests.cpp
@@ -369,7 +369,7 @@ TEST_CASE("Contact record numbers update")
         newRecord.numbers = std::vector<ContactRecord::Number>({ContactRecord::Number(numbersPL[0], std::string("")),
                                                                 ContactRecord::Number(numbersFR[1], std::string(""))});
         REQUIRE(records.Update(newRecord));
-        REQUIRE(contactDB.number.count() == 4);
+        REQUIRE(contactsDb.get().number.count() == 4);
 
         auto validationRecord = records.GetByID(1);
         REQUIRE(validationRecord.numbers.size() == 2);
@@ -395,13 +395,13 @@ TEST_CASE("Contact record numbers update")
         newRecord.numbers = std::vector<ContactRecord::Number>({ContactRecord::Number(numbersPL[0], std::string("")),
                                                                 ContactRecord::Number(numbersFR[1], std::string(""))});
         REQUIRE(records.Update(newRecord));
-        REQUIRE(contactDB.number.count() == 4);
+        REQUIRE(contactsDb.get().number.count() == 4);
 
         // deleting country code
         newRecord.numbers = std::vector<ContactRecord::Number>(
             {ContactRecord::Number(numbers[0], std::string("")), ContactRecord::Number(numbers[1], std::string(""))});
         REQUIRE(records.Update(newRecord));
-        REQUIRE(contactDB.number.count() == 4);
+        REQUIRE(contactsDb.get().number.count() == 4);
 
         auto validationRecord = records.GetByID(1);
         REQUIRE(validationRecord.numbers.size() == 2);
@@ -427,17 +427,17 @@ TEST_CASE("Contact record numbers update")
         newRecord.numbers = std::vector<ContactRecord::Number>({ContactRecord::Number(numbersPL[0], std::string("")),
                                                                 ContactRecord::Number(numbersPL[1], std::string(""))});
         REQUIRE(records.Update(newRecord));
-        REQUIRE(contactDB.number.count() == 4);
+        REQUIRE(contactsDb.get().number.count() == 4);
 
         // changing country code (to FR)
         newRecord.numbers = std::vector<ContactRecord::Number>({ContactRecord::Number(numbersFR[0], std::string("")),
                                                                 ContactRecord::Number(numbersFR[1], std::string(""))});
         REQUIRE(records.Update(newRecord));
-        REQUIRE(contactDB.number.count() == 6);
-        REQUIRE(contactDB.number.getById(1).contactID != 1); // old numbers do not belong to any contact
-        REQUIRE(contactDB.number.getById(1).contactID != 2);
-        REQUIRE(contactDB.number.getById(2).contactID != 1);
-        REQUIRE(contactDB.number.getById(2).contactID != 2);
+        REQUIRE(contactsDb.get().number.count() == 6);
+        REQUIRE(contactsDb.get().number.getById(1).contactID != 1); // old numbers do not belong to any contact
+        REQUIRE(contactsDb.get().number.getById(1).contactID != 2);
+        REQUIRE(contactsDb.get().number.getById(2).contactID != 1);
+        REQUIRE(contactsDb.get().number.getById(2).contactID != 2);
 
         auto validationRecord = records.GetByID(1);
         REQUIRE(validationRecord.numbers.size() == 2);

--- a/scripts/lua/share/consts.lua
+++ b/scripts/lua/share/consts.lua
@@ -1,6 +1,7 @@
 local consts = {}
 
 consts.version_file = "version.json"
+consts.legacy_version_file = "backup.json" -- Pre-UDM backup package had version.json file named as backup.json
 consts.indexer_cache_file = ".directory_is_indexed"
 
 return consts


### PR DESCRIPTION
Added checking if requested to restore backup
from pre-UDM version and setting db versions
to zero in such case, as version info file
(called backup.json in legacy backups) doesn't
contain info about versions.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
