### PR TITLE
[MOS-52] Fix the data displayed on snoozed alarms screen

### DIFF
--- a/module-apps/apps-common/popups/AlarmPopup.hpp
+++ b/module-apps/apps-common/popups/AlarmPopup.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -7,6 +7,7 @@
 
 #include <AppWindow.hpp>
 #include <TextFixedSize.hpp>
+#include <ImageBoxWithText.hpp>
 
 #include <string>
 
@@ -37,11 +38,6 @@ namespace style::popup::alarm
 
 namespace gui
 {
-    enum class SnoozeShow
-    {
-        First,
-        Next
-    };
     class AlarmPopup : public AppWindow, app::popup::AlarmPopupContract::View
     {
       public:
@@ -53,19 +49,20 @@ namespace gui
         bool onInput(const InputEvent &inputEvent) override;
 
         status_bar::Configuration configureStatusBar(status_bar::Configuration appConfiguration) override;
-        virtual void showSnoozeButton() override;
 
       private:
         VBox *body                         = nullptr;
+        VBox *snoozeLabelBox               = nullptr;
+        gui::TextFixedSize *alarmLabel     = nullptr;
         gui::TextFixedSize *alarmTimeLabel = nullptr;
         gui::TextFixedSize *snoozeLabel    = nullptr;
-        SnoozeShow snoozeShow              = SnoozeShow::First;
+        gui::ImageBoxWithText *snoozeIcon  = nullptr;
 
         void addArcOverlay();
         void createMainLayout();
-        void addAlarmLabels();
-        void addSnoozeLabel();
-        void addWindowElements();
+        void createLabels();
+        void createSnoozeButton();
+        void updateItems();
         void refillText();
     };
 

--- a/module-apps/apps-common/popups/presenter/AlarmPresenter.hpp
+++ b/module-apps/apps-common/popups/presenter/AlarmPresenter.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -63,7 +63,6 @@ namespace app::popup
             explicit View(std::shared_ptr<Presenter> presenter) : presenter(std::move(presenter))
             {}
             virtual ~View() noexcept        = default;
-            virtual void showSnoozeButton() = 0;
         };
 
         class Presenter : public BasePresenter<AlarmPopupContract::View>

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -52,6 +52,7 @@
 * Fixed displaying wrong screen after contact removal
 * Fixed improper font weight used in navbar
 * Fix for country code in new contact based on deleted one
+* Fixed the data displayed on snoozed alarms screen
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

When we were currently in the snoozed alarms screen and a new alarm rang, the data was displayed incorrectly.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
