### PR TITLE
[MOS-924] Fix redundant logs about CSQ reporting mode

### DIFF
--- a/module-services/service-cellular/src/CSQHandler.cpp
+++ b/module-services/service-cellular/src/CSQHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CSQHandler.hpp"
@@ -65,9 +65,9 @@ namespace cellular::service
 
     bool CSQHandler::switchToPermanentReportMode()
     {
-        LOG_INFO("Switch to permanent report mode.");
         if (onEnableCsqReporting != nullptr && onEnableCsqReporting()) {
             currentMode = CSQMode::PermanentReporting;
+            LOG_INFO("Switch to permanent report mode.");
             return true;
         }
 
@@ -80,9 +80,9 @@ namespace cellular::service
 
     bool CSQHandler::switchToHybridReportMode()
     {
-        LOG_INFO("Switch to hybrid report mode.");
         if (onEnableCsqReporting != nullptr && onEnableCsqReporting()) {
             currentMode = CSQMode::HybridReporting;
+            LOG_INFO("Switch to hybrid report mode.");
             return true;
         }
 
@@ -95,10 +95,10 @@ namespace cellular::service
 
     bool CSQHandler::switchToHybridPollMode()
     {
-        LOG_INFO("Too many signal strength updates, switch to hybrid poll mode.");
         if (onDisableCsqReporting != nullptr && onDisableCsqReporting()) {
             currentMode               = CSQMode::HybridPolling;
             switchToPollModeTimestamp = cpp_freertos::Ticks::TicksToMs(cpp_freertos::Ticks::GetTicks());
+            LOG_INFO("Too many signal strength updates, switch to hybrid poll mode.");
             return true;
         }
 

--- a/module-services/service-cellular/src/ServiceCellularPriv.cpp
+++ b/module-services/service-cellular/src/ServiceCellularPriv.cpp
@@ -528,6 +528,9 @@ namespace cellular::internal
         csqHandler->onInvalidCSQ = [this]() { AntennaServiceAPI::InvalidCSQNotification(owner); };
 
         csqHandler->onRetrySwitchMode = [this](service::CSQMode newMode) {
+            if (state->get() != State::ST::URCReady) {
+                return;
+            }
             switch (newMode) {
             case service::CSQMode::PermanentReporting:
                 owner->bus.sendUnicast(

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -77,6 +77,7 @@
 * Fixed going to Calls instead of Contacts after aborted or confirmed attempt to create contact from Calls
 * Fixed misleading "Nie" abbreviation for word "Niedziela" (Sunday) in new alarm window
 * Fixed automatic message pasting into content field in thread view after message forwarding
+* Fixed redundant logs about CSQ reporting mode
 
 ## [1.6.0 2023-02-27]
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

When the modem was turned off (e.g. due to a discharged battery), 
CSQ reporting mode logs caused logger buffer overflow.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
