### PR TITLE
[MOS-357] Broken navigation around contact adding

### DIFF
--- a/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
@@ -5,6 +5,7 @@
 
 #include "DialogMetadata.hpp"
 #include "application-phonebook/ApplicationPhonebook.hpp"
+#include <service-appmgr/Controller.hpp>
 
 #include <Dialog.hpp>
 #include <service-db/DBServiceAPI.hpp>
@@ -119,6 +120,16 @@ namespace gui
 
     auto PhonebookNewContact::onInput(const InputEvent &inputEvent) -> bool
     {
+        auto backToCallLogIfCameFromThere = [this]() {
+            // MOS-357: conditionally (@see ApplicationManagerCommon::handleSwitchBack) return to call log
+            return app::manager::Controller::switchBack(
+                application, std::make_unique<app::manager::SwitchBackRequest>("ApplicationCallLog"));
+        };
+
+        if (inputEvent.isShortRelease(gui::KeyCode::KEY_RF)) {
+            return backToCallLogIfCameFromThere();
+        }
+
         auto ret = AppWindow::onInput(inputEvent);
 
         setSaveButtonVisible(!newContactModel->emptyData());
@@ -132,7 +143,7 @@ namespace gui
             newContactModel->saveData(contact);
             verifyAndSave();
 
-            return true;
+            return backToCallLogIfCameFromThere();
         }
 
         return ret;

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -75,6 +75,7 @@
 * Fixed invalid screen displayed after missed call
 * Fixed minor issues in the Calculator Application
 * Fixed displaying usual SMS template call rejection window when no templates were defined
+* Fixed going back to wrong window after confirming or cancelling creation of new contact from call log
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
From now on, after cancelling or confirming a new contact creation initiated from the call log, the phone goes back to correct windows.


Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added