### PR TITLE
[MOS-882] Fix FLAC file playback with USB cable connected

### DIFF
--- a/module-audio/Audio/StreamFactory.cpp
+++ b/module-audio/Audio/StreamFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "StreamFactory.hpp"
@@ -18,9 +18,6 @@
 #include <cassert>
 #include <cmath>
 
-using audio::AudioFormat;
-using audio::Sink;
-using audio::Source;
 using audio::Stream;
 using audio::StreamFactory;
 using audio::transcode::InputTranscodeProxy;

--- a/module-audio/Audio/decoder/Decoder.cpp
+++ b/module-audio/Audio/decoder/Decoder.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <cstdio>
@@ -13,8 +13,7 @@
 
 namespace audio
 {
-    Decoder::Decoder(const std::string &path)
-        : filePath(path), workerBuffer(std::make_unique<std::int16_t[]>(workerBufferSize))
+    Decoder::Decoder(const std::string &path) : filePath(path)
     {
         fd = std::fopen(path.c_str(), "r");
         if (fd == nullptr) {
@@ -73,20 +72,6 @@ namespace audio
         }
 
         return dec;
-    }
-
-    void Decoder::convertmono2stereo(int16_t *pcm, uint32_t samplecount)
-    {
-        uint32_t i = 0, j = 0;
-
-        memset(workerBuffer.get(), 0, workerBufferSize * sizeof(int16_t));
-
-        for (; j < samplecount; j++) {
-            workerBuffer[i++] = pcm[j];
-            workerBuffer[i++] = pcm[j];
-        }
-
-        memcpy(pcm, &workerBuffer[0], samplecount * 2 * sizeof(int16_t));
     }
 
     void Decoder::startDecodingWorker(const DecoderWorker::EndOfFileCallback &endOfFileCallback)

--- a/module-audio/Audio/decoder/Decoder.hpp
+++ b/module-audio/Audio/decoder/Decoder.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -70,9 +70,6 @@ namespace audio
         }
         virtual std::unique_ptr<tags::fetcher::Tags> fetchTags();
 
-        void convertmono2stereo(std::int16_t *pcm, std::uint32_t samplecount);
-
-        static constexpr auto workerBufferSize        = 1024 * 8;
         static constexpr Endpoint::Traits decoderCaps = {.usesDMA = false};
 
         std::uint32_t sampleRate = 0;
@@ -84,8 +81,6 @@ namespace audio
         std::uint32_t fileSize = 0;
         std::string filePath;
 
-        // Worker buffer used for converting mono stream to stereo
-        std::unique_ptr<std::int16_t[]> workerBuffer;
         std::unique_ptr<tags::fetcher::Tags> tags;
         bool isInitialized = false;
 

--- a/module-audio/Audio/decoder/DecoderWorker.cpp
+++ b/module-audio/Audio/decoder/DecoderWorker.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DecoderWorker.hpp"
@@ -21,10 +21,10 @@ audio::DecoderWorker::~DecoderWorker()
 
 auto audio::DecoderWorker::init(std::list<sys::WorkerQueueInfo> queues) -> bool
 {
-    std::list<sys::WorkerQueueInfo> list{
+    const std::list<sys::WorkerQueueInfo> list{
         {listenerQueueName, StreamQueuedEventsListener::listenerElementSize, listenerQueueCapacity}};
 
-    auto isSuccessful = Worker::init(list);
+    const auto isSuccessful = Worker::init(list);
 
     queueListener = std::make_unique<StreamQueuedEventsListener>(getQueueByName(listenerQueueName));
     if (!queueListener) {

--- a/module-audio/board/rt1051/puretx/PureTxAudioCodec.cpp
+++ b/module-audio/board/rt1051/puretx/PureTxAudioCodec.cpp
@@ -1,12 +1,10 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PureTxAudioCodec.hpp"
 #include "board.h"
-#include "dma_config.h"
 #include <log/log.hpp>
 
-#include "board/BoardDefinitions.hpp"
 #include "board/rt1051/common/audio.hpp"
 
 using audio::codec::Configuration;

--- a/module-bsp/board/rt1051/os/include/FreeRTOSConfig.h
+++ b/module-bsp/board/rt1051/os/include/FreeRTOSConfig.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 /*
@@ -78,7 +78,7 @@ extern "C"
 /* Memory allocation related definitions. */
 #define configSUPPORT_STATIC_ALLOCATION  1
 #define configSUPPORT_DYNAMIC_ALLOCATION 1
-#define configTOTAL_HEAP_SIZE            ((size_t)(1024 * 386))
+#define configTOTAL_HEAP_SIZE            ((size_t)(1024 * 424))
 
 #define configAPPLICATION_ALLOCATED_HEAP 0
 

--- a/module-services/service-audio/ServiceAudio.cpp
+++ b/module-services/service-audio/ServiceAudio.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <AudioMessage.hpp>
@@ -22,7 +22,7 @@
 
 using namespace audio;
 
-inline constexpr auto audioServiceStackSize = 1024 * 8;
+static constexpr auto audioServiceStackSize = 1024 * 8;
 
 static constexpr auto defaultVolumeHigh              = "10";
 static constexpr auto defaultVolumeMid               = "7";

--- a/module-sys/Service/Worker.cpp
+++ b/module-sys/Service/Worker.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <Service/Worker.hpp>
@@ -136,7 +136,7 @@ namespace sys
         auto setSize = SERVICE_QUEUE_LENGTH + CONTROL_QUEUE_LENGTH;
 
         // iterate over all entries in the list of queues and summarize queue sizes
-        for (auto wqi : queuesList) {
+        for (const auto &wqi : queuesList) {
             setSize += wqi.length;
         }
 
@@ -154,7 +154,7 @@ namespace sys
         controlQueueIndex = addQueue(getControlQueueName(), CONTROL_QUEUE_LENGTH, sizeof(std::uint8_t));
 
         // create and add all queues provided from service
-        for (auto wqi : queuesList) {
+        for (const auto &wqi : queuesList) {
             addQueue(wqi.name, wqi.length, wqi.elementSize);
         };
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -33,6 +33,7 @@
 * Fixed full filesystem path displayed in music player for invalid files instead of just filename
 * Fixed problem with track info not being displayed correctly
 * Fixed alarm rings on the low battery screen
+* Fixed crash when trying to play 96kHz FLAC with USB cable connected
 
 ### Added
 


### PR DESCRIPTION
Fix of the issue that caused system crash when
trying to play 96kHz FLAC file with USB cable
connected. The reason of the issue was the lack
of FreeRTOS heap space left, what caused
pvPortMalloc() to fail when allocating
memory for stream buffer.

Additionally minor code cleanup.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
