### PR TITLE
[MOS-905] Fix crash on power off with USB cable connected

### DIFF
--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -99,9 +99,7 @@ sys::MessagePointer EventManagerCommon::DataReceivedHandler(sys::DataMessage *ms
     if (handled) {
         return std::make_shared<sys::ResponseMessage>();
     }
-    else {
-        return std::make_shared<sys::ResponseMessage>(sys::ReturnCodes::Unresolved);
-    }
+    return std::make_shared<sys::ResponseMessage>(sys::ReturnCodes::Unresolved);
 }
 
 // Invoked during initialization
@@ -206,7 +204,6 @@ sys::ReturnCodes EventManagerCommon::DeinitHandler()
 
     EventWorker->close();
     EventWorker.reset();
-    EventWorker = nullptr;
 
     return sys::ReturnCodes::Success;
 }

--- a/module-services/service-evtmgr/backlight-handler/BacklightHandlerCommon.hpp
+++ b/module-services/service-evtmgr/backlight-handler/BacklightHandlerCommon.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/products/PurePhone/services/evtmgr/EventManager.cpp
+++ b/products/PurePhone/services/evtmgr/EventManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <evtmgr/EventManager.hpp>
@@ -130,7 +130,7 @@ void EventManager::toggleTorchColor()
 
 void EventManager::ProcessCloseReason([[maybe_unused]] sys::CloseReason closeReason)
 {
-    backlightHandler.turnOffScreenLight();
+    backlightHandler.deinit();
 }
 
 sys::MessagePointer EventManager::DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp)
@@ -170,7 +170,7 @@ void EventManager::handleKeyEvent(sys::Message *msg)
 {
     EventManagerCommon::handleKeyEvent(msg);
 
-    auto kbdMessage = dynamic_cast<sevm::KbdMessage *>(msg);
+    const auto kbdMessage = dynamic_cast<sevm::KbdMessage *>(msg);
     if (kbdMessage->key.state == RawKey::State::Pressed) {
         if (kbdMessage->key.keyCode == bsp::KeyCodes::FnRight) {
             // Power key notification

--- a/products/PurePhone/services/evtmgr/include/evtmgr/BacklightHandler.hpp
+++ b/products/PurePhone/services/evtmgr/include/evtmgr/BacklightHandler.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -24,6 +24,7 @@ namespace backlight
         Handler(std::shared_ptr<settings::Settings> settings, sys::Service *parent);
 
         void init() override;
+        void deinit();
         void turnOffScreenLight();
         void handleKeyPressed(bsp::KeyCodes key = bsp::KeyCodes::Undefined);
         /// Process request of the keypad light control
@@ -42,6 +43,7 @@ namespace backlight
         bsp::keypad_backlight::State keypadLightState = bsp::keypad_backlight::State::off;
         bool isKeypadLightInCallMode                  = false;
         bool isPhoneLocked                            = false;
+        bool isInitialized                            = false;
 
         void startKeypadLightTimer();
         void stopKeypadTimer();

--- a/products/PurePhone/services/evtmgr/screen-light-control/ScreenLightControl.cpp
+++ b/products/PurePhone/services/evtmgr/screen-light-control/ScreenLightControl.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ScreenLightControl.hpp"
@@ -87,7 +87,7 @@ namespace pure::screen_light_control
         return lightOn;
     }
 
-    bool ScreenLightController::isAutoModeOn() const noexcept
+    auto ScreenLightController::isAutoModeOn() const noexcept -> bool
     {
         return automaticMode == ScreenLightMode::Automatic;
     }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -79,6 +79,7 @@
 * Fixed misleading popup on SMS send when modem is rebooting
 * Fixed window redirection when clicking SMS icon
 * Fixed navigation through the ringtone preview list to automatically switch playback to the currently selected option
+* Fixed crash when pressing button after turning off the phone with USB cable connected
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Fix of the issue that turning off the phone and
clicking any keyboard button resulted in
crash and reboot.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
