### PR TITLE
[CP-1579] Fix correct password inserted during Pure boot is not accepted

### DIFF
--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <service-desktop/ServiceDesktop.hpp>

--- a/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/products/PurePhone/PurePhoneMain.cpp
+++ b/products/PurePhone/PurePhoneMain.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "config.h"
@@ -185,9 +185,6 @@ int main()
 #ifdef ENABLE_SERVICE_BLUETOOTH
     systemServices.emplace_back(sys::CreatorFor<ServiceBluetooth>());
 #endif
-#ifdef ENABLE_SERVICE_DESKTOP
-    systemServices.emplace_back(sys::CreatorFor<ServiceDesktop>());
-#endif
 #ifdef ENABLE_SERVICE_TIME
     systemServices.emplace_back(sys::CreatorFor<stm::ServiceTime>(std::make_shared<alarms::AlarmOperationsFactory>()));
 #endif
@@ -197,6 +194,9 @@ int main()
 #ifdef ENABLE_SERVICE_GUI
     systemServices.emplace_back(
         sys::CreatorFor<service::gui::ServiceGUI>(gui::Size{BOARD_EINK_DISPLAY_RES_X, BOARD_EINK_DISPLAY_RES_Y}));
+#endif
+#ifdef ENABLE_SERVICE_DESKTOP
+    systemServices.emplace_back(sys::CreatorFor<ServiceDesktop>());
 #endif
 #if ENABLE_SERVICE_TEST
     systemServices.emplace_back(sys::CreatorFor<service::test::ServiceTest>());

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -5,6 +5,7 @@
 ### Changed / Improved
 * Improved dialog with network via USSD
 * Added serial number and timestamp to crashdump filename
+* Changed order of starting services, ServiceDesktop moved to the back
 
 ### Fixed
 * Fixed disappearing "confirm" button in PIN entering screen


### PR DESCRIPTION
Fix the issue when the USB cable connected to the device during boot up and Center requested a passcode before the device was fully up. What caused a 'Wrong passcode' message after typing a passcode via Center.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
