### PR TITLE
[MOS-48] Shorten phone modes pop-up duration

### DIFF
--- a/module-apps/apps-common/popups/HomeModesWindow.cpp
+++ b/module-apps/apps-common/popups/HomeModesWindow.cpp
@@ -9,9 +9,15 @@
 #include <module-gui/gui/widgets/Arc.hpp>
 #include <PhoneModes/Common.hpp>
 
+namespace
+{
+    constexpr auto oneSecondTimeout = std::chrono::seconds{1};
+}
+
 namespace gui
 {
-    HomeModesWindow::HomeModesWindow(app::ApplicationCommon *app, const std::string &name) : WindowWithTimer(app, name)
+    HomeModesWindow::HomeModesWindow(app::ApplicationCommon *app, const std::string &name)
+        : WindowWithTimer(app, name, oneSecondTimeout)
     {
         buildInterface();
     }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -6,6 +6,7 @@
 * Improved dialog with network via USSD
 * Added serial number and timestamp to crashdump filename
 * Changed order of starting services, ServiceDesktop moved to the back
+* Shortened duration of phone modes pop-up from 3s to 1s
 
 ### Fixed
 * Fixed not marking thread as read when new message arrives in the opened thread


### PR DESCRIPTION
From 3s to 1s

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added