### PR TITLE
[BH-1649] Reimplement I2C communication attempts

### DIFF
--- a/module-bsp/board/linux/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/linux/hal/battery_charger/BatteryCharger.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <hal/battery_charger/AbstractBatteryCharger.hpp>
@@ -36,7 +36,7 @@ namespace hal::battery
         explicit BatteryCharger(xQueueHandle irqQueueHandle);
         ~BatteryCharger();
 
-        Voltage getBatteryVoltage() const final;
+        std::optional<Voltage> getBatteryVoltage() const final;
         std::optional<SOC> getSOC() const final;
         ChargingStatus getChargingStatus() const final;
         ChargerPresence getChargerPresence() const final;
@@ -74,7 +74,7 @@ namespace hal::battery
         vTaskDelay(taskDelay * 2);
     }
 
-    AbstractBatteryCharger::Voltage BatteryCharger::getBatteryVoltage() const
+    std::optional<AbstractBatteryCharger::Voltage> BatteryCharger::getBatteryVoltage() const
     {
         return dummyBatteryVoltageLevel;
     }

--- a/module-bsp/board/rt1051/puretx/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/rt1051/puretx/hal/battery_charger/BatteryCharger.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BatteryChargerIRQ.hpp"
@@ -82,7 +82,7 @@ namespace hal::battery
         explicit PureBatteryCharger(xQueueHandle irqQueueHandle);
         ~PureBatteryCharger();
 
-        Voltage getBatteryVoltage() const final;
+        std::optional<Voltage> getBatteryVoltage() const final;
         std::optional<SOC> getSOC() const final;
         ChargingStatus getChargingStatus() const final;
         ChargerPresence getChargerPresence() const final;
@@ -151,7 +151,7 @@ namespace hal::battery
             break;
         }
     }
-    AbstractBatteryCharger::Voltage PureBatteryCharger::getBatteryVoltage() const
+    std::optional<AbstractBatteryCharger::Voltage> PureBatteryCharger::getBatteryVoltage() const
     {
         return bsp::battery_charger::getVoltageFilteredMeasurement();
     }

--- a/module-bsp/devices/power/CW2015.cpp
+++ b/module-bsp/devices/power/CW2015.cpp
@@ -317,34 +317,19 @@ namespace bsp::devices::power
 
     std::optional<std::uint8_t> CW2015::read(const std::uint8_t reg)
     {
-        constexpr std::uint8_t maxAttemps          = 5;
         const drivers::I2CAddress fuelGaugeAddress = {ADDRESS, reg, i2c_subaddr_size};
         std::uint8_t ret_val{};
-
-        for (std::uint8_t i = 0; i < maxAttemps; ++i) {
-            if (const auto result = i2c.Read(fuelGaugeAddress, &ret_val, i2c_subaddr_size);
-                result == i2c_subaddr_size) {
-                return ret_val;
-            }
-            i2c.ReInit();
-            LOG_INFO("Attempting to read I2C data: %d", i);
-            vTaskDelay(pdMS_TO_TICKS(i * 10));
+        if (const auto result = i2c.Read(fuelGaugeAddress, &ret_val, i2c_subaddr_size); result == i2c_subaddr_size) {
+            return ret_val;
         }
         return std::nullopt;
     }
 
     bool CW2015::write(const std::uint8_t reg, const std::uint8_t value)
     {
-        constexpr std::uint8_t maxAttemps          = 5;
         const drivers::I2CAddress fuelGaugeAddress = {ADDRESS, reg, i2c_subaddr_size};
-
-        for (std::uint8_t i = 0; i < maxAttemps; ++i) {
-            if (const auto result = i2c.Write(fuelGaugeAddress, &value, i2c_subaddr_size); result == i2c_subaddr_size) {
-                return true;
-            }
-            i2c.ReInit();
-            LOG_INFO("Attempting to write I2C data: %d", i);
-            vTaskDelay(pdMS_TO_TICKS(i * 10));
+        if (const auto result = i2c.Write(fuelGaugeAddress, &value, i2c_subaddr_size); result == i2c_subaddr_size) {
+            return true;
         }
         return false;
     }

--- a/module-bsp/hal/include/hal/battery_charger/AbstractBatteryCharger.hpp
+++ b/module-bsp/hal/include/hal/battery_charger/AbstractBatteryCharger.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -47,7 +47,7 @@ namespace hal::battery
 
         virtual ~AbstractBatteryCharger() = default;
 
-        virtual Voltage getBatteryVoltage() const          = 0;
+        virtual std::optional<Voltage> getBatteryVoltage() const = 0;
         virtual std::optional<SOC> getSOC() const          = 0;
         virtual ChargingStatus getChargingStatus() const   = 0;
         virtual ChargerPresence getChargerPresence() const = 0;

--- a/module-services/service-evtmgr/battery/BatteryController.cpp
+++ b/module-services/service-evtmgr/battery/BatteryController.cpp
@@ -95,7 +95,7 @@ BatteryController::BatteryController(sys::Service *service,
 
     LOG_INFO("Initial charger state:%s", magic_enum::enum_name(Store::Battery::get().state).data());
     LOG_INFO("Initial battery SOC:%d", Store::Battery::get().level);
-    LOG_INFO("Initial battery voltage:%" PRIu32 "mV", charger->getBatteryVoltage());
+    LOG_INFO("Initial battery voltage:%" PRIu32 "mV", getVoltage());
     LOG_INFO("Initial battery state:%s", magic_enum::enum_name(Store::Battery::get().levelState).data());
 }
 
@@ -125,7 +125,7 @@ void sevm::battery::BatteryController::printCurrentState()
     LOG_INFO("Charger state:%s Battery SOC %d voltage: %" PRIu32 "mV state: %s",
              magic_enum::enum_name(Store::Battery::get().state).data(),
              Store::Battery::get().level,
-             charger->getBatteryVoltage(),
+             getVoltage(),
              magic_enum::enum_name(Store::Battery::get().levelState).data());
 }
 void sevm::battery::BatteryController::update()
@@ -152,10 +152,20 @@ void sevm::battery::BatteryController::update()
 
 void sevm::battery::BatteryController::updateSoC()
 {
-    auto batteryLevel = charger->getSOC();
-    if (batteryLevel.has_value()) {
+    const auto batteryLevel = charger->getSOC();
+    if (batteryLevel) {
         Store::Battery::modify().level = batteryLevel.value();
     }
+}
+
+units::Voltage sevm::battery::BatteryController::getVoltage()
+{
+    const auto voltage = charger->getBatteryVoltage();
+    if (voltage) {
+        return *voltage;
+    }
+    LOG_ERROR("Can't get the voltage");
+    return 0;
 }
 
 void sevm::battery::BatteryController::checkChargerPresence()

--- a/module-services/service-evtmgr/battery/BatteryController.hpp
+++ b/module-services/service-evtmgr/battery/BatteryController.hpp
@@ -32,6 +32,7 @@ namespace sevm::battery
         void updateSoC();
         void printCurrentState();
         void checkChargerPresence();
+        units::Voltage getVoltage();
         sys::Service *service{nullptr};
         std::unique_ptr<hal::battery::AbstractBatteryCharger> charger;
         BatteryBrownoutDetector brownoutDetector;


### PR DESCRIPTION
The CW2015 driver should avoid any logic.
Thus I2C communication attempts were moved
to the BatteryCharger which is product specific.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
