### PR TITLE
[MOS-18] Fix calllog scrollbar

### DIFF
--- a/module-apps/application-calllog/CalllogModel.cpp
+++ b/module-apps/application-calllog/CalllogModel.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CalllogModel.hpp"
@@ -12,8 +12,6 @@
 #include <service-appmgr/Controller.hpp>
 #include "application-call/data/CallSwitchData.hpp"
 #include <module-db/queries/calllog/QueryCalllogGet.hpp>
-
-using namespace calllog;
 
 CalllogModel::CalllogModel(app::ApplicationCommon *app) : DatabaseModel(app), app::AsyncCallbackReceiver(app)
 {}
@@ -56,7 +54,7 @@ bool CalllogModel::updateRecords(std::vector<CalllogRecord> records)
 
 unsigned int CalllogModel::getMinimalItemSpaceRequired() const
 {
-    return gui::clItemStyle::h;
+    return gui::clItemStyle::h + gui::clItemStyle::top_margin;
 }
 
 gui::ListItem *CalllogModel::getItem(gui::Order order)

--- a/module-apps/application-calllog/widgets/CalllogItem.cpp
+++ b/module-apps/application-calllog/widgets/CalllogItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CalllogItem.hpp"
@@ -8,14 +8,11 @@
 
 #include <Style.hpp>
 
