### PR TITLE
[MOS-606] Fix inactive alarms after the timezone change and reboot.

### DIFF
--- a/module-services/service-time/AlarmMessageHandler.cpp
+++ b/module-services/service-time/AlarmMessageHandler.cpp
@@ -158,6 +158,7 @@ namespace alarms
         AlarmOperationsCommon::OnActiveAlarmCountChange callback) -> void
     {
         alarmOperations->addActiveAlarmCountChangeCallback(callback);
+        alarmOperations->updateEventsCache(TimePointNow());
     }
 
     auto AlarmMessageHandler::handleGetSnoozedAlarms(GetSnoozedAlarmsRequestMessage *request)

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -259,6 +259,7 @@
 * Fixed problem with Music Player application crashing when trying to play files with unknown formats.
 * Fixed problem with resuming music playback after connecting a headset.
 * Fixed problem of battery discharging of phone without SIM card.
+* Fixed inactive alarms after timezone change and reboot.
 
 ## [1.1.6 2022-01-20]
 


### PR DESCRIPTION
Fixed by adding additional alarm's event cache update after assigning the callback.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
