### PR TITLE
[MOS-902] Fix crash when entering message thread

### DIFF
--- a/module-apps/application-messages/widgets/SMSOutputWidget.cpp
+++ b/module-apps/application-messages/widgets/SMSOutputWidget.cpp
@@ -3,7 +3,6 @@
 
 #include "ApplicationMessages.hpp"
 #include "MessagesStyle.hpp"
-#include "OptionsMessages.hpp"
 #include "SMSOutputWidget.hpp"
 
 #include <OptionsWindow.hpp>
@@ -39,7 +38,6 @@ namespace gui
         switch (record->type) {
         case SMSType::QUEUED:
             // Handle in the same way as case below. (pending sending display as already sent)
-            [[fallthrough]];
         case SMSType::OUTBOX:
             smsBubble->setYaps(RectangleYap::TopRight);
             body->setReverseOrder(true);
@@ -66,8 +64,9 @@ namespace gui
             break;
         }
 
+        const auto timeLabelTextWidth = (timeLabel != nullptr) ? timeLabel->getTextNeedSpace() : 0;
         smsBubble->setMaximumSize(std::min(style::messages::smsOutput::sms_max_width,
-                                           style::listview::item_width_with_scroll - timeLabel->getTextNeedSpace()),
+                                           style::listview::item_width_with_scroll - timeLabelTextWidth),
                                   style::messages::smsOutput::sms_max_height);
         smsBubble->setText(record->body);
 
@@ -120,7 +119,7 @@ namespace gui
         if (timeLabel != nullptr) {
             timeLabel->setMinimumWidth(timeLabel->getTextNeedSpace());
             timeLabel->setMinimumHeight(style::messages::smsOutput::sms_label_high);
-            uint16_t timeLabelMargin = body->getWidth() - (smsBubble->getWidth() + timeLabel->getTextNeedSpace());
+            const auto timeLabelMargin = body->getWidth() - (smsBubble->getWidth() + timeLabel->getTextNeedSpace());
 
             if (body->getReverseOrder()) {
                 timeLabel->setMargins(Margins(0, 0, timeLabelMargin, 0));


### PR DESCRIPTION
Fix of the issue that entering messages
and trying to send SMS without SIM card
inserted (and in a few another cases
when sending resulted in failure)
phone would crash.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
