### PR TITLE
[MOS-192] Time should not include 0 at the beginning

### DIFF
--- a/module-utils/time/test/unittest_time.cpp
+++ b/module-utils/time/test/unittest_time.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <cstring>
@@ -34,9 +34,9 @@ class TimeSettings : public TimeSettingsInterface
     }
 };
 
-const std::regex reg12h("^(0[0-9]|1[0-2]):[0-5][0-9] (A|P)M$");
-const std::regex reg12hShort("^(0[0-9]|1[0-2]):[0-5][0-9]$");
-const std::regex reg24h("^([0-1][0-9]|2[0-4]):[0-5][0-9]$");
+const std::regex reg12h("^(00|[1-9]|1[0-2]):[0-5][0-9] (A|P)M$");
+const std::regex reg12hShort("^(00|[1-9]|1[0-2]):[0-5][0-9]$");
+const std::regex reg24h("^(00|[1-9]|1[0-9]|2[0-4]):[0-5][0-9]$");
 const std::regex regexDDMMYYYY("^([0-2]\\d|3[0-1])\\.(0[1-9]|1[0-2])\\.\\d{4}$");
 const std::regex regexDDMM("^([0-2]\\d|3[0-1])\\.(0[1-9]|1[0-2])$");
 const std::regex regexMMDDYYYY("^(0[1-9]|1[0-2])\\.([0-2]\\d|3[0-1])\\.\\d{4}$");

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -58,6 +58,7 @@
 * Fixed inability to import contacts from Orange SIM cards
 * Fixed improper asterisk button behavior when adding new contact
 * Fixed for contacts removed and imported from SIM card once again were added to database without names 
+* Fixed (removed) redundant leading zero from time representation unless exactly midnight
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Fix for displaying an additional 0 at the begging of the clock. It affects the clock in the status bar and messages and calls time.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
