### PR TITLE
[MOS-870] Fix undesirable notification on call

### DIFF
--- a/module-services/service-cellular/call/CallMachine.hpp
+++ b/module-services/service-cellular/call/CallMachine.hpp
@@ -268,6 +268,7 @@ namespace call
         {
             di.audio->stop();
             call.record.duration = di.timer->duration();
+            call.record.isRead   = true;
             di.db->endCall(call.record);
             di.multicast->notifyCallEnded();
             di.timer->stop();

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -38,6 +38,7 @@
 * Fixed the notification of unread messages are not deleted with the thread
 * Fixed several MTP issues
 * Fixed notifications of unread SMS threads on the home screen
+* Fixed false dotted notification above Calls app in case of answered call
 
 ### Added
 


### PR DESCRIPTION
Fixed the case when a dot appeared around the Calls app tile notifying about an answered call.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added