-using namespace calllog;
-
 namespace gui
 {
-
     CalllogItem::CalllogItem(CalllogModel *model) : model{model}
     {
-        setMargins(Margins(0, style::margins::big, 0, 0));
+        setMargins(Margins(0, clItemStyle::top_margin, 0, 0));
         setMinimumSize(clItemStyle::w, clItemStyle::h);
         setEdges(RectangleEdge::Bottom | RectangleEdge::Top);
 
@@ -24,7 +21,7 @@ namespace gui
         hBox->setPenFocusWidth(style::window::default_border_focus_w);
         hBox->setPenWidth(style::window::default_border_rect_no_focus);
 
-        auto newImg = [=](const UTF8 imageName) -> gui::Image * {
+        auto newImg = [=](const UTF8 &imageName) -> gui::Image * {
             auto img = new gui::Image(hBox, imageName, gui::ImageTypeSpecifier::W_M);
             img->setAlignment(gui::Alignment{gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center});
             img->setMargins(Margins(0, 0, clItemStyle::internal_margin, 0));

--- a/module-apps/application-calllog/widgets/CalllogItem.hpp
+++ b/module-apps/application-calllog/widgets/CalllogItem.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -12,13 +12,13 @@
 
 namespace gui
 {
-
     namespace clItemStyle
     {
         inline constexpr auto w               = style::window::default_body_width;
         inline constexpr auto h               = style::window::label::big_h;
         inline constexpr auto internal_margin = 4;
         inline constexpr auto right_margin    = 10;
+        inline constexpr auto top_margin      = style::margins::big;
 
         namespace timestamp
         {
@@ -41,7 +41,7 @@ namespace gui
         gui::Label *text                                                       = nullptr;
 
       public:
-        CalllogItem(CalllogModel *model);
+        explicit CalllogItem(CalllogModel *model);
         virtual ~CalllogItem() = default;
         // sets copy of alarm's
         void setCall(std::shared_ptr<CalllogRecord> &);

--- a/module-gui/gui/widgets/ListView.cpp
+++ b/module-gui/gui/widgets/ListView.cpp
@@ -1,10 +1,8 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ListView.hpp"
 #include "InputEvent.hpp"
-#include "cassert"
-#include <log/log.hpp>
 
 namespace gui
 {
@@ -21,11 +19,11 @@ namespace gui
 
     void ListViewScroll::updateProportional(const ListViewScrollUpdateData &data)
     {
-        double scrollStep =
+        const auto scrollStep =
             static_cast<double>((parent->widgetArea.h - topMargin)) / static_cast<double>(data.elementsCount);
 
-        auto scrollH = scrollStep * data.listPageSize;
-        auto scrollY = scrollStep * data.startIndex > 0 ? scrollStep * data.startIndex : topMargin;
+        const auto scrollH = scrollStep * data.listPageSize;
+        const auto scrollY = (scrollStep * data.startIndex > 0) ? scrollStep * data.startIndex : topMargin;
 
         setArea(BoundingBox(
             parent->widgetArea.w - style::listview::scroll::margin, scrollY, style::listview::scroll::w, scrollH));
@@ -33,15 +31,15 @@ namespace gui
 
     void ListViewScroll::updateFixed(const ListViewScrollUpdateData &data)
     {
-        auto elementsOnPage = parent->widgetArea.h / data.elementMinimalSpaceRequired;
+        const auto elementsOnPage = parent->widgetArea.h / data.elementMinimalSpaceRequired;
 
-        pagesCount = data.elementsCount % elementsOnPage == 0 ? data.elementsCount / elementsOnPage
-                                                              : data.elementsCount / elementsOnPage + 1;
+        pagesCount = (data.elementsCount % elementsOnPage == 0) ? data.elementsCount / elementsOnPage
+                                                                : data.elementsCount / elementsOnPage + 1;
 
         currentPage = data.startIndex / elementsOnPage;
 
-        auto scrollH = (parent->widgetArea.h - topMargin) / pagesCount;
-        auto scrollY = scrollH * currentPage > 0 ? scrollH * currentPage : topMargin;
+        const auto scrollH = (parent->widgetArea.h - topMargin) / pagesCount;
+        const auto scrollY = (scrollH * currentPage > 0) ? scrollH * currentPage : topMargin;
 
         setArea(BoundingBox(
             parent->widgetArea.w - style::listview::scroll::margin, scrollY, style::listview::scroll::w, scrollH));
@@ -110,8 +108,9 @@ namespace gui
 
             setVisible(true);
         }
-        else
+        else {
             setVisible(false);
+        }
     }
     void ListViewScroll::setTopMargin(int _topMargin)
     {
@@ -125,7 +124,7 @@ namespace gui
                        unsigned int h,
                        std::shared_ptr<ListItemProvider> prov,
                        listview::ScrollBarType scrollBarType)
-        : Rect{parent, x, y, w, h}, ListViewEngine(prov)
+        : Rect{parent, x, y, w, h}, ListViewEngine(std::move(prov))
     {
         this->setEdges(RectangleEdge::None);
 
@@ -143,12 +142,10 @@ namespace gui
             else if (inputEvent.is(KeyCode::KEY_DOWN) && pageLoaded) {
                 return this->requestNextPage();
             }
-            else {
-                return false;
-            }
+            return false;
         };
 
-        inputCallback = [&](Item &item, const InputEvent &event) { return body->onInput(event); };
+        inputCallback = [&]([[maybe_unused]] Item &item, const InputEvent &event) { return body->onInput(event); };
 
         focusChangedCallback = [this]([[maybe_unused]] Item &item) -> bool {
             if (focus) {
@@ -161,8 +158,9 @@ namespace gui
         };
 
         body->parentOnRequestedResizeCallback = [this]() {
-            if (pageLoaded)
+            if (pageLoaded) {
                 recalculateOnBoxRequestedResize();
+            }
         };
 
         checkFullRenderRequirementCallback = [this]() {

--- a/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
@@ -62,7 +62,6 @@ class ServiceDesktop : public sys::Service
     sys::ReturnCodes SwitchPowerModeHandler(sys::ServicePowerMode mode) override;
     sys::MessagePointer DataReceivedHandler(sys::DataMessage *msg, sys::ResponseMessage *resp) override;
 
-    std::string prepareSyncFilename();
     void prepareSyncData();
     const Sync::OperationStatus getSyncStatus()
     {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -44,6 +44,7 @@
 * Fixed false dotted notification above Calls app in case of answered call
 * Fixed broken French translation on 'Configure passcode' screen in Onboarding
 * Fixed time disappearing in SMS thread
+* Fixed scrollbar behavior in call log view
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Fix of the issue that scrollbar in
call log didn't represent the actual
page being shown correctly.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
