### PR TITLE
[CP-1974] Deleting all templates leaves some text on pure screen

### DIFF
--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -108,6 +108,10 @@ namespace gui
             list->rebuildList();
         }
 
+        if (list->isEmpty()) {
+            list->clear();
+        }
+
         navBar->setActive(nav_bar::Side::Center, !list->isEmpty());
         emptyListIcon->setVisible(list->isEmpty());
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -39,6 +39,7 @@
 * Fixed problem with an unresponsive device after playing specific WAV files.
 * Fixed unresponsive Templates window for user input after templates were changed via MC.
 * Fixed USB charging port detection.
+* Fixed Template window clearing after all templates are removed.
 
 ## [1.7.0 2023-03-23]
 ### Changed / Improved


### PR DESCRIPTION
Fixed Template window clearing after all templates are removed.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
