### PR TITLE
[MOS-828] Fix 'j' glyph issue in Contacts app

### DIFF
--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -13,6 +13,7 @@
 * Fixed French translation for SIM cards texts
 * Fixed crash on music file with invalid tags
 * Fixed backspace behavior in text edit
+* Fixed text not showing when adding/editing contact if text began with 'j' glyph
 
 ### Added
 


### PR DESCRIPTION
Fix of the issue that email, first name and last
name fields were not able to display strings that
started with 'j'. Nothing was shown in such case.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
