### PR TITLE
[MOS-969] Unify GUI action after contact adding

### DIFF
--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -11,7 +11,7 @@
 * Added new field to deviceInfo endpoint
 * Made EULA window scroll by a few lines at once
 * Updated Bluetooth stack
-
+* Unified GUI flow for adding contact with number already present in another contact
 
 ### Fixed
 


### PR DESCRIPTION
Fix of the issue that after adding new contact
a window with contact details was shown, whereas
after adding new contact with the same number
as the one already present in another contact,
a list of all contacts was shown.
Minor cleanup.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
