### PR TITLE
[MOS-871] Loudspeaker icon is not updated when audio routing has changed

### DIFF
--- a/module-apps/application-call/include/application-call/ApplicationCall.hpp
+++ b/module-apps/application-call/include/application-call/ApplicationCall.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <application-call/model/CallModel.hpp>
-
+#include <application-call/presenter/CallPresenter.hpp>
 #include <Timers/TimerHandle.hpp>
 #include <service-cellular/CellularMessage.hpp>
 #include <service-evtmgr/Constants.hpp>
@@ -67,7 +67,7 @@ namespace app
         void handleCallEvent(const std::string &number, ExternalRequest isExternalRequest) override;
         void handleAddContactEvent(const std::string &number) override;
 
-        sys::MessagePointer handleAudioMessageEvent(AudioEventRequest *message);
+        sys::MessagePointer handleRoutingNotification(AudioRoutingNotification *message);
 
         auto showNotification(std::function<bool()> action, const std::string &icon, const std::string &text) -> bool;
         enum class NotificationType
@@ -78,7 +78,8 @@ namespace app
         auto showNotificationAndRestartCallFlow(NotificationType type, const std::string &text) -> bool;
 
       private:
-        std::shared_ptr<app::call::AbstractCallModel> callModel;
+        std::shared_ptr<call::AbstractCallModel> callModel;
+        std::unique_ptr<call::CallWindowContract::Presenter> callPresenter;
 
       protected:
         ExternalRequest externalRequest = ExternalRequest::False;

--- a/module-apps/application-call/model/CallModel.cpp
+++ b/module-apps/application-call/model/CallModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CallModel.hpp"

--- a/module-apps/application-call/presenter/CallPresenter.cpp
+++ b/module-apps/application-call/presenter/CallPresenter.cpp
@@ -8,6 +8,9 @@ namespace app::call
 {
 
     CallWindowContract::Presenter::Presenter(std::shared_ptr<app::call::AbstractCallModel> callModel) : model(callModel)
+    {}
+
+    void CallWindowContract::Presenter::Presenter::attachCallbacks()
     {
         model->attachCallStateChangeCallback([this]() { this->handleCallStateChange(); });
         model->attachDurationChangeCallback([this]() { this->handleCallDurationChange(); });
@@ -41,38 +44,46 @@ namespace app::call
         auto callState = model->getState();
 
         switch (callState) {
-        case app::call::CallState::Incoming:
+        case app::call::CallState::Incoming: {
             view->updateDuration(utils::translate(callAppStyle::strings::iscalling));
             view->setIncomingCallLayout(model->getCallerId().empty());
             view->updateNumber(getCallerId());
             break;
-        case app::call::CallState::Outgoing:
+        }
+        case app::call::CallState::Outgoing: {
             view->updateDuration(utils::translate(callAppStyle::strings::calling));
             view->updateNumber(getCallerId());
             view->setActiveCallLayout();
             break;
-        case app::call::CallState::Active:
+        }
+        case app::call::CallState::Active: {
             view->updateDuration(utils::time::Duration(model->getTime()).str());
             view->setActiveCallLayout();
             break;
-        case app::call::CallState::Rejected:
+        }
+        case app::call::CallState::Rejected: {
             view->updateDuration(utils::translate(callAppStyle::strings::callrejected));
             view->setCallEndedLayout();
             break;
-        case app::call::CallState::Ended:
+        }
+        case app::call::CallState::Ended: {
             view->updateDuration(utils::translate(callAppStyle::strings::callended));
             view->setCallEndedLayout();
             break;
-        case app::call::CallState::Missed:
+        }
+        case app::call::CallState::Missed: {
             model->setState(CallState::None);
             break;
-        case app::call::CallState::Disconnecting:
+        }
+        case app::call::CallState::Disconnecting: {
             view->updateDuration(utils::translate(callAppStyle::strings::endingcall));
             view->setCallEndedLayout(false);
             break;
-        case app::call::CallState::None:
+        }
+        case app::call::CallState::None: {
             view->clearNavBar();
             break;
+        }
         }
     }
 
@@ -179,4 +190,19 @@ namespace app::call
     {
         model->setState(CallState::None);
     }
+
+    void CallWindowContract::Presenter::processCurrentRouting(const audio::Profile::Type &routingType)
+    {
+        if (routingType == audio::Profile::Type::RoutingLoudspeaker) {
+            getView()->setSpeakerIconState(gui::SpeakerIconState::SPEAKERON);
+        }
+        else {
+            getView()->setSpeakerIconState(gui::SpeakerIconState::SPEAKER);
+        }
+    }
+    void CallWindowContract::Presenter::clearModel()
+    {
+        model->clear();
+    }
+
 } // namespace app::call

