### PR TITLE
[CP-1942] Re-adding the same file results in an increase in the amoun…

### DIFF
--- a/module-services/service-desktop/endpoints/filesystem/FileContext.cpp
+++ b/module-services/service-desktop/endpoints/filesystem/FileContext.cpp
@@ -35,7 +35,7 @@ FileWriteContext::FileWriteContext(const std::filesystem::path &path,
                                    std::string crc32Digest,
                                    std::size_t offset)
     : FileContext(path, size, chunkSize, offset), crc32Digest(std::move(crc32Digest)),
-      file(path, std::ios::binary | std::ios::app)
+      file(path, std::ios::binary | std::ios::out)
 {}
 
 FileWriteContext::~FileWriteContext()


### PR DESCRIPTION
…t of occupied space

Fixed problem with adding files with the same name resulting in increasing its size instead of replacing the file. USB Stack changes.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
