### PR TITLE
[MOS-558] Fixed invalid label on alarm edit window load

### DIFF
--- a/module-apps/application-alarm-clock/widgets/AlarmRRuleOptionsItem.cpp
+++ b/module-apps/application-alarm-clock/widgets/AlarmRRuleOptionsItem.cpp
@@ -56,7 +56,7 @@ namespace gui
         onLoadCallback = [&]([[maybe_unused]] std::shared_ptr<AlarmEventRecord> alarm) {
             checkCustomOption(getPresenter()->getDescription());
             optionSpinner->setCurrentValue(getPresenter()->getDescription());
-            if (getRRuleOption(optionSpinner->getCurrentValue()) == RRule::Custom) {
+            if (optionSpinner->focus && getRRuleOption(optionSpinner->getCurrentValue()) == RRule::Custom) {
                 this->navBarTemporaryMode(utils::translate(style::strings::common::edit));
             }
             else {


### PR DESCRIPTION
There was no control if widget's required text has to be set while on focus only

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
