### PR TITLE
[MOS-663] Regression fix

### DIFF
--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -40,6 +40,7 @@ namespace gui
         setTitle(utils::translate("app_messages_templates"));
 
         navBar->setText(nav_bar::Side::Center, utils::translate(style::strings::common::use));
+        navBar->setActive(nav_bar::Side::Center, false);
         navBar->setText(nav_bar::Side::Right, utils::translate(style::strings::common::back));
 
         namespace style = style::messages::templates::list;
@@ -103,11 +104,11 @@ namespace gui
         preventsAutoLock = false;
         if (mode == ShowMode::GUI_SHOW_INIT) {
             list->rebuildList();
-            if (list->isEmpty()) {
-                list->setVisible(false);
-                navBar->setActive(nav_bar::Side::Center, false);
-                emptyListIcon->setVisible(true);
-            }
+        }
+
+        if (list->isEmpty()) {
+            navBar->setActive(nav_bar::Side::Center, false);
+            emptyListIcon->setVisible(true);
         }
 
         if (auto switchData = dynamic_cast<SMSTemplateRequest *>(data)) {


### PR DESCRIPTION
Fixed a regression that the SMS template list showed always the state representing no templates defined, regardless if there were any in the database.

There's a minor side effect that querying the database and refreshing the window is doubled which can be seen in debugging, but it's unnoticeable in usage.



Make sure that this PR:
- [x] Complies with our guidelines for contributions
- Has changelog entry added <--- _done previously alongside the original change which wasn't released publicly yet, so not needed for this regression fix_
