### PR TITLE
[MOS-960] Fixed SMS flow after failed try in Offline

### DIFF
--- a/module-services/service-cellular/src/SMSSendHandler.cpp
+++ b/module-services/service-cellular/src/SMSSendHandler.cpp
@@ -95,7 +95,7 @@ namespace cellular::internal::sms
             LOG_ERROR("Failed to send SMS");
             record->type = SMSType::FAILED;
             context.onSendQuery(db::Interface::Name::SMS, std::make_unique<db::query::SMSUpdate>(std::move(*record)));
-            return {};
+            return std::make_unique<IdleState>(context);
         }
 
         context.onSend(*record);


### PR DESCRIPTION
SMS handling is now fixed after attempt to send SMS in offline mode. After SMS was rejected by Offline mode, Pure was not able to send any message until device reboot.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
