### PR TITLE
[MOS-340] Fix notifications of unread SMS threads on the home screen

### DIFF
--- a/module-apps/application-messages/include/application-messages/ApplicationMessages.hpp
+++ b/module-apps/application-messages/include/application-messages/ApplicationMessages.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -42,7 +42,7 @@ namespace app
 
         bool removeSms(const SMSRecord &record);
         bool removeSmsThread(const ThreadRecord *record);
-        bool markSmsThreadAsRead(const uint32_t id);
+        bool markSmsThreadAsRead(const ThreadRecord *record);
         bool markSmsThreadAsUnread(const uint32_t id);
         /// show dialog with big search icon and text which was used for query
         bool searchEmpty(const std::string &query = "");

--- a/module-apps/application-messages/windows/SMSThreadViewWindow.cpp
+++ b/module-apps/application-messages/windows/SMSThreadViewWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationMessages.hpp"
@@ -72,21 +72,12 @@ namespace gui
                 auto app = dynamic_cast<app::ApplicationMessages *>(application);
                 assert(app != nullptr);
                 if (application->getCurrentWindow() == this) {
-                    app->markSmsThreadAsRead(pdata->thread->ID);
+                    app->markSmsThreadAsRead(pdata->thread.get());
                 }
             }
             smsModel->numberID    = pdata->thread->numberID;
             smsModel->smsThreadID = pdata->thread->ID;
             smsList->rebuildList();
-
-            if (pdata->thread->unreadMsgCount) {
-                const auto countToClear = pdata->thread->unreadMsgCount;
-
-                DBServiceAPI::GetQuery(
-                    application,
-                    db::Interface::Name::Notifications,
-                    std::make_unique<db::query::notifications::Decrement>(NotificationsRecord::Key::Sms, countToClear));
-            }
         }
         else if (smsModel->numberID != DB_ID_NONE) {
             requestContact(smsModel->numberID);

--- a/module-apps/application-messages/windows/ThreadWindowOptions.cpp
+++ b/module-apps/application-messages/windows/ThreadWindowOptions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ThreadWindowOptions.hpp"
@@ -74,7 +74,7 @@ namespace gui
 
         if (record->isUnread()) {
             options.emplace_back(gui::Option{utils::translate("sms_mark_read"), [=](gui::Item &item) {
-                                                 app->markSmsThreadAsRead(record->ID);
+                                                 app->markSmsThreadAsRead(record);
                                                  app->returnToPreviousWindow();
                                                  return true;
                                              }});

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -36,6 +36,7 @@
 * Fixed crash when trying to play 96kHz FLAC with USB cable connected
 * Fixed the notification of unread messages are not deleted with the thread
 * Fixed several MTP issues
+* Fixed notifications of unread SMS threads on the home screen
 
 ### Added
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

Conversation marked in OPTIONS as read did not disappear from notifications about SMS threads on the main screen.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
