### PR TITLE
[BH-1672] Add logging of eMMC parameters

### DIFF
--- a/module-bsp/board/rt1051/bsp/eMMC/fsl_mmc.c
+++ b/module-bsp/board/rt1051/bsp/eMMC/fsl_mmc.c
@@ -1621,20 +1621,21 @@ static void MMC_DecodeCid(mmc_card_t *card, uint32_t *rawCid)
 
     cid                 = &(card->cid);
     cid->manufacturerID = (uint8_t)((rawCid[3U] & 0xFF000000U) >> 24U);
-    cid->applicationID  = (uint16_t)((rawCid[3U] & 0xFFFF00U) >> 8U);
+    cid->applicationID  = (uint16_t)((rawCid[3U] & 0x00FFFF00U) >> 8U);
 
-    cid->productName[0U] = (uint8_t)((rawCid[3U] & 0xFFU));
+    cid->productName[0U] = (uint8_t)((rawCid[3U] & 0x000000FFU));
     cid->productName[1U] = (uint8_t)((rawCid[2U] & 0xFF000000U) >> 24U);
-    cid->productName[2U] = (uint8_t)((rawCid[2U] & 0xFF0000U) >> 16U);
-    cid->productName[3U] = (uint8_t)((rawCid[2U] & 0xFF00U) >> 8U);
-    cid->productName[4U] = (uint8_t)((rawCid[2U] & 0xFFU));
+    cid->productName[2U] = (uint8_t)((rawCid[2U] & 0x00FF0000U) >> 16U);
+    cid->productName[3U] = (uint8_t)((rawCid[2U] & 0x0000FF00U) >> 8U);
+    cid->productName[4U] = (uint8_t)((rawCid[2U] & 0x000000FFU));
+    cid->productName[5U] = (uint8_t)((rawCid[1U] & 0xFF000000U) >> 24U);
 
-    cid->productVersion = (uint8_t)((rawCid[1U] & 0xFF000000U) >> 24U);
+    cid->productVersion = (uint8_t)((rawCid[1U] & 0x00FF0000U) >> 16U);
 
-    cid->productSerialNumber = (uint32_t)((rawCid[1U] & 0xFFFFFFU) << 8U);
-    cid->productSerialNumber |= (uint32_t)((rawCid[0U] & 0xFF000000U) >> 24U);
+    cid->productSerialNumber = (uint32_t)((rawCid[1U] & 0x0000FFFFU) << 16U);
+    cid->productSerialNumber |= (uint32_t)((rawCid[0U] & 0xFFFF0000U) >> 16U);
 
-    cid->manufacturerData = (uint16_t)((rawCid[0U] & 0xFFF00U) >> 8U);
+    cid->manufacturerData = (uint8_t)((rawCid[0U] & 0x0000FF00U) >> 8U);
 }
 
 static status_t MMC_AllSendCid(mmc_card_t *card)

--- a/module-platform/rt1051/src/disk_emmc.hpp
+++ b/module-platform/rt1051/src/disk_emmc.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -8,6 +8,7 @@
 #include <mutex.hpp>
 #include <memory>
 #include <atomic>
+#include <map>
 
 #if !defined(TARGET_RT1051)
 static_assert(false, "Unsupported target.");
@@ -20,6 +21,20 @@ namespace purefs::blkdev
     class disk_emmc final : public disk
     {
       public:
+        struct disk_emmc_info
+        {
+            std::string manufacturer;
+            std::uint32_t blocksCount;
+            std::uint32_t blockSize;
+            std::uint64_t capacity;
+            std::string name;
+            std::uint8_t versionMajor;
+            std::uint8_t versionMinor;
+            std::uint32_t serialNumber;
+            std::uint8_t productionMonth;
+            std::uint16_t productionYear;
+        };
+
         static constexpr auto statusBlkDevSuccess = 0;
         static constexpr auto statusBlkDevFail    = -1;
 
@@ -35,11 +50,13 @@ namespace purefs::blkdev
         auto get_info(info_type what, hwpart_t hwpart) const -> scount_t override;
         auto pm_control(pm_state target_state) -> int override;
         auto pm_read(pm_state &current_state) -> int override;
+        auto get_emmc_info() const -> disk_emmc_info;
+        auto get_emmc_info_str() const -> std::string;
 
       private:
         auto switch_partition(hwpart_t newpart) -> int;
+        auto get_emmc_manufacturer() const -> std::string;
 
-      private:
         int initStatus;
         pm_state pmState{pm_state::active};
         mutable cpp_freertos::MutexRecursive mutex;
@@ -47,5 +64,9 @@ namespace purefs::blkdev
 
         std::unique_ptr<_mmc_card> mmcCard;
         std::shared_ptr<drivers::DriverUSDHC> driverUSDHC;
+
+        /* Read from datasheets */
+        const std::map<std::uint8_t, std::string> mmcManufacturersMap{
+            {0x15, "Samsung"}, {0x70, "Kingston"}, {0xF4, "Biwin"}};
     };
 } // namespace purefs::blkdev


### PR DESCRIPTION
Added logging of eMMC storage card
parameters so that it's easy to
determine what chip is installed
in the device the logs are from.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
