### PR TITLE
[MOS-606] Fix the Pure's alarm plays indefinitely

### DIFF
--- a/module-apps/apps-common/popups/presenter/AlarmPresenter.cpp
+++ b/module-apps/apps-common/popups/presenter/AlarmPresenter.cpp
@@ -196,7 +196,7 @@ namespace app::popup
     AlarmPopupPresenter::AlarmPopupPresenter(ApplicationCommon *app) : AlarmPopupContract::Presenter(app)
     {
         timerHandle = sys::TimerFactory::createSingleShotTimer(
-            app, "AlarmTimer", ACTIVE_ALARM_TIMEOUT, [this](sys::Timer &) { snoozeHit(); });
+            app, "AlarmTimer", ACTIVE_ALARM_TIMEOUT, [this](sys::Timer &) { stopAlarm(); });
         timerHandle.start();
     }
 } // namespace app::popup


### PR DESCRIPTION
According to the requirements the alarm after.
30 minutes of playing will be stopped
instead of snoozed.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
