### PR TITLE
[BH-1630] Turn off the device for low voltage

### DIFF
--- a/module-bsp/board/linux/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/linux/hal/battery_charger/BatteryCharger.cpp
@@ -19,11 +19,11 @@ namespace hal::battery
         constexpr auto queueTimeoutTicks    = 100;
         constexpr auto taskDelay            = 50;
 
-        constexpr auto dummyBatteryVoltageLevel = 3700;
-
         constexpr auto chargerPlugStateChange = 'p';
         constexpr auto batteryLevelUp         = ']';
         constexpr auto batteryLevelDown       = '[';
+        constexpr auto batteryVoltageUp       = '=';
+        constexpr auto batteryVoltageDown     = '-';
         constexpr auto chargerTypeDcdSDP      = 'l';
         constexpr auto chargerTypeDcdCDP      = ';';
         constexpr auto chargerTypeDcdDCP      = '\'';
@@ -47,6 +47,7 @@ namespace hal::battery
         xQueueHandle notificationChannel = nullptr;
         TaskHandle_t batteryWorkerHandle = nullptr;
         unsigned batteryLevel            = 100;
+        unsigned batteryVoltageLevel     = 3700;
         bool isPlugged                   = false;
         bool shouldRun                   = true;
     };
@@ -76,7 +77,7 @@ namespace hal::battery
 
     std::optional<AbstractBatteryCharger::Voltage> BatteryCharger::getBatteryVoltage() const
     {
-        return dummyBatteryVoltageLevel;
+        return batteryVoltageLevel;
     }
 
     std::optional<AbstractBatteryCharger::SOC> BatteryCharger::getSOC() const
@@ -125,6 +126,14 @@ namespace hal::battery
                     break;
                 case batteryLevelDown:
                     batteryLevel--;
+                    evt = Events::SOC;
+                    break;
+                case batteryVoltageUp:
+                    batteryVoltageLevel += 10;
+                    evt = Events::SOC;
+                    break;
+                case batteryVoltageDown:
+                    batteryVoltageLevel -= 10;
                     evt = Events::SOC;
                     break;
                 case chargerTypeDcdSDP:

--- a/module-services/service-eink/board/linux/renderer/src/RWindow.cpp
+++ b/module-services/service-eink/board/linux/renderer/src/RWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "RWindow.hpp"
@@ -69,6 +69,8 @@ void RWindow::keyMapInit(void)
     batteryKeyMap.insert(std::pair<int8_t, uint32_t>('l', 3));
     batteryKeyMap.insert(std::pair<int8_t, uint32_t>(';', 4));
     batteryKeyMap.insert(std::pair<int8_t, uint32_t>('\'', 5));
