### PR TITLE
[BH-1582] Fix alarm edit inactivity handling

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -6,6 +6,7 @@
 * Fixed displayed device name when connected to Windows
 * Fixed the wrong front light on back action in alarms
 * Fixed the pause deactivation by a deep press in relaxation
+* Fixed canceling of alarm editing after 10s of inactivity
 
 ### Added
 

--- a/products/BellHybrid/apps/application-bell-main/presenters/StateController.cpp
+++ b/products/BellHybrid/apps/application-bell-main/presenters/StateController.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "application-bell-main/presenters/HomeScreenPresenter.hpp"
@@ -160,6 +160,7 @@ namespace app::home_screen
                 [](AbstractView &view, AbstractPresenter &presenter, AbstractTemperatureModel &temperatureModel) {
                     view.setViewState(ViewState::AlarmEdit);
                     view.setTemperature(temperatureModel.getTemperature());
+                    presenter.spawnTimer(defaultAlarmSetTime);
                 };
             auto exit = [](AbstractView &view, AbstractPresenter &presenter) { presenter.detachTimer(); };
 


### PR DESCRIPTION
Add missing timer start in entry event handler

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [X] Has changelog entry added

<!-- Thanks for your work ♥ -->
