### PR TITLE
[MOS-68] Deleting a contact flow finishes with a wrong screen

### DIFF
--- a/module-apps/application-phonebook/windows/PhonebookContactOptions.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookContactOptions.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhonebookContactOptions.hpp"
@@ -93,25 +93,30 @@ namespace gui
     auto PhonebookContactOptions::showNotification(NotificationType notificationType) -> bool
     {
         std::string dialogText;
+        std::string icon;
 
         switch (notificationType) {
-        case NotificationType::Block:
+        case NotificationType::Block: {
             dialogText = utils::translate("app_phonebook_options_block_notification");
-            break;
-        case NotificationType::Delete:
-            dialogText = utils::translate("app_phonebook_options_delete_notification");
-            break;
-        case NotificationType::Unblock:
-            dialogText = utils::translate("app_phonebook_options_unblock_notification");
+            icon       = "info_128px_W_G";
             break;
         }
 
+        case NotificationType::Delete: {
+            dialogText = utils::translate("app_phonebook_options_delete_notification");
+            icon       = "success_128px_W_G";
+            break;
+        }
+
+        case NotificationType::Unblock: {
+            dialogText = utils::translate("app_phonebook_options_unblock_notification");
+            icon       = "info_128px_W_G";
+            break;
+        }
+        }
+
         auto metaData                        = std::make_unique<gui::DialogMetadataMessage>(gui::DialogMetadata{
-            contact->getFormattedName(ContactRecord::NameFormatType::Title),
-            "info_128px_W_G",
-            dialogText,
-            "",
-            [=]() -> bool {
+            contact->getFormattedName(ContactRecord::NameFormatType::Title), icon, dialogText, "", [=]() -> bool {
                 if (requestType == PhonebookItemData::RequestType::External) {
                     app::manager::Controller::switchBack(application);
                 }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -49,6 +49,7 @@
 * Fixed broken events counter on main screen for more than 99 events
 * Fixed incorrect signal strength displayed in Center
 * Fixed inability to enter text in search field after clicking right arrow
+* Fixed displaying wrong screen after contact removal
 
 ### Added
 


### PR DESCRIPTION
Fix for displaying wrong screen after contact removal

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
