### PR TITLE
[MOS-172] Fix asterisk button behavior in contacts

### DIFF
--- a/module-apps/application-phonebook/widgets/InputLinesWithLabelWidget.cpp
+++ b/module-apps/application-phonebook/widgets/InputLinesWithLabelWidget.cpp
@@ -87,8 +87,7 @@ namespace gui
         inputCallback = [&](Item &item, const InputEvent &event) {
             auto result = inputText->onInput(event);
 
-            if (!event.isShortRelease(gui::KeyCode::KEY_AST) &&
-                (!inputText->isEmpty() || Clipboard::getInstance().gotData())) {
+            if (!event.is(KeyCode::KEY_AST) && (!inputText->isEmpty() || Clipboard::getInstance().gotData())) {
                 this->navBarTemporaryMode(utils::translate(style::strings::common::options), false);
             }
 

--- a/module-apps/apps-common/windows/AppWindow.cpp
+++ b/module-apps/apps-common/windows/AppWindow.cpp
@@ -192,12 +192,10 @@ namespace gui
         if (inputEvent.isShortRelease()) {
             switch (inputEvent.getKeyCode()) {
             case KeyCode::HEADSET_VOLUP:
-                [[fallthrough]];
             case KeyCode::KEY_VOLUP: {
                 return application->increaseCurrentVolume();
             }
             case KeyCode::HEADSET_VOLDN:
-                [[fallthrough]];
             case KeyCode::KEY_VOLDN: {
                 return application->decreaseCurrentVolume();
             }

--- a/module-gui/gui/widgets/text/Text.cpp
+++ b/module-gui/gui/widgets/text/Text.cpp
@@ -62,9 +62,7 @@ namespace gui
 
     Text::~Text()
     {
-        if (inputMode != nullptr) {
-            delete inputMode;
-        }
+        delete inputMode;
     }
 
     void Text::setEditMode(EditMode new_mode)
@@ -180,7 +178,7 @@ namespace gui
             debug_text("Nothing to parse/parser error in rich text: %s", text.c_str());
             return addText(text); // fallback
         }
-        for (auto block : tmp_document->getBlockCursor(0)) {
+        for (const auto &block : tmp_document->getBlockCursor(0)) {
             *cursor << block;
         }
         drawLines();
@@ -312,7 +310,7 @@ namespace gui
 
     bool Text::onFocus(bool state)
     {
-        if (state != focus && state == true) {
+        if (state != focus && state) {
             drawLines();
         }
         showCursor(state);
@@ -323,10 +321,12 @@ namespace gui
     {
         Rect::setRadius(value);
         // if padding are smaller than radius update the padding
-        if (padding.left < value)
+        if (padding.left < value) {
             padding.left = value;
-        if (padding.right < value)
+        }
+        if (padding.right < value) {
             padding.right = value;
+        }
     }
 
     void Text::setColor(Color color)
@@ -355,26 +355,22 @@ namespace gui
 
     void Text::setInputMode(InputMode *&&mode)
     {
-        if (this->inputMode != nullptr) {
-            delete this->inputMode;
-        }
+        delete this->inputMode;
+
         this->inputMode = mode;
     }
 
     std::string Text::getInputModeKeyMap()
     {
-        if (inputMode != nullptr) {
-
-            if (inputMode->is(InputMode::Abc)) {
-                return inputMode->get(detectInputMode());
-            }
-            else {
-                return inputMode->get();
-            }
-        }
-        else {
+        if (inputMode == nullptr) {
             return "";
         }
+
+        if (inputMode->is(InputMode::Abc)) {
+            return inputMode->get(detectInputMode());
+        }
+
+        return inputMode->get();
     }
 
     InputMode::Mode Text::detectInputMode()
@@ -454,7 +450,7 @@ namespace gui
             Length hUsed = padding.top + lines->linesHeight() + padding.bottom;
             Length wUsed = lines->maxWidth() + padding.getSumInAxis(Axis::X);
 
-            if (lines->size() == 0) {
+            if (lines->empty()) {
                 debug_text("No lines to show, try to at least fit in cursor");
                 if (format.getFont() != nullptr &&
                     padding.top + lines->linesHeight() < format.getFont()->info.line_height) {

--- a/module-gui/gui/widgets/text/modes/InputMode.cpp
+++ b/module-gui/gui/widgets/text/modes/InputMode.cpp
@@ -1,10 +1,11 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "InputMode.hpp"
 #include <i18n/i18n.hpp>
 #include <map>
 #include <log/log.hpp>
+#include <utility>
 
 /// input mode strings - as these are stored in json (in files...)
 const std::map<InputMode::Mode, std::string> input_mode = {
@@ -36,11 +37,12 @@ InputMode::InputMode(std::list<InputMode::Mode> mode_list,
                      std::function<void(const UTF8 &text)> show_type_cb,
                      std::function<void()> restore_after_show_type_cb,
                      std::function<void()> show_special_char_selector)
-    : input_mode_list(mode_list), show_type_cb(show_type_cb), restore_after_show_type_cb(restore_after_show_type_cb),
-      show_special_char_selector(show_special_char_selector)
+    : input_mode_list(std::move(mode_list)), show_type_cb(std::move(show_type_cb)),
+      restore_after_show_type_cb(std::move(restore_after_show_type_cb)),
+      show_special_char_selector(std::move(show_special_char_selector))
 {
     // failsafe
-    if (input_mode_list.size() == 0) {
+    if (input_mode_list.empty()) {
         input_mode_list.push_back(Mode::digit);
     }
 }
@@ -73,7 +75,7 @@ const std::string &InputMode::get()
 
 const std::string &InputMode::get(InputMode::Mode mode)
 {
-    auto selectedInputMode = input_mode.at(mode);
+    const auto &selectedInputMode = input_mode.at(mode);
     return utils::getInputLanguageFilename(selectedInputMode);
 }
 

--- a/module-gui/gui/widgets/text/modes/InputMode.hpp
+++ b/module-gui/gui/widgets/text/modes/InputMode.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -39,11 +39,7 @@ class InputMode
               std::function<void(const UTF8 &text)> show_type_cb = nullptr,
               std::function<void()> restore_after_show_type_cb   = nullptr,
               std::function<void()> show_special_char_selector   = nullptr);
-    void on_focus(bool focus)
-    {
-        if (!focus)
-            show_restore();
-    }
+
     void next();
     const std::string &get();
     const std::string &get(Mode mode);

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -56,6 +56,7 @@
 * Fixed displaying an incorrect window after double ending a phone call
 * Fixed templates list not looping
 * Fixed inability to import contacts from Orange SIM cards
+* Fixed improper asterisk button behavior when adding new contact
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Fix of the improper asterisk button behavior
in new contact window - pressing the button
to change an input mode resulted in
'OPTIONS' label being displayed for the
left function button in navbar when the
asterisk button was held.

Additionally, as usual, minor code cleanup.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
