### PR TITLE
[BH-1640][BH-1645] Fix About and Factory Reset windows

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -7,6 +7,8 @@
 * Fixed the wrong front light on back action in alarms
 * Fixed the pause deactivation by a deep press in relaxation
 * Fixed canceling of alarm editing after 10s of inactivity
+* Fixed yes/no behavior in factory reset window
+* Fixed missing software version in French language
 
 ### Added
 

--- a/products/BellHybrid/apps/application-bell-settings/widgets/DialogYesNo.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/widgets/DialogYesNo.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "DialogYesNo.hpp"
@@ -15,7 +15,7 @@ using namespace gui;
 BellDialogYesNo::BellDialogYesNo(app::ApplicationCommon *app, const std::string &name)
     : BellShortOptionWindow(app, name)
 {
-    optionsList->setBoundaries(Boundaries::Continuous);
+    optionsList->setBoundaries(Boundaries::Fixed);
 
     statusBar->setVisible(false);
     header->setTitleVisibility(true);

--- a/products/BellHybrid/apps/application-bell-settings/windows/AboutYourBellWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/windows/AboutYourBellWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AboutYourBellWindow.hpp"
@@ -9,6 +9,11 @@
 
 namespace gui
 {
+    namespace
+    {
+        static constexpr auto top_margin = 41U;
+    }
+
     AboutYourBellWindow::AboutYourBellWindow(
         app::ApplicationCommon *app,
         std::shared_ptr<app::bell_settings::AboutYourBellWindowContract::Presenter> technicalPresenter)
@@ -29,8 +34,8 @@ namespace gui
         list = new ListView(this,
                             style::window::default_left_margin,
                             top_margin,
-                            width,
-                            height,
+                            style::window::default_body_width,
+                            style::window::default_body_height,
                             presenter->getPagesProvider(),
                             listview::ScrollBarType::Fixed);
         list->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));

--- a/products/BellHybrid/apps/application-bell-settings/windows/AboutYourBellWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-settings/windows/AboutYourBellWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -18,10 +18,6 @@ namespace gui
                             std::shared_ptr<app::bell_settings::AboutYourBellWindowContract::Presenter> presenter);
 
       private:
-        static constexpr auto height     = 400;
-        static constexpr auto width      = 380;
-        static constexpr auto top_margin = 41;
-
         void buildInterface() override;
         void onBeforeShow(gui::ShowMode mode, gui::SwitchData *data) override;
 


### PR DESCRIPTION
In the french language, the software version was missing. 
Now the About window is able to display even longer software versions.

Yes/No behavior in the Factory Reset window is
fixed. Earlier it worked in carousel mode.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
