### PR TITLE
[MOS-27] Fix invisible message text after pasting

### DIFF
--- a/image/assets/lang/Deutsch.json
+++ b/image/assets/lang/Deutsch.json
@@ -612,7 +612,6 @@
   "sms_delete_message": "Nachricht löschen",
   "sms_use_template": "Vorlage verwenden",
   "sms_paste": "Einfügen",
-  "sms_temp_reply": "Antworten",
   "sms_mark_read": "Als gelesen markieren",
   "sms_mark_unread": "Als ungelesen markieren",
   "app_desktop_update": "Aktualisierung",

--- a/image/assets/lang/English.json
+++ b/image/assets/lang/English.json
@@ -586,7 +586,6 @@
   "sms_delete_message": "Delete message",
   "sms_use_template": "Use template",
   "sms_paste": "Paste",
-  "sms_temp_reply": "Reply",
   "sms_mark_read": "Mark as read",
   "sms_mark_unread": "Mark as unread",
   "app_desktop_update": "Update",

--- a/image/assets/lang/Espanol.json
+++ b/image/assets/lang/Espanol.json
@@ -613,7 +613,6 @@
   "sms_delete_message": "Eliminar mensaje",
   "sms_use_template": "Usar plantilla",
   "sms_paste": "Pegar",
-  "sms_temp_reply": "Responder",
   "sms_mark_read": "Marcar como leído",
   "sms_mark_unread": "Marcar como no leído",
   "app_desktop_update": "Actualizar",

--- a/image/assets/lang/Francais.json
+++ b/image/assets/lang/Francais.json
@@ -581,7 +581,6 @@
   "sms_delete_message": "Supprimer le message",
   "sms_use_template": "Utiliser le modèle",
   "sms_paste": "Coller",
-  "sms_temp_reply": "Réponse",
   "sms_mark_read": "Marquer comme lu",
   "sms_mark_unread": "Marquer comme non lu",
   "app_desktop_update": "Mettre à jour",

--- a/image/assets/lang/Polski.json
+++ b/image/assets/lang/Polski.json
@@ -630,7 +630,6 @@
   "sms_delete_message": "Usuń wiadomość",
   "sms_use_template": "Użyj szablonu",
   "sms_paste": "Wklej",
-  "sms_temp_reply": "Odpowiedz",
   "sms_mark_read": "Oznacz jako przeczytaną",
   "sms_mark_unread": "Oznacz jako nieprzeczytaną",
   "app_desktop_update": "Aktualizuj",

--- a/image/assets/lang/Svenska.json
+++ b/image/assets/lang/Svenska.json
@@ -516,7 +516,6 @@
   "sms_delete_message": "Radera meddelande",
   "sms_use_template": "Använd mall",
   "sms_paste": "Klistra in",
-  "sms_temp_reply": "Svara",
   "sms_mark_read": "Markera som läst",
   "sms_mark_unread": "Markera som oläst",
   "app_desktop_update": "Uppdatera",

--- a/module-apps/application-messages/widgets/SMSInputWidget.cpp
+++ b/module-apps/application-messages/widgets/SMSInputWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationMessages.hpp"
@@ -72,28 +72,15 @@ namespace gui
             assert(body != nullptr);
             assert(application != nullptr);
 
+            const auto threadViewWindow = application->getWindow(gui::name::window::thread_view);
+
             if (inputText->focus) {
-
-                application->getWindow(gui::name::window::thread_view)
-                    ->setNavBarText(utils::translate(utils::translate(style::strings::common::send)),
-                                    nav_bar::Side::Center);
-
-                if (inputText->getText() == utils::translate("sms_temp_reply")) {
-                    inputText->clear();
-                }
-
                 inputText->setCursorStartPosition(CursorStartPosition::DocumentEnd);
+                threadViewWindow->setNavBarText(utils::translate(utils::translate(style::strings::common::send)),
+                                                nav_bar::Side::Center);
             }
             else {
-
-                if (inputText->isEmpty()) {
-
-                    inputText->setColor(Color(7, 0));
-                    inputText->setText(utils::translate("sms_temp_reply"));
-                }
-
-                application->getWindow(gui::name::window::thread_view)
-                    ->setNavBarText(utils::translate(style::strings::common::reply), nav_bar::Side::Center);
+                threadViewWindow->setNavBarText(utils::translate(style::strings::common::reply), nav_bar::Side::Center);
             }
 
             return true;
@@ -117,12 +104,8 @@ namespace gui
 
     void SMSInputWidget::handleDraftMessage()
     {
-        if (const auto &text = inputText->getText(); text.empty() || (text == utils::translate("sms_temp_reply"))) {
-            clearDraftMessage();
-        }
-        else {
-            updateDraftMessage(text);
-        }
+        const auto &text = inputText->getText();
+        text.empty() ? clearDraftMessage() : updateDraftMessage(text);
     }
 
     void SMSInputWidget::clearDraftMessage()

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -15,6 +15,7 @@
 * Fixed backspace behavior in text edit
 * Fixed text not showing when adding/editing contact if text began with 'j' glyph
 * Fixed VoLTE switch availability after taking out SIM card
+* Fixed improper message text displaying after pasting from clipboard
 
 ### Added
 


### PR DESCRIPTION
Fix of the issue that pasting previously copied
text in new message field on thread screen
resulted in text shown in gray and invisibility
of each subsequently entered character.

Further analysis of this issue shown two
additional bugs in this place in code,
as a result a decision to completely
remove 'Reply' prompt text has been
made. Extended description of these
issues can be found in comment under
MOS-27 Jira ticket.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->


[MOS-27]: https://appnroll.atlassian.net/browse/MOS-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