### PR TITLE
[MOS-925] Fix redirection on BACK from sending message from Contact view

### DIFF
--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -113,9 +113,9 @@ namespace gui
         sendSmsIcon->activatedCallback = [=](gui::Item &item) {
             LOG_INFO("Send message template and reject the call");
             constexpr auto preventAutoLock = true;
-            auto msg                       = std::make_unique<SMSSendTemplateRequest>(
-                presenter.getPhoneNumber().getView(), preventAutoLock, application->GetName());
+            auto msg = std::make_unique<SMSSendTemplateRequest>(presenter.getPhoneNumber().getView(), preventAutoLock);
             msg->ignoreCurrentWindowOnStack = true;
+            msg->nameOfSenderApplication    = application->GetName();
             return app::manager::Controller::sendAction(application,
                                                         app::manager::actions::ShowSmsTemplates,
                                                         std::move(msg),

--- a/module-apps/application-messages/ApplicationMessages.cpp
+++ b/module-apps/application-messages/ApplicationMessages.cpp
@@ -452,6 +452,7 @@ namespace app
                 else {
                     auto switchData = std::make_unique<SMSThreadData>(std::make_unique<ThreadRecord>(thread));
                     switchData->ignoreCurrentWindowOnStack = true;
+                    switchData->nameOfSenderApplication    = capturedData->nameOfSenderApplication;
                     switchWindow(gui::name::window::thread_view, std::move(switchData));
                 }
 

--- a/module-apps/application-messages/data/SMSdata.hpp
+++ b/module-apps/application-messages/data/SMSdata.hpp
@@ -72,10 +72,8 @@ class SMSSendRequest : public SMSRequest
 class SMSSendTemplateRequest : public SMSRequest
 {
   public:
-    explicit SMSSendTemplateRequest(const utils::PhoneNumber::View &phoneNumber,
-                                    bool preventAutoLock                                = false,
-                                    std::optional<app::ApplicationName> nameOfSenderApp = std::nullopt)
-        : SMSRequest(phoneNumber), preventAutoLock(preventAutoLock), nameOfSenderApp(nameOfSenderApp)
+    explicit SMSSendTemplateRequest(const utils::PhoneNumber::View &phoneNumber, bool preventAutoLock = false)
+        : SMSRequest(phoneNumber), preventAutoLock(preventAutoLock)
     {}
     ~SMSSendTemplateRequest() override = default;
 
@@ -84,14 +82,8 @@ class SMSSendTemplateRequest : public SMSRequest
         return preventAutoLock;
     }
 
-    [[nodiscard]] auto getNameOfSenderApp() const -> std::optional<app::ApplicationName>
-    {
-        return nameOfSenderApp;
-    }
-
   private:
     bool preventAutoLock;
-    std::optional<app::ApplicationName> nameOfSenderApp;
 };
 
 class SMSTemplateSent : public gui::SwitchData

--- a/module-apps/application-messages/windows/NewMessage.hpp
+++ b/module-apps/application-messages/windows/NewMessage.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -15,7 +15,9 @@
 
 namespace gui
 {
-    class NewMessageWindow : public AppWindow, public app::AsyncCallbackReceiver
+    class NewMessageWindow : public AppWindow,
+                             public app::AsyncCallbackReceiver,
+                             public gui::InfoAboutPreviousAppWhereWeComeFrom
     {
       public:
         explicit NewMessageWindow(app::ApplicationCommon *app);

--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -113,20 +113,19 @@ namespace gui
         }
 
         if (auto switchData = dynamic_cast<SMSSendTemplateRequest *>(data); switchData != nullptr) {
-            ignoreWindowsOfThisAppOnSwitchBack = data->ignoreCurrentWindowOnStack;
-            appNameToSwitchBack                = switchData->getNameOfSenderApp();
+            saveInfoAboutPreviousAppForProperSwitchBack(data);
             smsSendTemplateRequestHandler(switchData);
         }
     }
 
     bool SMSTemplatesWindow::onInput(const InputEvent &inputEvent)
     {
-        if (!inputEvent.isShortRelease(KeyCode::KEY_RF) || !ignoreWindowsOfThisAppOnSwitchBack ||
-            !appNameToSwitchBack.has_value()) {
+        if (!inputEvent.isShortRelease(KeyCode::KEY_RF) || !shouldCurrentAppBeIgnoredOnSwitchBack()) {
             return AppWindow::onInput(inputEvent);
         }
 
         return app::manager::Controller::switchBack(
-            application, std::make_unique<app::manager::SwitchBackRequest>(appNameToSwitchBack.value(), nullptr, true));
+            application,
+            std::make_unique<app::manager::SwitchBackRequest>(nameOfPreviousApplication.value(), nullptr, true));
     }
 } /* namespace gui */

