### PR TITLE
[MOS-864] Fix for country code in new contact based on deleted one

### DIFF
--- a/module-db/Interface/ContactRecord.hpp
+++ b/module-db/Interface/ContactRecord.hpp
@@ -301,4 +301,15 @@ class ContactRecordInterface : public RecordInterface<ContactRecord, ContactReco
         -> std::optional<std::uint32_t>;
     auto addOrUpdateRingtone(std::uint32_t contactID, std::uint32_t ringtoneID, const ContactRecord &contact)
         -> std::optional<std::uint32_t>;
+
+    /**
+     * @brief Changing number table record in place if new number is same as old number but with/without country code
+     *
+     * @param oldNumberIDs vector of old number IDs in contact_number table which can be changed in place
+     *                     only if in  newNumbers  is same number but with/without country code
+     * @param newNumbers  vector of numbers to which we want to change the old ones
+     * @return true if operation have no error
+     */
+    auto changeNumberRecordInPlaceIfCountryCodeIsOnlyDifferent(const std::vector<std::uint32_t> &oldNumberIDs,
+                                                               std::vector<ContactRecord::Number> &newNumbers) -> bool;
 };

--- a/module-db/Tables/ContactsTable.cpp
+++ b/module-db/Tables/ContactsTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ContactsTable.hpp"

--- a/module-services/service-db/DBServiceAPI.cpp
+++ b/module-services/service-db/DBServiceAPI.cpp
@@ -102,7 +102,7 @@ auto DBServiceAPI::MatchContactByNumberID(sys::Service *serv, std::uint32_t numb
 
 auto DBServiceAPI::NumberByID(sys::Service *serv, std::uint32_t numberID) -> utils::PhoneNumber::View
 {
-    auto msg = std::make_unique<db::query::NumberGetByID>(numberID);
+    auto msg                      = std::make_unique<db::query::NumberGetByID>(numberID);
     const auto [status, response] = DBServiceAPI::GetQueryWithReply(
         serv, db::Interface::Name::Contact, std::move(msg), constants::DefaultTimeoutInMs);
     if (status != sys::ReturnCodes::Success || !response) {
@@ -168,8 +168,8 @@ auto DBServiceAPI::verifyContact(sys::Service *serv, const ContactRecord &rec)
     }
 
     if (rec.numbers.size() > 1 && rec.numbers[1].number.getEntered().size() > 0) {
-        auto retPhone2 = MatchContactByPhoneNumber(serv, rec.numbers[1].number);
-        if (retPhone2 && retPhone2->ID != rec.ID) {
+        auto retPhone2 = MatchContactByPhoneNumber(serv, rec.numbers[1].number, rec.ID);
+        if (retPhone2) {
             if (retPhone2->isTemporary()) {
                 return ContactVerificationResult::temporaryContactExists;
             }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -51,8 +51,7 @@
 * Fixed inability to enter text in search field after clicking right arrow
 * Fixed displaying wrong screen after contact removal
 * Fixed improper font weight used in navbar
-
-### Added
+* Fix for country code in new contact based on deleted one
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Fix for scenario when contact with some number with/without country code was deleted, and new contact with same number but without/with country code is added and then new contact have same prefix as deleted one. Now new contact will have number exacly like provided.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
