### PR TITLE
[MOS-981] Fix crash on phone turn off

### DIFF
--- a/module-bsp/board/rt1051/bsp/magnetometer/magnetometer.cpp
+++ b/module-bsp/board/rt1051/bsp/magnetometer/magnetometer.cpp
@@ -88,6 +88,10 @@ namespace bsp::magnetometer
 
         bool i2cRead(std::uint8_t regAddr, als31300::whole_reg_t &wholeReg)
         {
+            if (i2c == nullptr) {
+                return false;
+            }
+
             i2cAddress.subAddress = regAddr;
             if (i2c->Read(i2cAddress, i2cBuffer.buf, sizeof(als31300::whole_reg_t)) != sizeof(als31300::whole_reg_t)) {
                 return false;
@@ -99,6 +103,10 @@ namespace bsp::magnetometer
 
         bool i2cWrite(std::uint8_t regAddr, const als31300::whole_reg_t wholeReg)
         {
+            if (i2c == nullptr) {
+                return false;
+            }
+
             i2cAddress.subAddress = regAddr;
             i2cBuffer.whole_reg   = correctRegisterEndianness(wholeReg);
 
@@ -273,8 +281,13 @@ namespace bsp::magnetometer
         std::uint8_t dummy;
         i2cAddress.subAddress = 0x00;
 
-        const auto readStatus = i2c->Read(i2cAddress, &dummy, sizeof(std::uint8_t)) == sizeof(std::uint8_t);
-        return readStatus;
+        if (i2c == nullptr) {
+            return false;
+        }
+        if (i2c->Read(i2cAddress, &dummy, sizeof(dummy)) != sizeof(dummy)) {
+            return false;
+        }
+        return true;
     }
 
     std::optional<Measurements> getMeasurement()

--- a/module-bsp/bsp/magnetometer/magnetometer.hpp
+++ b/module-bsp/bsp/magnetometer/magnetometer.hpp
@@ -14,28 +14,26 @@ extern "C"
 
 #include "../common.hpp"
 
-namespace bsp
+namespace bsp::magnetometer
 {
-    namespace magnetometer
+    /// unit: 4 LSB/Gauss
+    struct Measurements
     {
-        int32_t init(xQueueHandle qHandle);
-        void deinit();
+        std::int16_t X;
+        std::int16_t Y;
+        std::int16_t Z;
+    };
 
-        bool isPresent(void);
+    std::int32_t init(xQueueHandle qHandle);
+    void deinit();
 
-        /// unit: 4 LSB/Gauss
-        struct Measurements
-        {
-            int16_t X;
-            int16_t Y;
-            int16_t Z;
-        };
+    bool isPresent();
 
-        /// returns new data readout if it is available
-        std::optional<Measurements> getMeasurement();
+    /// returns new data readout if it is available
+    std::optional<Measurements> getMeasurement();
 
-        bsp::KeyCodes parse(const Measurements &measurements);
-        std::optional<bsp::KeyCodes> WorkerEventHandler();
-        void resetCurrentParsedValue();
-    } // namespace magnetometer
-} // namespace bsp
+    bsp::KeyCodes parse(const Measurements &measurements);
+    void resetCurrentParsedValue();
+
+    std::optional<bsp::KeyCodes> WorkerEventHandler();
+}

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -31,6 +31,7 @@
 * Fixed automatic message pasting into content field in thread view after message forwarding
 * Fixed redundant logs about CSQ reporting mode
 * Fixed adding USSD codes to phonebook
+* Fixed slider-related crash on phone turn off
 
 
 ## [1.7.0 2023-03-23]


### PR DESCRIPTION
Fix of the magnetometer-related
issue causing the phone to crash
on shutdown on some rare 
occasions.
Cleanup of the magnetometer driver.
Added checks of all I2C operations
return codes and error messages
in case of failures.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
