### PR TITLE
[MOS-59] Always display network technology and signal strength

### DIFF
--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationDesktop.hpp"
@@ -66,7 +66,7 @@ namespace gui
 
     status_bar::Configuration DesktopMainWindow::configureStatusBar(status_bar::Configuration appConfiguration)
     {
-        appConfiguration.disable(status_bar::Indicator::NetworkAccessTechnology);
+        appConfiguration.enable(status_bar::Indicator::NetworkAccessTechnology);
         appConfiguration.disable(status_bar::Indicator::Time);
         appConfiguration.enable(status_bar::Indicator::PhoneMode);
         appConfiguration.enable(status_bar::Indicator::Battery);

--- a/module-apps/apps-common/ApplicationCommon.cpp
+++ b/module-apps/apps-common/ApplicationCommon.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ApplicationCommon.hpp"
@@ -89,9 +89,12 @@ namespace app
           lockPolicyHandler(this), simLockSubject(this)
     {
         popupFilter->attachWindowsStack(windowsStackImpl.get());
-        statusBarManager->enableIndicators({gui::status_bar::Indicator::Time});
+        statusBarManager->enableIndicators({gui::status_bar::Indicator::Time,
+                                            gui::status_bar::Indicator::Signal,
+                                            gui::status_bar::Indicator::NetworkAccessTechnology});
 
         bus.channels.push_back(sys::BusChannel::ServiceCellularNotifications);
+
         bus.channels.push_back(sys::BusChannel::USBNotifications);
 
         longPressTimer = sys::TimerFactory::createPeriodicTimer(this,

--- a/module-apps/apps-common/locks/windows/LockInputWindow.cpp
+++ b/module-apps/apps-common/locks/windows/LockInputWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "LockInputWindow.hpp"
@@ -105,7 +105,7 @@ namespace gui
 
     status_bar::Configuration LockInputWindow::configureStatusBar(status_bar::Configuration appConfiguration)
     {
-        appConfiguration.disable(status_bar::Indicator::NetworkAccessTechnology);
+        appConfiguration.enable(status_bar::Indicator::NetworkAccessTechnology);
         appConfiguration.enable(status_bar::Indicator::Time);
         appConfiguration.enable(status_bar::Indicator::PhoneMode);
         appConfiguration.enable(status_bar::Indicator::Battery);

--- a/module-apps/apps-common/popups/lock-popups/PhoneLockedInfoWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/PhoneLockedInfoWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhoneLockedInfoWindow.hpp"
@@ -92,7 +92,7 @@ bool PhoneLockedInfoWindow::onInput(const InputEvent &inputEvent)
 
 status_bar::Configuration PhoneLockedInfoWindow::configureStatusBar(status_bar::Configuration appConfiguration)
 {
-    appConfiguration.disable(status_bar::Indicator::NetworkAccessTechnology);
+    appConfiguration.enable(status_bar::Indicator::NetworkAccessTechnology);
     appConfiguration.disable(status_bar::Indicator::Time);
     appConfiguration.disable(status_bar::Indicator::SimCard);
     appConfiguration.enable(status_bar::Indicator::PhoneMode);

--- a/module-apps/apps-common/popups/lock-popups/PhoneLockedWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/PhoneLockedWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhoneLockedWindow.hpp"
@@ -141,7 +141,7 @@ namespace gui
 
     status_bar::Configuration PhoneLockedWindow::configureStatusBar(status_bar::Configuration appConfiguration)
     {
-        appConfiguration.disable(status_bar::Indicator::NetworkAccessTechnology);
+        appConfiguration.enable(status_bar::Indicator::NetworkAccessTechnology);
         appConfiguration.disable(status_bar::Indicator::Time);
         appConfiguration.enable(status_bar::Indicator::PhoneMode);
         appConfiguration.enable(status_bar::Indicator::Lock);

--- a/module-apps/apps-common/popups/lock-popups/SimLockInputWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/SimLockInputWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SimLockInputWindow.hpp"
@@ -48,7 +48,7 @@ namespace gui
 
     status_bar::Configuration SimLockInputWindow::configureStatusBar(status_bar::Configuration appConfiguration)
     {
-        appConfiguration.disable(status_bar::Indicator::NetworkAccessTechnology);
+        appConfiguration.enable(status_bar::Indicator::NetworkAccessTechnology);
         appConfiguration.enable(status_bar::Indicator::Time);
         appConfiguration.enable(status_bar::Indicator::PhoneMode);
         appConfiguration.enable(status_bar::Indicator::Battery);

--- a/module-apps/apps-common/popups/lock-popups/SimNotReadyWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/SimNotReadyWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SimNotReadyWindow.hpp"
@@ -16,7 +16,7 @@ SimNotReadyWindow::SimNotReadyWindow(app::ApplicationCommon *app, const std::str
 
 status_bar::Configuration SimNotReadyWindow::configureStatusBar(status_bar::Configuration appConfiguration)
 {
-    appConfiguration.disable(status_bar::Indicator::NetworkAccessTechnology);
+    appConfiguration.enable(status_bar::Indicator::NetworkAccessTechnology);
     appConfiguration.disable(status_bar::Indicator::Lock);
     appConfiguration.enable(status_bar::Indicator::PhoneMode);
     appConfiguration.enable(status_bar::Indicator::Time);

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -1,7 +1,9 @@
 # MuditaOS changelog - PurePhone
 
 ## Unreleased
-
+### Added
+* Always display network access technology and signal strength on the status bar
+* 
 ### Changed / Improved
 * Improved dialog with network via USSD
 * Added serial number and timestamp to crashdump filename
@@ -42,8 +44,6 @@
 * Fixed false dotted notification above Calls app in case of answered call
 * Fixed broken French translation on 'Configure passcode' screen in Onboarding
 * Fixed time disappearing in SMS thread
-
-### Added
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Now those parameters are always on the statusbar

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
