### PR TITLE
[BH-1655] Fix memory leaks in clock faces and shortcuts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -115,6 +115,8 @@
             "jlinkscript": "${workspaceFolder}/evkbimxrt1050_sdram_init_T6.jlinkscript",
             "rtos": "FreeRTOS",
             "overrideLaunchCommands": [
+                "source tools/gdb_crash_extend.py",
+                "source tools/misc/puregdb/puregdb.py",
                 "monitor reset 0",
                 "monitor halt",
                 "monitor memU32 0x401BC000 = 128;",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -88,7 +88,10 @@
         "assert": "cpp",
         "narrow": "cpp",
         "util": "cpp",
-        "filesystem": "cpp"
+        "filesystem": "cpp",
+        "numbers": "cpp",
+        "semaphore": "cpp",
+        "byte": "cpp"
     },
     "favorites.sortDirection": "ASC",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -55,6 +55,7 @@
                 "bell",
                 "linux",
                 "Debug",
+                //"-DLINUX_ENABLE_SANITIZER=OFF",
                 "-G",
                 "Ninja"
             ],

--- a/module-apps/apps-common/widgets/spinners/ItemSpinner.hpp
+++ b/module-apps/apps-common/widgets/spinners/ItemSpinner.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -21,6 +21,7 @@ namespace gui
                              range range,
                              Boundaries boundaries   = Boundaries::Continuous,
                              Orientation orientation = Orientation::Vertical);
+        ~ItemSpinner();
 
         [[nodiscard]] value_type getCurrentValue() const noexcept;
         void setCurrentValue(value_type val);
@@ -67,6 +68,16 @@ namespace gui
         this->parent = parent;
         if (parent != nullptr) {
             parent->addWidget(this);
+        }
+    }
+
+    template <typename Container>
+    ItemSpinner<Container>::~ItemSpinner()
+    {
+        for (Item *layout : container) {
+            if (layout != currentLayout) {
+                delete layout;
+            }
         }
     }
 

--- a/module-apps/apps-common/widgets/spinners/Model.hpp
+++ b/module-apps/apps-common/widgets/spinners/Model.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -100,6 +100,16 @@ class Model
     [[nodiscard]] bool is_max() const
     {
         return std::next(it) == elements.end();
+    }
+
+    auto begin() const
+    {
+        return elements.begin();
+    }
+
+    auto end() const
+    {
+        return elements.end();
     }
 
   private:

--- a/module-bsp/board/rt1051/bsp/rtc/rtc.cpp
+++ b/module-bsp/board/rt1051/bsp/rtc/rtc.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "rtc_configuration.hpp"

--- a/module-os/memory/UserMemStatsLogger.hpp
+++ b/module-os/memory/UserMemStatsLogger.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <log/log.hpp>
+
+#include "usermem.h"
+
+struct UserMemStatsLogger
+{
+#if DEBUG_HEAP_ALLOCATIONS == 1
+    UserMemStatsLogger()
+    {
+        usermemResetStatistics();
+        freeHeapSize1 = usermemGetFreeHeapSize();
+    }
+
+    ~UserMemStatsLogger()
+    {
+        size_t freeHeapSize2      = usermemGetFreeHeapSize();
+        size_t allocationsCount   = usermemGetAllocationsCount();
+        size_t deallocationsCount = usermemGetDeallocationsCount();
+        size_t allocatedMin       = usermemGetAllocatedMin();
+        size_t allocatedMax       = usermemGetAllocatedMax();
+        size_t allocatedSum       = usermemGetAllocatedSum();
+        LOG_INFO("\nFree before: %zu\nFree after: %zu\n# allocations: %zu\n# deallocations: %zu\nSmallest block: %zu\nBiggest block: %zu\nAllocated: %zu",
+                 freeHeapSize1, freeHeapSize2, allocationsCount, deallocationsCount, allocatedMin, allocatedMax, allocatedSum);
+    }
+
+private:
+    size_t freeHeapSize1;
+#endif
+};

