### PR TITLE
[CP-1842] Extremely long title tag causes delay when loading Relaxati…

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -13,6 +13,7 @@
 * Fixed problems with displaying file names in Relaxation
 * Fixed polish Meditation summary text
 * Fixed problems with copying files via Mudita Center to Relaxation
+* Fixed problem with long Relaxation loading when titles were too long
 
 ### Added
 

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationMainWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationMainWindow.cpp
@@ -8,6 +8,11 @@
 #include <common/options/OptionBellMenu.hpp>
 #include <i18n/i18n.hpp>
 
+namespace
+{
+    constexpr auto maxDisplayedTitleLength = 30U;
+}
+
 namespace gui
 {
     RelaxationMainWindow::RelaxationMainWindow(
@@ -25,7 +30,7 @@ namespace gui
         std::list<gui::Option> menuOptionList;
         auto addRecord = [&](const db::multimedia_files::MultimediaFilesRecord &sound) {
             menuOptionList.emplace_back(std::make_unique<gui::option::OptionBellMenu>(
-                sound.tags.title,
+                sound.tags.title.substr(0, maxDisplayedTitleLength),
                 [=](gui::Item &item) {
                     onActivated(sound);
                     return true;


### PR DESCRIPTION
…on songs list

Fixed by limiting the maximum text length in relaxation main window

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
