### PR TITLE
[CP-1837] Random crashes while copying files

### DIFF
--- a/module-audio/tags_fetcher/TagsFetcher.cpp
+++ b/module-audio/tags_fetcher/TagsFetcher.cpp
@@ -20,7 +20,7 @@ namespace tags::fetcher
 
         std::optional<Tags> fetchTagsInternal(const std::string &filePath)
         {
-            const TagLib::ConstFileRef tagReader(filePath.c_str());
+            const TagLib::ConstMemoryConstrainedFileRef tagReader(filePath.c_str(), TAGSFETCHER_MAX_TAG_SIZE);
             const auto tags = tagReader.tag();
             if (!tagReader.isNull() && (tags != nullptr)) {
                 const auto properties = tagReader.audioProperties();

--- a/products/BellHybrid/CMakeLists.txt
+++ b/products/BellHybrid/CMakeLists.txt
@@ -176,3 +176,5 @@ add_subdirectory(paths)
 option(CONFIG_ENABLE_TEMP "Enable displaying temperature" OFF)
 option(CONFIG_SHOW_MEMORY_INFO "Enable displaying memory info" OFF)
 configure_file(config/ProductConfig.in.hpp ${CMAKE_BINARY_DIR}/ProductConfig.hpp  @ONLY)
+
+target_compile_definitions(tagsfetcher PRIVATE TAGSFETCHER_MAX_TAG_SIZE=204800)

--- a/products/PurePhone/CMakeLists.txt
+++ b/products/PurePhone/CMakeLists.txt
@@ -196,3 +196,5 @@ add_subdirectory(sys)
 if (${ENABLE_TESTS})
     add_subdirectory(test)
 endif ()
+
+target_compile_definitions(tagsfetcher PRIVATE TAGSFETCHER_MAX_TAG_SIZE=SIZE_MAX)


### PR DESCRIPTION
Use ConstMemoryConstrainedFileRef newly added to taglib

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
