### PR TITLE
[MOS-814] Fix no sound after BT reconnection

### DIFF
--- a/module-bluetooth/Bluetooth/interface/profiles/HFP/HFP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/HFP/HFP.cpp
@@ -286,6 +286,7 @@ namespace bluetooth
                 LOG_DEBUG("Audio connection established with SCO handle 0x%04x", scoHandle);
                 codec = static_cast<SCOCodec>(hfp_subevent_audio_connection_established_get_negotiated_codec(event));
                 dump_supported_codecs();
+                audioInterface->startAudioRouting(const_cast<sys::Service *>(ownerService));
                 hci_request_sco_can_send_now_event();
                 RunLoop::trigger();
             }


### PR DESCRIPTION
Fix of the issue that previous commit
didn't resolve - for some Bluetooth
devices voice still wasn't heard
after disconnection and reconnection
during a call.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
