### PR TITLE
[CP-1831] Editing contact which is deleted via Center can still be sa…

### DIFF
--- a/image/system_a/data/lang/Deutsch.json
+++ b/image/system_a/data/lang/Deutsch.json
@@ -591,6 +591,7 @@
   "app_phonebook_uncheck": "AUSWAHL ENTFERNEN",
   "app_phonebook_multiple_numbers_first": "Nummer",
   "app_phonebook_multiple_numbers_second": "Zweite nummer",
+  "app_phonebook_contact_deleted": "<text>Der Kontakt wurde gelöscht.<br></br>Die Bearbeitung ist nicht möglich.</text>",
   "app_meditation_title_main": "Meditationstimer",
   "app_meditation_preparation_time": "Vorbereitungstimer",
   "app_meditation_put_down_phone_and_wait": "<text>Legen Sie das Telefon weg<br>und warten Sie auf den Gong.</text>",

--- a/image/system_a/data/lang/English.json
+++ b/image/system_a/data/lang/English.json
@@ -556,6 +556,7 @@
   "app_phonebook_uncheck": "UNCHECK",
   "app_phonebook_multiple_numbers_first": "Number",
   "app_phonebook_multiple_numbers_second": "Second number",
+  "app_phonebook_contact_deleted": "<text>Contact has been deleted.<br></br>Editing is not possible.</text>",
   "app_meditation_title_main": "Meditation timer",
   "app_meditation_preparation_time": "Preparation time",
   "app_meditation_put_down_phone_and_wait": "<text>Put down the phone<br>and wait for the gong.</text>",

--- a/image/system_a/data/lang/Espanol.json
+++ b/image/system_a/data/lang/Espanol.json
@@ -592,6 +592,7 @@
   "app_phonebook_uncheck": "DESMARCAR",
   "app_phonebook_multiple_numbers_first": "Número",
   "app_phonebook_multiple_numbers_second": "Número alternativo",
+  "app_phonebook_contact_deleted": "<text>Se ha eliminado el contacto.<br></br>No es posible editar.</text>",
   "app_meditation_title_main": "Temporizador de meditación",
   "app_meditation_preparation_time": "Tiempo de preparación",
   "app_meditation_put_down_phone_and_wait": "<text>Deja a un lado el teléfono<br>y espera a que suene el gong.</text>",

--- a/image/system_a/data/lang/Francais.json
+++ b/image/system_a/data/lang/Francais.json
@@ -560,6 +560,7 @@
   "app_phonebook_uncheck": "DÉCOCHER",
   "app_phonebook_multiple_numbers_first": "Numéro",
   "app_phonebook_multiple_numbers_second": "Second numéro",
+  "app_phonebook_contact_deleted": "<text>Le contact a été supprimé.<br></br>La modification n'est pas possible.</text>",
   "app_meditation_title_main": "Minuterie de méditation",
   "app_meditation_preparation_time": "Temps de préparation",
   "app_meditation_put_down_phone_and_wait": "<text>Posez le téléphone<br>et attendez le son du gong.</text>",

--- a/image/system_a/data/lang/Polski.json
+++ b/image/system_a/data/lang/Polski.json
@@ -590,6 +590,7 @@
   "app_phonebook_uncheck": "ODZNACZ",
   "app_phonebook_multiple_numbers_first": "Numer",
   "app_phonebook_multiple_numbers_second": "Drugi numer",
+  "app_phonebook_contact_deleted": "<text>Kontakt został usunięty.<br></br>Brak możliwości edycji.</text>",
   "app_meditation_title_main": "Medytacja",
   "app_meditation_preparation_time": "Czas przygotowania",
   "app_meditation_put_down_phone_and_wait": "<text>Odłóż telefon<br>i zaczekaj na gong.</text>",

