### PR TITLE
[MOS-944] Fixed handling USSD started by #

### DIFF
--- a/module-services/service-cellular/service-cellular/requests/UssdRequest.hpp
+++ b/module-services/service-cellular/service-cellular/requests/UssdRequest.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -10,7 +10,7 @@
 
 namespace cellular
 {
-    constexpr inline auto UssdRegex = "^[\\*].*[\\#]$";
+    constexpr inline auto UssdRegex = "^[\\*\\#].*[\\#]$";
 
     class UssdRequest : public Request
     {


### PR DESCRIPTION
Now call request begins with # character is dicoverd and handled as a USSD code.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [x] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
