### PR TITLE
[MOS-33] Mark thread as read when new message arrives

### DIFF
--- a/module-apps/application-messages/models/SMSThreadModel.hpp
+++ b/module-apps/application-messages/models/SMSThreadModel.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -26,6 +26,7 @@ class SMSThreadModel : public app::DatabaseModel<SMSRecord>,
     void addReturnNumber();
     void handleDraftMessage();
     void resetInputWidget();
+    void markCurrentThreadAsRead();
 
     auto handleQueryResponse(db::QueryResult *) -> bool;
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -8,6 +8,7 @@
 * Changed order of starting services, ServiceDesktop moved to the back
 
 ### Fixed
+* Fixed not marking thread as read when new message arrives in the opened thread
 * Fixed disappearing "confirm" button in PIN entering screen
 * Fixed looping on the SIM card selection screen
 * Fixed notes paste option showing for empty clipboard


### PR DESCRIPTION
Now thread will be marked as read when new message arrives when the thread is opened

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
