### PR TITLE
[MOS-60] Fix displaying an incorrect window after ending a call

### DIFF
--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -162,13 +162,14 @@ namespace gui
     bool CallWindow::onInput(const InputEvent &inputEvent)
     {
         bool handled = false;
+        const auto keyCode = inputEvent.getKeyCode();
 
         // process only if key is released
         // InputEvent::State::keyReleasedLong is necessary for KeyCode::KEY_RF to properly abort the active call
         if (inputEvent.isKeyRelease()) {
             LOG_INFO("key released");
-            auto code = translator.handle(inputEvent.getRawKey(), InputMode({InputMode::phone}).get());
-            switch (inputEvent.getKeyCode()) {
+            const auto code = translator.handle(inputEvent.getRawKey(), InputMode({InputMode::phone}).get());
+            switch (keyCode) {
             case KeyCode::KEY_LF:
                 handled = presenter->handleLeftButton();
                 break;
@@ -191,7 +192,7 @@ namespace gui
             return true;
         }
         else {
-            return AppWindow::onInput(inputEvent);
+            return keyCode == KeyCode::KEY_RF ? true : AppWindow::onInput(inputEvent);
         }
     }
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -53,6 +53,7 @@
 * Fixed improper font weight used in navbar
 * Fix for country code in new contact based on deleted one
 * Fixed the data displayed on snoozed alarms screen
+* Fixed displaying an incorrect window after double ending a phone call
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

After quick dobule "END CALL" selection, the window for adding a contact is displayed for a while.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
