### PR TITLE
[MOS-663] SMS templates: no empty state can be allowed

### DIFF
--- a/image/system_a/data/lang/Deutsch.json
+++ b/image/system_a/data/lang/Deutsch.json
@@ -338,6 +338,7 @@
   "app_call_wrong_emergency": "Anruf nicht möglich.\n$NUMBER ist keine Notrufnummer.",
   "app_messages_title_main": "Nachrichten",
   "app_messages_no_messages": "<text align='center' color='4'>Noch keine Nachrichten.<p>Zum Hinzufügen <b>linken Pfeil</b> drücken.</p></text>",
+  "app_messages_no_templates": "<text align='center'>Noch keine Vorlagen.<p><b>Erstellen Sie eine neue Vorlage</b></p><p>im Mudita Center, um sie in Ihrem</p><p>Pure zu verwenden.</p></text>",
   "app_messages_thread_delete_confirmation": "Dieses Gespräch löschen?",
   "app_messages_message_delete_confirmation": "<text align='center'><p>Diese Nachricht wirklich <text weight='bold'>löschen</text></p>?</text>",
   "app_messages_thread_no_result": "Keine Ergebnisse",

--- a/image/system_a/data/lang/English.json
+++ b/image/system_a/data/lang/English.json
@@ -309,6 +309,7 @@
   "app_call_wrong_emergency": "Can't make a call.\n$NUMBER is not an emergency number.",
   "app_messages_title_main": "Messages",
   "app_messages_no_messages": "<text align='center' color='4'>No messages yet.<p>Press <b>left arrow</b> to add new.</p></text>",
+  "app_messages_no_templates": "<text align='center'>No templates yet.<p><b>Create a new template</b> in Mudita</p><p>Center to use in your Pure.</p></text>",
   "app_messages_thread_delete_confirmation": "Delete this conversation?",
   "app_messages_message_delete_confirmation": "Delete this message?",
   "app_messages_thread_no_result": "There are no results",

--- a/image/system_a/data/lang/Espanol.json
+++ b/image/system_a/data/lang/Espanol.json
@@ -338,6 +338,7 @@
   "app_call_wrong_emergency": "No es posible realizar la llamada.\n$NUMBER no es un número de emergencias.",
   "app_messages_title_main": "Mensajes",
   "app_messages_no_messages": "<text align='center' color='4'>No hay mensajes.<p>Pulsa la <b>flecha izquierda</b> para añadir uno.</p></text>",
+  "app_messages_no_templates": "<text align='center'>Aún no hay plantillas.<p><b>Crea una nueva plantilla</b> en Mudita</p><p>Center para usar en tu Pure.</p></text>",
   "app_messages_thread_delete_confirmation": "¿Eliminar esta conversación?",
   "app_messages_message_delete_confirmation": "<text align='center'><p>¿Seguro que quieres <text weight='bold'>eliminar</text></p> este mensaje?</text>",
   "app_messages_thread_no_result": "No hay resultados",

--- a/image/system_a/data/lang/Francais.json
+++ b/image/system_a/data/lang/Francais.json
@@ -307,6 +307,7 @@
   "app_call_wrong_emergency": "Impossible de faire un appel.\n$NUMBER n'est pas un numéro d'urgence.",
   "app_messages_title_main": "Messages",
   "app_messages_no_messages": "<text align = 'center' color = '4'>Aucun message.<p>Appuyez sur la <b>flèche gauche</b> pour en composer un nouveau.</p></text>",
+  "app_messages_no_templates": "<text align='center'>Pas encore de modèles.<p><b>Créez un nouveau modèle</b> sur Mudita</p><p>Center à utiliser dans votre Pure.</p></text>",
   "app_messages_thread_delete_confirmation": "Supprimer cette conversation ?",
   "app_messages_message_delete_confirmation": "<text align='center'><p>Do you really want to <text weight='bold'>delete</text></p>this message?</text>",
   "app_messages_thread_no_result": "Aucun résultat",

--- a/image/system_a/data/lang/Polski.json
+++ b/image/system_a/data/lang/Polski.json
@@ -330,6 +330,7 @@
   "app_call_wrong_emergency": "Nie można wykonać połączenia.\n$NUMBER nie jest numerem alarmowym.",
   "app_messages_title_main": "Wiadomości",
   "app_messages_no_messages": "<text align='center' color='4'>Nie ma jeszcze żadnych wiadomości.<p>Wciśnij <b>lewą strzałkę</b>, by dodać nową.</p></text>",
