### PR TITLE
[MOS-29] Fix invalid screen after rejecting with template

### DIFF
--- a/module-apps/application-call/model/CallModel.cpp
+++ b/module-apps/application-call/model/CallModel.cpp
@@ -34,7 +34,8 @@ namespace app::call
             LOG_INFO("Dropping call state change");
         }
 
-        if (callState == CallState::Incoming && newState == CallState::Ended && callWasRejected) {
+        if (((callState == CallState::Incoming) || (callState == CallState::Disconnecting)) &&
+            (newState == CallState::Ended) && callWasRejected) {
             callWasRejected = false;
             callState       = CallState::Rejected;
         }

--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -105,10 +105,8 @@ namespace gui
             list->rebuildList();
         }
 
-        if (list->isEmpty()) {
-            navBar->setActive(nav_bar::Side::Center, false);
-            emptyListIcon->setVisible(true);
-        }
+        navBar->setActive(nav_bar::Side::Center, !list->isEmpty());
+        emptyListIcon->setVisible(list->isEmpty());
 
         if (auto switchData = dynamic_cast<SMSTemplateRequest *>(data)) {
             smsTemplateRequestHandler(switchData);

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -91,6 +91,7 @@
 * Fixed phonebook is not handling database notification about contacts action done by Center
 * Fixed contact deleted via Center cannot be edited by Phonebook app and saved again
 * Fixed returning to call screen from message template
+* Fixed displaying wrong information on screen after rejecting call with SMS template
 
 ## [1.5.0 2022-12-20]
 


### PR DESCRIPTION
Fix of the issue that rejecting call with template 
resulted in displaying 'Call ended' screen, while
'Call rejected' screen should be displayed.

Fixed missing 'USE' label in templates
window.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
