### PR TITLE
[MOS-722] Fix time disappearing in SMS thread

### DIFF
--- a/module-apps/application-messages/widgets/SMSOutputWidget.cpp
+++ b/module-apps/application-messages/widgets/SMSOutputWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationMessages.hpp"
@@ -92,6 +92,14 @@ namespace gui
                 return true;
             }
             return false;
+        };
+
+        smsBubble->dimensionChangedCallback = [this](gui::Item &, const BoundingBox &newDim) -> bool {
+            if (timeLabel != nullptr) {
+                timeLabel->setVisible(focus);
+                positionTimeLabel();
+            }
+            return true;
         };
 
         dimensionChangedCallback = [&](gui::Item &, const BoundingBox &newDim) -> bool {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -41,6 +41,7 @@
 * Fixed notifications of unread SMS threads on the home screen
 * Fixed false dotted notification above Calls app in case of answered call
 * Fixed broken French translation on 'Configure passcode' screen in Onboarding
+* Fixed time disappearing in SMS thread
 
 ### Added
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

When the width of the box with the currently read SMS changed, the label with the time of receiving the message disappeared.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
