### PR TITLE
[MOS-38] Fix window redirection when clicking on the SMS icon

### DIFF
--- a/module-apps/application-messages/include/application-messages/ApplicationMessages.hpp
+++ b/module-apps/application-messages/include/application-messages/ApplicationMessages.hpp
@@ -66,6 +66,9 @@ namespace app
 
         // used by sms template items
         std::function<bool(std::shared_ptr<SMSTemplateRecord> templ)> templatesCallback;
+
+      private:
+        ActionResult handleCreateSmsAction(std::unique_ptr<gui::SwitchData> data);
     };
 
     template <>

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -77,6 +77,7 @@
 * Fixed displaying usual SMS template call rejection window when no templates were defined
 * Fixed going back to wrong window after confirming or cancelling creation of new contact from call log
 * Fixed misleading popup on SMS send when modem is rebooting
+* Fixed window redirection when clicking SMS icon
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

After clicking the message icon on the "contact details" screen,
the user will be redirected to either the message thread with that person
or to the new message screen (only if thread does not exist yet
or has been deleted in the past)

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
