### PR TITLE
[MOS-558] Fix disappearing edit label in alarms

### DIFF
--- a/module-apps/application-alarm-clock/widgets/AlarmRRuleOptionsItem.cpp
+++ b/module-apps/application-alarm-clock/widgets/AlarmRRuleOptionsItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlarmRRuleOptionsItem.hpp"
@@ -56,8 +56,12 @@ namespace gui
         onLoadCallback = [&]([[maybe_unused]] std::shared_ptr<AlarmEventRecord> alarm) {
             checkCustomOption(getPresenter()->getDescription());
             optionSpinner->setCurrentValue(getPresenter()->getDescription());
-            if (app::alarmClock::AlarmRRulePresenter::RRuleOptions::Never == getPresenter()->getOption())
+            if (getRRuleOption(optionSpinner->getCurrentValue()) == RRule::Custom) {
+                this->navBarTemporaryMode(utils::translate(style::strings::common::edit));
+            }
+            else {
                 this->navBarRestoreFromTemporaryMode();
+            }
 
         };
     }


### PR DESCRIPTION
Fixed disappearing edit label in alarm add window
when custom interval has been selected

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
