### PR TITLE
[MOS-578] Fix misleading SMS notification text

### DIFF
--- a/image/system_a/data/lang/Deutsch.json
+++ b/image/system_a/data/lang/Deutsch.json
@@ -274,6 +274,7 @@
     "app_desktop_tools_title": "Werkzeuge",
     "app_desktop_unlock": "ENTSPERREN",
     "app_desktop_unread_messages": "<text>Ungelesene Nachrichten</text>",
+    "app_desktop_unread_single_message": "<text>Ungelesene Nachricht</text>",
     "app_emoji_input_window": "Emoji",
     "app_meditation_countdown_desc": "Beginnt in",
     "app_meditation_interval_chime": "Glocken-Intervall",

--- a/image/system_a/data/lang/English.json
+++ b/image/system_a/data/lang/English.json
@@ -277,6 +277,7 @@
     "app_desktop_tools_title": "Tools",
     "app_desktop_unlock": "UNLOCK",
     "app_desktop_unread_messages": "<text>Unread messages</text>",
+    "app_desktop_unread_single_message": "<text>Unread message</text>",
     "app_emoji_input_window": "Emoji",
     "app_meditation_countdown_desc": "Starts in",
     "app_meditation_interval_chime": "Interval chime",

--- a/image/system_a/data/lang/Espanol.json
+++ b/image/system_a/data/lang/Espanol.json
@@ -273,6 +273,7 @@
     "app_desktop_tools_title": "Herramientas",
     "app_desktop_unlock": "DESBLOQUEAR",
     "app_desktop_unread_messages": "<text>Mensajes no le\u00eddos</text>",
+    "app_desktop_unread_single_message": "<text>Mensaje no le\u00eddo</text>",
     "app_emoji_input_window": "Emoji",
     "app_meditation_countdown_desc": "Empieza en",
     "app_meditation_interval_chime": "Campanilla de intervalo",

--- a/image/system_a/data/lang/Francais.json
+++ b/image/system_a/data/lang/Francais.json
@@ -241,6 +241,7 @@
     "app_desktop_tools_title": "Outils",
     "app_desktop_unlock": "D\u00c9V\u00c9ROUILLER",
     "app_desktop_unread_messages": "<text>Messages non lus</text>",
+    "app_desktop_unread_single_message": "<text>Message non lu</text>",
     "app_emoji_input_window": "Emoji",
     "app_meditation_countdown_desc": "D\u00e9but dans",
     "app_meditation_interval_chime": "Carillon d'intervalle",

--- a/image/system_a/data/lang/Polski.json
+++ b/image/system_a/data/lang/Polski.json
@@ -266,6 +266,7 @@
     "app_desktop_tools_title": "Narz\u0119dzia",
     "app_desktop_unlock": "ODBLOKUJ",
     "app_desktop_unread_messages": "<text>Nowe wiadomo\u015bci</text>",
+    "app_desktop_unread_single_message": "<text>Nowa wiadomo\u015b\u0107</text>",
     "app_emoji_input_window": "Emoji",
     "app_meditation_countdown_desc": "Startuje za",
     "app_meditation_interval_chime": "Cykliczny d\u017awi\u0119k",

--- a/image/system_a/data/lang/Svenska.json
+++ b/image/system_a/data/lang/Svenska.json
@@ -144,6 +144,7 @@
     "app_desktop_tools_title": "Verktyg",
     "app_desktop_unlock": "L\u00c5S UPP",
     "app_desktop_unread_messages": "<text>Ol\u00e4sta meddelanden</text>",
+    "app_desktop_unread_single_message": "<text>Ol\u00e4st meddelande</text>",
     "app_emoji_input_window": "Emoji",
     "app_meditation_interval_chime": "Klinga d\u00e5 och d\u00e5",
     "app_meditation_interval_every_x_minutes": "Var %0:e minut",

--- a/module-apps/apps-common/notifications/NotificationsListPresenter.cpp
+++ b/module-apps/apps-common/notifications/NotificationsListPresenter.cpp
@@ -77,7 +77,10 @@ auto NotificationsListPresenter::create(const notifications::NotSeenSMSNotificat
     -> NotificationListItem *
 {
     auto item = new NotificationWithEventCounter(notifications::NotificationType::NotSeenSms, notification->getValue());
-    setNotificationText(item, notification, "app_desktop_unread_messages");
+    setNotificationText(item,
+                        notification,
+                        (notification->getValue() == 1) ? "app_desktop_unread_single_message"
+                                                        : "app_desktop_unread_messages");
     item->deleteByList = false;
     return item;
 }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -40,6 +40,7 @@
 * Fixed unresponsive Templates window for user input after templates were changed via MC.
 * Fixed USB charging port detection.
 * Fixed Template window clearing after all templates are removed.
+* Fixed wrong notification about multiple unread messages in case there's only one unread left
 
 ## [1.7.0 2023-03-23]
 ### Changed / Improved


### PR DESCRIPTION
Display "New message", translated accordingly - in singular - in case there had been multiple unread
SMS messages and now only one remains unread.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has changelog entry added