### PR TITLE
[MOS-838] Unable to unlock SIM card (corner case)

### DIFF
--- a/module-apps/apps-common/locks/handlers/SimLockHandler.cpp
+++ b/module-apps/apps-common/locks/handlers/SimLockHandler.cpp
@@ -292,6 +292,8 @@ namespace locks
 
     sys::MessagePointer SimLockHandler::handleSimNotRespondingMessage()
     {
+        simSwitching = false;
+
         setSimInputTypeAction(SimInputTypeAction::Error);
 
         lock.lockName = utils::enumToString(Store::GSM::get()->selected);

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -24,6 +24,7 @@
 * Fixed wrong navigation bar state after exit from custom repeat window
 * Fixed OS crash when editing contact by adding country prefix to number
 * Fixed unwanted Mudita Center passcode prompt after long press '#' while dialing 
+* Fixed inability to unblock SIM card when previously ejected during slot switching
 
 ### Added
 


### PR DESCRIPTION
Fixed with adding a missing internal state reset on SIM connection failure.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added
