### PR TITLE
[MOS-757] Fix wrong cursor final position after deleting

### DIFF
--- a/module-gui/gui/widgets/text/Text.cpp
+++ b/module-gui/gui/widgets/text/Text.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Text.hpp"
@@ -196,7 +196,7 @@ namespace gui
         buildDocument(newText);
 
         /* Rewind cursor to the beginning of the line */
-        cursor->moveCursor(NavigationDirection::LEFT, cursorPosition);
+        cursor->moveCursor(NavigationDirection::LEFT, substrLength);
 
         onTextChanged();
     }


### PR DESCRIPTION
Fix of the issue that after partially deleting
the text, the cursor sometimes was positioned
somewhere in the middle of the remaining text,
not at the beginning where it should.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
