### PR TITLE
[CP-1848] Problems with displaying file names

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -10,6 +10,7 @@
 * Fixed canceling of alarm editing after 10s of inactivity
 * Fixed yes/no behavior in factory reset window
 * Fixed missing software version in French language
+* Fixed problems with displaying file names in Relaxation
 
 ### Added
 

--- a/products/BellHybrid/assets/assets_proprietary.json
+++ b/products/BellHybrid/assets/assets_proprietary.json
@@ -66,7 +66,7 @@
         },
         {
             "name": "./fonts/common/gt_pressura_light_46.mpf",
-            "ref": "10c74fcb09c2022325767cad735c0183b6f5393a",
+            "ref": "a68aa1b2a82e2f4f55739242a435132102eddf31",
             "output": "assets/fonts/gt_pressura/gt_pressura_light_46.mpf"
         },
         {


### PR DESCRIPTION
Added missing characters to font 'gt_pressura_light_46' used in Relaxation

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
