### PR TITLE
[MOS-878] Don't break audio playback on file deletion

### DIFF
--- a/module-audio/Audio/decoder/decoderCommon.hpp
+++ b/module-audio/Audio/decoder/decoderCommon.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <log/log.hpp>
+#include <sys/stat.h>
+#include <cerrno>
+#include <cstdio>
+
+namespace
+{
+    inline bool statFd(FILE *fd, char const *logMessage)
+    {
+        struct stat fdStats;
+        constexpr int statFailed = -1;
+        if (fstat(fileno(fd), &fdStats) != statFailed) {
+            return true;
+        }
+
+        auto originalErrno = errno;
+        LOG_WARN("%s", logMessage);
+        errno = originalErrno;
+        return false;
+    }
+} // namespace

--- a/module-audio/Audio/decoder/decoderFLAC.cpp
+++ b/module-audio/Audio/decoder/decoderFLAC.cpp
@@ -1,9 +1,10 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <Utils.hpp>
 #include "decoderFLAC.hpp"
 #include "flac/flacfile.h"
+#include "decoderCommon.hpp"
 
 #define DR_FLAC_IMPLEMENTATION
 #define DR_FLAC_NO_STDIO
@@ -76,7 +77,9 @@ namespace audio
     size_t decoderFLAC::drflac_read(void *pUserData, void *pBufferOut, size_t bytesToRead)
     {
         const auto decoderContext = reinterpret_cast<decoderFLAC *>(pUserData);
-        return std::fread(pBufferOut, 1, bytesToRead, decoderContext->fd);
+        return !statFd(decoderContext->fd, "FLAC audio file deleted by user!")
+                   ? 0
+                   : std::fread(pBufferOut, 1, bytesToRead, decoderContext->fd);
     }
 
     drflac_bool32 decoderFLAC::drflac_seek(void *pUserData, int offset, drflac_seek_origin origin)

--- a/module-audio/Audio/decoder/decoderMP3.cpp
+++ b/module-audio/Audio/decoder/decoderMP3.cpp
@@ -1,9 +1,10 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #define DR_MP3_IMPLEMENTATION
 #define DR_MP3_NO_STDIO
 
+#include "decoderCommon.hpp"
 #include "decoderMP3.hpp"
 #include <cstdio>
 
@@ -59,7 +60,9 @@ namespace audio
     size_t decoderMP3::drmp3_read(void *pUserData, void *pBufferOut, size_t bytesToRead)
     {
         const auto decoderContext = reinterpret_cast<decoderMP3 *>(pUserData);
-        return std::fread(pBufferOut, 1, bytesToRead, decoderContext->fd);
+        return !statFd(decoderContext->fd, "MP3 audio file deleted by user!")
+                   ? 0
+                   : std::fread(pBufferOut, 1, bytesToRead, decoderContext->fd);
     }
 
     drmp3_bool32 decoderMP3::drmp3_seek(void *pUserData, int offset, drmp3_seek_origin origin)

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -83,6 +83,7 @@
 * Fixed notification on the home screen shouldn't be bolded
 * Fixed long phone shutdown time
 * Fixed missing translation for words "show" and "replace"
+* Fixed music playback disablement after currently played audio file gets deleted
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Since a currently played file is deleted, the player goes to the next file from the list. A special case: if the deleted file is the last one, the playback stops (and can be resumed by the user).


Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added
