### PR TITLE
[MOS-29] Fix invalid screen after missed call

### DIFF
--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -161,6 +161,12 @@ namespace app
             return sys::MessageNone{};
         });
 
+        connect(typeid(cellular::CallMissedNotification), [&](sys::Message *request) {
+            callModel->setState(app::call::CallState::Missed);
+            app::manager::Controller::switchBack(this);
+            return sys::MessageNone{};
+        });
+
         connect(typeid(cellular::CallEndedNotification), [&](sys::Message *request) {
             callModel->setState(app::call::CallState::Ended);
             switchWindow(app::window::name_call);

--- a/module-apps/application-call/model/CallModel.hpp
+++ b/module-apps/application-call/model/CallModel.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -20,6 +20,7 @@ namespace app::call
         Active,
         Ended,
         Rejected,
+        Missed,
         Disconnecting
     };
 
@@ -37,7 +38,9 @@ namespace app::call
         case CallState::Ended:
             return "Ended";
         case CallState::Rejected:
-            return "Ended";
+            return "Rejected";
+        case CallState::Missed:
+            return "Missed";
         case CallState::Disconnecting:
             return "Disconnecting";
         }

--- a/module-apps/application-call/presenter/CallPresenter.cpp
+++ b/module-apps/application-call/presenter/CallPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CallPresenter.hpp"
@@ -43,7 +43,7 @@ namespace app::call
         switch (callState) {
         case app::call::CallState::Incoming:
             view->updateDuration(utils::translate(callAppStyle::strings::iscalling));
-            view->setIncomingCallLayout(model->getCallerId().empty() ? true : false);
+            view->setIncomingCallLayout(model->getCallerId().empty());
             view->updateNumber(getCallerId());
             break;
         case app::call::CallState::Outgoing:
@@ -62,6 +62,9 @@ namespace app::call
         case app::call::CallState::Ended:
             view->updateDuration(utils::translate(callAppStyle::strings::callended));
             view->setCallEndedLayout();
+            break;
+        case app::call::CallState::Missed:
+            model->setState(CallState::None);
             break;
         case app::call::CallState::Disconnecting:
             view->updateDuration(utils::translate(callAppStyle::strings::endingcall));

--- a/module-services/service-cellular/call/CallMachine.hpp
+++ b/module-services/service-cellular/call/CallMachine.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <boost/sml.hpp>
@@ -257,7 +257,7 @@ namespace call
             call.record.type   = CallType::CT_MISSED;
             call.record.isRead = false;
             di.db->endCall(call.record);
-            di.multicast->notifyCallEnded();
+            di.multicast->notifyCallMissed();
             di.modem->rejectCall();
         };
     } constexpr HandleMissedCall;
@@ -280,7 +280,7 @@ namespace call
     {
         void operator()(Dependencies &di, const call::event::AudioRequest &request)
         {
-            cellular::CallAudioEventRequest::EventType event = request.event;
+            const auto event = request.event;
             switch (event) {
             case cellular::CallAudioEventRequest::EventType::Mute:
                 di.audio->muteCall();

--- a/module-services/service-cellular/call/api/CallMulticast.cpp
+++ b/module-services/service-cellular/call/api/CallMulticast.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CallMulticast.hpp"
@@ -36,6 +36,12 @@ void CallMulticast::notifyCallStarted(const utils::PhoneNumber &number, const Ca
 void CallMulticast::notifyCallEnded()
 {
     owner->bus.sendMulticast(std::make_shared<cellular::CallEndedNotification>(),
+                             sys::BusChannel::ServiceCellularNotifications);
+}
+
+void CallMulticast::notifyCallMissed()
+{
+    owner->bus.sendMulticast(std::make_shared<cellular::CallMissedNotification>(),
                              sys::BusChannel::ServiceCellularNotifications);
 }
 

--- a/module-services/service-cellular/call/api/CallMulticast.hpp
+++ b/module-services/service-cellular/call/api/CallMulticast.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -23,6 +23,7 @@ namespace call::api
         virtual void notifyOutgoingCallAnswered()                                              = 0;
         virtual void notifyCallStarted(const utils::PhoneNumber &number, const CallType &type) = 0;
         virtual void notifyCallEnded()                                                         = 0;
+        virtual void notifyCallMissed()                                                        = 0;
         virtual void notifyCallDurationUpdate(const time_t &duration)                          = 0;
 
         virtual ~Multicast() = default;
@@ -43,5 +44,6 @@ class CallMulticast : public call::api::Multicast
     void notifyOutgoingCallAnswered() override;
     void notifyCallStarted(const utils::PhoneNumber &number, const CallType &type) override;
     void notifyCallEnded() override;
+    void notifyCallMissed() override;
     void notifyCallDurationUpdate(const time_t &duration) override;
 };

--- a/module-services/service-cellular/call/tests/test-CallMachine.cpp
+++ b/module-services/service-cellular/call/tests/test-CallMachine.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "call/CallEvents.hpp"
@@ -49,6 +49,7 @@ namespace mocks
         fakeit::When(Method(multicast, notifyCallAborted)).AlwaysReturn();
         fakeit::When(Method(multicast, notifyCallStarted)).AlwaysReturn();
         fakeit::When(Method(multicast, notifyCallEnded)).AlwaysReturn();
+        fakeit::When(Method(multicast, notifyCallMissed)).AlwaysReturn();
         fakeit::When(Method(multicast, notifyCallDurationUpdate)).AlwaysReturn();
         fakeit::When(Method(multicast, notifyOutgoingCallAnswered)).AlwaysReturn();
         return multicast;

--- a/module-services/service-cellular/service-cellular/CellularMessage.hpp
+++ b/module-services/service-cellular/service-cellular/CellularMessage.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -970,6 +970,12 @@ namespace cellular
       private:
         utils::PhoneNumber phoneNumber;
         bool isIncoming;
+    };
+
+    class CallMissedNotification : public sys::DataMessage
+    {
+      public:
+        explicit CallMissedNotification() : sys::DataMessage(MessageType::MessageTypeUninitialized){};
     };
 
     class CallEndedNotification : public sys::DataMessage

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -65,6 +65,7 @@
 * Fixed inability to type characters other than digits in USSD replies
 * Fixed screen ghosting after emoji selection
 * Fixed incorrect loudspeaker icon in call window when headset was connected during a call
+* Fixed invalid screen displayed after missed call
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Fix of the issue that missed call triggered
view that shown 'call ended' text.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
