### PR TITLE
[MOS-28] Change alarm sounds and ringtones preview behavior

### DIFF
--- a/module-apps/application-alarm-clock/widgets/AlarmMusicOptionsItem.cpp
+++ b/module-apps/application-alarm-clock/widgets/AlarmMusicOptionsItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlarmMusicOptionsItem.hpp"
@@ -47,17 +47,13 @@ namespace gui
             if (player->isInState(SoundsPlayer::State::Playing) && event.isShortRelease(gui::KeyCode::KEY_RF)) {
                 player->stop();
             }
-            auto res = optionSpinner->onInput(event);
 
-            if (res && player->previouslyPlayed(getFilePath(optionSpinner->getCurrentValue())) &&
-                player->isInState(SoundsPlayer::State::Playing)) {
-                this->navBarTemporaryMode(utils::translate(style::strings::common::pause));
+            const auto actionHandled = optionSpinner->onInput(event);
+            if (actionHandled && player->isInState(SoundsPlayer::State::Playing)) {
+                player->play(getFilePath(optionSpinner->getCurrentValue()),
+                             [=]() { this->navBarTemporaryMode(utils::translate(style::strings::common::play)); });
             }
-            else if (res) {
-                this->navBarTemporaryMode(utils::translate(style::strings::common::play));
-            }
-
-            return res;
+            return actionHandled;
         };
 
         focusChangedCallback = [=](Item &item) {

--- a/module-apps/application-settings/windows/apps/SoundSelectWindow.cpp
+++ b/module-apps/application-settings/windows/apps/SoundSelectWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SoundSelectWindow.hpp"
@@ -39,6 +39,7 @@ namespace gui
                                             style::nav_bar::height + style::margins::small,
                                         mSoundsModel,
                                         listview::ScrollBarType::Proportional);
+        mSoundsList->setBoundaries(Boundaries::Continuous);
 
         setFocusItem(mSoundsList);
     }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -78,6 +78,7 @@
 * Fixed going back to wrong window after confirming or cancelling creation of new contact from call log
 * Fixed misleading popup on SMS send when modem is rebooting
 * Fixed window redirection when clicking SMS icon
+* Fixed navigation through the ringtone preview list to automatically switch playback to the currently selected option
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Change of the behavior of alarm sounds
and ringtones preview, so that it matches
the design.

Additionally fixed lack of ringtones list
looping.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
