### PR TITLE
[MOS-884] Importing contacts from SIM card more than once

### DIFF
--- a/module-db/Interface/ContactRecord.hpp
+++ b/module-db/Interface/ContactRecord.hpp
@@ -302,6 +302,8 @@ class ContactRecordInterface : public RecordInterface<ContactRecord, ContactReco
     auto addOrUpdateRingtone(std::uint32_t contactID, std::uint32_t ringtoneID, const ContactRecord &contact)
         -> std::optional<std::uint32_t>;
 
+    auto matchedNumberRefersToTemporary(const ContactNumberHolder &matchedNumber) -> bool;
+
     /**
      * @brief Changing number table record in place if new number is same as old number but with/without country code
      *

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -57,6 +57,7 @@
 * Fixed templates list not looping
 * Fixed inability to import contacts from Orange SIM cards
 * Fixed improper asterisk button behavior when adding new contact
+* Fixed for contacts removed and imported from SIM card once again were added to database without names 
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Fix for importing and removing contacts from SIM card causes issue that imported contacts didn't have a name and could by multiplied.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
