### PR TITLE
[MOS-928] Fix pasting in new contact view fields

### DIFF
--- a/module-apps/application-phonebook/windows/PhonebookInputOptions.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookInputOptions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhonebookInputOptions.hpp"
@@ -15,7 +15,7 @@ namespace gui
 
     void PhonebookInputOptions::onBeforeShow(ShowMode mode, SwitchData *data)
     {
-        if (auto message = dynamic_cast<PhonebookInputOptionData *>(data)) {
+        if (const auto message = dynamic_cast<PhonebookInputOptionData *>(data)) {
             addOptions(inputOptionsList(message->getInputText()));
             optionsList->rebuildList();
         }
@@ -35,7 +35,10 @@ namespace gui
 
         if (Clipboard::getInstance().gotData()) {
             options.emplace_back(utils::translate("common_text_paste"), [=](gui::Item &item) {
-                text->addText(Clipboard::getInstance().paste(), AdditionType::perBlock);
+                /* Single line text ellipsis implementation doesn't properly support
+                 * text that consists of multiple blocks - use character addition
+                 * type, so that whole text is stored in one block. */
+                text->addText(Clipboard::getInstance().paste(), AdditionType::perChar);
                 application->returnToPreviousWindow();
                 return true;
             });

--- a/module-apps/application-phonebook/windows/PhonebookMainWindow.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookMainWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhonebookMainWindow.hpp"
@@ -87,8 +87,6 @@ namespace gui
 
     void PhonebookMainWindow::onBeforeShow(ShowMode mode, SwitchData *data)
     {
-        LOG_INFO("onBeforeShow");
-
         auto contactRequest = dynamic_cast<PhonebookSearchRequest *>(data);
         model->setRequested(contactRequest != nullptr);
         if (model->requestedSearch()) {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -68,6 +68,7 @@
 * Fixed wrong USSD flow when user closed USSD popup with back button
 * Fixed broken abbreviating of multiline text messages content in deletion window
 * Fixed misleading labels in the Phonebook application when using search engine
+* Fixed text pasting in new contact window when some text is already present there
 
 ## [1.6.0 2023-02-27]
 


### PR DESCRIPTION
Fix of the issue that pasting text into fields
in new contact view when there was already some
text present there resulted in improper
ellipsis placement and cursor misalignment.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
