### PR TITLE
[MOS-840] VoLTE switch unavailability fix

### DIFF
--- a/module-services/service-cellular/ServiceCellular.cpp
+++ b/module-services/service-cellular/ServiceCellular.cpp
@@ -594,8 +594,11 @@ void ServiceCellular::registerMessageHandlers()
     });
 
     connect(typeid(cellular::GetVolteStateRequest), [&](sys::Message *request) -> sys::MessagePointer {
-        bus.sendUnicast(std::make_shared<cellular::GetVolteStateResponse>(priv->volteHandler->getVolteState()),
-                        request->sender);
+        auto simInsertedStatus = priv->simCard->getSimInsertedStatus();
+        auto volteState = (simInsertedStatus.has_value() && *simInsertedStatus == at::SimInsertedStatus::Inserted)
+                              ? priv->volteHandler->getVolteState()
+                              : VolteState{VolteState::Enablement::Off, false};
+        bus.sendUnicast(std::make_shared<cellular::GetVolteStateResponse>(volteState), request->sender);
         return sys::MessageNone{};
     });
 


### PR DESCRIPTION
Added checking if a SIM card is present in the active slot during ApplicationSettings initialization so that in case there's no SIM, the VoLTE switch is made anavailable to toggle.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added --> from a previous commit on this topic, this one is only kind of a fixup for that one
