### PR TITLE
[MOS-853] Purge multimedia database when initializing indexer

### DIFF
--- a/module-services/service-fileindexer/CMakeLists.txt
+++ b/module-services/service-fileindexer/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(service-fileindexer
 		module-os 
 		module-utils 
 		module-vfs 
-		module-sys 
+		module-sys
+		module-db
 		tag
 )

--- a/module-services/service-fileindexer/StartupIndexer.cpp
+++ b/module-services/service-fileindexer/StartupIndexer.cpp
@@ -10,9 +10,9 @@
 #include <purefs/fs/inotify_message.hpp>
 #include <log/log.hpp>
 
-#include <filesystem>
 #include <fstream>
-#include <optional>
+#include <queries/multimedia_files/QueryMultimediaFilesRemove.hpp>
+#include <service-db/DBServiceAPI.hpp>
 
 namespace service::detail
 {
@@ -126,6 +126,10 @@ namespace service::detail
     {
         if (!hasLockFile()) {
             LOG_INFO("Initial startup indexer - Started...");
+
+            auto query = std::make_unique<db::multimedia_files::query::RemoveAll>();
+            DBServiceAPI::GetQuery(svc.get(), db::Interface::Name::MultimediaFiles, std::move(query));
+
             mTopDirIterator = std::begin(directoriesToScan);
             setupTimers(svc, svc_name);
             mForceStop = false;


### PR DESCRIPTION
When startup indexer for FileIndexer starts, it checks for lock file. If it's not present, it starts the indexing.

Due to changes in DB initialization we have to purge the DB before starting the init scan because of potential restore content

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
