### PR TITLE
[CP-1512] Add information allowing indetification to crashdump file

### DIFF
--- a/board/linux/CMakeLists.txt
+++ b/board/linux/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(board INTERFACE)
 add_subdirectory(libiosyscalls)
+add_subdirectory(crashdump-serial-number)
 target_compile_definitions(board-config INTERFACE PROJECT_CONFIG_USER_DYNMEM_SIZE=0)

--- a/board/linux/crashdump-serial-number/CMakeLists.txt
+++ b/board/linux/crashdump-serial-number/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(crashdump-serial-number STATIC)
+
+target_include_directories(crashdump-serial-number
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>/include
+)
+
+target_sources(crashdump-serial-number
+    PUBLIC
+        crashdump_serial_number.cpp
+)
+
+

--- a/board/linux/crashdump-serial-number/crashdump_serial_number.cpp
+++ b/board/linux/crashdump-serial-number/crashdump_serial_number.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <crashdump-serial-number/crashdump_serial_number.hpp>
+
+namespace crashdump
+{
+    void setSerialNumber(const std::string &)
+    {}
+    std::string getSerialNumber()
+    {
+        return "";
+    }
+
+} // namespace crashdump

--- a/board/linux/crashdump-serial-number/include/crashdump-serial-number/crashdump_serial_number.hpp
+++ b/board/linux/crashdump-serial-number/include/crashdump-serial-number/crashdump_serial_number.hpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+// Dummy file to keep linux variant compiling.
+
+#pragma once
+#include <string>
+namespace crashdump
+{
+    void setSerialNumber(const std::string &sn);
+    std::string getSerialNumber();
+
+} // namespace crashdump

--- a/board/rt1051/CMakeLists.txt
+++ b/board/rt1051/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(board STATIC)
 
 add_subdirectory(cmsis)
 add_subdirectory(${BOARD})
+add_subdirectory(crashdump-serial-number)
 
 if (${MEMORY_LINKER_FILE_PATH} STREQUAL "")
     message(FATAL_ERROR "Linker RAM layout not provided")
