### PR TITLE
[BH-1650][BH-1651] Fix the frontlight settings

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -14,6 +14,8 @@
 * Fixed polish Meditation summary text
 * Fixed problems with copying files via Mudita Center to Relaxation
 * Fixed problem with long Relaxation loading when titles were too long
+* Fixed backlight behavior after returning to the main window
+* Fixed settings frontlight intensity in on demand mode
 
 ### Added
 

--- a/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PowerNapProgressPresenter.hpp"
@@ -89,7 +89,7 @@ namespace app::powernap
                                         ? screen_light_control::ScreenLightMode::Automatic
                                         : screen_light_control::ScreenLightMode::Manual);
             frontLightModel.setBrightness(frontLightModel.getBrightnessModel().getValue());
-            frontLightModel.setStatus(true);
+            frontLightModel.setBacklight(bell_settings::BacklightState::On);
         }
 
         const auto filePath = soundsRepository->titleToPath(

--- a/products/BellHybrid/apps/application-bell-settings/models/FrontlightListItemProvider.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/models/FrontlightListItemProvider.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "FrontlightListItemProvider.hpp"
@@ -22,7 +22,7 @@ namespace app::bell_settings
             model.getBrightnessModel(),
             utils::translate("app_bell_settings_frontlight_top_message"));
         brightness->set_on_value_change_cb([this](const auto val) {
-            model.setStatus(true);
+            model.setBacklight(BacklightState::On);
             model.setBrightness(val);
         });
         internalData.emplace_back(brightness);

--- a/products/BellHybrid/apps/application-bell-settings/presenter/FrontlightPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/presenter/FrontlightPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "FrontlightPresenter.hpp"
@@ -17,9 +17,7 @@ namespace app::bell_settings
     }
 
     FrontlightPresenter::~FrontlightPresenter()
-    {
-        revertUnsavedChanges();
-    }
+    {}
 
     auto FrontlightPresenter::getPagesProvider() const -> std::shared_ptr<gui::ListItemProvider>
     {
@@ -31,13 +29,23 @@ namespace app::bell_settings
         provider->clearData();
     }
 
-    void FrontlightPresenter::saveChanges()
+    void FrontlightPresenter::saveConfig()
     {
-        frontlightModel->setChangesSaved();
+        frontlightModel->saveConfig();
     }
 
-    void FrontlightPresenter::revertUnsavedChanges()
+    void FrontlightPresenter::revertConfig()
     {
-        frontlightModel->revertUnsavedChanges();
+        frontlightModel->revertConfig();
+    }
+
+    void FrontlightPresenter::setBacklight()
+    {
+        frontlightModel->setBacklight(BacklightState::On);
+    }
+
+    bool FrontlightPresenter::isConfigSaved()
+    {
+        return frontlightModel->isConfigSaved();
     }
 } // namespace app::bell_settings

--- a/products/BellHybrid/apps/application-bell-settings/presenter/FrontlightPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-settings/presenter/FrontlightPresenter.hpp
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -32,8 +32,10 @@ namespace app::bell_settings
         virtual ~AbstractFrontlightPresenter()                                          = default;
         virtual auto getPagesProvider() const -> std::shared_ptr<gui::ListItemProvider> = 0;
         virtual void eraseProviderData()                                                = 0;
-        virtual void saveChanges()                                                      = 0;
-        virtual void revertUnsavedChanges()                                             = 0;
+        virtual void saveConfig()                                                       = 0;
+        virtual void setBacklight()                                                     = 0;
+        virtual void revertConfig()                                                     = 0;
+        virtual bool isConfigSaved()                                                    = 0;
     };
 
     class FrontlightPresenter : public AbstractFrontlightPresenter
@@ -45,8 +47,10 @@ namespace app::bell_settings
 
         auto getPagesProvider() const -> std::shared_ptr<gui::ListItemProvider> override;
         void eraseProviderData() override;
-        void saveChanges() override;
-        void revertUnsavedChanges() override;
+        void saveConfig() override;
+        void setBacklight() override;
+        void revertConfig() override;
+        bool isConfigSaved() override;
 
       private:
         std::shared_ptr<FrontlightListItemProvider> provider;

--- a/products/BellHybrid/apps/application-bell-settings/presenter/alarm_settings/AlarmSettingsPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/presenter/alarm_settings/AlarmSettingsPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlarmSettingsPresenter.hpp"
@@ -32,13 +32,16 @@ namespace app::bell_settings
         };
 
         auto setBrightness = [this](const auto &brightness) {
-            this->frontlight->setStatus(true);
+            this->frontlight->setBacklight(BacklightState::On);
             this->frontlight->setBrightness(brightness);
         };
 
         this->provider->onFrontlightEnter  = setBrightness;
         this->provider->onFrontlightChange = setBrightness;
