### PR TITLE
[MOS-525] Fix BT autoconnect when another device is already connected

### DIFF
--- a/module-bluetooth/Bluetooth/btstack_config.h
+++ b/module-bluetooth/Bluetooth/btstack_config.h
@@ -38,14 +38,15 @@
 
 // BTstack configuration. buffers, sizes, ...
 #define HCI_INCOMING_PRE_BUFFER_SIZE 14 // sizeof benep heade, avoid memcpy
-//#define HCI_ACL_PAYLOAD_SIZE         (1691 + 4)
-#define HCI_ACL_PAYLOAD_SIZE         (1021+4)
+#define HCI_ACL_PAYLOAD_SIZE         (1691 + 4)
+//#define HCI_ACL_PAYLOAD_SIZE         (1021+4)
 
 #define ENABLE_GATT_CLIENT_PAIRING
 #define ENABLE_L2CAP_ENHANCED_RETRANSMISSION_MODE
 #define ENABLE_CC256X_BAUDRATE_CHANGE_FLOWCONTROL_BUG_WORKAROUND
 //#define HAVE_EMBEDDED_TIME_MS
 
+#define MAX_NR_HFP_CONNECTIONS 1
 //#define MAX_NR_HCI_CONNECTIONS                    4
 //#define MAX_NR_L2CAP_SERVICES                     5
 //#define MAX_NR_L2CAP_CHANNELS                     6

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -21,6 +21,7 @@
 * Replaced English labels occuring in French translation with French ones
 * Added new field to deviceInfo endpoint
 * Made EULA window scroll by a few lines at once
+* Updated Bluetooth stack
 
 ### Fixed
 
@@ -72,6 +73,7 @@
 * Fixed text pasting in new contact window when some text is already present there
 * Fixed unnecessary deep refresh when pressing up arrow in empty list view
 * Fixed going back to Messages instead of Contacts in case message thread was previously opened from Contacts
+* Fixed autoconnecting other BT devices when another one is already connected
 
 ## [1.6.0 2023-02-27]
 


### PR DESCRIPTION
Fixes an issue when another device is connected via HFP and a new device wants to connect

Updated BT stack to 1.5.5 version

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
