### PR TITLE
[MOS-906] Fix missing tick mark in ringtones list

### DIFF
--- a/module-apps/application-settings/models/apps/SoundsModel.cpp
+++ b/module-apps/application-settings/models/apps/SoundsModel.cpp
@@ -97,7 +97,7 @@ void SoundsModel::applyItems(const std::vector<std::filesystem::path> &sounds,
     auto currentItemIndex  = 0;
     auto selectedItemIndex = 0;
 
-    const auto selectedSound = purefs::dir::getAssetsDirPath() / model->getSound();
+    const auto selectedSound = purefs::dir::getSystemDiskPath() / model->getSound();
     for (const auto &sound : sounds) {
 
         bool isSelected = false;

--- a/module-apps/application-settings/windows/apps/SoundSelectWindow.cpp
+++ b/module-apps/application-settings/windows/apps/SoundSelectWindow.cpp
@@ -4,7 +4,6 @@
 #include "SoundSelectWindow.hpp"
 
 #include <application-settings/data/SoundSelectData.hpp>
-#include <application-settings/models/apps/SoundsModel.hpp>
 
 #include <ListView.hpp>
 #include <i18n/i18n.hpp>
@@ -14,7 +13,7 @@ namespace gui
     SoundSelectWindow::SoundSelectWindow(app::ApplicationCommon *app,
                                          std::string name,
                                          std::shared_ptr<AbstractSoundsModel> model)
-        : AppWindow(app, name), mSoundsModel{std::move(model)}
+        : AppWindow(app, std::move(name)), mSoundsModel{std::move(model)}
     {
         buildInterface();
     }
@@ -51,7 +50,7 @@ namespace gui
 
     void SoundSelectWindow::onBeforeShow([[maybe_unused]] ShowMode mode, SwitchData *data)
     {
-        auto info = dynamic_cast<SoundSelectData *>(data);
+        const auto info = dynamic_cast<SoundSelectData *>(data);
         if (info == nullptr) {
             LOG_ERROR("Null switch data pointer!");
             return;


### PR DESCRIPTION
Fix of the missing tick mark that should appear
on the currently selected ringtone, but didn't.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
