### PR TITLE
[MOS-275] Fix alarm rings on the low battery screen

### DIFF
--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "service-evtmgr/BatteryMessages.hpp"
@@ -49,9 +49,11 @@
 #define debug_input_events(...)
 #endif
 
-EventManagerCommon::EventManagerCommon(LogDumpFunction logDumpFunction, const std::string &name)
+EventManagerCommon::EventManagerCommon(LogDumpFunction logDumpFunction,
+                                       EventManagerParams params,
+                                       const std::string &name)
     : sys::Service(name, "", stackDepth), logDumpFunction(std::move(logDumpFunction)),
-      settings(std::make_shared<settings::Settings>())
+      settings(std::make_shared<settings::Settings>()), eventManagerParams(params)
 {
     LOG_INFO("[%s] Initializing", name.c_str());
     alarmTimestamp = 0;
@@ -180,7 +182,7 @@ sys::ReturnCodes EventManagerCommon::InitHandler()
     initProductEvents();
 
     EventWorker = createEventWorker();
-    EventWorker->init(settings);
+    EventWorker->init(settings, eventManagerParams);
     EventWorker->run();
 
     cpuSentinel                  = std::make_shared<sys::TimedCpuSentinel>(service::name::evt_manager, this);

--- a/module-services/service-evtmgr/WorkerEventCommon.cpp
+++ b/module-services/service-evtmgr/WorkerEventCommon.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "service-evtmgr/EVMessages.hpp"
@@ -107,12 +107,12 @@ bool WorkerEventCommon::initEventQueues()
     return Worker::init(queuesList);
 }
 
-bool WorkerEventCommon::initCommonHardwareComponents()
+bool WorkerEventCommon::initCommonHardwareComponents(EventManagerParams params)
 {
     keyInput->init(queues[static_cast<int32_t>(WorkerEventQueues::queueKeyboardIRQ)]->GetQueueHandle());
     auto queueBatteryHandle = queues[static_cast<int32_t>(WorkerEventQueues::queueBatteryController)]->GetQueueHandle();
 
-    batteryController = std::make_shared<sevm::battery::BatteryController>(service, queueBatteryHandle);
+    batteryController = std::make_shared<sevm::battery::BatteryController>(service, queueBatteryHandle, params.battery);
     bsp::rtc::init(queues[static_cast<int32_t>(WorkerEventQueues::queueRTC)]->GetQueueHandle());
 
     time_t timestamp;
@@ -131,10 +131,10 @@ bool WorkerEventCommon::initCommonHardwareComponents()
     return true;
 }
 
-void WorkerEventCommon::init(std::shared_ptr<settings::Settings> settings)
+void WorkerEventCommon::init(std::shared_ptr<settings::Settings> settings, EventManagerParams params)
 {
     initEventQueues();
-    initCommonHardwareComponents();
+    initCommonHardwareComponents(params);
 }
 
 bool WorkerEventCommon::deinit(void)

--- a/module-services/service-evtmgr/battery/BatteryController.hpp
+++ b/module-services/service-evtmgr/battery/BatteryController.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -20,7 +20,7 @@ namespace sevm::battery
       public:
         using Events          = hal::battery::AbstractBatteryCharger::Events;
         using ChargerPresence = hal::battery::AbstractBatteryCharger::ChargerPresence;
-        explicit BatteryController(sys::Service *service, xQueueHandle notificationChannel);
+        BatteryController(sys::Service *service, xQueueHandle notificationChannel, BatteryState::Thresholds thresholds);
 
         void poll();
 

--- a/module-services/service-evtmgr/battery/BatteryState.cpp
+++ b/module-services/service-evtmgr/battery/BatteryState.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BatteryState.hpp"
@@ -128,22 +128,21 @@ class BatteryState::Pimpl
     friend BatteryState;
 
   public:
