### PR TITLE
Revert "[MOS-357] Broken navigation around contact adding"

### DIFF
--- a/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
@@ -5,7 +5,6 @@
 
 #include "DialogMetadata.hpp"
 #include "application-phonebook/ApplicationPhonebook.hpp"
-#include <service-appmgr/Controller.hpp>
 
 #include <Dialog.hpp>
 #include <service-db/DBServiceAPI.hpp>
@@ -120,16 +119,6 @@ namespace gui
 
     auto PhonebookNewContact::onInput(const InputEvent &inputEvent) -> bool
     {
-        auto backToCallLogIfCameFromThere = [this]() {
-            // MOS-357: conditionally (@see ApplicationManagerCommon::handleSwitchBack) return to call log
-            return app::manager::Controller::switchBack(
-                application, std::make_unique<app::manager::SwitchBackRequest>("ApplicationCallLog"));
-        };
-
-        if (inputEvent.isShortRelease(gui::KeyCode::KEY_RF)) {
-            return backToCallLogIfCameFromThere();
-        }
-
         auto ret = AppWindow::onInput(inputEvent);
 
         setSaveButtonVisible(!newContactModel->emptyData());
@@ -143,7 +132,7 @@ namespace gui
             newContactModel->saveData(contact);
             verifyAndSave();
 
-            return backToCallLogIfCameFromThere();
+            return true;
         }
 
         return ret;

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -75,7 +75,6 @@
 * Fixed invalid screen displayed after missed call
 * Fixed minor issues in the Calculator Application
 * Fixed displaying usual SMS template call rejection window when no templates were defined
-* Fixed going back to wrong window after confirming or cancelling creation of new contact from call log
 * Fixed misleading popup on SMS send when modem is rebooting
 * Fixed window redirection when clicking SMS icon
 * Fixed navigation through the ringtone preview list to automatically switch playback to the currently selected option


### PR DESCRIPTION
Reverted due to a regression spotted that is de facto worse than the original problem. Needs reworking