### PR TITLE
[MOS-651] Update the unread message counter after a thread deletion

### DIFF
--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -28,12 +28,13 @@
 * Fixed inability to unblock SIM card when previously ejected during slot switching
 * Fixed French translations for Ulock Screen
 * Fixed crash when syncing with Mudita Center
-* Fixed inactive alarms after timezone change and reboot.
+* Fixed inactive alarms after timezone change and reboot
 * Fixed no sound when Bluetooth audio device connected/disconnected during call
 * Fixed full filesystem path displayed in music player for invalid files instead of just filename
 * Fixed problem with track info not being displayed correctly
 * Fixed alarm rings on the low battery screen
 * Fixed crash when trying to play 96kHz FLAC with USB cable connected
+* Fixed the notification of unread messages are not deleted with the thread
 
 ### Added
 


### PR DESCRIPTION
In order to delete notification of unread messages from the thread, which was deleted.
After successful deletion of the thread
the unread messages counter is updated
as when the thread is opened.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