-        this->provider->onFrontlightExit   = [this]() { this->frontlight->revertUnsavedChanges(); };
+        this->provider->onFrontlightExit   = [this]() {
+            this->frontlight->revertConfig();
+            this->frontlight->setBacklight(BacklightState::On);
+        };
     }
 
     auto AlarmSettingsPresenter::saveData() -> void

--- a/products/BellHybrid/apps/application-bell-settings/presenter/alarm_settings/PrewakeUpPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/presenter/alarm_settings/PrewakeUpPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PrewakeUpPresenter.hpp"
@@ -37,13 +37,16 @@ namespace app::bell_settings
         };
 
         auto setBrightness = [this](const auto &brightness) {
-            this->frontlight->setStatus(true);
+            this->frontlight->setBacklight(BacklightState::On);
             this->frontlight->setBrightness(brightness);
         };
 
         this->provider->onFrontlightEnter  = setBrightness;
         this->provider->onFrontlightChange = setBrightness;
-        this->provider->onFrontlightExit   = [this]() { this->frontlight->revertUnsavedChanges(); };
+        this->provider->onFrontlightExit   = [this]() {
+            this->frontlight->revertConfig();
+            this->frontlight->setBacklight(BacklightState::On);
+        };
     }
 
     auto PrewakeUpWindowPresenter::saveData() -> void

--- a/products/BellHybrid/apps/application-bell-settings/windows/BellSettingsFrontlightWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/windows/BellSettingsFrontlightWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "application-bell-settings/ApplicationBellSettings.hpp"
@@ -56,14 +56,15 @@ namespace gui
         }
 
         if (inputEvent.isShortRelease(KeyCode::KEY_RF)) {
-            presenter->revertUnsavedChanges();
+            presenter->revertConfig();
+            presenter->setBacklight();
         }
 
         return AppWindow::onInput(inputEvent);
     }
     void BellSettingsFrontlightWindow::exit()
     {
-        presenter->saveChanges();
+        presenter->saveConfig();
         application->switchWindow(
             window::bell_finished::defaultName,
             BellFinishedWindowData::Factory::create("circle_success_big", window::name::bellSettings));
@@ -71,6 +72,9 @@ namespace gui
     void BellSettingsFrontlightWindow::onClose(Window::CloseReason reason)
     {
         if (reason != CloseReason::Popup) {
+            if (!presenter->isConfigSaved()) {
+                presenter->revertConfig();
+            }
             presenter->eraseProviderData();
         }
     }

--- a/products/BellHybrid/apps/common/include/common/models/FrontlightModel.hpp
+++ b/products/BellHybrid/apps/common/include/common/models/FrontlightModel.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -15,15 +15,22 @@ namespace app
 
 namespace app::bell_settings
 {
+    enum class BacklightState
+    {
+        On,
+        Off
+    };
+
     class AbstractFrontlightModel
     {
       public:
         virtual ~AbstractFrontlightModel()                               = default;
         virtual void setBrightness(frontlight_utils::Brightness value)   = 0;
         virtual void setMode(screen_light_control::ScreenLightMode mode) = 0;
-        virtual void setStatus(bool onOff)                               = 0;
-        virtual void revertUnsavedChanges()                              = 0;
-        virtual void setChangesSaved()                                   = 0;
+        virtual void setBacklight(BacklightState state)                  = 0;
+        virtual void revertConfig()                                      = 0;
+        virtual void saveConfig()                                        = 0;
+        virtual bool isConfigSaved()                                     = 0;
 
         virtual gui::AbstractSettingsModel<std::uint8_t> &getBrightnessModel() = 0;
         virtual gui::AbstractSettingsModel<UTF8> &getModeModel()               = 0;
@@ -41,9 +48,10 @@ namespace app::bell_settings
 
         void setBrightness(frontlight_utils::Brightness value) override;
         void setMode(screen_light_control::ScreenLightMode mode) override;
-        void setStatus(bool onOff) override;
-        void revertUnsavedChanges() override;
-        void setChangesSaved() override;
+        void setBacklight(BacklightState state) override;
+        void revertConfig() override;
+        void saveConfig() override;
+        bool isConfigSaved() override;
 
       private:
         template <typename ValueT>
@@ -70,7 +78,7 @@ namespace app::bell_settings
         std::unique_ptr<BrightnessAdapter> brightnessAdapter;
         std::unique_ptr<ModeAdapter> modeAdapter;
         ApplicationCommon *app{};
-        bool hasUnsavedChanges{false};
+        bool configSaved{false};
         const std::string autoStr;
         const std::string onDemandStr;
     };


### PR DESCRIPTION
Run the frontlight settings in "on demand" mode now turn on the backlight with the proper intensity.
If the device is idle in the frontlight settings the backlight isn't turned on after backing to the main window.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