-    explicit Pimpl(NotifyStateChangedCallback notifyCallback) : notifyCallback{std::move(notifyCallback)}
+    Pimpl(NotifyStateChangedCallback notifyCallback, Thresholds thresholds)
+        : thresholds(thresholds), notifyCallback{std::move(notifyCallback)}
     {}
 
   private:
+    const Thresholds thresholds;
     NotifyStateChangedCallback notifyCallback;
     sml::sm<StateMachine, NotifyStateChangedCallback> sm{notifyCallback};
-
-    static constexpr auto criticalThreshold = 10; // %
-    static constexpr auto shutdownThreshold = 1;  // %
 };
 
 void BatteryState::check(const ChargingState state, const float soc)
 {
-    pimpl->sm.process_event(events::Check{soc, state, Pimpl::criticalThreshold, Pimpl::shutdownThreshold});
+    pimpl->sm.process_event(events::Check{soc, state, pimpl->thresholds.critical, pimpl->thresholds.shutdown});
 }
 
-BatteryState::BatteryState(sys::Service *service, NotifyStateChangedCallback notifyCallback)
-    : pimpl{std::make_shared<Pimpl>(notifyCallback)}
+BatteryState::BatteryState(sys::Service *service, NotifyStateChangedCallback notifyCallback, Thresholds thresholds)
+    : pimpl{std::make_shared<Pimpl>(notifyCallback, thresholds)}
 {}

--- a/module-services/service-evtmgr/battery/BatteryState.hpp
+++ b/module-services/service-evtmgr/battery/BatteryState.hpp
@@ -1,10 +1,11 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include <memory>
 #include <functional>
+#include <Units.hpp>
 
 namespace sys
 {
@@ -30,9 +31,15 @@ class BatteryState
         CriticalNotCharging
     };
 
+    struct Thresholds
+    {
+        units::Percent critical;
+        units::Percent shutdown;
+    };
+
     using NotifyStateChangedCallback = std::function<void(State)>;
 
-    BatteryState(sys::Service *service, NotifyStateChangedCallback notifyCallback);
+    BatteryState(sys::Service *service, NotifyStateChangedCallback notifyCallback, Thresholds thresholds);
 
     void check(ChargingState state, float soc);
 

--- a/module-services/service-evtmgr/service-evtmgr/BatteryMessages.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/BatteryMessages.hpp
@@ -1,27 +1,29 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include "Service/Message.hpp"
-
-#include <module-bsp/bsp/torch/torch.hpp>
+#include <battery/BatteryState.hpp>
 
 namespace sevm
 {
     class BatteryStatusChangeMessage : public sys::DataMessage
     {};
 
-    class BatterySetCriticalLevel : public sys::DataMessage
+    class BatteryStateChangeMessage : public sys::DataMessage
     {
       public:
-        BatterySetCriticalLevel(std::uint8_t level) : criticalLevel(level)
-        {}
-        const unsigned int criticalLevel = 0;
-    };
+        explicit BatteryStateChangeMessage(BatteryState::State state) : state{state} {};
 
-    class BatteryStateChangeMessage : public sys::DataMessage
-    {};
+        [[nodiscard]] BatteryState::State getState() const
+        {
+            return state;
+        }
+
+      private:
+        BatteryState::State state{BatteryState::State::Normal};
+    };
 
     class BatteryBrownoutMessage : public sys::DataMessage
     {};

--- a/module-services/service-evtmgr/service-evtmgr/EventManagerCommon.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/EventManagerCommon.hpp
@@ -1,9 +1,10 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include "Constants.hpp"
+#include "EventManagerParams.hpp"
 
 #include <hal/key_input/RawKey.hpp>
 #include <MessageType.hpp>
@@ -28,7 +29,9 @@ class EventManagerCommon : public sys::Service
   public:
     using LogDumpFunction = std::function<int()>;
 
