### PR TITLE
[MOS-879] Fixed misleding SMS flow

### DIFF
--- a/module-services/service-cellular/src/SMSSendHandler.hpp
+++ b/module-services/service-cellular/src/SMSSendHandler.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -58,7 +58,6 @@ namespace cellular::internal::sms
     {
       public:
         SMSSendHandler();
-
         /**
          * External action events
          */
@@ -66,6 +65,7 @@ namespace cellular::internal::sms
         void handleIncomingDbRecord(SMSRecord &record, bool onDelay);
         void handleNoMoreDbRecords();
         void sendMessageIfDelayed();
+        void requestNotSendMessage();
 
         /**
          * User defined callbacks/events
@@ -79,6 +79,8 @@ namespace cellular::internal::sms
         std::function<bool()> onGetOfflineMode;
         /// Called when SMSSendHandler wants to check SIM state
         std::function<bool()> onSIMNotInitialized;
+        /// Called when SMSHandler wants to check if modem is rebooting
+        std::function<bool()> onGetModemResetInProgress;
 
       private:
         void handleStateChange(OptionalState state);

--- a/module-services/service-cellular/tests/unittest_smssendhandler.cpp
+++ b/module-services/service-cellular/tests/unittest_smssendhandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -31,6 +31,8 @@ TEST_CASE("SMSSendHandler functionality")
     outSMS.onGetOfflineMode = []() -> bool { return false; };
 
     outSMS.onSIMNotInitialized = []() -> bool { return false; };
+
+    outSMS.onGetModemResetInProgress = []() -> bool { return false; };
 
     SECTION("Schedule standard send SMS procedure")
     {
@@ -87,7 +89,7 @@ TEST_CASE("SMSSendHandler functionality")
         outSMS.handleIncomingDbRecord(record, sendOnDelay);
 
         CHECK(wasOnSendInvoked == 0);
-        CHECK(wasOnSendQueryInvoked == 3);
+        CHECK(wasOnSendQueryInvoked == 2);
     }
 
     SECTION("Delayed send - positive flow")

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -76,6 +76,7 @@
 * Fixed minor issues in the Calculator Application
 * Fixed displaying usual SMS template call rejection window when no templates were defined
 * Fixed going back to wrong window after confirming or cancelling creation of new contact from call log
+* Fixed misleading popup on SMS send when modem is rebooting
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Fixed misleading SMS flow after sending error.
When modem was rebooting attempt to send SMS was causing Rejected by no sim popup, which was misleading for user.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [x] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
