### PR TITLE
[MOS-932] Fix unneeded deep refresh in empty list

### DIFF
--- a/module-gui/gui/widgets/ListViewEngine.cpp
+++ b/module-gui/gui/widgets/ListViewEngine.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ListViewEngine.hpp"
@@ -20,7 +20,7 @@ namespace gui
 
     void ListViewEngine::setElementsCount(unsigned int count)
     {
-        if (elementsCount != count || elementsCount == 0) {
+        if ((elementsCount != count) || (elementsCount == listview::nPos)) {
             onElementsCountChanged(count);
         }
     }

--- a/module-gui/gui/widgets/ListViewEngine.hpp
+++ b/module-gui/gui/widgets/ListViewEngine.hpp
@@ -10,7 +10,7 @@ namespace gui
 {
     namespace listview
     {
-        inline constexpr auto nPos = std::numeric_limits<unsigned int>::max();
+        inline constexpr auto nPos = std::numeric_limits<unsigned>::max();
 
         /// Possible List scrolling directions
         enum class Direction
@@ -59,24 +59,24 @@ namespace gui
 
     struct ListViewScrollSetupData
     {
-        const unsigned int storedStartIndex;
-        const unsigned int currentPage;
-        const unsigned int pagesCount;
+        const unsigned storedStartIndex;
+        const unsigned currentPage;
+        const unsigned pagesCount;
     };
 
     struct ListViewScrollUpdateData
     {
-        const unsigned int startIndex;
-        const unsigned int listPageSize;
-        const unsigned int elementsCount;
-        const unsigned int elementMinimalSpaceRequired;
+        const unsigned startIndex;
+        const unsigned listPageSize;
+        const unsigned elementsCount;
+        const unsigned elementMinimalSpaceRequired;
         const listview::Direction direction;
         const Boundaries boundaries;
     };
 
     class ListItemProvider;
 
-    using rebuildRequest = std::pair<listview::RebuildType, unsigned int>;
+    using rebuildRequest = std::pair<listview::RebuildType, unsigned>;
 
     class ListViewEngine
     {
@@ -85,15 +85,15 @@ namespace gui
         virtual ~ListViewEngine();
 
         /// First requested index from provider
-        unsigned int startIndex = 0;
+        unsigned startIndex = 0;
         void setStartIndex();
         /// Recalculating startIndex if list internal conditions (i.e. size has changed).
         void recalculateStartIndex();
         /// Calculate max items on page based on provided minimal item in axis size from provider.
         /// That method is used when full list render can be omitted.
-        unsigned int calculateMaxItemsOnPage();
+        unsigned calculateMaxItemsOnPage();
         /// Calculates request elements count to full next request page with small excess
-        unsigned int calculateLimit(listview::Direction value = listview::Direction::Bottom);
+        unsigned calculateLimit(listview::Direction value = listview::Direction::Bottom);
         /// Recalculate startIndex on body resize requests
         void recalculateOnBoxRequestedResize();
 
@@ -105,13 +105,13 @@ namespace gui
         void fillFirstPage();
 
         /// Stored index of focused element before new data request
-        unsigned int storedFocusIndex = listview::nPos;
-        [[nodiscard]] unsigned int getFocusItemIndex();
+        unsigned storedFocusIndex = listview::nPos;
+        [[nodiscard]] unsigned getFocusItemIndex();
 
         /// Total provider elements count
         unsigned int elementsCount = listview::nPos;
-        void setElementsCount(unsigned int count);
-        void onElementsCountChanged(unsigned int count);
+        void setElementsCount(unsigned count);
+        void onElementsCountChanged(unsigned count);
         bool shouldCallEmptyListCallbacks = false;
         void checkEmptyListCallbacks();
 
@@ -119,7 +119,7 @@ namespace gui
         std::shared_ptr<ListItemProvider> provider = nullptr;
 
         /// Count of elements displayed on current page
-        unsigned int currentPageSize = 0;
+        unsigned currentPageSize = 0;
         /// Flag indicating that page has been loaded
         bool pageLoaded = true;
         /// Handle focusing method
@@ -145,11 +145,11 @@ namespace gui
         /// Stored last executed rebuildRequest
         rebuildRequest lastRebuildRequest = {listview::RebuildType::Full, 0};
         /// Setup method for list rebuild request
-        void setup(listview::RebuildType rebuildType, unsigned int dataOffset = 0);
+        void setup(listview::RebuildType rebuildType, unsigned dataOffset = 0);
         void prepareFullRebuild();
-        void prepareOnOffsetRebuild(unsigned int dataOffset);
+        void prepareOnOffsetRebuild(unsigned dataOffset);
         void prepareInPlaceRebuild();
-        void prepareOnPageElementRebuild(unsigned int dataOffset);
+        void prepareOnPageElementRebuild(unsigned dataOffset);
 
         /// List boundaries types
         Boundaries boundaries = Boundaries::Fixed;
@@ -179,7 +179,7 @@ namespace gui
 
         /// send list rebuild request
         void rebuildList(listview::RebuildType rebuildType = listview::RebuildType::Full,
-                         unsigned int dataOffset           = 0,
+                         unsigned dataOffset               = 0,
                          bool forceRebuild                 = false);
         /// In case of elements count change there can be a need to resend request in case of having one async query for
         /// count and records.

--- a/module-gui/gui/widgets/ListViewEngine.hpp
+++ b/module-gui/gui/widgets/ListViewEngine.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -109,7 +109,7 @@ namespace gui
         [[nodiscard]] unsigned int getFocusItemIndex();
 
         /// Total provider elements count
-        unsigned int elementsCount = 0;
+        unsigned int elementsCount = listview::nPos;
         void setElementsCount(unsigned int count);
         void onElementsCountChanged(unsigned int count);
         bool shouldCallEmptyListCallbacks = false;

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -70,6 +70,7 @@
 * Fixed broken abbreviating of multiline text messages content in deletion window
 * Fixed misleading labels in the Phonebook application when using search engine
 * Fixed text pasting in new contact window when some text is already present there
+* Fixed unnecessary deep refresh when pressing up arrow in empty list view
 
 ## [1.6.0 2023-02-27]
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

Fix of the issue that pressing up arrow in
empty list (e.g. notes, messages, alarms)
resulted in unnecessary deep refresh of
the screen, as the content didn't change.

Additionally minor code cleanup in separate
commit.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
