### PR TITLE
[MOS-390] Fixed emergency number recognition

### DIFF
--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -224,6 +224,12 @@ namespace app
             LOG_WARN("Cannot call in %s state", c_str(state));
             return;
         }
+
+        if (DBServiceAPI::IsContactInEmergency(this, utils::PhoneNumber(number).getView())) {
+            CellularServiceAPI::DialNumber(this, utils::PhoneNumber(number));
+            return;
+        }
+
         CellularServiceAPI::DialEmergencyNumber(this, utils::PhoneNumber(number));
     }
 

--- a/module-services/service-db/DBServiceAPI.cpp
+++ b/module-services/service-db/DBServiceAPI.cpp
@@ -125,6 +125,19 @@ auto DBServiceAPI::IsContactInFavourites(sys::Service *serv, const utils::PhoneN
     return contactResponse->contact != nullptr && contactResponse->contact->isOnFavourites();
 }
 
+auto DBServiceAPI::IsContactInEmergency(sys::Service *serv, const utils::PhoneNumber::View &numberView) -> bool
+{
+    auto msg = std::make_shared<DBContactNumberMessage>(numberView);
+
+    auto ret             = serv->bus.sendUnicastSync(std::move(msg), service::name::db, DefaultTimeoutInMs);
+    auto contactResponse = dynamic_cast<DBContactNumberResponseMessage *>(ret.second.get());
+    if (contactResponse == nullptr || contactResponse->retCode != sys::ReturnCodes::Success) {
+        LOG_ERROR("DB response error, return code: %s", c_str(ret.first));
+        return false;
+    }
+    return contactResponse->contact != nullptr && contactResponse->contact->isOnIce();
+}
+
 auto DBServiceAPI::verifyContact(sys::Service *serv, const ContactRecord &rec)
     -> DBServiceAPI::ContactVerificationResult
 {

--- a/module-services/service-db/include/service-db/DBServiceAPI.hpp
+++ b/module-services/service-db/include/service-db/DBServiceAPI.hpp
@@ -114,6 +114,7 @@ class DBServiceAPI
     static auto DBBackup(sys::Service *serv, std::string backupPath) -> bool;
 
     static auto IsContactInFavourites(sys::Service *serv, const utils::PhoneNumber::View &numberView) -> bool;
+    static auto IsContactInEmergency(sys::Service *serv, const utils::PhoneNumber::View &numberView) -> bool;
     /**
      * @brief Add sms via DBService interface
      *


### PR DESCRIPTION
Emergency contact is now recognized when typed mannualy.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [x] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