-    explicit EventManagerCommon(LogDumpFunction logDumpFunction, const std::string &name = service::name::evt_manager);
+    EventManagerCommon(LogDumpFunction logDumpFunction,
+                       EventManagerParams params,
+                       const std::string &name = service::name::evt_manager);
     ~EventManagerCommon() override;
 
     sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;
@@ -79,4 +82,5 @@ class EventManagerCommon : public sys::Service
     uint32_t alarmTimestamp;
     // ID of alarm waiting to trigger
     uint32_t alarmID;
+    const EventManagerParams eventManagerParams;
 };

--- a/module-services/service-evtmgr/service-evtmgr/WorkerEventCommon.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/WorkerEventCommon.hpp
@@ -1,9 +1,10 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include "EventManagerCommon.hpp"
+#include "EventManagerParams.hpp"
 
 #include <Service/Message.hpp>
 #include <Service/Service.hpp>
@@ -67,7 +68,7 @@ class WorkerEventCommon : public sys::Worker
      */
     void updateResourcesAfterCpuFrequencyChange(bsp::CpuFrequencyMHz newFrequency);
     bool initEventQueues();
-    bool initCommonHardwareComponents();
+    bool initCommonHardwareComponents(EventManagerParams params);
     void sendKeyUnicast(RawKey const &key);
 
     /**
@@ -83,7 +84,7 @@ class WorkerEventCommon : public sys::Worker
   public:
     explicit WorkerEventCommon(sys::Service *service);
 
-    void init(std::shared_ptr<settings::Settings> settings);
+    void init(std::shared_ptr<settings::Settings> settings, EventManagerParams params);
     virtual void deinitProductHardware();
     virtual bool deinit() override;
 

--- a/module-services/service-evtmgr/service-evtmgr/include/EventManagerParams.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/include/EventManagerParams.hpp
@@ -1,0 +1,11 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <battery/BatteryController.hpp>
+
+struct EventManagerParams
+{
+    BatteryState::Thresholds battery;
+};

--- a/module-services/service-time/AlarmMessageHandler.cpp
+++ b/module-services/service-time/AlarmMessageHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlarmMessageHandler.hpp"
@@ -170,6 +170,20 @@ namespace alarms
             request, [&](GetSnoozedAlarmsRequestMessage *request, IAlarmOperations::OnGetSnoozedAlarms callback) {
                 alarmOperations->getSnoozedAlarms(callback);
             });
+    }
+
+    auto AlarmMessageHandler::handleBatteryStateChange(sevm::BatteryStateChangeMessage *request) -> void
+    {
+        switch (request->getState()) {
+        case BatteryState::State::Normal:
+            alarmOperations->handleNormalBatteryLevel();
+            break;
+        case BatteryState::State::Shutdown:
+        case BatteryState::State::CriticalCharging:
+        case BatteryState::State::CriticalNotCharging:
+            alarmOperations->handleCriticalBatteryLevel();
+            break;
+        }
     }
 
     template <class RequestType, class ResponseType, class CallbackParamType>

--- a/module-services/service-time/AlarmMessageHandler.hpp
+++ b/module-services/service-time/AlarmMessageHandler.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -6,7 +6,7 @@
 #include "AlarmOperations.hpp"
 
 #include <service-time/AlarmMessage.hpp>
-
+#include <service-evtmgr/BatteryMessages.hpp>
 #include <Service/Service.hpp>
 
 namespace stm
@@ -47,6 +47,7 @@ namespace alarms
         auto handleToggleAll(AlarmToggleAllRequestMessage *request) -> std::shared_ptr<AlarmToggleAllResponseMessage>;
         auto handleGetSnoozedAlarms(GetSnoozedAlarmsRequestMessage *request)
             -> std::shared_ptr<GetSnoozedAlarmsResponseMessage>;
+        auto handleBatteryStateChange(sevm::BatteryStateChangeMessage *request) -> void;
 
       private:
         stm::ServiceTime *service = nullptr;

--- a/module-services/service-time/AlarmOperations.cpp
+++ b/module-services/service-time/AlarmOperations.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlarmOperations.hpp"
@@ -345,9 +345,9 @@ namespace alarms
     auto AlarmOperationsCommon::processNextEventsQueue(const TimePoint now) -> void
     {
         if (nextSingleEvents.front()->startDate <= now) {
-            ongoingSingleEvents.insert(ongoingSingleEvents.end(),
-                                       std::make_move_iterator(nextSingleEvents.begin()),
-                                       std::make_move_iterator(nextSingleEvents.end()));
+            if (!isCriticalBatteryLevel) {
+                triggerAlarm();
+            }
             nextSingleEvents.clear();
             updateEventsCache(now);
         }
@@ -371,6 +371,24 @@ namespace alarms
         snoozedSingleEvents.clear();
         handleSnoozedAlarmsCountChange();
         handleActiveAlarmsCountChange();
+    }
+
+    auto AlarmOperationsCommon::stopAllRingingAlarms() -> void
+    {
+        if (!ongoingSingleEvents.empty()) {
+            for (auto &event : ongoingSingleEvents) {
+                switchAlarmExecution(*event, false);
+            }
+            ongoingSingleEvents.clear();
+            handleActiveAlarmsCountChange();
+        }
+    }
+
+    void AlarmOperationsCommon::triggerAlarm()
+    {
+        ongoingSingleEvents.insert(ongoingSingleEvents.end(),
+                                   std::make_move_iterator(nextSingleEvents.begin()),
+                                   std::make_move_iterator(nextSingleEvents.end()));
     }
 
     void AlarmOperationsCommon::toggleAll(bool toggle, OnToggleAll callback)
@@ -431,6 +449,18 @@ namespace alarms
             std::sort(snoozedEvents.begin(), snoozedEvents.end(), isEarlier);
         }
         callback(std::move(snoozedEvents));
+    }
+
+    void AlarmOperationsCommon::handleCriticalBatteryLevel()
+    {
+        isCriticalBatteryLevel = true;
+        stopAllRingingAlarms();
+        stopAllSnoozedAlarms();
+    }
+
+    void AlarmOperationsCommon::handleNormalBatteryLevel()
+    {
+        isCriticalBatteryLevel = false;
     }
 
     auto findSingleEventById(std::vector<std::unique_ptr<SingleEventRecord>> &events, const std::uint32_t id)

--- a/module-services/service-time/AlarmOperations.hpp
+++ b/module-services/service-time/AlarmOperations.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -64,6 +64,8 @@ namespace alarms
         virtual void addActiveAlarmCountChangeCallback(OnActiveAlarmCountChange)                             = 0;
         virtual void toggleAll(bool toggle, OnToggleAll callback)                                            = 0;
         virtual void getSnoozedAlarms(OnGetSnoozedAlarms callback)                                           = 0;
+        virtual void handleCriticalBatteryLevel()                                                            = 0;
+        virtual void handleNormalBatteryLevel()                                                              = 0;
     };
 
     class IAlarmOperationsFactory
@@ -108,6 +110,8 @@ namespace alarms
         void addActiveAlarmCountChangeCallback(OnActiveAlarmCountChange callback) override;
         void toggleAll(bool toggle, OnToggleAll callback) override;
         void getSnoozedAlarms(OnGetSnoozedAlarms callback) override;
+        void handleCriticalBatteryLevel() override;
+        void handleNormalBatteryLevel() override;
 
       protected:
         std::unique_ptr<AbstractAlarmEventsRepository> alarmEventsRepo;
@@ -124,6 +128,7 @@ namespace alarms
                                       bool newStateOn);
 
       private:
+        bool isCriticalBatteryLevel{false};
         GetCurrentTime getCurrentTimeCallback;
         OnSnoozedAlarmsCountChange onSnoozedAlarmsCountChangeCallback = nullptr;
         OnActiveAlarmCountChange onActiveAlarmCountChangeCallback     = nullptr;
@@ -144,6 +149,8 @@ namespace alarms
         void processOngoingEvents();
         void processNextEventsQueue(const TimePoint now);
         void processSnoozedEventsQueue(const TimePoint now);
+        void stopAllRingingAlarms();
+        void triggerAlarm();
         virtual void onAlarmTurnedOff(const std::shared_ptr<AlarmEventRecord> &event, alarms::AlarmType alarmType);
 
         TimePoint getCurrentTime();

--- a/module-services/service-time/AlarmServiceAPI.cpp
+++ b/module-services/service-time/AlarmServiceAPI.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Constants.hpp"

--- a/module-services/service-time/ServiceTime.cpp
+++ b/module-services/service-time/ServiceTime.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ServiceTime.hpp"
@@ -184,6 +184,11 @@ namespace stm
         connect(typeid(alarms::GetSnoozedAlarmsRequestMessage), [&](sys::Message *request) -> sys::MessagePointer {
             auto message = static_cast<alarms::GetSnoozedAlarmsRequestMessage *>(request);
             return alarmMessageHandler->handleGetSnoozedAlarms(message);
+        });
+        connect(typeid(sevm::BatteryStateChangeMessage), [&](sys::Message *request) -> sys::MessagePointer {
+            auto message = static_cast<sevm::BatteryStateChangeMessage *>(request);
+            alarmMessageHandler->handleBatteryStateChange(message);
+            return std::make_shared<sys::ResponseMessage>();
         });
     }
 

--- a/module-services/service-time/include/service-time/AlarmMessage.hpp
+++ b/module-services/service-time/include/service-time/AlarmMessage.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/module-services/service-time/include/service-time/AlarmServiceAPI.hpp
+++ b/module-services/service-time/include/service-time/AlarmServiceAPI.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/module-utils/utility/Units.hpp
+++ b/module-utils/utility/Units.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -10,4 +10,5 @@ namespace units
     using Voltage     = std::uint32_t; /// mV
     using SOC         = std::uint8_t;  /// 0-100%
     using Temperature = float;
+    using Percent     = float;
 } // namespace units

--- a/products/BellHybrid/services/evtmgr/CMakeLists.txt
+++ b/products/BellHybrid/services/evtmgr/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(evtmgr
         include/evtmgr/api/TemperatureApi.hpp
         include/evtmgr/backlight-handler/BacklightHandler.hpp
         include/evtmgr/user-activity-handler/UserActivityHandler.hpp
+        include/evtmgr/battery/Thresholds.hpp
 )
 
 target_include_directories(evtmgr

--- a/products/BellHybrid/services/evtmgr/EventManager.cpp
+++ b/products/BellHybrid/services/evtmgr/EventManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "WorkerEvent.hpp"
@@ -14,6 +14,7 @@
 #include <appmgr/messages/PowerOffPopupRequestParams.hpp>
 #include <appmgr/messages/RebootPopupRequestParams.hpp>
 #include <evtmgr/EventManager.hpp>
+#include <evtmgr/battery/Thresholds.hpp>
 #include <service-appmgr/Controller.hpp>
 #include <hal/temperature_source/TemperatureSource.hpp>
 #include <system/Constants.hpp>
@@ -38,8 +39,10 @@ namespace
 }
 
 EventManager::EventManager(LogDumpFunction logDumpFunction, const std::string &name)
-    : EventManagerCommon(logDumpFunction, name), backlightHandler(settings, this),
-      userActivityHandler(std::make_shared<sys::CpuSentinel>(name, this), this)
+    : EventManagerCommon(logDumpFunction,
+                         {.battery{.critical = constants::criticalThreshold, .shutdown = constants::shutdownThreshold}},
+                         name),
+      backlightHandler(settings, this), userActivityHandler(std::make_shared<sys::CpuSentinel>(name, this), this)
 {
     buildKeySequences();
 

--- a/products/BellHybrid/services/evtmgr/include/evtmgr/battery/Thresholds.hpp
+++ b/products/BellHybrid/services/evtmgr/include/evtmgr/battery/Thresholds.hpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <Units.hpp>
+
+namespace constants
+{
+    static constexpr units::Percent criticalThreshold = 1;
+    static constexpr units::Percent shutdownThreshold = 1;
+} // namespace constants

--- a/products/PurePhone/services/evtmgr/CMakeLists.txt
+++ b/products/PurePhone/services/evtmgr/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(evtmgr
     PUBLIC
         include/evtmgr/EVMessages.hpp
         include/evtmgr/EventManager.hpp
+        include/evtmgr/battery/Thresholds.hpp
 )
 
 target_include_directories(evtmgr

--- a/products/PurePhone/services/evtmgr/include/evtmgr/EventManager.hpp
+++ b/products/PurePhone/services/evtmgr/include/evtmgr/EventManager.hpp
@@ -1,10 +1,10 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include <service-evtmgr/EventManagerCommon.hpp>
-
+#include <evtmgr/battery/Thresholds.hpp>
 #include "BacklightHandler.hpp"
 #include "UserActivityHandler.hpp"
 #include <bsp/vibrator/vibrator.hpp>
@@ -15,8 +15,12 @@ class EventManager : public EventManagerCommon
   public:
     explicit EventManager(LogDumpFunction logDumpFunction = nullptr,
                           const std::string &name         = service::name::evt_manager)
-        : EventManagerCommon(logDumpFunction, name), vibrator(std::make_unique<vibra_handle::Vibra>(this)),
-          backlightHandler(settings, this), userActivityHandler(std::make_shared<sys::CpuSentinel>(name, this), this)
+        : EventManagerCommon(
+              logDumpFunction,
+              {.battery{.critical = constants::criticalThreshold, .shutdown = constants::shutdownThreshold}},
+              name),
+          vibrator(std::make_unique<vibra_handle::Vibra>(this)), backlightHandler(settings, this),
+          userActivityHandler(std::make_shared<sys::CpuSentinel>(name, this), this)
     {}
 
   private:

--- a/products/PurePhone/services/evtmgr/include/evtmgr/battery/Thresholds.hpp
+++ b/products/PurePhone/services/evtmgr/include/evtmgr/battery/Thresholds.hpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <Units.hpp>
+
+namespace constants
+{
+    static constexpr units::Percent criticalThreshold = 10;
+    static constexpr units::Percent shutdownThreshold = 1;
+} // namespace constants

--- a/products/PurePhone/services/time/AlarmOperations.cpp
+++ b/products/PurePhone/services/time/AlarmOperations.cpp
@@ -1,7 +1,7 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include <time/AlarmOperations.hpp>
+#include "include/time/AlarmOperations.hpp"
 
 #include <PureAlarmHandler.hpp>
 

--- a/products/PurePhone/services/time/include/time/AlarmOperations.hpp
+++ b/products/PurePhone/services/time/include/time/AlarmOperations.hpp
@@ -1,9 +1,9 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
-#include <AlarmOperations.hpp>
+#include <service-time/AlarmOperations.hpp>
 
 namespace alarms
 {

--- a/products/PurePhone/sys/SystemManager.cpp
+++ b/products/PurePhone/sys/SystemManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <sys/SystemManager.hpp>

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -32,6 +32,7 @@
 * Fixed no sound when Bluetooth audio device connected/disconnected during call
 * Fixed full filesystem path displayed in music player for invalid files instead of just filename
 * Fixed problem with track info not being displayed correctly
+* Fixed alarm rings on the low battery screen
 
 ### Added
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

When we had a critical battery level and the alarm clock rang, it was impossible to turn it off.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
