### PR TITLE
[MOS-757] Fixed backspace behavior

### DIFF
--- a/module-gui/gui/widgets/text/Text.cpp
+++ b/module-gui/gui/widgets/text/Text.cpp
@@ -186,6 +186,21 @@ namespace gui
         drawLines();
     }
 
+    void Text::removeFromCursor()
+    {
+        const auto currentText    = getText();
+        const auto cursorPosition = cursor->getAbsolutePosition();
+        const auto substrLength   = currentText.length() - cursorPosition;
+
+        const auto newText = currentText.substr(cursorPosition, substrLength);
+        buildDocument(newText);
+
+        /* Rewind cursor to the beginning of the line */
+        cursor->moveCursor(NavigationDirection::LEFT, cursorPosition);
+
+        onTextChanged();
+    }
+
     void Text::clear()
     {
         buildDocument("");
@@ -634,7 +649,7 @@ namespace gui
         }
         if (inputEvent.isLongRelease(removeKey)) {
             if (!document->isEmpty()) {
-                clear();
+                removeFromCursor();
                 return true;
             }
         }

--- a/module-gui/gui/widgets/text/Text.hpp
+++ b/module-gui/gui/widgets/text/Text.hpp
@@ -149,6 +149,7 @@ namespace gui
         /// add rich text with default RichTextParser - please see RichTextParser documentation on how to use format
         void addRichText(const UTF8 &text, text::RichTextParser::TokenMap &&tokens = text::RichTextParser::TokenMap{});
         /// @}
+        void removeFromCursor();
         virtual void clear();
         bool isEmpty();
         virtual UTF8 getText() const;

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -12,6 +12,7 @@
 * Fixed adding and deleting country code prefix to existing contact
 * Fixed French translation for SIM cards texts
 * Fixed crash on music file with invalid tags
+* Fixed backspace behavior in text edit
 
 ### Added
 


### PR DESCRIPTION
Now backspace (held # button) removes everything from the beginning up to the cursor

Coauthored with @Lefucjusz

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