@@ -42,6 +43,7 @@ target_include_directories(board
 target_link_libraries(board
     PRIVATE
         utils-rotator
+        crashdump-serial-number
     PUBLIC
         fsl
         module-vfs

--- a/board/rt1051/crashdump-serial-number/CMakeLists.txt
+++ b/board/rt1051/crashdump-serial-number/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(crashdump-serial-number STATIC)
+
+target_include_directories(crashdump-serial-number
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>/include
+)
+
+target_sources(crashdump-serial-number
+    PUBLIC
+        crashdump_serial_number.cpp
+)
+
+

--- a/board/rt1051/crashdump-serial-number/crashdump_serial_number.cpp
+++ b/board/rt1051/crashdump-serial-number/crashdump_serial_number.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <crashdump-serial-number/crashdump_serial_number.hpp>
+
+namespace
+{
+    std::string serial_number = "0000000000000";
+}
+namespace crashdump
+{
+    void setSerialNumber(const std::string &sn)
+    {
+        serial_number = sn;
+    }
+    std::string getSerialNumber()
+    {
+        return serial_number;
+    }
+
+} // namespace crashdump

--- a/board/rt1051/crashdump-serial-number/include/crashdump-serial-number/crashdump_serial_number.hpp
+++ b/board/rt1051/crashdump-serial-number/include/crashdump-serial-number/crashdump_serial_number.hpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+// The purpose of this file is to keep the devices serial number in the memory.
+// In case of any crash, the serial number could be easily added to a crash dump filename.
+// It will allow to identify the crash even after it is moved or copied from the device.
+// setSerialNumber() should be called during system initialization.
+// getSerialNumber() is called by the crash dump writer during file creation.
+
+#pragma once
+#include <string>
+namespace crashdump
+{
+    void setSerialNumber(const std::string &sn);
+    std::string getSerialNumber();
+
+} // namespace crashdump

--- a/board/rt1051/crashdump/crashcatcher_impl.cpp
+++ b/board/rt1051/crashdump/crashcatcher_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma GCC optimize("Og")
@@ -60,6 +60,7 @@ void CrashCatcher_DumpMemory(const void *pvMemory, CrashCatcherElementSizes elem
 CrashCatcherReturnCodes CrashCatcher_DumpEnd(void)
 {
     cwrite.saveDump();
+    cwrite.deleteOldDump();
     _exit_backtrace(-1, false);
     return CRASH_CATCHER_EXIT;
 }

--- a/board/rt1051/crashdump/crashdumpwriter_vfs.cpp
+++ b/board/rt1051/crashdump/crashdumpwriter_vfs.cpp
@@ -1,31 +1,46 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "crashdumpwriter_vfs.hpp"
-
+#include <crashdump-serial-number/crashdump_serial_number.hpp>
 #include <cstdio>
-#include <log/log.hpp>
 #include <fcntl.h>
 #include "purefs/vfs_subsystem.hpp"
 #include <purefs/filesystem_paths.hpp>
 #include <exit_backtrace.h>
 
+#include <log/log.hpp>
 #include <filesystem>
 #include <stdint.h>
 #include <unistd.h>
+#include <chrono>
+#include <set>
+
+namespace
+{
+    constexpr inline auto suffix = "_crashdump.hex";
+
+    // Crashdump filename pattern:
+    // [serial-number]_[timestamp-in-seconds]_crashdump.hex
+
+    inline std::string generate_crashdump_filename()
+    {
+        const auto crash_time =
+            std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch())
+                .count();
+        auto filename = std::string("/") + crashdump::getSerialNumber() + "_" + std::to_string(crash_time) + suffix;
+        return filename;
+    }
+} // namespace
 
 namespace crashdump
 {
-    constexpr inline auto crashDumpFileName = "crashdump.hex";
 
     void CrashDumpWriterVFS::openDump()
     {
-        const auto crashDumpFilePath = purefs::dir::getCrashDumpsPath() / crashDumpFileName;
+        const auto crashDumpFilePath = purefs::dir::getCrashDumpsPath().string() + generate_crashdump_filename();
+
         LOG_INFO("Crash dump %s preparing ...", crashDumpFilePath.c_str());
-        if (!rotator.rotateFile(crashDumpFilePath)) {
-            LOG_FATAL("Failed to rotate crash dumps errno: %i", errno);
-            _exit_backtrace(-1, false);
-        }
         file = std::fopen(crashDumpFilePath.c_str(), "w");
         if (!file) {
             LOG_FATAL("Failed to open crash dump file errno %i", errno);
@@ -39,6 +54,23 @@ namespace crashdump
         fflush(file);
         fsync(fileno(file));
         std::fclose(file);
+    }
+
+    void CrashDumpWriterVFS::deleteOldDump()
+    {
+        std::set<std::filesystem::path> crashdumps{};
+        for (const auto &entry : std::filesystem::directory_iterator(purefs::dir::getCrashDumpsPath())) {
+            std::cout << entry.path() << std::endl;
+            crashdumps.insert(entry.path());
+        }
+
+        if (crashdumps.size() > maxFilesCount) {
+            auto crashdump_to_delete = crashdumps.begin();
+            LOG_INFO("Deleting %s ...", crashdump_to_delete->c_str());
+            if (not std::filesystem::remove(crashdump_to_delete->c_str())) {
+                LOG_WARN("File: %s was not deleted.", crashdump_to_delete->c_str());
+            }
+        }
     }
 
     void CrashDumpWriterVFS::writeBytes(const uint8_t *buff, std::size_t size)

--- a/board/rt1051/crashdump/crashdumpwriter_vfs.hpp
+++ b/board/rt1051/crashdump/crashdumpwriter_vfs.hpp
@@ -1,9 +1,7 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
-
-#include <rotator/Rotator.hpp>
 
 #include <array>
 #include <ctime>
@@ -17,21 +15,21 @@ namespace purefs::fs
 
 namespace crashdump
 {
-    constexpr inline auto maxRotationFilesCount = 5;
+    constexpr inline auto maxFilesCount = 5;
     class CrashDumpWriterVFS
     {
       public:
-        CrashDumpWriterVFS() : rotator{".hex"}
+        CrashDumpWriterVFS()
         {}
         void openDump();
         void saveDump();
+        void deleteOldDump();
 
         void writeBytes(const std::uint8_t *buff, std::size_t size);
         void writeHalfWords(const std::uint16_t *buff, std::size_t size);
         void writeWords(const std::uint32_t *buff, std::size_t size);
 
       private:
-        utils::Rotator<maxRotationFilesCount> rotator;
         std::FILE *file{};
     };
 

--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -10,6 +10,7 @@
 ### Added
 
 ### Changed
+* Added serial number and timestamp to crashdump filename
 
 ## [1.8.0 2022-12-14]
 

--- a/module-services/service-db/agents/settings/FactorySettings.cpp
+++ b/module-services/service-db/agents/settings/FactorySettings.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "FactorySettings.hpp"

--- a/module-services/service-desktop/WorkerDesktop.cpp
+++ b/module-services/service-desktop/WorkerDesktop.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "service-desktop/ServiceDesktop.hpp"

--- a/products/BellHybrid/CMakeLists.txt
+++ b/products/BellHybrid/CMakeLists.txt
@@ -143,6 +143,7 @@ add_subdirectory(apps)
 add_subdirectory(keymap)
 add_subdirectory(services)
 add_subdirectory(sys)
+add_subdirectory(serial-number-reader)
 
 option(CONFIG_ENABLE_TEMP "Enable displaying temperature" OFF)
 option(CONFIG_SHOW_MEMORY_INFO "Enable displaying memory info" OFF)

--- a/products/BellHybrid/serial-number-reader/CMakeLists.txt
+++ b/products/BellHybrid/serial-number-reader/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(serial-number-reader STATIC)
+
+
+target_sources(serial-number-reader
+    PUBLIC
+        SerialNumberReader.cpp
+)
+
+target_include_directories(serial-number-reader
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+)
+
+target_link_libraries(serial-number-reader
+    PRIVATE
+    module-vfs
+)

--- a/products/BellHybrid/serial-number-reader/SerialNumberReader.cpp
+++ b/products/BellHybrid/serial-number-reader/SerialNumberReader.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <purefs/vfs_subsystem.hpp>
+
+#include <serial-number-reader/SerialNumberReader.hpp>
+
+namespace
+{
+    constexpr auto DEVICE_NAME      = "emmc0sys1";
+    constexpr auto EMMC_SN_LENGTH   = 13;
+    constexpr auto EMMC_BUFFER_SIZE = 512;
+    constexpr auto SECTOR_TO_READ   = 2;
+    constexpr auto SECTOR_COUNT     = 1U;
+
+    std::string readSerialNumberFromEmmc()
+    {
+        char buffer[EMMC_BUFFER_SIZE];
+        purefs::subsystem::disk_mgr()->read(DEVICE_NAME, buffer, SECTOR_TO_READ, SECTOR_COUNT);
+        buffer[EMMC_SN_LENGTH] = '\0';
+        return std::string(buffer);
+    }
+} // namespace
+namespace serial_number_reader
+{
+    std::string readSerialNumber()
+    {
+        return readSerialNumberFromEmmc();
+    }
+} // namespace serial_number_reader

--- a/products/BellHybrid/serial-number-reader/include/serial-number-reader/SerialNumberReader.hpp
+++ b/products/BellHybrid/serial-number-reader/include/serial-number-reader/SerialNumberReader.hpp
@@ -1,0 +1,10 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+#include <string>
+
+namespace serial_number_reader
+{
+    std::string readSerialNumber();
+} // namespace serial_number_reader

--- a/products/BellHybrid/services/db/CMakeLists.txt
+++ b/products/BellHybrid/services/db/CMakeLists.txt
@@ -21,6 +21,8 @@ target_link_libraries(databases
    PRIVATE
         bell::db::meditation_stats
         service-db
+        serial-number-reader
+        crashdump-serial-number
 )
 
 if (${ENABLE_TESTS})

--- a/products/BellHybrid/services/db/ServiceDB.cpp
+++ b/products/BellHybrid/services/db/ServiceDB.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <db/ServiceDB.hpp>
@@ -16,6 +16,9 @@
 #include <time/ScopedTime.hpp>
 
 #include <purefs/filesystem_paths.hpp>
+
+#include <serial-number-reader/SerialNumberReader.hpp>
+#include <crashdump-serial-number/crashdump_serial_number.hpp>
 
 ServiceDB::~ServiceDB()
 {
@@ -89,6 +92,11 @@ sys::ReturnCodes ServiceDB::InitHandler()
     for (auto &dbAgent : databaseAgents) {
         dbAgent->registerMessages();
     }
+
+    LOG_INFO("Serial number: %s", serial_number_reader::readSerialNumber().c_str());
+
+    // Saving serial number for crashdump generation purpose.
+    crashdump::setSerialNumber(serial_number_reader::readSerialNumber());
 
     return sys::ReturnCodes::Success;
 }

--- a/products/BellHybrid/services/desktop/endpoints/CMakeLists.txt
+++ b/products/BellHybrid/services/desktop/endpoints/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(
         desktop-endpoints-common
     PRIVATE
         version-header
+        serial-number-reader
 )
 
 target_compile_definitions(

--- a/products/BellHybrid/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
+++ b/products/BellHybrid/services/desktop/endpoints/deviceInfo/DeviceInfoEndpoint.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <endpoints/deviceInfo/DeviceInfoEndpoint.hpp>
@@ -15,31 +15,16 @@
 #include <sys/statvfs.h>
 #include <purefs/filesystem_paths.hpp>
 #include <purefs/vfs_subsystem.hpp>
+#include <serial-number-reader/SerialNumberReader.hpp>
 
 #include <ctime>
-namespace
-{
-    constexpr auto DEVICE_NAME      = "emmc0sys1";
-    constexpr auto EMMC_SN_LENGTH   = 13;
-    constexpr auto EMMC_BUFFER_SIZE = 512;
-    constexpr auto SECTOR_TO_READ   = 2;
-    constexpr auto SECTOR_COUNT     = 1U;
 
-    std::string readSerialNumberFromEmmc()
-    {
-        char buffer[EMMC_BUFFER_SIZE];
-        purefs::subsystem::disk_mgr()->read(DEVICE_NAME, buffer, SECTOR_TO_READ, SECTOR_COUNT);
-        buffer[EMMC_SN_LENGTH] = '\0';
-        return std::string(buffer);
-    }
-
-} // namespace
 namespace sdesktop::endpoints
 {
 
     auto DeviceInfoEndpoint::getSerialNumber() -> std::string
     {
-        return readSerialNumberFromEmmc();
+        return serial_number_reader::readSerialNumber();
     }
 
     auto DeviceInfoEndpoint::getDeviceInfo(Context &context) -> http::Code

--- a/products/PurePhone/services/db/CMakeLists.txt
+++ b/products/PurePhone/services/db/CMakeLists.txt
@@ -16,4 +16,5 @@ target_link_libraries(db
    PRIVATE
         module-db
         service-db
+        crashdump-serial-number
 )

--- a/products/PurePhone/services/db/ServiceDB.cpp
+++ b/products/PurePhone/services/db/ServiceDB.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <db/ServiceDB.hpp>
@@ -23,7 +23,12 @@
 #include <service-db/DBServiceMessage.hpp>
 #include <service-db/QueryMessage.hpp>
 #include <time/ScopedTime.hpp>
+#include <crashdump-serial-number/crashdump_serial_number.hpp>
 
+namespace
+{
+    constexpr auto serial_number_path = "factory_data/serial";
+}
 ServiceDB::~ServiceDB()
 {
     eventsDB.reset();
@@ -275,6 +280,9 @@ sys::ReturnCodes ServiceDB::InitHandler()
 
     auto settings = std::make_unique<settings::Settings>();
     settings->init(service::ServiceProxy(shared_from_this()));
+
+    // Saving serial number for crashdump generation purpose.
+    crashdump::setSerialNumber(settings->getValue(serial_number_path, settings::SettingsScope::Global));
 
     quotesRecordInterface =
         std::make_unique<Quotes::QuotesAgent>(predefinedQuotesDB.get(), customQuotesDB.get(), std::move(settings));

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -4,6 +4,7 @@
 
 ### Changed / Improved
 * Improved dialog with network via USSD
+* Added serial number and timestamp to crashdump filename
 
 ### Fixed
 * Fixed disappearing "confirm" button in PIN entering screen


### PR DESCRIPTION
Add the serial number and generation timestamp to crashdump filename.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