--- a/module-apps/application-call/presenter/CallPresenter.hpp
+++ b/module-apps/application-call/presenter/CallPresenter.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -24,6 +24,8 @@ namespace app::call
             virtual void setActiveCallLayout()                                   = 0;
             virtual void setCallEndedLayout(bool delayedClose = true)            = 0;
             virtual void updateNumber(const UTF8 &text)                          = 0;
+            virtual gui::SpeakerIconState getSpeakerIconState()                  = 0;
+            virtual void setSpeakerIconState(const gui::SpeakerIconState &icon)  = 0;
 
             virtual ~View() noexcept = default;
         };
@@ -52,6 +54,10 @@ namespace app::call
             utils::PhoneNumber getPhoneNumber();
 
             void handleDelayedViewClose();
+
+            void processCurrentRouting(const audio::Profile::Type &routingType);
+            void attachCallbacks();
+            void clearModel();
 
           private:
             std::shared_ptr<app::call::AbstractCallModel> model;

--- a/module-apps/application-call/test/mock/CallPresenterMocks.hpp
+++ b/module-apps/application-call/test/mock/CallPresenterMocks.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -31,7 +31,7 @@ namespace app::call
         {
             layoutShowed = LayoutShowed::Active;
         };
-        ;
+
         void setCallEndedLayout(bool delayedClose = true) override
         {
             layoutShowed = LayoutShowed::Ended;
@@ -41,6 +41,12 @@ namespace app::call
         {
             number = text;
         };
+        gui::SpeakerIconState getSpeakerIconState() override
+        {
+            return gui::SpeakerIconState::SPEAKER;
+        }
+        void setSpeakerIconState(const gui::SpeakerIconState &icon) override
+        {}
 
         bool windowRefreshed = false;
 
@@ -85,7 +91,6 @@ namespace app::call
         {
             return callerId;
         };
-
         void hangUpCall() override
         {
             hangupCallCalled = true;

--- a/module-apps/application-call/windows/CallWindow.hpp
+++ b/module-apps/application-call/windows/CallWindow.hpp
@@ -26,8 +26,7 @@ namespace gui
         {
             return callDelayedStopTime;
         }
-
-        std::unique_ptr<app::call::CallWindowContract::Presenter> presenter;
+        app::call::CallWindowContract::Presenter &presenter;
 
       protected:
         // used to display both number and name of contact
@@ -44,11 +43,9 @@ namespace gui
 
         utils::PhoneNumber::View phoneNumber;
 
-        std::set<audio::EventType> devices_connected{};
-
       public:
-        CallWindow(app::ApplicationCommon *app,
-                   std::unique_ptr<app::call::CallWindowContract::Presenter> &&windowPresenter);
+        CallWindow(app::ApplicationCommon *app, app::call::CallWindowContract::Presenter &presenter);
+        ~CallWindow() noexcept override;
 
         bool onInput(const InputEvent &inputEvent) override;
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
@@ -69,8 +66,8 @@ namespace gui
         void setActiveCallLayout() override;
         void setCallEndedLayout(bool delayedClose = true) override;
         void updateNumber(const UTF8 &text) override;
-        void handleAudioEvent(const audio::Event &event);
-        void changeSpeakerIconIfNeeded();
+        gui::SpeakerIconState getSpeakerIconState() override;
+        void setSpeakerIconState(const gui::SpeakerIconState &icon) override;
     };
 
 } /* namespace gui */

