### PR TITLE
[MOS-202] Add meditation parameters to non-volatile memory

### DIFF
--- a/module-apps/application-meditation/data/Constants.hpp
+++ b/module-apps/application-meditation/data/Constants.hpp
@@ -16,8 +16,9 @@ namespace Constants
         constexpr std::array<minutes, 6> chimeIntervals{
             minutes{2}, minutes{5}, minutes{10}, minutes{15}, minutes{30}, minutes{0}};
 
-        constexpr int defaultMeditationDuration                = 15;
-        constexpr std::array<const int, 4> meditationDurations = {15, 30, 60, 90};
+        constexpr int defaultMeditationDuration = 15;
+        constexpr int minimalMeditationDuration = 1;
+        constexpr int maximalMeditationDuration = 99;
 
         using namespace std::chrono_literals;
         constexpr auto defaultPreparationTime{5s};

--- a/module-apps/application-meditation/widgets/TimerProperty.hpp
+++ b/module-apps/application-meditation/widgets/TimerProperty.hpp
@@ -16,9 +16,8 @@ namespace gui
     {
         class State
         {
-            static constexpr int counterMaxDigits             = 2;
-            static constexpr int minimalValue                 = 1;
-            static constexpr int maximalValue                 = 99;
+            static constexpr int counterMaxDigits               = 2;
+            static constexpr std::array<const int, 4> timeArray = {15, 30, 60, 90};
 
             bool resetValueOnNumeric = true;
             int timeInMinutes;


### PR DESCRIPTION
<!-- Please describe your pull request here -->

The meditation time entered from the keyboard will be remembered.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
