### PR TITLE
[MOS-544] MTP integration issues

### DIFF
--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -35,6 +35,7 @@
 * Fixed alarm rings on the low battery screen
 * Fixed crash when trying to play 96kHz FLAC with USB cable connected
 * Fixed the notification of unread messages are not deleted with the thread
+* Fixed several MTP issues
 
 ### Added
 


### PR DESCRIPTION
* It's now possible to rename files using MTP
* Fixed issue with fs notification being sent from MTP before file transfer is complete. This resulted in audio tracks appearing on the MusicPlayer list while still being transferred.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
