### PR TITLE
[BH-1624] Fix shutdown procedure

### DIFF
--- a/module-services/service-gui/DrawCommandsQueue.hpp
+++ b/module-services/service-gui/DrawCommandsQueue.hpp
@@ -1,11 +1,10 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
-#include "SynchronizationMechanism.hpp"
-
 #include <gui/core/DrawCommand.hpp>
+#include <mutex.hpp>
 
 #include <cstdint>
 #include <list>
@@ -25,12 +24,11 @@ namespace service::gui
         };
         using QueueContainer = std::vector<QueueItem>;
 
-        explicit DrawCommandsQueue(
-            std::size_t expectedSize,
-            std::unique_ptr<SynchronizationMechanism> &&synchronization = getFreeRtosSynchronizationMechanism());
+        explicit DrawCommandsQueue(std::size_t expectedSize);
 
         void enqueue(QueueItem &&item);
-        [[nodiscard]] auto dequeue() -> QueueItem;
+        auto stop() -> void;
+        [[nodiscard]] auto dequeue() -> std::optional<QueueItem>;
         [[nodiscard]] auto getMaxRefreshModeAndClear() -> ::gui::RefreshModes;
         void clear();
         [[nodiscard]] auto size() const noexcept -> QueueContainer::size_type;
@@ -39,6 +37,5 @@ namespace service::gui
         QueueContainer queue;
 
         mutable cpp_freertos::MutexStandard queueMutex;
-        std::unique_ptr<SynchronizationMechanism> synchronization;
     };
 } // namespace service::gui

--- a/module-services/service-gui/tests/test-DrawCommandsQueue.cpp
+++ b/module-services/service-gui/tests/test-DrawCommandsQueue.cpp
@@ -1,10 +1,9 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
 
 #include "DrawCommandsQueue.hpp"
-#include "MockedSynchronizationMechanism.hpp"
 
 #include <chrono>
 #include <thread>
@@ -14,7 +13,7 @@ using namespace service::gui;
 TEST_CASE("DrawCommandsQueueTests")
 {
     constexpr auto ExpectedQueueSize = 4U;
-    DrawCommandsQueue queue{ExpectedQueueSize, std::make_unique<MockedSynchronizationMechanism>()};
+    DrawCommandsQueue queue{ExpectedQueueSize};
 
     SECTION("Enqueue")
     {
@@ -28,25 +27,25 @@ TEST_CASE("DrawCommandsQueueTests")
         REQUIRE(queue.size() == 1U);
 
         const auto item = queue.dequeue();
-        REQUIRE(item.commands.empty());
-        REQUIRE(item.refreshMode == ::gui::RefreshModes::GUI_REFRESH_FAST);
+        REQUIRE(item->commands.empty());
+        REQUIRE(item->refreshMode == ::gui::RefreshModes::GUI_REFRESH_FAST);
         REQUIRE(queue.size() == 0);
     }
 
     SECTION("Multi-thread dequeue")
     {
         std::thread thr{[&queue]() {
-            std::this_thread::sleep_for(std::chrono::milliseconds{100});
             queue.enqueue(DrawCommandsQueue::QueueItem{});
         }};
 
+        std::this_thread::sleep_for(std::chrono::milliseconds{100});
         const auto item = queue.dequeue();
         if (thr.joinable()) {
             thr.join();
         }
 
-        REQUIRE(item.commands.empty());
-        REQUIRE(item.refreshMode == ::gui::RefreshModes::GUI_REFRESH_FAST);
+        REQUIRE(item->commands.empty());
+        REQUIRE(item->refreshMode == ::gui::RefreshModes::GUI_REFRESH_FAST);
         REQUIRE(queue.size() == 0U);
     }
 

--- a/module-sys/Service/Worker.cpp
+++ b/module-sys/Service/Worker.cpp
@@ -206,8 +206,6 @@ namespace sys
     {
         assert(getState() == State::Initiated);
 
-        runnerTask = xTaskGetCurrentTaskHandle();
-
         BaseType_t task_error = 0;
         task_error            = xTaskCreate(
             Worker::taskAdapter, name.c_str(), stackDepth / sizeof(StackType_t), this, priority, &taskHandle);
@@ -222,12 +220,8 @@ namespace sys
 
     bool Worker::stop()
     {
-        if (runnerTask) {
-            assert(xTaskGetCurrentTaskHandle() == runnerTask);
-            assert(getState() == State::Running);
-            return sendControlMessage(ControlMessage::Stop);
-        }
-        return true;
+        assert(getState() == State::Running);
+        return sendControlMessage(ControlMessage::Stop);
     }
 
     bool Worker::sendControlMessage(ControlMessage message)
@@ -243,7 +237,6 @@ namespace sys
 
     bool Worker::send(uint32_t cmd, uint32_t *data)
     {
-        assert(xTaskGetCurrentTaskHandle() == runnerTask);
         assert(getState() == State::Running);
 
         WorkerCommand workerCommand{cmd, data};
@@ -275,15 +268,11 @@ namespace sys
 
     bool Worker::join(TickType_t timeout)
     {
-        if (runnerTask) {
-            assert(xTaskGetCurrentTaskHandle() == runnerTask);
-            assert(getState() == State::Running || getState() == State::Stopped);
-
-            if (xSemaphoreTake(joinSemaphore, timeout) != pdTRUE) {
-                return false;
-            }
-            while (eTaskGetState(taskHandle) != eDeleted) {}
+        assert(getState() == State::Running || getState() == State::Stopped);
+        if (xSemaphoreTake(joinSemaphore, timeout) != pdTRUE) {
+            return false;
         }
+        while (eTaskGetState(taskHandle) != eDeleted) {}
         return true;
     }
 

--- a/module-sys/Service/include/Service/Worker.hpp
+++ b/module-sys/Service/include/Service/Worker.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -108,7 +108,6 @@ namespace sys
         static constexpr auto controlQueueNamePrefix      = "wctrl";
 
         xSemaphoreHandle joinSemaphore = nullptr;
-        xTaskHandle runnerTask         = nullptr;
         xSemaphoreHandle stateMutex    = nullptr;
         xTaskHandle taskHandle         = nullptr;
 

--- a/module-utils/log/Logger.hpp
+++ b/module-utils/log/Logger.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -46,7 +46,7 @@ namespace Log
         auto log(logger_level level, const char *file, int line, const char *function, const char *fmt, va_list args)
             -> int;
         auto logAssert(const char *fmt, va_list args) -> int;
-        auto dumpToFile(std::filesystem::path logPath) -> int;
+        auto dumpToFile(std::filesystem::path logPath, bool isLoggerRunning = true) -> int;
         auto diagnosticDump() -> int;
         auto flushLogs() -> int;
 


### PR DESCRIPTION
In some cases, the system wasn't able to turn off
because the GUI service got stuck. The device
was still working in the background. The cause
was an empty queue in DrawCommandQueue which
hang the GUI worker.

The interface was modified and synchronization
the mechanism was removed.
The thread no longer waits in dequeue().

Also changed the worker to close in the right
the way the logger worker.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
