### PR TITLE
[MOS-35] Add more input modes for USSD reply

### DIFF
--- a/module-apps/application-desktop/windows/MmiPullWindow.cpp
+++ b/module-apps/application-desktop/windows/MmiPullWindow.cpp
@@ -56,7 +56,7 @@ MmiPullWindow::MmiPullWindow(app::ApplicationCommon *app, const std::string &nam
                                       style::desktop::inputWidget::h);
 
     InputBox->inputText->setInputMode(new InputMode(
-        {InputMode::digit},
+        {InputMode::digit, InputMode::Abc, InputMode::ABC, InputMode::abc},
         [=](const UTF8 &text1) { navBarTemporaryMode(text1); },
         [=]() { navBarRestoreFromTemporaryMode(); },
         [=]() { selectSpecialCharacter(); }));

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -59,6 +59,7 @@
 * Fixed improper asterisk button behavior when adding new contact
 * Fixed for contacts removed and imported from SIM card once again were added to database without names 
 * Fixed (removed) redundant leading zero from time representation unless exactly midnight
+* Fixed inability to type characters other than digits in USSD replies
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Previously only the mode restricted to digits was available.


- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added
