### PR TITLE
[MOS-204] Fix screen ghosting after emoji selection

### DIFF
--- a/module-apps/application-special-input/widgets/SpecialInputTableWidget.cpp
+++ b/module-apps/application-special-input/widgets/SpecialInputTableWidget.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SpecialInputTableWidget.hpp"
@@ -16,7 +16,7 @@ namespace gui
 
     using namespace specialInputStyle;
 
-    SpecialInputTableWidget::SpecialInputTableWidget(app::ApplicationCommon *app, std::list<Carrier> &&carrier)
+    SpecialInputTableWidget::SpecialInputTableWidget(app::ApplicationCommon *app, std::list<Carrier> &&carriers)
         : application(app)
     {
         setMinimumSize(specialCharacterTableWidget::window_grid_w, specialCharacterTableWidget::window_grid_h);
@@ -28,7 +28,7 @@ namespace gui
                              specialCharacterTableWidget::window_grid_h,
                              {specialCharacterTableWidget::char_grid_w, specialCharacterTableWidget::char_grid_h});
 
-        for (auto &carrier : carrier) {
+        for (auto &carrier : carriers) {
             box->addWidget(carrier.item);
             decorateActionActivated(carrier.item, carrier.val);
         }
@@ -71,12 +71,13 @@ namespace gui
     void SpecialInputTableWidget::decorateActionActivated(Item *it, const std::string &str)
     {
         assert(application);
-        auto app = dynamic_cast<app::ApplicationSpecialInput *>(application);
+        const auto app = dynamic_cast<app::ApplicationSpecialInput *>(application);
         assert(app);
 
         it->activatedCallback = [=](Item &it) {
             setFocusItem(nullptr);
             LOG_INFO("handled special char for %s", application->getCurrentWindow()->getName().c_str());
+
             auto switchData =
                 std::make_unique<gui::SwitchSpecialChar>(gui::SwitchSpecialChar::Type::Response, app->requester, str);
             return app::manager::Controller::switchBack(
@@ -99,16 +100,16 @@ namespace gui
         return {rect, std::string(&text::newline, 1)};
     }
 
-    auto generateCharSign(uint32_t val) -> Carrier
+    auto generateCharSign(std::uint32_t val) -> Carrier
     {
         std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> convert;
-        std::string schar_string = convert.to_bytes(std::u32string(1, val));
-        auto el                  = new gui::Label(
+        const auto scharString = convert.to_bytes(std::u32string(1, val));
+        const auto charLabel   = new gui::Label(
             nullptr, 0, 0, specialCharacterTableWidget::char_label_w, specialCharacterTableWidget::char_label_h);
-        style::window::decorate(el);
-        el->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center));
-        el->setFont(style::window::font::medium);
-        el->setText(schar_string);
-        return {el, schar_string};
+        style::window::decorate(charLabel);
+        charLabel->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center));
+        charLabel->setFont(style::window::font::medium);
+        charLabel->setText(scharString);
+        return {charLabel, scharString};
     }
 } /* namespace gui */

--- a/module-apps/application-special-input/widgets/SpecialInputTableWidget.hpp
+++ b/module-apps/application-special-input/widgets/SpecialInputTableWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -22,7 +22,7 @@ namespace gui
     };
 
     auto generateNewLineSign() -> Carrier;
-    auto generateCharSign(uint32_t val) -> Carrier;
+    auto generateCharSign(std::uint32_t val) -> Carrier;
 
     class SpecialInputTableWidget : public ListItem
     {

--- a/module-apps/apps-common/ApplicationCommon.cpp
+++ b/module-apps/apps-common/ApplicationCommon.cpp
@@ -619,7 +619,7 @@ namespace app
             auto text = dynamic_cast<gui::Text *>(getCurrentWindow()->getFocusItem());
             if (text != nullptr) {
                 text->addText(ret->getDescription());
-                refreshWindow(gui::RefreshModes::GUI_REFRESH_FAST);
+                refreshWindow(gui::RefreshModes::GUI_REFRESH_DEEP);
                 return true;
             }
         }

--- a/module-services/service-appmgr/Controller.cpp
+++ b/module-services/service-appmgr/Controller.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Controller.hpp"
@@ -49,8 +49,7 @@ namespace app::manager
 
     auto Controller::switchBack(sys::Service *sender, std::unique_ptr<SwitchBackRequest> msg) -> bool
     {
-        std::shared_ptr<SwitchBackRequest> switchMsg =
-            msg ? std::move(msg) : std::make_shared<app::manager::SwitchBackRequest>(sender->GetName());
+        auto switchMsg = msg ? std::move(msg) : std::make_shared<app::manager::SwitchBackRequest>(sender->GetName());
         return sender->bus.sendUnicast(switchMsg, service::name::appmgr);
     }
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -61,6 +61,7 @@
 * Fixed for contacts removed and imported from SIM card once again were added to database without names 
 * Fixed (removed) redundant leading zero from time representation unless exactly midnight
 * Fixed inability to type characters other than digits in USSD replies
+* Fixed screen ghosting after emoji selection
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Fix of the issue of screen ghosting after
emoji selection, visible particularly well
in messages app - changed fast refresh
to deep one on returning from emoji selection
screen to the previous application.

Additionally minor code cleanup.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
