### PR TITLE
[MOS-205] Unneeded fs notify events

### DIFF
--- a/module-audio/tags_fetcher/TagsFetcher.cpp
+++ b/module-audio/tags_fetcher/TagsFetcher.cpp
@@ -20,7 +20,7 @@ namespace tags::fetcher
 
         std::optional<Tags> fetchTagsInternal(const std::string &filePath)
         {
-            const TagLib::FileRef tagReader(filePath.c_str());
+            const TagLib::ConstFileRef tagReader(filePath.c_str());
             const auto tags = tagReader.tag();
             if (!tagReader.isNull() && (tags != nullptr)) {
                 const auto properties = tagReader.audioProperties();
@@ -66,7 +66,7 @@ namespace tags::fetcher
 
             return {};
         }
-    }
+    } // namespace
 
     Tags fetchTags(const std::string &filePath)
     {


### PR DESCRIPTION
Fixed problem with fs notification events
being sent one time too many.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
