### PR TITLE
[MOS-938] Allow Text control to scroll several lines at once

### DIFF
--- a/module-apps/application-onboarding/windows/EULALicenseWindow.cpp
+++ b/module-apps/application-onboarding/windows/EULALicenseWindow.cpp
@@ -52,6 +52,7 @@ namespace app::onBoarding
         eulaText->setPenWidth(::style::window::default_border_rect_no_focus);
         eulaText->setEditMode(gui::EditMode::Scroll);
         eulaText->setCursorStartPosition(gui::CursorStartPosition::DocumentBegin);
+        eulaText->setScrollLeap(4);
 
         navBar->setActive(gui::nav_bar::Side::Left, true);
 

--- a/module-gui/gui/widgets/text/Text.cpp
+++ b/module-gui/gui/widgets/text/Text.cpp
@@ -586,18 +586,26 @@ namespace gui
         }
 
         if (isMode(EditMode::Scroll) && textType == TextType::MultiLine) {
-
             debug_text("Text in scroll mode ignores left/right navigation");
             if (inputEvent.is(KeyCode::KEY_LEFT) || inputEvent.is(KeyCode::KEY_RIGHT)) {
                 return false;
             }
 
+            auto scroll_ = [this](auto activity) {
+                bool notAtEdge = true;
+                for (size_t ii = 0; ii < scrollLeap && notAtEdge; ++ii) {
+                    notAtEdge &= activity();
+                }
+                return notAtEdge;
+            };
+            auto cursor_ = static_cast<TextLinesCursor *>(cursor);
+
             if (inputEvent.is(KeyCode::KEY_DOWN)) {
-                return cursor->handleNextLine();
+                return scroll_(std::bind(&TextLinesCursor::displayNextLine, cursor_));
             }
 
             if (inputEvent.is(KeyCode::KEY_UP)) {
-                return cursor->handlePreviousLine();
+                return scroll_(std::bind(&TextLinesCursor::displayPreviousLine, cursor_));
             }
         }
 

--- a/module-gui/gui/widgets/text/Text.hpp
+++ b/module-gui/gui/widgets/text/Text.hpp
@@ -134,6 +134,14 @@ namespace gui
         void setTextLimitType(TextLimitType limitType, unsigned int val = 0);
         void clearTextLimits();
         void drawUnderline(bool val);
+        size_t getScrollLeap() const
+        {
+            return scrollLeap;
+        }
+        void setScrollLeap(size_t leap)
+        {
+            scrollLeap = leap;
+        }
 
         TextBackup backupText() const;
         void restoreFrom(const TextBackup &backup);
@@ -182,6 +190,7 @@ namespace gui
 
       private:
         gui::KeyInputMappedTranslation translator;
+        size_t scrollLeap = 1;
 
       public:
         /// Callback when text changed

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -20,6 +20,7 @@
 * Unified grey color tones used while displaying texts
 * Replaced English labels occuring in French translation with French ones
 * Added new field to deviceInfo endpoint
+* Made EULA window scroll by a few lines at once
 
 ### Fixed
 


### PR DESCRIPTION
Optional feature: the _Text_ control can be setup to do this; the default is line-by-line (as it had been before). Now this has been used to scroll the EULA window as it contains plenty of text.