--- a/module-os/memory/usermem.h
+++ b/module-os/memory/usermem.h
@@ -24,6 +24,13 @@ size_t usermemGetFreeHeapSize(void);
 
 size_t usermemGetMinimumEverFreeHeapSize(void);
 
+void usermemResetStatistics(void);
+size_t usermemGetAllocationsCount(void);
+size_t usermemGetDeallocationsCount(void);
+size_t usermemGetAllocatedMin(void);
+size_t usermemGetAllocatedMax(void);
+size_t usermemGetAllocatedSum(void);
+
 void *userrealloc(void *pv, size_t xWantedSize);
 
 #ifdef __cplusplus

--- a/module-services/service-evtmgr/WorkerEventCommon.cpp
+++ b/module-services/service-evtmgr/WorkerEventCommon.cpp
@@ -25,6 +25,7 @@
 #include <optional>
 
 #include <log/log.hpp>
+#include <memory/usermem.h>
 
 WorkerEventCommon::WorkerEventCommon(sys::Service *service)
     : sys::Worker(service, stackDepthBytes),
@@ -33,6 +34,10 @@ WorkerEventCommon::WorkerEventCommon(sys::Service *service)
 
 bool WorkerEventCommon::handleMessage(uint32_t queueID)
 {
+#if DEBUG_HEAP_ALLOCATIONS == 1
+    LOG_INFO("Free space: %zu", usermemGetFreeHeapSize());
+#endif
+
     auto &queue = queues[queueID];
 
     // service queue

--- a/module-utils/log/api/log/debug.hpp
+++ b/module-utils/log/api/log/debug.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -13,6 +13,7 @@
 #define DEBUG_GUI_TEXT               0 /// show basic debug messages for gui::Text - warning this can be hard on cpu
 #define DEBUG_GUI_TEXT_LINES         0 /// show extended debug messages for gui::Text - lines building
 #define DEBUG_GUI_TEXT_CURSOR        0 /// show extended debug messages for gui::Text - cursor handling
+#define DEBUG_HEAP_ALLOCATIONS       0 /// gather heap allocations statictics
 #define DEBUG_INPUT_EVENTS           0 /// show input events prints in system
 #define DEBUG_MISSING_ASSETS         0 /// show debug concerning missing assets
 #define DEBUG_SCOPED_TIMINGS         0 /// show timings in measured functions

--- a/products/BellHybrid/BellHybridMain.cpp
+++ b/products/BellHybrid/BellHybridMain.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PlatformFactory.hpp"
@@ -104,10 +104,6 @@ int main()
             }
 
             Log::Logger::get().init(Log::Application{ApplicationName, GIT_REV, VERSION, GIT_BRANCH});
-            /// force initialization of PhonenumberUtil because of its stack usage
-            /// otherwise we would end up with an init race and PhonenumberUtil could
-            /// be initiated in a task with stack not big enough to handle it
-            i18n::phonenumbers::PhoneNumberUtil::GetInstance();
             return true;
         },
         [sysmgr]() {

--- a/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BellHomeScreenWindow.hpp"
@@ -52,6 +52,8 @@ namespace gui
     {
         if (currentLayout) {
             removeWidget(currentLayout->getLayout());
+            delete currentLayout;
+            currentLayout = nullptr;
         }
         currentLayout = layoutGenerator();
         addWidget(static_cast<BellBaseLayout *>(currentLayout->getLayout()));

--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutVerticalSimple.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutVerticalSimple.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "layouts/HomeScreenLayoutVerticalSimple.hpp"
@@ -35,4 +35,4 @@ namespace gui
         leftBox->resizeItems();
         rightBox->resizeItems();
     }
-}; // namespace gui
+} // namespace gui


### PR DESCRIPTION
Disable libphonenumber initialization since it is not used in Harmony but takes around 1.4MB of memory

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
