### PR TITLE
[MOS-765] Fixed crash on invalid ID3 tag

### DIFF
--- a/module-audio/tags_fetcher/CMakeLists.txt
+++ b/module-audio/tags_fetcher/CMakeLists.txt
@@ -11,5 +11,6 @@ target_sources(tagsfetcher
 target_link_libraries(tagsfetcher
     PRIVATE
     tag
+    module-utils
     Microsoft.GSL::GSL
 )

--- a/module-audio/tags_fetcher/TagsFetcher.cpp
+++ b/module-audio/tags_fetcher/TagsFetcher.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TagsFetcher.hpp"
@@ -14,8 +14,8 @@ namespace tags::fetcher
 {
     std::optional<Tags> fetchTagsInternal(std::string filePath)
     {
-        TagLib::FileRef tagReader(filePath.c_str());
-        if (!tagReader.isNull() && tagReader.tag()) {
+        TagLib::FileRef const tagReader(filePath.c_str());
+        if (!tagReader.isNull() && (tagReader.tag() != nullptr)) {
             TagLib::Tag *tags                   = tagReader.tag();
             TagLib::AudioProperties *properties = tagReader.audioProperties();
 
@@ -24,8 +24,8 @@ namespace tags::fetcher
             auto getTitle = [&]() -> std::string {
                 const auto title = tags->title().to8Bit(unicode);
                 // If title tag empty fill it with raw file name
-                if (title.size() == 0) {
-                    if (const auto pos = filePath.rfind("/"); pos == std::string::npos) {
+                if (title.empty()) {
+                    if (const auto pos = filePath.rfind('/'); pos == std::string::npos) {
                         return filePath;
                     }
                     else {
@@ -71,7 +71,7 @@ namespace tags::fetcher
         return {};
     }
 
-    Tags fetchTags(std::string filePath)
+    Tags fetchTags(const std::string &filePath)
     {
         return fetchTagsInternal(filePath).value_or(Tags{filePath});
     }

--- a/module-audio/tags_fetcher/TagsFetcher.hpp
+++ b/module-audio/tags_fetcher/TagsFetcher.hpp
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -64,5 +64,5 @@ namespace tags::fetcher
         {}
     };
 
-    Tags fetchTags(std::string fileName);
+    Tags fetchTags(const std::string &fileName);
 } // namespace tags::fetcher

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -11,6 +11,7 @@
 * Fixed notes window title
 * Fixed adding and deleting country code prefix to existing contact
 * Fixed French translation for SIM cards texts
+* Fixed crash on music file with invalid tags
 
 ### Added
 


### PR DESCRIPTION
Bumped taglib version to latest master
Added sanity check for version field in tag parser in taglib so in case of damaged/invalid tag it returns no tag at all

It was caused by zipped mp3 files and renamed to mp3 again

Changes in taglib:
https://github.com/mudita/taglib/commit/f700e74025f56de2d35ef0c2a460f0ee2abaa034

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
