### PR TITLE
[MOS-840] Make VoLTE switch unavailable after SIM card is taken out

### DIFF
--- a/module-services/service-cellular/src/ServiceCellularPriv.cpp
+++ b/module-services/service-cellular/src/ServiceCellularPriv.cpp
@@ -15,7 +15,6 @@
 #include <volte/VolteCapabilityHandlerCellular.hpp>
 
 #include <service-evtmgr/EVMessages.hpp>
-#include <service-evtmgr/Constants.hpp>
 
 #include <service-bluetooth/messages/BluetoothModeChanged.hpp>
 #include <locks/data/PhoneLockMessages.hpp>
@@ -31,7 +30,6 @@
 #include <ucs2/UCS2.hpp>
 #include <service-appmgr/Constants.hpp>
 
-#include "service-cellular/MessageConstants.hpp"
 #include "checkSmsCenter.hpp"
 
 using service::name::service_time;

--- a/products/PurePhone/services/appmgr/ApplicationManager.cpp
+++ b/products/PurePhone/services/appmgr/ApplicationManager.cpp
@@ -10,6 +10,7 @@
 #include <apps-common/popups/data/PhoneModeParams.hpp>
 #include <apps-common/actions/AlarmClockStatusChangeParams.hpp>
 #include <module-db/queries/notifications/QueryNotificationsGetAll.hpp>
+#include <module-services/service-cellular/service-cellular/VolteState.hpp>
 #include <system/messages/TetheringQuestionRequest.hpp>
 #include <Timers/TimerFactory.hpp>
 #include <service-appmgr/Constants.hpp>
@@ -313,6 +314,10 @@ namespace app::manager
             return simLockHandler.handleCMEErrorRequest(data->code);
         });
         connect(typeid(cellular::msg::notification::SimNotInserted), [&](sys::Message *request) -> sys::MessagePointer {
+            using cellular::VolteState;
+            auto notification =
+                std::make_shared<cellular::VolteStateNotification>(VolteState{VolteState::Enablement::Off, false});
+            bus.sendMulticast(std::move(notification), sys::BusChannel::ServiceCellularNotifications);
             return simLockHandler.handleSimNotInsertedMessage();
         });
         connect(typeid(locks::SetSim), [&](sys::Message *request) -> sys::MessagePointer {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -14,6 +14,7 @@
 * Fixed crash on music file with invalid tags
 * Fixed backspace behavior in text edit
 * Fixed text not showing when adding/editing contact if text began with 'j' glyph
+* Fixed VoLTE switch availability after taking out SIM card
 
 ### Added
 


### PR DESCRIPTION
Also, done a minor code cleanup.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added
