### PR TITLE
[CP-1210] Contacts imported from SIM don't show up in Mudita Center

### DIFF
--- a/module-apps/application-settings/models/network/SimContactsRepository.cpp
+++ b/module-apps/application-settings/models/network/SimContactsRepository.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SimContactsRepository.hpp"
@@ -93,11 +93,15 @@ void SimContactsRepository::save(const std::vector<bool> &selectedContacts,
         if (result == nullptr) {
             return false;
         }
+        for (const auto &r : result->getResult()) {
+            sendNotification(r);
+        }
         if (callback) {
             callback();
         }
         return true;
     });
+
     task->execute(application, this);
 }
 
@@ -139,6 +143,13 @@ void SimContactsRepository::updateImportedRecords(const std::vector<cellular::Si
 #if DEBUG_SIM_IMPORT_DATA == 1
     printRecordsData("Imported records from sim", importedRecords);
 #endif
+}
+
+void SimContactsRepository::sendNotification(const NotificationData &notificationData)
+{
+    auto notificationMessage = std::make_shared<db::NotificationMessage>(
+        db::Interface::Name::Contact, notificationData.first, notificationData.second);
+    application->bus.sendMulticast(notificationMessage, sys::BusChannel::ServiceDBNotifications);
 }
 
 #if DEBUG_SIM_IMPORT_DATA == 1

--- a/module-apps/application-settings/models/network/SimContactsRepository.hpp
+++ b/module-apps/application-settings/models/network/SimContactsRepository.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -27,6 +27,7 @@ class AbstractSimContactsRepository
 class SimContactsRepository : public AbstractSimContactsRepository, public app::AsyncCallbackReceiver
 {
   public:
+    using NotificationData = std::pair<db::Query::Type, uint32_t>;
     explicit SimContactsRepository(app::ApplicationCommon *application);
 
     const std::vector<ContactRecord> &getImportedRecords() override;
@@ -36,6 +37,9 @@ class SimContactsRepository : public AbstractSimContactsRepository, public app::
     void save(const std::vector<bool> &selectedContacts, bool duplicatesFound, OnSaveCallback callback) override;
     void findDuplicates(const std::vector<bool> &selectedContacts, OnDupplicatesCheckCallback callback) override;
     void updateImportedRecords(const std::vector<cellular::SimContact> &simData);
+
+  protected:
+    void sendNotification(const NotificationData &notificationData);
 
   private:
     std::vector<ContactRecord> importedRecords;

--- a/module-apps/apps-common/AsyncTask.cpp
+++ b/module-apps/apps-common/AsyncTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AsyncTask.hpp"

--- a/module-db/Interface/ContactRecord.hpp
+++ b/module-db/Interface/ContactRecord.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -227,7 +227,7 @@ class ContactRecordInterface : public RecordInterface<ContactRecord, ContactReco
      * @param contacts vector of contacts with single number
      * @return boolean status
      */
-    auto MergeContactsList(std::vector<ContactRecord> &contacts) -> bool;
+    auto MergeContactsList(std::vector<ContactRecord> &contacts) -> std::vector<std::pair<db::Query::Type, uint32_t>>;
 
     /**
      * @brief Check which contacts in vector are duplicating contacts in DB

--- a/module-db/queries/phonebook/QueryMergeContactsList.cpp
+++ b/module-db/queries/phonebook/QueryMergeContactsList.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "QueryMergeContactsList.hpp"
@@ -15,8 +15,14 @@ std::vector<ContactRecord> &MergeContactsList::getContactsList()
     return contacts;
 }
 
-MergeContactsListResult::MergeContactsListResult(bool result) : result(result)
+MergeContactsListResult::MergeContactsListResult(const std::vector<std::pair<db::Query::Type, uint32_t>> &addedContacts)
+    : addedContacts(addedContacts)
 {}
+
+std::vector<std::pair<db::Query::Type, uint32_t>> &MergeContactsListResult::getResult()
+{
+    return addedContacts;
+}
 
 [[nodiscard]] auto MergeContactsList::debugInfo() const -> std::string
 {

--- a/module-db/queries/phonebook/QueryMergeContactsList.hpp
+++ b/module-db/queries/phonebook/QueryMergeContactsList.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -28,15 +28,12 @@ namespace db::query
     class MergeContactsListResult : public QueryResult
     {
       public:
-        MergeContactsListResult(bool result);
-        [[nodiscard]] auto getResult() const noexcept -> bool
-        {
-            return result;
-        }
+        MergeContactsListResult(const std::vector<std::pair<db::Query::Type, uint32_t>> &addedContacts);
+        std::vector<std::pair<db::Query::Type, uint32_t>> &getResult();
         [[nodiscard]] auto debugInfo() const -> std::string override;
 
       private:
-        bool result = false;
+        std::vector<std::pair<db::Query::Type, uint32_t>> addedContacts{};
     };
 
 }; // namespace db::query

--- a/module-db/tests/ContactsRecord_tests.cpp
+++ b/module-db/tests/ContactsRecord_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "common.hpp"
@@ -523,7 +523,7 @@ TEST_CASE("Contacts list merge")
                 std::vector<ContactRecord::Number>({ContactRecord::Number(rawContact.first, std::string(""))});
             contacts.push_back(record);
         }
-        REQUIRE(records.MergeContactsList(contacts));
+        REQUIRE(!records.MergeContactsList(contacts).empty());
 
         // Validate if non-overlapping were appended to DB
         REQUIRE(records.GetCount() == (rawContactsInitial.size() + rawContactsToAdd.size()));
@@ -565,7 +565,7 @@ TEST_CASE("Contacts list merge")
                 std::vector<ContactRecord::Number>({ContactRecord::Number(rawContact.first, std::string(""))});
             contacts.push_back(record);
         }
-        REQUIRE(records.MergeContactsList(contacts));
+        REQUIRE(!records.MergeContactsList(contacts).empty());
 
         REQUIRE(records.GetCount() == (rawContactsInitial.size() + numberOfNewContacts));
 
@@ -612,7 +612,7 @@ TEST_CASE("Contacts list merge - advanced cases")
         record.primaryName = rawContact.second;
         record.numbers = std::vector<ContactRecord::Number>({ContactRecord::Number(rawContact.first, std::string(""))});
         contacts.push_back(record);
-        REQUIRE(records.MergeContactsList(contacts));
+        REQUIRE(!records.MergeContactsList(contacts).empty());
 
         REQUIRE(records.GetCount() == 1);
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -45,6 +45,9 @@
 * Fixed broken French translation on 'Configure passcode' screen in Onboarding
 * Fixed time disappearing in SMS thread
 * Fixed scrollbar behavior in call log view
+* Fixed contacts imported from SIM do not show up in Mudita Center 
+
+### Added
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Fix for imported contacts from SIM don't show up in Mudita Center. Added functionality to send notifications after all imported contacts are added to the database.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
