### PR TITLE
[MOS-495] Fix deleting message content when changing phone mode

### DIFF
--- a/module-apps/application-messages/windows/NewMessage.cpp
+++ b/module-apps/application-messages/windows/NewMessage.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationMessages.hpp"
@@ -287,9 +287,6 @@ namespace gui
             if (event.isShortRelease(KeyCode::KEY_RF)) {
                 onClose(CloseReason::WindowSwitch);
             }
-            if (event.isKeyRelease(KeyCode::KEY_VOLUP) || event.isKeyRelease(KeyCode::KEY_VOLDN)) {
-                memento->setState(message);
-            }
             return false;
         };
         body->addWidget(message);
@@ -309,11 +306,12 @@ namespace gui
             return;
         }
 
-        if (reason == CloseReason::PhoneLock) {
+        if ((reason == CloseReason::PhoneLock) || (reason == CloseReason::Popup)) {
             memento->setState(message);
             message->clear();
             return;
         }
+
         if (const auto handled = handleMessageText(); !handled) {
             message->clear();
         }

--- a/module-apps/apps-common/ApplicationCommonPopupBlueprints.cpp
+++ b/module-apps/apps-common/ApplicationCommonPopupBlueprints.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AppWindow.hpp"
@@ -32,7 +32,8 @@ namespace app
                 else {
                     switchWindowPopup(popupName,
                                       popupParams->getDisposition(),
-                                      std::make_unique<gui::ModesPopupData>(mode, flightMode));
+                                      std::make_unique<gui::ModesPopupData>(mode, flightMode),
+                                      SwitchReason::Popup);
                 }
                 return true;
             });
@@ -56,7 +57,8 @@ namespace app
                     updateCurrentWindow(std::move(popupData));
                 }
                 else {
-                    switchWindowPopup(popupName, volumeParams->getDisposition(), std::move(popupData));
+                    switchWindowPopup(
+                        popupName, volumeParams->getDisposition(), std::move(popupData), SwitchReason::Popup);
                 }
                 return true;
             });

--- a/module-apps/apps-common/locks/input/PhoneLockedKeysWhitelist.cpp
+++ b/module-apps/apps-common/locks/input/PhoneLockedKeysWhitelist.cpp
@@ -1,8 +1,7 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhoneLockedKeysWhitelist.hpp"
-#include <array>
 
 namespace locks::PhoneLockedKeysWhitelist
 {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -19,6 +19,7 @@
 * Fixed improper message text displaying after pasting from clipboard
 * Fixed USSD handling crash
 * Fixed calls to emergency contact when typed manually
+* Fixed message content being deleted when phone mode changed on new message window
 
 ### Added
 


### PR DESCRIPTION
Fix of the issue that moving mode slider on new message window caused the content of the message to be deleted.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