--- a/module-audio/Audio/Audio.hpp
+++ b/module-audio/Audio/Audio.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -89,7 +89,7 @@ namespace audio
             if (audioSinkState.isConnected(EventType::JackState)) {
                 return Profile::Type::PlaybackHeadphones;
             }
-            if (audioSinkState.isConnected(EventType::BlutoothA2DPDeviceState)) {
+            if (audioSinkState.isConnected(EventType::BluetoothA2DPDeviceState)) {
                 return Profile::Type::PlaybackBluetoothA2DP;
             }
             return Profile::Type::PlaybackLoudspeaker;

--- a/module-audio/Audio/AudioCommon.hpp
+++ b/module-audio/Audio/AudioCommon.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -103,11 +103,11 @@ namespace audio
     enum class EventType
     {
         // HW state change notifications
-        JackState,               //!< Jack input plugged / unplugged event
-        MicrophoneState,         //!< Microphone presence in headset (3-pole w/o microphone or 4-pole with microphone)
-        BlutoothHSPDeviceState,  //!< BT device connected / disconnected event (Headset Profile)
-        BlutoothHFPDeviceState,  //!< BT device connected / disconnected event (Headset Profile)
-        BlutoothA2DPDeviceState, //!< BT device connected / disconnected event (Advanced Audio Distribution Profile)
+        JackState,                //!< Jack input plugged / unplugged event
+        MicrophoneState,          //!< Microphone presence in headset (3-pole w/o microphone or 4-pole with microphone)
+        BluetoothHSPDeviceState,  //!< BT device connected / disconnected event (Headset Profile)
+        BluetoothHFPDeviceState,  //!< BT device connected / disconnected event (Headset Profile)
+        BluetoothA2DPDeviceState, //!< BT device connected / disconnected event (Advanced Audio Distribution Profile)
 
         // call control
         CallMute,
@@ -116,7 +116,7 @@ namespace audio
         CallLoudspeakerOff,
     };
 
-    constexpr auto hwStateUpdateMaxEvent = magic_enum::enum_index(EventType::BlutoothA2DPDeviceState);
+    constexpr auto hwStateUpdateMaxEvent = magic_enum::enum_index(EventType::BluetoothA2DPDeviceState);
 
     class Event
     {

--- a/module-audio/Audio/Operation/PlaybackOperation.cpp
+++ b/module-audio/Audio/Operation/PlaybackOperation.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PlaybackOperation.hpp"
@@ -164,7 +164,7 @@ namespace audio
             SetProfileAvailability({Profile::Type::PlaybackHeadphones}, isAvailable);
             Operation::SwitchToPriorityProfile();
             break;
-        case EventType::BlutoothA2DPDeviceState:
+        case EventType::BluetoothA2DPDeviceState:
             SetProfileAvailability({Profile::Type::PlaybackBluetoothA2DP}, isAvailable);
             Operation::SwitchToPriorityProfile();
             break;

--- a/module-audio/Audio/Operation/RecorderOperation.cpp
+++ b/module-audio/Audio/Operation/RecorderOperation.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "RecorderOperation.hpp"
@@ -132,7 +132,7 @@ namespace audio
             SetProfileAvailability({Profile::Type::RecordingHeadphones}, isAvailable);
             SwitchToPriorityProfile();
             break;
-        case EventType::BlutoothHSPDeviceState:
+        case EventType::BluetoothHSPDeviceState:
             SetProfileAvailability({Profile::Type::RecordingBluetoothHSP}, isAvailable);
             SwitchToPriorityProfile();
             break;

--- a/module-audio/Audio/Operation/RouterOperation.cpp
+++ b/module-audio/Audio/Operation/RouterOperation.cpp
@@ -143,11 +143,11 @@ namespace audio
             setInputPathForHeadset(headsetHasMicrophone);
             SwitchToPriorityProfile();
         } break;
-        case EventType::BlutoothHSPDeviceState:
+        case EventType::BluetoothHSPDeviceState:
             SetProfileAvailability({Profile::Type::RoutingBluetoothHSP}, isAvailable);
             SwitchToPriorityProfile();
             break;
-        case EventType::BlutoothHFPDeviceState:
+        case EventType::BluetoothHFPDeviceState:
             SetProfileAvailability({Profile::Type::RoutingBluetoothHFP}, isAvailable);
             SwitchToPriorityProfile();
             break;

--- a/module-audio/Audio/test/unittest_audio.cpp
+++ b/module-audio/Audio/test/unittest_audio.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -524,14 +524,14 @@ SCENARIO("Profile playback priorities tests")
         WHEN("All audio devices are connected")
         {
             audio.setConnected(EventType::JackState);
-            audio.setConnected(EventType::BlutoothA2DPDeviceState);
+            audio.setConnected(EventType::BluetoothA2DPDeviceState);
             THEN("Headphones are prioritized")
             {
                 REQUIRE(audio.GetPriorityPlaybackProfile() == Profile::Type::PlaybackHeadphones);
             }
             AND_WHEN("Bluetooth is disconnected")
             {
-                audio.setDisconnected(EventType::BlutoothA2DPDeviceState);
+                audio.setDisconnected(EventType::BluetoothA2DPDeviceState);
                 THEN("Headphones are prioritized")
                 {
                     REQUIRE(audio.GetPriorityPlaybackProfile() == Profile::Type::PlaybackHeadphones);
@@ -548,7 +548,7 @@ SCENARIO("Profile playback priorities tests")
         }
         WHEN("Only bluetooth device is connected")
         {
-            audio.setConnected(EventType::BlutoothA2DPDeviceState);
+            audio.setConnected(EventType::BluetoothA2DPDeviceState);
             THEN("Bluetooth is prioritized")
             {
                 REQUIRE(audio.GetPriorityPlaybackProfile() == Profile::Type::PlaybackBluetoothA2DP);
@@ -598,7 +598,7 @@ SCENARIO("Router playback priorities tests")
         WHEN("All audio devices are connected, loudspeaker is off")
         {
             routerOperation.SendEvent(
-                std::make_shared<Event>(audio::EventType::BlutoothHSPDeviceState, Event::DeviceState::Connected));
+                std::make_shared<Event>(audio::EventType::BluetoothHSPDeviceState, Event::DeviceState::Connected));
             routerOperation.SendEvent(
                 std::make_shared<Event>(audio::EventType::JackState, Event::DeviceState::Connected));
             routerOperation.SendEvent(std::make_shared<Event>(audio::EventType::CallLoudspeakerOff));
@@ -641,7 +641,7 @@ SCENARIO("Router playback priorities tests")
         WHEN("Only bluetooth HSP is connected, loudspeaker is off")
         {
             routerOperation.SendEvent(
-                std::make_shared<Event>(audio::EventType::BlutoothHSPDeviceState, Event::DeviceState::Connected));
+                std::make_shared<Event>(audio::EventType::BluetoothHSPDeviceState, Event::DeviceState::Connected));
             routerOperation.SendEvent(std::make_shared<Event>(audio::EventType::CallLoudspeakerOff));
 
             THEN("Bluetooth HSP is prioritized")

--- a/module-bluetooth/Bluetooth/interface/profiles/A2DP/A2DP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/A2DP/A2DP.cpp
@@ -452,7 +452,7 @@ namespace bluetooth
 
             sourceQueue = xQueueCreate(5, sizeof(AudioData_t));
             if (sourceQueue != nullptr) {
-                sendAudioEvent(audio::EventType::BlutoothA2DPDeviceState, audio::Event::DeviceState::Connected);
+                sendAudioEvent(audio::EventType::BluetoothA2DPDeviceState, audio::Event::DeviceState::Connected);
             }
             else {
                 LOG_ERROR("failed to create queue!");
@@ -528,7 +528,7 @@ namespace bluetooth
                 cid,
                 AVRCP::mediaTracker.local_seid,
                 local_seid);
-            sendAudioEvent(audio::EventType::BlutoothA2DPDeviceState, audio::Event::DeviceState::Disconnected);
+            sendAudioEvent(audio::EventType::BluetoothA2DPDeviceState, audio::Event::DeviceState::Disconnected);
             if (cid == AVRCP::mediaTracker.a2dp_cid) {
                 AVRCP::mediaTracker.stream_opened = 0;
                 LOG_INFO("A2DP Source: Stream released");

--- a/module-bluetooth/Bluetooth/interface/profiles/HFP/HFP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/HFP/HFP.cpp
@@ -248,13 +248,13 @@ namespace bluetooth
             status = hfp_subevent_service_level_connection_established_get_status(event);
             if (status) {
                 LOG_DEBUG("Connection failed, status 0x%02x", status);
-                sendAudioEvent(audio::EventType::BlutoothHFPDeviceState, audio::Event::DeviceState::Disconnected);
+                sendAudioEvent(audio::EventType::BluetoothHFPDeviceState, audio::Event::DeviceState::Disconnected);
                 break;
             }
             aclHandle = hfp_subevent_service_level_connection_established_get_acl_handle(event);
             hfp_subevent_service_level_connection_established_get_bd_addr(event, device.address);
             LOG_DEBUG("Service level connection established to %s", bd_addr_to_str(device.address));
-            sendAudioEvent(audio::EventType::BlutoothHFPDeviceState, audio::Event::DeviceState::Connected);
+            sendAudioEvent(audio::EventType::BluetoothHFPDeviceState, audio::Event::DeviceState::Connected);
             {
                 auto &busProxy     = const_cast<sys::Service *>(ownerService)->bus;
                 device.deviceState = DeviceState::ConnectedVoice;
@@ -269,7 +269,7 @@ namespace bluetooth
         case HFP_SUBEVENT_SERVICE_LEVEL_CONNECTION_RELEASED:
             LOG_DEBUG("Service level connection released");
             aclHandle = HCI_CON_HANDLE_INVALID;
-            sendAudioEvent(audio::EventType::BlutoothHFPDeviceState, audio::Event::DeviceState::Disconnected);
+            sendAudioEvent(audio::EventType::BluetoothHFPDeviceState, audio::Event::DeviceState::Disconnected);
             {
                 auto &busProxy = const_cast<sys::Service *>(ownerService)->bus;
                 busProxy.sendUnicast(std::make_shared<message::bluetooth::DisconnectResult>(device),

--- a/module-bluetooth/Bluetooth/interface/profiles/HSP/HSP.cpp
+++ b/module-bluetooth/Bluetooth/interface/profiles/HSP/HSP.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <log/log.hpp>
@@ -158,12 +158,12 @@ namespace bluetooth
             if (hsp_subevent_rfcomm_connection_complete_get_status(event) != 0u) {
                 LOG_DEBUG("RFCOMM connection establishement failed with status %u\n",
                           hsp_subevent_rfcomm_connection_complete_get_status(event));
-                sendAudioEvent(audio::EventType::BlutoothHSPDeviceState, audio::Event::DeviceState::Disconnected);
+                sendAudioEvent(audio::EventType::BluetoothHSPDeviceState, audio::Event::DeviceState::Disconnected);
                 isConnected = false;
                 break;
             }
             LOG_DEBUG("RFCOMM connection established.\n");
-            sendAudioEvent(audio::EventType::BlutoothHSPDeviceState, audio::Event::DeviceState::Connected);
+            sendAudioEvent(audio::EventType::BluetoothHSPDeviceState, audio::Event::DeviceState::Connected);
             {
                 auto &busProxy     = const_cast<sys::Service *>(ownerService)->bus;
                 device.deviceState = DeviceState::ConnectedVoice;
@@ -174,7 +174,7 @@ namespace bluetooth
             break;
         case HSP_SUBEVENT_RFCOMM_DISCONNECTION_COMPLETE: {
             LOG_DEBUG("RFCOMM disconnected.\n");
-            sendAudioEvent(audio::EventType::BlutoothHSPDeviceState, audio::Event::DeviceState::Disconnected);
+            sendAudioEvent(audio::EventType::BluetoothHSPDeviceState, audio::Event::DeviceState::Disconnected);
             auto &busProxy = const_cast<sys::Service *>(ownerService)->bus;
             busProxy.sendUnicast(std::make_shared<message::bluetooth::DisconnectResult>(device),
                                  service::name::bluetooth);
@@ -200,7 +200,7 @@ namespace bluetooth
             LOG_DEBUG("Audio connection released.\n\n");
             scoHandle    = HCI_CON_HANDLE_INVALID;
             callAnswered = false;
-            sendAudioEvent(audio::EventType::BlutoothHSPDeviceState, audio::Event::DeviceState::Disconnected);
+            sendAudioEvent(audio::EventType::BluetoothHSPDeviceState, audio::Event::DeviceState::Disconnected);
             break;
         case HSP_SUBEVENT_MICROPHONE_GAIN_CHANGED:
             LOG_DEBUG("Received microphone gain change %d\n", hsp_subevent_microphone_gain_changed_get_gain(event));

--- a/module-services/service-audio/AudioServiceAPI.cpp
+++ b/module-services/service-audio/AudioServiceAPI.cpp
@@ -90,18 +90,16 @@ namespace AudioServiceAPI
         return serv->bus.sendUnicast(msg, service::name::audio);
     }
 
-    void SendEvent(sys::Service *serv, std::shared_ptr<audio::Event> evt)
+    bool SendEvent(sys::Service *serv, std::shared_ptr<audio::Event> evt)
     {
         auto msg = std::make_shared<AudioEventRequest>(std::move(evt));
-        serv->bus.sendMulticast(msg, sys::BusChannel::ServiceAudioNotifications);
-        // return true;
+        return serv->bus.sendUnicast(msg, service::name::audio);
     }
 
-    void SendEvent(sys::Service *serv, audio::EventType eType, audio::Event::DeviceState state)
+    bool SendEvent(sys::Service *serv, audio::EventType eType, audio::Event::DeviceState state)
     {
         auto msg = std::make_shared<AudioEventRequest>(eType, state);
-        serv->bus.sendMulticast(msg, sys::BusChannel::ServiceAudioNotifications);
-        // return true;
+        return serv->bus.sendUnicast(msg, service::name::audio);
     }
 
     std::string GetSetting(sys::Service *serv, audio::Setting setting, audio::PlaybackType playbackType)
@@ -251,4 +249,5 @@ namespace AudioServiceAPI
     {
         return serv->bus.sendUnicast(std::make_shared<HFPDeviceVolumeChanged>(volume), service::name::audio);
     }
+
 } // namespace AudioServiceAPI

--- a/module-services/service-audio/include/service-audio/AudioMessage.hpp
+++ b/module-services/service-audio/include/service-audio/AudioMessage.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -166,6 +166,14 @@ class AudioStartRoutingResponse : public AudioResponseMessage
     {}
 
     const audio::Token token;
+};
+
+class AudioRoutingNotification : public AudioMessage
+{
+  public:
+    AudioRoutingNotification(const audio::Profile::Type &profileType) : profileType(profileType)
+    {}
+    const audio::Profile::Type profileType;
 };
 
 class AudioStartRecorderRequest : public AudioMessage

--- a/module-services/service-audio/include/service-audio/AudioServiceAPI.hpp
+++ b/module-services/service-audio/include/service-audio/AudioServiceAPI.hpp
@@ -104,18 +104,22 @@ namespace AudioServiceAPI
      */
     bool Resume(sys::Service *serv, const audio::Token &token);
     /**
-     * @brief Sends audio event as multicast
+     * @brief Sends audio event.
      * @param serv Requesting service.
      * @param evt Event to be sent.
+     * @return True if request has been sent successfully, false otherwise
+     *   Response will come as message AudioSendEventResponse
      */
-    void SendEvent(sys::Service *serv, std::shared_ptr<audio::Event> evt);
+    bool SendEvent(sys::Service *serv, std::shared_ptr<audio::Event> evt);
     /**
-     * @brief Sends audio event as multicast
+     * @brief Sends audio event.
      * @param serv Requesting service.
      * @param evt Event to be sent.
      * @param state Optional parameter to request.
+     * @return True if request has been sent successfully, false otherwise
+     *   Response will come as message AudioSendEventResponse
      */
-    void SendEvent(sys::Service *serv,
+    bool SendEvent(sys::Service *serv,
                    audio::EventType evt,
                    audio::Event::DeviceState state = audio::Event::DeviceState::Connected);
 

--- a/module-services/service-audio/include/service-audio/ServiceAudio.hpp
+++ b/module-services/service-audio/include/service-audio/ServiceAudio.hpp
@@ -78,7 +78,7 @@ class ServiceAudio : public sys::Service
     };
 
     auto StopInput(audio::AudioMux::Input *input, StopReason stopReason = StopReason::Other) -> audio::RetCode;
-    auto HandleSendEvent(std::shared_ptr<audio::Event> evt) -> sys::MessagePointer;
+    auto HandleSendEvent(std::shared_ptr<audio::Event> evt) -> std::unique_ptr<AudioResponseMessage>;
     auto HandlePause(const audio::Token &token) -> std::unique_ptr<AudioResponseMessage>;
     auto HandlePause(std::optional<audio::AudioMux::Input *> input) -> std::unique_ptr<AudioResponseMessage>;
     auto HandleResume(const audio::Token &token) -> std::unique_ptr<AudioResponseMessage>;
@@ -127,6 +127,8 @@ class ServiceAudio : public sys::Service
     auto handleHFPVolumeChangedOnBluetoothDevice(sys::Message *msgl) -> sys::MessagePointer;
     auto handleMultimediaAudioPause() -> sys::MessagePointer;
     auto handleMultimediaAudioStart() -> sys::MessagePointer;
+
+    void notifyAboutNewRoutingIfRouterAvailable();
 };
 
 namespace sys

--- a/module-services/service-evtmgr/AppSettingsNotify.cpp
+++ b/module-services/service-evtmgr/AppSettingsNotify.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Service/BusProxy.hpp"
@@ -9,17 +9,17 @@ namespace evm::api
     void notifySettingsBluetoothAudio(sys::BusProxy &bus, std::shared_ptr<audio::Event> event)
     {
         switch (event->getType()) {
-        case audio::EventType::BlutoothA2DPDeviceState: {
+        case audio::EventType::BluetoothA2DPDeviceState: {
             auto message = std::make_shared<message::bluetooth::ProfileStatus>(
                 bluetooth::AudioProfile::A2DP, (event->getDeviceState() == audio::Event::DeviceState::Connected));
             bus.sendUnicast(message, app::name_settings);
         } break;
-        case audio::EventType::BlutoothHSPDeviceState: {
+        case audio::EventType::BluetoothHSPDeviceState: {
             auto message = std::make_shared<message::bluetooth::ProfileStatus>(
                 bluetooth::AudioProfile::HSP, (event->getDeviceState() == audio::Event::DeviceState::Connected));
             bus.sendUnicast(message, app::name_settings);
         } break;
-        case audio::EventType::BlutoothHFPDeviceState: {
+        case audio::EventType::BluetoothHFPDeviceState: {
             auto message = std::make_shared<message::bluetooth::ProfileStatus>(
                 bluetooth::AudioProfile::HFP, (event->getDeviceState() == audio::Event::DeviceState::Connected));
             bus.sendUnicast(message, app::name_settings);

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -72,7 +72,7 @@
 * Fixed (removed) redundant leading zero from time representation unless exactly midnight
 * Fixed inability to type characters other than digits in USSD replies
 * Fixed screen ghosting after emoji selection
-* Fixed incorrect loudspeaker icon in call window when headset was connected during a call
+* Fixed incorrect loudspeaker icon in call window when headset was connected or disconnected during a call
 * Fixed invalid screen displayed after missed call
 * Fixed minor issues in the Calculator Application
 * Fixed displaying usual SMS template call rejection window when no templates were defined


### PR DESCRIPTION
Fix for the loudspeaker becomes active again when a headset is unplugged if it was on while the headset was connected to the phone.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