--- a/image/system_a/data/lang/Svenska.json
+++ b/image/system_a/data/lang/Svenska.json
@@ -496,6 +496,7 @@
   "app_phonebook_uncheck": "AVMARKERA",
   "app_phonebook_multiple_numbers_first": "Nummer",
   "app_phonebook_multiple_numbers_second": "Alternativnummer",
+  "app_phonebook_contact_deleted": "<text>Kontakten är raderad;<br></br>den kan inte redigeras.</text>",
   "app_meditation_title_main": "Meditationsklocka",
   "app_meditation_preparation_time": "Förbered dig",
   "app_meditation_put_down_phone_and_wait": "<text>Sätt ner telefonen<br>och vänta på klockslaget.</text>",

--- a/module-apps/application-phonebook/windows/PhonebookContactDetails.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookContactDetails.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhonebookContactDetails.hpp"

--- a/module-apps/application-phonebook/windows/PhonebookContactDetails.hpp
+++ b/module-apps/application-phonebook/windows/PhonebookContactDetails.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/module-apps/application-phonebook/windows/PhonebookNewContact.hpp
+++ b/module-apps/application-phonebook/windows/PhonebookNewContact.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -39,6 +39,8 @@ namespace gui
                                         const std::uint32_t duplicatedNumberContactID = 0u);
         void showDialogDuplicatedSpeedDialNumber();
         void setSaveButtonVisible(bool visible);
+        void showContactDeletedNotification();
+        bool checkIfContactWasDeletedDuringEditProcess() const;
 
         std::shared_ptr<ContactRecord> contact           = nullptr;
         std::shared_ptr<NewContactModel> newContactModel = nullptr;

--- a/module-db/queries/phonebook/QueryContactAdd.cpp
+++ b/module-db/queries/phonebook/QueryContactAdd.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "QueryContactAdd.hpp"
@@ -8,7 +8,7 @@
 
 using namespace db::query;
 
-ContactAdd::ContactAdd(const ContactRecord &rec) : Query(Query::Type::Read), rec(rec)
+ContactAdd::ContactAdd(const ContactRecord &rec) : Query(Query::Type::Create), rec(rec)
 {}
 
 ContactAddResult::ContactAddResult(bool result, unsigned int id, bool duplicated)

--- a/module-db/queries/phonebook/QueryContactRemove.cpp
+++ b/module-db/queries/phonebook/QueryContactRemove.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "QueryContactRemove.hpp"
@@ -7,7 +7,7 @@
 
 using namespace db::query;
 
-ContactRemove::ContactRemove(unsigned int id) : Query(Query::Type::Read), id(id)
+ContactRemove::ContactRemove(unsigned int id) : Query(Query::Type::Delete), id(id)
 {}
 
 ContactRemoveResult::ContactRemoveResult(bool result) : result(result)

--- a/module-db/queries/phonebook/QueryContactUpdate.cpp
+++ b/module-db/queries/phonebook/QueryContactUpdate.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "QueryContactUpdate.hpp"
@@ -8,7 +8,7 @@
 
 using namespace db::query;
 
-ContactUpdate::ContactUpdate(const ContactRecord &rec) : Query(Query::Type::Read), rec(std::move(rec))
+ContactUpdate::ContactUpdate(const ContactRecord &rec) : Query(Query::Type::Update), rec(std::move(rec))
 {}
 
 ContactUpdateResult::ContactUpdateResult(bool result) : result(result)

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -88,6 +88,8 @@
 * Fixed incorrectly displayed Swedish translations in Onboarding
 * Fixed going back to wrong window after confirming or cancelling creation of new contact from call log
 * Fixed missing "No calls yet" text in call log
+* Fixed phonebook is not handling database notification about contacts action done by Center
+* Fixed contact deleted via Center cannot be edited by Phonebook app and saved again
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
…ved but with incomplete data

Fix for editing contact when it was deleted via Center. Edited contact cannot be saved if it was deleted earlier. Proper communication is shown. Fix for phonebook app was not handling database notifications correctly.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
