### PR TITLE
[MOS-767] Fix full path displayed for invalid audio file

### DIFF
--- a/module-audio/tags_fetcher/TagsFetcher.cpp
+++ b/module-audio/tags_fetcher/TagsFetcher.cpp
@@ -1,79 +1,76 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TagsFetcher.hpp"
-
-#include <gsl/util>
 #include <Utils.hpp>
-
 #include "fileref.h"
-#include "tag.h"
-#include "tfilestream.h"
 
 namespace tags::fetcher
 {
-    std::optional<Tags> fetchTagsInternal(std::string filePath)
+    namespace
     {
-        TagLib::FileRef const tagReader(filePath.c_str());
-        if (!tagReader.isNull() && (tagReader.tag() != nullptr)) {
-            TagLib::Tag *tags                   = tagReader.tag();
-            TagLib::AudioProperties *properties = tagReader.audioProperties();
-
-            constexpr auto unicode = true;
-
-            auto getTitle = [&]() -> std::string {
-                const auto title = tags->title().to8Bit(unicode);
-                // If title tag empty fill it with raw file name
-                if (title.empty()) {
-                    if (const auto pos = filePath.rfind('/'); pos == std::string::npos) {
-                        return filePath;
-                    }
-                    else {
-                        return &filePath[pos + 1];
-                    }
-                }
-                return title;
-            };
-
-            const auto artist  = tags->artist().to8Bit(unicode);
-            const auto album   = tags->album().to8Bit(unicode);
-            const auto genre   = tags->genre().to8Bit(unicode);
-            const auto year    = tags->year();
-            const auto comment = tags->comment().to8Bit(unicode);
-            const auto track   = tags->track();
-
-            const uint32_t total_duration_s = properties->length();
-            const uint32_t duration_min     = total_duration_s / utils::secondsInMinute;
-            const uint32_t duration_hour    = duration_min / utils::secondsInMinute;
-            const uint32_t duration_sec     = total_duration_s % utils::secondsInMinute;
-            const uint32_t sample_rate      = properties->sampleRate();
-            const uint32_t num_channel      = properties->channels();
-            const uint32_t bitrate          = properties->bitrate();
-            const auto title                = getTitle();
-
-            return Tags{total_duration_s,
-                        duration_hour,
-                        duration_min,
-                        duration_sec,
-                        sample_rate,
-                        num_channel,
-                        bitrate,
-                        artist,
-                        genre,
-                        title,
-                        album,
-                        year,
-                        filePath,
-                        comment,
-                        track};
+        std::string getTitleFromFilePath(const std::string &path)
+        {
+            const auto pos = path.rfind('/');
+            if (pos != std::string::npos) {
+                return path.substr(pos + 1);
+            }
+            return path;
         }
 
-        return {};
+        std::optional<Tags> fetchTagsInternal(const std::string &filePath)
+        {
+            const TagLib::FileRef tagReader(filePath.c_str());
+            const auto tags = tagReader.tag();
+            if (!tagReader.isNull() && (tags != nullptr)) {
+                const auto properties = tagReader.audioProperties();
+
+                constexpr bool unicode = true;
+
+                const auto artist  = tags->artist().to8Bit(unicode);
+                const auto album   = tags->album().to8Bit(unicode);
+                const auto genre   = tags->genre().to8Bit(unicode);
+                const auto year    = tags->year();
+                const auto comment = tags->comment().to8Bit(unicode);
+                const auto track   = tags->track();
+
+                auto title = tags->title().to8Bit(unicode);
+                if (title.empty()) {
+                    title = getTitleFromFilePath(filePath);
+                }
+
+                const uint32_t total_duration_s = properties->length();
+                const uint32_t duration_min     = total_duration_s / utils::secondsInMinute;
+                const uint32_t duration_hour    = duration_min / utils::secondsInMinute;
+                const uint32_t duration_sec     = total_duration_s % utils::secondsInMinute;
+                const uint32_t sample_rate      = properties->sampleRate();
+                const uint32_t num_channel      = properties->channels();
+                const uint32_t bitrate          = properties->bitrate();
+
+                return Tags{total_duration_s,
+                            duration_hour,
+                            duration_min,
+                            duration_sec,
+                            sample_rate,
+                            num_channel,
+                            bitrate,
+                            artist,
+                            genre,
+                            title,
+                            album,
+                            year,
+                            filePath,
+                            comment,
+                            track};
+            }
+
+            return {};
+        }
     }
 
     Tags fetchTags(const std::string &filePath)
     {
-        return fetchTagsInternal(filePath).value_or(Tags{filePath});
+        return fetchTagsInternal(filePath).value_or(Tags{filePath, getTitleFromFilePath(filePath)});
     }
 
 } // namespace tags::fetcher

--- a/module-audio/tags_fetcher/TagsFetcher.hpp
+++ b/module-audio/tags_fetcher/TagsFetcher.hpp
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -7,12 +7,12 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <utility>
 
 namespace tags::fetcher
 {
     struct Tags
     {
-
         /* Total audio duration in seconds */
         uint32_t total_duration_s = 0;
         /* Audio duration - hours part */
@@ -55,12 +55,12 @@ namespace tags::fetcher
              std::string comment,
              uint32_t track)
             : total_duration_s{total_duration_s}, duration_hour{duration_hour}, duration_min{duration_min},
-              duration_sec{duration_sec}, sample_rate{sample_rate},
-              num_channel{num_channel}, bitrate{bitrate}, artist{artist}, genre{genre}, album{album}, year{year},
-              filePath{filePath}, title{title}, comment{comment}, track{track}
+              duration_sec{duration_sec}, sample_rate{sample_rate}, num_channel{num_channel}, bitrate{bitrate},
+              artist{std::move(artist)}, genre{std::move(genre)}, album{std::move(album)}, year{year},
+              filePath{std::move(filePath)}, title{std::move(title)}, comment{std::move(comment)}, track{track}
         {}
 
-        explicit Tags(std::string filePath) : filePath{filePath}, title{filePath}
+        Tags(std::string filePath, std::string title) : filePath{std::move(filePath)}, title{std::move(title)}
         {}
     };
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -30,6 +30,7 @@
 * Fixed crash when syncing with Mudita Center
 * Fixed inactive alarms after timezone change and reboot.
 * Fixed no sound when Bluetooth audio device connected/disconnected during call
+* Fixed full filesystem path displayed in music player for invalid files instead of just filename
 
 ### Added
 


### PR DESCRIPTION
Fix of the issue that whole file path was
displayed instead of just filename in music 
player for invalid audio file for which Taglib 
failed to obtain tags.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
