### PR TITLE
[MOS-942] Fix access to contacts when onboarding in progress

### DIFF
--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -11,6 +11,7 @@
 #include <apps-common/messages/DialogMetadataMessage.hpp>
 #include <apps-common/windows/Dialog.hpp>
 #include <apps-common/windows/DialogMetadata.hpp>
+#include <apps-common/WindowsStack.hpp>
 #include <log/log.hpp>
 #include <module-apps/application-phonebook/data/PhonebookItemData.hpp>
 
@@ -21,6 +22,8 @@
 #include <time/time_conversion.hpp>
 #include <WindowsPopupFilter.hpp>
 #include <service-audio/AudioServiceAPI.hpp>
+#include <service-db/Settings.hpp>
+#include <service-db/agents/settings/SystemSettings.hpp>
 
 #include <cassert>
 #include <memory>
@@ -127,6 +130,14 @@ namespace app
             app::manager::Controller::switchBack(this);
             return true;
         }
+
+        // Onboarding app should not have access to main screen so if onboarding is in progress, we pop the main window
+        // from the stack
+        if (!utils::getNumericValue<bool>(
+                settings->getValue(settings::SystemProperties::onboardingDone, settings::SettingsScope::Global))) {
+            ApplicationCommon::popWindow(gui::name::window::main_window);
+        }
+
         returnToPreviousWindow();
         return true;
     }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -87,6 +87,7 @@
 * Fixed returning to call screen from message template
 * Fixed displaying wrong information on screen after rejecting call with SMS template
 * Fixed lack of contact search list update when returning to list after contact edition
+* Fixed access to contacts when onboarding is in progress
 
 ## [1.6.0 2023-02-27]
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

During onboarding, the user could add new contacts by entering the emergency call screen.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
