### PR TITLE
[BH-1689] Turn off USB charging for CDP and SPD modes

### DIFF
--- a/module-bsp/board/rt1051/bellpx/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/rt1051/bellpx/hal/battery_charger/BatteryCharger.cpp
@@ -240,12 +240,13 @@ namespace hal::battery
                                   LOG_INFO("USB charging port discovery result: %s",
                                            std::string{magic_enum::enum_name(evt)}.c_str());
                                   switch (evt) {
-                                  case events::DCD::DCP:
-                                  case events::DCD::CDP:
                                   case events::DCD::Timeout:
+                                  case events::DCD::DCP:
                                       LOG_INFO("Valid charger detected, enabling charging");
                                       charger.enable_charging(true);
                                       break;
+                                  case events::DCD::CDP:
+                                  case events::DCD::SDP:
                                   default:
                                       charger.enable_charging(false);
                                   }


### PR DESCRIPTION
Due to high current consumption the device
will be charging only for DCP mode and if the timeout will occur.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