+    batteryKeyMap.insert(std::pair<int8_t, uint32_t>('-', 6));
+    batteryKeyMap.insert(std::pair<int8_t, uint32_t>('=', 7));
 }
 void RWindow::updateDrawBuffer()
 {

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -193,11 +193,6 @@ sys::ReturnCodes EventManagerCommon::InitHandler()
 void EventManagerCommon::initProductEvents()
 {}
 
-auto EventManagerCommon::createEventWorker() -> std::unique_ptr<WorkerEventCommon>
-{
-    return std::make_unique<WorkerEventCommon>(this);
-}
-
 sys::ReturnCodes EventManagerCommon::DeinitHandler()
 {
     settings->deinit();

--- a/module-services/service-evtmgr/WorkerEventCommon.cpp
+++ b/module-services/service-evtmgr/WorkerEventCommon.cpp
@@ -112,7 +112,7 @@ bool WorkerEventCommon::initCommonHardwareComponents(EventManagerParams params)
     keyInput->init(queues[static_cast<int32_t>(WorkerEventQueues::queueKeyboardIRQ)]->GetQueueHandle());
     auto queueBatteryHandle = queues[static_cast<int32_t>(WorkerEventQueues::queueBatteryController)]->GetQueueHandle();
 
-    batteryController = std::make_shared<sevm::battery::BatteryController>(service, queueBatteryHandle, params.battery);
+    batteryController = std::make_shared<sevm::battery::BatteryController>(service, queueBatteryHandle, params);
     bsp::rtc::init(queues[static_cast<int32_t>(WorkerEventQueues::queueRTC)]->GetQueueHandle());
 
     time_t timestamp;

--- a/module-services/service-evtmgr/battery/BatteryBrownoutDetector.hpp
+++ b/module-services/service-evtmgr/battery/BatteryBrownoutDetector.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -6,8 +6,6 @@
 #include <hal/battery_charger/AbstractBatteryCharger.hpp>
 #include <Service/Service.hpp>
 #include <Timers/TimerHandle.hpp>
-
-#include <memory>
 
 namespace sys
 {
@@ -17,16 +15,40 @@ namespace sys
 class BatteryBrownoutDetector
 {
   public:
-    BatteryBrownoutDetector(sys::Service *service, hal::battery::AbstractBatteryCharger &charger);
-    void startDetection();
+    struct Thresholds
+    {
+        units::Voltage shutdown;
+        std::uint8_t measurementMaxCount;
+    };
+
+    enum class DetectionResult : std::uint8_t
+    {
+        eventDetected,
+        detectionNegative
+    };
+
+    using Callback = std::function<void(DetectionResult result)>;
+
+    BatteryBrownoutDetector(sys::Service *service,
+                            hal::battery::AbstractBatteryCharger &charger,
+                            Thresholds voltage,
+                            Callback callback);
+
+    void poll();
 
   private:
-    void checkBrownout();
-
-    sys::Service *parentService;
+    void tick();
+    bool isTimerExpired();
+    bool isVoltageThresholdExceeded();
+    void brownoutDetected();
+    void brownoutNotDetected();
+    void clearDetection();
+    void triggerDetection();
     hal::battery::AbstractBatteryCharger &charger;
 
-    bool detectionOngoing     = false;
-    unsigned measurementCount = 0;
+    bool eventDetectionOngoing        = false;
+    unsigned measurementBrownoutCount = 0;
+    Thresholds voltage;
+    Callback callback;
     sys::TimerHandle measurementTick;
 };

--- a/module-services/service-evtmgr/battery/BatteryController.hpp
+++ b/module-services/service-evtmgr/battery/BatteryController.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <hal/battery_charger/AbstractBatteryCharger.hpp>
+#include "EventManagerParams.hpp"
 #include "BatteryBrownoutDetector.hpp"
 #include "BatteryState.hpp"
 
@@ -20,16 +21,15 @@ namespace sevm::battery
       public:
         using Events          = hal::battery::AbstractBatteryCharger::Events;
         using ChargerPresence = hal::battery::AbstractBatteryCharger::ChargerPresence;
-        BatteryController(sys::Service *service, xQueueHandle notificationChannel, BatteryState::Thresholds thresholds);
-
-        void poll();
+        BatteryController(sys::Service *service, xQueueHandle notificationChannel, EventManagerParams params);
 
         /// Handler for incoming async notifications from the back-end
         void handleNotification(Events);
+        void poll();
 
       private:
         void update();
-        void updateSoC();
+        void updateSoc();
         void printCurrentState();
         void checkChargerPresence();
         units::Voltage getVoltage();

--- a/module-services/service-evtmgr/service-evtmgr/EventManagerCommon.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/EventManagerCommon.hpp
@@ -70,7 +70,7 @@ class EventManagerCommon : public sys::Service
     std::function<void(const time_t)> onMinuteTick;
     virtual void handleKeyEvent(sys::Message *msg);
     virtual void initProductEvents();
-    virtual auto createEventWorker() -> std::unique_ptr<WorkerEventCommon>;
+    virtual auto createEventWorker() -> std::unique_ptr<WorkerEventCommon> = 0;
 
     std::shared_ptr<settings::Settings> settings;
     std::unique_ptr<WorkerEventCommon> EventWorker;

--- a/module-services/service-evtmgr/service-evtmgr/WorkerEventCommon.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/WorkerEventCommon.hpp
@@ -44,7 +44,6 @@ class WorkerEventCommon : public sys::Worker
   protected:
     virtual void addProductQueues(std::list<sys::WorkerQueueInfo> &queueList);
     virtual void initProductHardware();
-
     virtual void processKeyEvent(bsp::KeyEvents event, bsp::KeyCodes code);
 
     sys::Service *service = nullptr;

--- a/module-services/service-evtmgr/service-evtmgr/include/EventManagerParams.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/include/EventManagerParams.hpp
@@ -3,9 +3,11 @@
 
 #pragma once
 
-#include <battery/BatteryController.hpp>
+#include <battery/BatteryState.hpp>
+#include <battery/BatteryBrownoutDetector.hpp>
 
 struct EventManagerParams
 {
     BatteryState::Thresholds battery;
+    BatteryBrownoutDetector::Thresholds voltage;
 };

--- a/module-utils/EventStore/EventStore.hpp
+++ b/module-utils/EventStore/EventStore.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/products/BellHybrid/services/evtmgr/EventManager.cpp
+++ b/products/BellHybrid/services/evtmgr/EventManager.cpp
@@ -40,7 +40,9 @@ namespace
 
 EventManager::EventManager(LogDumpFunction logDumpFunction, const std::string &name)
     : EventManagerCommon(logDumpFunction,
-                         {.battery{.critical = constants::criticalThreshold, .shutdown = constants::shutdownThreshold}},
+                         {.battery{.critical = constants::criticalThreshold, .shutdown = constants::shutdownThreshold},
+                          .voltage{.shutdown            = constants::shutdownVoltageThreshold,
+                                   .measurementMaxCount = constants::measurementThreshold}},
                          name),
       backlightHandler(settings, this), userActivityHandler(std::make_shared<sys::CpuSentinel>(name, this), this)
 {

--- a/products/BellHybrid/services/evtmgr/WorkerEvent.cpp
+++ b/products/BellHybrid/services/evtmgr/WorkerEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "WorkerEvent.hpp"

--- a/products/BellHybrid/services/evtmgr/WorkerEvent.hpp
+++ b/products/BellHybrid/services/evtmgr/WorkerEvent.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/products/BellHybrid/services/evtmgr/include/evtmgr/battery/Thresholds.hpp
+++ b/products/BellHybrid/services/evtmgr/include/evtmgr/battery/Thresholds.hpp
@@ -9,4 +9,7 @@ namespace constants
 {
     static constexpr units::Percent criticalThreshold = 1;
     static constexpr units::Percent shutdownThreshold = 1;
+
+    static constexpr units::Voltage shutdownVoltageThreshold = 3400;
+    static constexpr std::uint8_t measurementThreshold       = 0;
 } // namespace constants

--- a/products/PurePhone/services/evtmgr/WorkerEvent.cpp
+++ b/products/PurePhone/services/evtmgr/WorkerEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "WorkerEvent.hpp"

--- a/products/PurePhone/services/evtmgr/WorkerEvent.hpp
+++ b/products/PurePhone/services/evtmgr/WorkerEvent.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/products/PurePhone/services/evtmgr/include/evtmgr/EventManager.hpp
+++ b/products/PurePhone/services/evtmgr/include/evtmgr/EventManager.hpp
@@ -17,7 +17,9 @@ class EventManager : public EventManagerCommon
                           const std::string &name         = service::name::evt_manager)
         : EventManagerCommon(
               logDumpFunction,
-              {.battery{.critical = constants::criticalThreshold, .shutdown = constants::shutdownThreshold}},
+              {.battery{.critical = constants::criticalThreshold, .shutdown = constants::shutdownThreshold},
+               .voltage{.shutdown            = constants::shutdownVoltageThreshold,
+                        .measurementMaxCount = constants::measurementThreshold}},
               name),
           vibrator(std::make_unique<vibra_handle::Vibra>(this)), backlightHandler(settings, this),
           userActivityHandler(std::make_shared<sys::CpuSentinel>(name, this), this)

--- a/products/PurePhone/services/evtmgr/include/evtmgr/battery/Thresholds.hpp
+++ b/products/PurePhone/services/evtmgr/include/evtmgr/battery/Thresholds.hpp
@@ -9,4 +9,7 @@ namespace constants
 {
     static constexpr units::Percent criticalThreshold = 10;
     static constexpr units::Percent shutdownThreshold = 1;
+
+    static constexpr units::Voltage shutdownVoltageThreshold = 3600;
+    static constexpr std::uint8_t measurementThreshold       = 5;
 } // namespace constants


### PR DESCRIPTION
The system closes only if the SoC is 0%, but
it doesn't react if the voltage has a low level.
The new implementation invokes the close
procedure if the voltage is less than 3.4V.
This solution should avoid the possibility to
hang the MCU.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