--- a/module-apps/application-messages/windows/SMSTemplatesWindow.hpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.hpp
@@ -14,13 +14,11 @@
 
 namespace gui
 {
-    class SMSTemplatesWindow : public AppWindow
+    class SMSTemplatesWindow : public AppWindow, public InfoAboutPreviousAppWhereWeComeFrom
     {
         std::shared_ptr<SMSTemplateModel> smsTemplateModel;
-        gui::ListView *list                                     = nullptr;
-        gui::Icon *emptyListIcon                                = nullptr;
-        bool ignoreWindowsOfThisAppOnSwitchBack                 = false;
-        std::optional<app::ApplicationName> appNameToSwitchBack = std::nullopt;
+        gui::ListView *list      = nullptr;
+        gui::Icon *emptyListIcon = nullptr;
 
         void smsSendTemplateRequestHandler(const SMSSendTemplateRequest *const switchData);
         void smsTemplateRequestHandler(const SMSTemplateRequest *const switchData);

--- a/module-apps/application-messages/windows/SMSThreadViewWindow.cpp
+++ b/module-apps/application-messages/windows/SMSThreadViewWindow.cpp
@@ -5,6 +5,7 @@
 #include "MessagesStyle.hpp"
 #include "SMSdata.hpp"
 #include "SMSThreadViewWindow.hpp"
+#include "service-appmgr/Controller.hpp"
 
 #include <log/log.hpp>
 #include <module-db/queries/notifications/QueryNotificationsDecrement.hpp>
@@ -65,6 +66,7 @@ namespace gui
     {
         if (auto pdata = dynamic_cast<SMSThreadData *>(data); pdata) {
             LOG_INFO("Thread data received: %" PRIu32, pdata->thread->ID);
+            saveInfoAboutPreviousAppForProperSwitchBack(data);
             requestContact(pdata->thread->numberID);
 
             // Mark thread as Read
@@ -102,6 +104,11 @@ namespace gui
         }
         if (inputEvent.isShortRelease(KeyCode::KEY_RF)) {
             onClose(CloseReason::WindowSwitch);
+            if (shouldCurrentAppBeIgnoredOnSwitchBack()) {
+                return app::manager::Controller::switchBack(application,
+                                                            std::make_unique<app::manager::SwitchBackRequest>(
+                                                                nameOfPreviousApplication.value(), nullptr, true));
+            }
         }
         return AppWindow::onInput(inputEvent);
     }

--- a/module-apps/application-messages/windows/SMSThreadViewWindow.hpp
+++ b/module-apps/application-messages/windows/SMSThreadViewWindow.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -14,7 +14,9 @@
 
 namespace gui
 {
-    class SMSThreadViewWindow : public AppWindow, public app::AsyncCallbackReceiver
+    class SMSThreadViewWindow : public AppWindow,
+                                public app::AsyncCallbackReceiver,
+                                public gui::InfoAboutPreviousAppWhereWeComeFrom
     {
       private:
         std::shared_ptr<SMSThreadModel> smsModel;

--- a/module-apps/application-phonebook/models/ContactDetailsModel.cpp
+++ b/module-apps/application-phonebook/models/ContactDetailsModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ContactDetailsModel.hpp"

--- a/module-apps/application-phonebook/widgets/InformationWidget.cpp
+++ b/module-apps/application-phonebook/widgets/InformationWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "InformationWidget.hpp"

--- a/module-apps/apps-common/widgets/ActiveIconFactory.cpp
+++ b/module-apps/apps-common/widgets/ActiveIconFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ActiveIconFactory.hpp"
@@ -45,6 +45,7 @@ auto ActiveIconFactory::makeSMSIcon(const utils::PhoneNumber::View &number) -> I
         [application = app, number](gui::Item &item) {
             auto data                        = std::make_unique<SMSSendRequest>(number, std::string{});
             data->ignoreCurrentWindowOnStack = true;
+            data->nameOfSenderApplication    = application->GetName();
             return app::manager::Controller::sendAction(application,
                                                         app::manager::actions::CreateSms,
                                                         std::move(data),

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -71,6 +71,7 @@
 * Fixed misleading labels in the Phonebook application when using search engine
 * Fixed text pasting in new contact window when some text is already present there
 * Fixed unnecessary deep refresh when pressing up arrow in empty list view
+* Fixed going back to Messages instead of Contacts in case message thread was previously opened from Contacts
 
 ## [1.6.0 2023-02-27]
 


### PR DESCRIPTION
Fix for inconsistent redirection to message threads list when pressing BACK from sending message from Contact view. Also proveded mechanizm to help switching back to previous App, when some App call window from another App.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
