### PR TITLE
[MOS-176] Fix long turn off time

### DIFF
--- a/module-bsp/board/rt1051/puretx/board.cpp
+++ b/module-bsp/board/rt1051/puretx/board.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "bsp.hpp"
@@ -8,7 +8,7 @@
 
 namespace
 {
-    void board_power_off()
+    void board_shutdown()
     {
         /// No memory allocation here as this specific GPIO was initialized at the startup. We are just grabbing here a
         /// reference to the already existing object.
@@ -32,7 +32,7 @@ namespace bsp
         case rebootState::none:
             break;
         case rebootState::poweroff:
-            board_power_off();
+            board_shutdown();
             break;
         case rebootState::reboot:
             board_reset();

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -81,6 +81,7 @@
 * Fixed navigation through the ringtone preview list to automatically switch playback to the currently selected option
 * Fixed crash when pressing button after turning off the phone with USB cable connected
 * Fixed notification on the home screen shouldn't be bolded
+* Fixed long phone shutdown time
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Fix of the issue that resulted in long
turn off time of the phone, which was
caused by unfortunate coincidence
of functions names - as a result the
one from the included header file was
called instead of the one from the
anonymous namespace inside the file,
what resulted in not cutting off
board power until the watchdog
triggered.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
