### PR TITLE
[BH-1609] Fix resizing of format in TimeSetFmtSpinner

### DIFF
--- a/module-apps/apps-common/widgets/TimeSetFmtSpinner.cpp
+++ b/module-apps/apps-common/widgets/TimeSetFmtSpinner.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TimeSetFmtSpinner.hpp"
@@ -11,18 +11,18 @@
 namespace gui
 {
 
-    TimeSetFmtSpinner::TimeSetFmtSpinner(Item *parent, utils::time::Locale::TimeFormat timeFormat) : HBox{parent}
+    TimeSetFmtSpinner::TimeSetFmtSpinner(Item *parent) : HBox{parent}
     {
         using namespace utils;
 
         setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
         setEdges(RectangleEdge::None);
 
-        timeSetSpinner = new TimeSetSpinner(this, 0, 0, 0, 0);
+        timeSetSpinner = new TimeSetSpinner(nullptr);
         timeSetSpinner->setFont(focusFontName, noFocusFontName);
         timeSetSpinner->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
 
-        auto textRange = StringSpinner::range{time::Locale::getAM(), time::Locale::getPM()};
+        auto textRange = {time::Locale::getAM(), time::Locale::getPM()};
         fmt            = new StringSpinner(textRange, Boundaries::Continuous);
         updateFmtFont(noFocusFontName);
         fmt->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
@@ -30,8 +30,14 @@ namespace gui
         fmt->setEdges(RectangleEdge::None);
         fmt->setVisible(false);
         fmt->setPenFocusWidth(style::time_set_spinner::focus::size);
-        addWidget(fmt);
         fmt->setEdges(RectangleEdge::Bottom);
+
+        addWidget(timeSetSpinner);
+        addWidget(fmt);
+
+        setTimeFormat(timeFormat, false);
+
+        resizeItems();
 
         focusChangedCallback = [&](Item &) {
             if (focus) {
@@ -55,11 +61,15 @@ namespace gui
             }
             return true;
         };
-
-        setTimeFormat(timeFormat);
     }
 
     auto TimeSetFmtSpinner::setTimeFormat(utils::time::Locale::TimeFormat newFormat) noexcept -> void
+    {
+        setTimeFormat(newFormat, true);
+    }
+
+    auto TimeSetFmtSpinner::setTimeFormat(utils::time::Locale::TimeFormat newFormat, bool informContentChanged) noexcept
+        -> void
     {
         using namespace utils;
 
@@ -93,7 +103,10 @@ namespace gui
         }
 
         timeFormat = newFormat;
-        fmt->handleContentChanged();
+
+        if (informContentChanged) {
+            fmt->handleContentChanged();
+        }
     }
 
     auto TimeSetFmtSpinner::setMinute(int value) noexcept -> void

--- a/module-apps/apps-common/widgets/TimeSetFmtSpinner.hpp
+++ b/module-apps/apps-common/widgets/TimeSetFmtSpinner.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -35,9 +35,7 @@ namespace gui
             AM,
             PM
         };
-        explicit TimeSetFmtSpinner(
-            Item *parent                               = nullptr,
-            utils::time::Locale::TimeFormat timeFormat = utils::time::Locale::TimeFormat::FormatTime12H);
+        explicit TimeSetFmtSpinner(Item *parent = nullptr);
 
         /// Switches currently displayed time format
         auto setTimeFormat(utils::time::Locale::TimeFormat fmt) noexcept -> void;
@@ -68,6 +66,8 @@ namespace gui
             Left,
             Right
         };
+
+        auto setTimeFormat(utils::time::Locale::TimeFormat fmt, bool informContentChanged) noexcept -> void;
 
         std::map<std::string, Margins> fmtMarginsMap = {
             {style::window::font::verybiglight, {style::time_set_fmt_spinner::small_margin, 0, 0, 0}},

--- a/module-gui/gui/widgets/Item.cpp
+++ b/module-gui/gui/widgets/Item.cpp
@@ -180,8 +180,7 @@ namespace gui
 
     void Item::informContentChanged()
     {
-        // check if item has been initialized to prevent looping
-        if (parent != nullptr && widgetArea != BoundingBox()) {
+        if (parent != nullptr) {
             contentChanged = true;
             parent->handleContentChanged();
         }
@@ -189,9 +188,7 @@ namespace gui
 
     void Item::handleContentChanged()
     {
-        if (parent != nullptr) {
-            informContentChanged();
-        }
+        informContentChanged();
     }
 
     void Item::setSize(Length w, Length h)

--- a/products/BellHybrid/apps/common/include/common/widgets/BellStatusClock.hpp
+++ b/products/BellHybrid/apps/common/include/common/widgets/BellStatusClock.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -10,9 +10,7 @@ namespace gui
     class BellStatusClock : public TimeSetFmtSpinner
     {
       public:
-        explicit BellStatusClock(
-            Item *parent                               = nullptr,
-            utils::time::Locale::TimeFormat timeFormat = utils::time::Locale::TimeFormat::FormatTime12H);
+        explicit BellStatusClock(Item *parent = nullptr);
     };
 
 } // namespace gui

--- a/products/BellHybrid/apps/common/src/widgets/BellStatusClock.cpp
+++ b/products/BellHybrid/apps/common/src/widgets/BellStatusClock.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <common/widgets/BellStatusClock.hpp>
@@ -8,8 +8,7 @@
 namespace gui
 {
 
-    BellStatusClock::BellStatusClock(Item *parent, utils::time::Locale::TimeFormat timeFormat)
-        : TimeSetFmtSpinner{parent, timeFormat}
+    BellStatusClock::BellStatusClock(Item *parent) : TimeSetFmtSpinner{parent}
     {
         setFont(bell_style::statusClockFont);
         setEditMode(EditMode::Browse);

--- a/products/BellHybrid/apps/common/src/widgets/ListItems.cpp
+++ b/products/BellHybrid/apps/common/src/widgets/ListItems.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <common/data/StyleCommon.hpp>
@@ -48,7 +48,8 @@ namespace gui
                                const std::string &topDescription)
         : BellSideListItemWithCallbacks(topDescription)
     {
-        spinner = new TimeSetFmtSpinner(body->getCenterBox(), timeFormat);
+        spinner = new TimeSetFmtSpinner(body->getCenterBox());
+        spinner->setTimeFormat(timeFormat);
         spinner->setMaximumSize(::style::bell_base_layout::w, ::style::bell_base_layout::h);
         spinner->setFont(focusFont, noFocusFont);
         spinner->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));


### PR DESCRIPTION
Change the resizing logic of the children of TimeSetFmtSpinner.
Remove arguments of TimeSetFmtSpinner and BellStatusClock ctors.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
