### PR TITLE
[MOS-863] Fix phonebook crash when adding country prefix

### DIFF
--- a/module-apps/application-phonebook/include/application-phonebook/ApplicationPhonebook.hpp
+++ b/module-apps/application-phonebook/include/application-phonebook/ApplicationPhonebook.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -28,7 +28,7 @@ namespace gui::window::name
 namespace app
 {
     inline constexpr auto name_phonebook         = "ApplicationPhonebook";
-    constexpr std::uint16_t phonebook_stack_size = 4096;
+    constexpr std::uint16_t phonebook_stack_size = 1024 * 5;
 
     class ApplicationPhonebook : public app::Application
     {

--- a/module-apps/application-phonebook/widgets/InputLinesWithLabelWidget.cpp
+++ b/module-apps/application-phonebook/widgets/InputLinesWithLabelWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "InputLinesWithLabelWidget.hpp"
@@ -185,7 +185,7 @@ namespace gui
             }
         };
         onLoadCallback = [&](std::shared_ptr<ContactRecord> contact) {
-            if (contact->numbers.size() > 0) {
+            if (!contact->numbers.empty()) {
                 inputText->setText(contact->numbers[0].number.getEntered());
             }
         };

--- a/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhonebookNewContact.hpp"
@@ -71,7 +71,7 @@ namespace gui
             break;
         }
 
-        !newContactModel->emptyData() ? setSaveButtonVisible(true) : setSaveButtonVisible(false);
+        setSaveButtonVisible(!newContactModel->emptyData());
     }
 
     void PhonebookNewContact::onClose(Window::CloseReason reason)
@@ -121,7 +121,7 @@ namespace gui
     {
         auto ret = AppWindow::onInput(inputEvent);
 
-        !newContactModel->emptyData() ? setSaveButtonVisible(true) : setSaveButtonVisible(false);
+        setSaveButtonVisible(!newContactModel->emptyData());
 
         if (inputEvent.isShortRelease(gui::KeyCode::KEY_ENTER) && !newContactModel->emptyData() &&
             newContactModel->verifyData()) {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -20,6 +20,8 @@
 * Fixed USSD handling crash
 * Fixed calls to emergency contact when typed manually
 * Fixed message content being deleted when phone mode changed on new message window
+* Fixed wrong navigation bar state after exit from custom repeat window
+* Fixed OS crash when editing contact by adding country prefix to number
 
 ### Added
 
@@ -108,7 +110,6 @@
 * Fixed the order in which contacts are displayed in the list.
 * Fixed incorrect navigation text in onboarding for timezone and date time.
 * Fixed wrong time displayed on password locked screen with 'Quotes' or 'Logo' wallpaper.
-* Fixed wrong navigation bar state after exit from custom repeat window
 
 
 ## [1.3.0 2022-08-04]


### PR DESCRIPTION
Fix of the issue that editing existing contact's
number by adding country prefix resulted in
PureOS crash due to application stack overflow.
Additionally moved misplaced changelog entry.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