+  "app_messages_no_templates": "<text align='center'>Nie ma jeszcze żadnych szablonów.<p><b>Stwórz nowy szablon</b> w Mudita</p><p>Center, aby użyć go w swoim Pure.</p></text>",
   "app_messages_thread_delete_confirmation": "Usunąć tę rozmowę?",
   "app_messages_message_delete_confirmation": "<text align='center'><p>Czy na pewno chcesz <text weight='bold'>usunąć</text></p>tę wiadomość?</text>",
   "app_messages_thread_no_result": "Brak wyników",

--- a/image/system_a/data/lang/Svenska.json
+++ b/image/system_a/data/lang/Svenska.json
@@ -273,6 +273,7 @@
   "app_call_wrong_emergency": "Kan inte ringa..\n$NUMBER är inte ett nödnummer.",
   "app_messages_title_main": "Meddelanden",
   "app_messages_no_messages": "<text align='center' color='4'>Inga meddelanden än.<p>Tryck <b>vänsterpil</b> för att börja skriva ett.</p></text>",
+  "app_messages_no_templates": "<text align='center'>Inga mallar ännu.<p><b>Skapa en ny mall</b> i Mudita</p><p>Center som du kan använda i din Pure.</p></text>",
   "app_messages_thread_delete_confirmation": "Radera konversation?",
   "app_messages_message_delete_confirmation": "<text align='center'><p>Vill du <text weight='bold'>radera</text></p>konversationen?</text>",
   "app_messages_thread_no_result": "Inga resultat",

--- a/module-apps/application-messages/models/SMSTemplateModel.cpp
+++ b/module-apps/application-messages/models/SMSTemplateModel.cpp
@@ -10,7 +10,11 @@
 #include <service-db/DBServiceAPI.hpp>
 
 SMSTemplateModel::SMSTemplateModel(app::ApplicationCommon *app) : DatabaseModel(app), app::AsyncCallbackReceiver{app}
-{}
+{
+    /* In the base class DatabaseModel, this is initialised to maximal unsigned int value, but in fact should be 0.
+       Not wanting to tinker with the whole database handling framework, let's correct this here in a smaller scale. */
+    recordsCount = 0;
+}
 
 unsigned int SMSTemplateModel::requestRecordsCount()
 {

--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -48,6 +48,16 @@ namespace gui
             this, style::x, style::y, style::w, style::h, smsTemplateModel, listview::ScrollBarType::Fixed);
         list->setBoundaries(Boundaries::Continuous);
 
+        using namespace ::style;
+        emptyListIcon = new Icon(this,
+                                 0,
+                                 window::default_vertical_pos,
+                                 window_width,
+                                 window_height - window::default_vertical_pos - ::style::nav_bar::height,
+                                 "info_128px_W_G",
+                                 utils::translate("app_messages_no_templates"));
+        emptyListIcon->setVisible(false);
+
         setFocusItem(list);
     }
 
@@ -93,6 +103,11 @@ namespace gui
         preventsAutoLock = false;
         if (mode == ShowMode::GUI_SHOW_INIT) {
             list->rebuildList();
+            if (list->isEmpty()) {
+                list->setVisible(false);
+                navBar->setActive(nav_bar::Side::Center, false);
+                emptyListIcon->setVisible(true);
+            }
         }
 
         if (auto switchData = dynamic_cast<SMSTemplateRequest *>(data)) {

--- a/module-apps/application-messages/windows/SMSTemplatesWindow.hpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.hpp
@@ -7,6 +7,8 @@
 #include "SMSTemplateModel.hpp"
 
 #include <AppWindow.hpp>
+
+#include <Icon.hpp>
 #include <gui/widgets/text/Label.hpp>
 #include <gui/widgets/ListView.hpp>
 
@@ -19,6 +21,7 @@ namespace gui
     {
         std::shared_ptr<SMSTemplateModel> smsTemplateModel;
         gui::ListView *list = nullptr;
+        gui::Icon *emptyListIcon = nullptr;
 
         void smsSendTemplateRequestHandler(const SMSSendTemplateRequest *const switchData);
         void smsTemplateRequestHandler(const SMSTemplateRequest *const switchData);

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -15,6 +15,7 @@
 * Changed order of starting services, ServiceDesktop moved to the back
 * Shortened duration of phone modes pop-up from 3s to 1s
 * Changed responses in contacts and messages endpoints used to communicate with Center
+* Added SMS template call rejection window for case when no templates are defined
 
 ### Fixed
 
@@ -72,6 +73,7 @@
 * Fixed incorrect loudspeaker icon in call window when headset was connected during a call
 * Fixed invalid screen displayed after missed call
 * Fixed minor issues in the Calculator Application
+* Fixed displaying usual SMS template call rejection window when no templates were defined
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Now there's information displayed that there are no templates and in order to add some, the user needs to use Mudita Center. Also, given no templates, the screen doesn't show the 'USE' button.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added
