### PR TITLE
[MOS-686] Fixed MTP availability only after phone unlocked

### DIFF
--- a/module-apps/apps-common/ApplicationCommon.cpp
+++ b/module-apps/apps-common/ApplicationCommon.cpp
@@ -835,11 +835,20 @@ namespace app
             assert(0 && "invalid popup data received");
             return;
         }
+
         // two lines below is to **not** loose data on copy on dynamic_cast, but to move the data
         (void)params.release();
-        auto data      = std::unique_ptr<gui::PopupRequestParams>(rdata);
-        auto id        = data->getPopupId();
-        auto blueprint = popupBlueprint.getBlueprint(id);
+        auto data                    = std::unique_ptr<gui::PopupRequestParams>(rdata);
+        auto id                      = data->getPopupId();
+        auto blueprint               = popupBlueprint.getBlueprint(id);
+        auto appNameWhichAskForPopup = data->nameOfSenderApplication;
+
+        auto topOfWindowsStackId = windowsStack().getWindowData(app::topWindow)->disposition.id;
+        if (data->ignoreIfTheSamePopupIsOnTopOfTheStack && id == topOfWindowsStackId) {
+            LOG_WARN("ignoring popup because the same is already on the top of the stack");
+            return;
+        }
+
         if (!blueprint) {
             LOG_ERROR("no blueprint to handle %s popup - fallback", std::string(magic_enum::enum_name(id)).c_str());
             blueprint = popupBlueprintFallback(id);

--- a/module-apps/apps-common/ApplicationCommonPopupBlueprints.cpp
+++ b/module-apps/apps-common/ApplicationCommonPopupBlueprints.cpp
@@ -95,9 +95,6 @@ namespace app
                 return false;
             }
 
-            popupParams->setDisposition(gui::popup::Disposition{gui::popup::Disposition::Priority::Normal,
-                                                                gui::popup::Disposition::WindowType::Popup,
-                                                                params->getPopupId()});
             switchWindowPopup(
                 gui::popup::resolveWindowName(id),
                 popupParams->getDisposition(),

--- a/module-apps/apps-common/WindowsPopupFilter.cpp
+++ b/module-apps/apps-common/WindowsPopupFilter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "WindowsPopupFilter.hpp"

--- a/module-apps/apps-common/locks/data/LockData.hpp
+++ b/module-apps/apps-common/locks/data/LockData.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once

--- a/module-apps/apps-common/locks/data/PhoneLockMessages.hpp
+++ b/module-apps/apps-common/locks/data/PhoneLockMessages.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -10,6 +10,9 @@
 namespace locks
 {
     class UnlockPhone : public sys::DataMessage
+    {};
+
+    class UnlockPhoneForMTP : public sys::DataMessage
     {};
 
     class CancelUnlockPhone : public sys::DataMessage

--- a/module-apps/apps-common/locks/handlers/PhoneLockHandler.hpp
+++ b/module-apps/apps-common/locks/handlers/PhoneLockHandler.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -20,6 +20,13 @@ namespace locks
 
     class PhoneLockHandler
     {
+      public:
+        enum class ReasonForRequest
+        {
+            Default = 0, // For default behaviors
+            MTPUnlock
+        };
+
       private:
         enum class PhoneState
         {
@@ -65,7 +72,7 @@ namespace locks
         void phoneLockDisableAction();
         void phoneLockChangeAction();
         void phoneLockSetAction();
-        void phoneInputRequiredAction();
+        void phoneInputRequiredAction(ReasonForRequest reqReason = ReasonForRequest::Default);
         void phoneUnlockPopupsCloseAction();
         void phoneLockChangeInfoAction();
         void phoneExternalUnlockInfoAction();
@@ -82,7 +89,7 @@ namespace locks
         explicit PhoneLockHandler(sys::Service *owner, std::shared_ptr<settings::Settings> settings);
 
         sys::MessagePointer handleLockRequest();
-        sys::MessagePointer handleUnlockRequest();
+        sys::MessagePointer handleUnlockRequest(ReasonForRequest reqReason = ReasonForRequest::Default);
         sys::MessagePointer handleUnlockCancelRequest();
         sys::MessagePointer handleEnablePhoneLock();
         sys::MessagePointer handleDisablePhoneLock();

--- a/module-apps/apps-common/popups/data/PopupRequestParams.hpp
+++ b/module-apps/apps-common/popups/data/PopupRequestParams.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -17,10 +17,13 @@ namespace gui
     class PhoneUnlockInputRequestParams : public PopupRequestParams
     {
       public:
-        PhoneUnlockInputRequestParams(gui::popup::ID popupId,
+        PhoneUnlockInputRequestParams(popup::ID popupId,
                                       locks::Lock lock,
-                                      locks::PhoneLockInputTypeAction phoneLockInputTypeAction)
-            : PopupRequestParams{popupId}, lock{std::move(lock)}, phoneLockInputTypeAction(phoneLockInputTypeAction)
+                                      locks::PhoneLockInputTypeAction phoneLockInputTypeAction,
+                                      popup::Disposition::Priority priority = popup::Disposition::Priority::Normal)
+            : PopupRequestParams{popupId,
+                                 gui::popup::Disposition{priority, popup::Disposition::WindowType::Popup, popupId}},
+              lock{std::move(lock)}, phoneLockInputTypeAction(phoneLockInputTypeAction)
         {}
 
         [[nodiscard]] auto getLock() const noexcept

--- a/module-apps/apps-common/popups/data/PopupRequestParamsBase.hpp
+++ b/module-apps/apps-common/popups/data/PopupRequestParamsBase.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -18,6 +18,8 @@ namespace gui
         [[nodiscard]] gui::popup::ID getPopupId() const noexcept;
         [[nodiscard]] const popup::Disposition &getDisposition() const noexcept;
         void setDisposition(const popup::Disposition &d);
+
+        bool ignoreIfTheSamePopupIsOnTopOfTheStack = false;
 
       private:
         gui::popup::ID popupId;

--- a/module-apps/apps-common/popups/lock-popups/PhoneLockInputWindow.cpp
+++ b/module-apps/apps-common/popups/lock-popups/PhoneLockInputWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PhoneLockInputWindow.hpp"

--- a/module-bsp/board/linux/usb_cdc/usb_cdc.cpp
+++ b/module-bsp/board/linux/usb_cdc/usb_cdc.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "bsp/usb/usb.hpp"
@@ -154,6 +154,11 @@ namespace bsp
         std::remove(ptsFileName);
         if (taskHandleReceive)
             vTaskDelete(taskHandleReceive);
+    }
+
+    void usbUnlockMTP()
+    {
+        LOG_INFO("mtpUnlock");
     }
 
     int usbInit(const bsp::usbInitParams &initParams)

--- a/module-bsp/bsp/usb/usb.hpp
+++ b/module-bsp/bsp/usb/usb.hpp
@@ -45,7 +45,7 @@ namespace bsp
     int usbCDCSend(std::string *sendMsg);
     int usbCDCSendRaw(const char *dataPtr, size_t dataLen);
     void usbDeinit();
-    void usbSuspend();
     void usbHandleDataReceived();
+    void usbUnlockMTP();
 
 } // namespace bsp

--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -184,10 +184,11 @@ auto ServiceDesktop::usbWorkerInit() -> sys::ReturnCodes
                                                     caseColour,
                                                     mtpRootPath);
 
-    initialized =
-        desktopWorker->init({{sdesktop::RECEIVE_QUEUE_BUFFER_NAME, sizeof(std::string *), sdesktop::cdc_queue_len},
-                             {sdesktop::SEND_QUEUE_BUFFER_NAME, sizeof(std::string *), sdesktop::cdc_queue_object_size},
-                             {sdesktop::IRQ_QUEUE_BUFFER_NAME, 1, sdesktop::irq_queue_object_size}});
+    initialized = desktopWorker->init(
+        {{sdesktop::RECEIVE_QUEUE_BUFFER_NAME, sizeof(std::string *), sdesktop::cdcReceiveQueueLength},
+         {sdesktop::SEND_QUEUE_BUFFER_NAME, sizeof(std::string *), sdesktop::cdcSendQueueLength},
+         {sdesktop::IRQ_QUEUE_BUFFER_NAME, sdesktop::irqQueueSize, sdesktop::irqQueueLength},
+         {sdesktop::SIGNALLING_QUEUE_BUFFER_NAME, sizeof(WorkerDesktop::Signal), sdesktop::signallingQueueLength}});
 
     if (!initialized) {
         LOG_ERROR("!!! service-desktop usbWorkerInit failed to initialize worker, service-desktop won't work");
@@ -247,6 +248,7 @@ auto ServiceDesktop::handle(locks::UnlockedPhone * /*msg*/) -> std::shared_ptr<s
         bus.sendUnicast(std::make_shared<sys::TetheringStateRequest>(sys::phone_modes::Tethering::On),
                         service::name::system_manager);
         isPlugEventUnhandled = false;
+        desktopWorker->notify(WorkerDesktop::Signal::unlockMTP);
     }
 
     return sys::MessageNone{};
@@ -324,13 +326,14 @@ auto ServiceDesktop::handle(sdesktop::usb::USBConfigured *msg) -> std::shared_pt
     isUsbConfigured = true;
     if (usbSecurityModel->isSecurityEnabled()) {
         LOG_INFO("Endpoint security enabled, requesting passcode");
-        bus.sendUnicast(std::make_shared<locks::UnlockPhone>(), service::name::appmgr);
+        bus.sendUnicast(std::make_shared<locks::UnlockPhoneForMTP>(), service::name::appmgr);
     }
     else {
         if (isPlugEventUnhandled) {
             bus.sendUnicast(std::make_shared<sys::TetheringStateRequest>(sys::phone_modes::Tethering::On),
                             service::name::system_manager);
             isPlugEventUnhandled = false;
+            desktopWorker->notify(WorkerDesktop::Signal::unlockMTP);
         }
     }
 

--- a/module-services/service-desktop/WorkerDesktop.cpp
+++ b/module-services/service-desktop/WorkerDesktop.cpp
@@ -106,6 +106,13 @@ void WorkerDesktop::reset()
     }
 }
 
+void WorkerDesktop::notify(Signal command)
+{
+    if (auto queue = getQueueByName(sdesktop::SIGNALLING_QUEUE_BUFFER_NAME); !queue->Overwrite(&command)) {
+        LOG_ERROR("Unable to overwrite the command in the commands queue.");
+    }
+}
+
 bool WorkerDesktop::handleMessage(std::uint32_t queueID)
 {
     bool result       = false;
@@ -123,6 +130,9 @@ bool WorkerDesktop::handleMessage(std::uint32_t queueID)
     }
     else if (qname == sdesktop::IRQ_QUEUE_BUFFER_NAME) {
         result = handleIrqQueueMessage(queue);
+    }
+    else if (qname == sdesktop::SIGNALLING_QUEUE_BUFFER_NAME) {
+        result = handleSignallingQueueMessage(queue);
     }
     else {
         LOG_INFO("handeMessage got message on an unhandled queue");
@@ -217,6 +227,28 @@ bool WorkerDesktop::handleIrqQueueMessage(std::shared_ptr<sys::WorkerQueue> &que
     }
     else if (notification == bsp::USBDeviceStatus::Reset) {
         LOG_DEBUG("USB status: Reset");
+    }
+    return true;
+}
+
+bool WorkerDesktop::handleSignallingQueueMessage(std::shared_ptr<sys::WorkerQueue> &queue)
+{
+    if (!initialized) {
+        return false;
+    }
+    sys::WorkerCommand command;
+    if (!queue->Dequeue(&command, 0)) {
+        LOG_ERROR("handleMessage failed to receive from \"%s\"", sdesktop::SIGNALLING_QUEUE_BUFFER_NAME);
+        return false;
+    }
+
+    switch (static_cast<Signal>(command.command)) {
+    case Signal::unlockMTP:
+        bsp::usbUnlockMTP();
+        break;
+    default:
+        LOG_ERROR("Command not valid.");
+        return false;
     }
     return true;
 }

--- a/module-services/service-desktop/WorkerDesktop.hpp
+++ b/module-services/service-desktop/WorkerDesktop.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -19,6 +19,11 @@
 class WorkerDesktop : public sys::Worker
 {
   public:
+    enum class Signal
+    {
+        unlockMTP
+    };
+
     WorkerDesktop(sys::Service *ownerServicePtr,
                   std::function<void()> messageProcessedCallback,
                   const sdesktop::USBSecurityModel &securityModel,
@@ -30,6 +35,7 @@ class WorkerDesktop : public sys::Worker
     void closeWorker();
 
     bool handleMessage(std::uint32_t queueID) override final;
+    void notify(Signal command);
 
     xQueueHandle getReceiveQueue()
     {
@@ -44,6 +50,7 @@ class WorkerDesktop : public sys::Worker
     bool handleSendQueueMessage(std::shared_ptr<sys::WorkerQueue> &queue);
     bool handleServiceQueueMessage(std::shared_ptr<sys::WorkerQueue> &queue);
     bool handleIrqQueueMessage(std::shared_ptr<sys::WorkerQueue> &queue);
+    bool handleSignallingQueueMessage(std::shared_ptr<sys::WorkerQueue> &queue);
 
     std::atomic<bool> initialized = false;
 

--- a/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
@@ -26,20 +26,23 @@ class WorkerDesktop;
 
 namespace sdesktop
 {
-    inline constexpr auto service_stack             = 8192;
-    inline constexpr auto worker_stack              = 8704;
-    inline constexpr auto cdc_queue_len             = 1024;
-    inline constexpr auto cdc_queue_object_size     = 1024;
-    inline constexpr auto irq_queue_object_size     = sizeof(bsp::USBDeviceStatus);
-    constexpr auto connectionActiveTimerName        = "connectionActiveTimer";
-    constexpr auto connectionActiveTimerDelayMs     = std::chrono::milliseconds{1000 * 20};
-    inline constexpr auto RECEIVE_QUEUE_BUFFER_NAME = "receiveQueueBuffer";
-    inline constexpr auto SEND_QUEUE_BUFFER_NAME    = "sendQueueBuffer";
-    inline constexpr auto IRQ_QUEUE_BUFFER_NAME     = "irqQueueBuffer";
-    inline constexpr auto DeviceUniqueIdLength      = 32;
-    inline constexpr auto DeviceUniqueIdName        = "sd_device_unique_id";
-    constexpr auto pathFactoryDataSerial            = "factory_data/serial";
-    constexpr auto pathFactoryDataCaseColour        = "factory_data/case_colour";
+    inline constexpr auto service_stack                = 8192;
+    inline constexpr auto worker_stack                 = 8704;
+    inline constexpr auto cdcReceiveQueueLength        = 1024;
+    inline constexpr auto cdcSendQueueLength           = 1024;
+    inline constexpr auto signallingQueueLength        = 4;
+    inline constexpr auto irqQueueLength               = 4;
+    inline constexpr auto irqQueueSize                 = sizeof(bsp::USBDeviceStatus);
+    constexpr auto connectionActiveTimerName           = "connectionActiveTimer";
+    constexpr auto connectionActiveTimerDelayMs        = std::chrono::milliseconds{1000 * 20};
+    inline constexpr auto RECEIVE_QUEUE_BUFFER_NAME    = "receiveQueueBuffer";
+    inline constexpr auto SEND_QUEUE_BUFFER_NAME       = "sendQueueBuffer";
+    inline constexpr auto IRQ_QUEUE_BUFFER_NAME        = "irqQueueBuffer";
+    inline constexpr auto SIGNALLING_QUEUE_BUFFER_NAME = "signallingQueueBuffer";
+    inline constexpr auto DeviceUniqueIdLength         = 32;
+    inline constexpr auto DeviceUniqueIdName           = "sd_device_unique_id";
+    constexpr auto pathFactoryDataSerial               = "factory_data/serial";
+    constexpr auto pathFactoryDataCaseColour           = "factory_data/case_colour";
 
 }; // namespace sdesktop
 

--- a/products/PurePhone/services/appmgr/ApplicationManager.cpp
+++ b/products/PurePhone/services/appmgr/ApplicationManager.cpp
@@ -185,6 +185,9 @@ namespace app::manager
                 [&](sys::Message *request) -> sys::MessagePointer { return phoneLockHandler.handleLockRequest(); });
         connect(typeid(locks::UnlockPhone),
                 [&](sys::Message *request) -> sys::MessagePointer { return phoneLockHandler.handleUnlockRequest(); });
+        connect(typeid(locks::UnlockPhoneForMTP), [&](sys::Message *request) -> sys::MessagePointer {
+            return phoneLockHandler.handleUnlockRequest(locks::PhoneLockHandler::ReasonForRequest::MTPUnlock);
+        });
         connect(typeid(locks::CancelUnlockPhone), [&](sys::Message *request) -> sys::MessagePointer {
             return phoneLockHandler.handleUnlockCancelRequest();
         });
@@ -527,7 +530,8 @@ namespace app::manager
             autoLockTimer.stop();
             return;
         }
-        if (const auto focusedApp = getFocusedApplication(); (focusedApp == nullptr) || focusedApp->preventsAutoLocking()) {
+        if (const auto focusedApp = getFocusedApplication();
+            (focusedApp == nullptr) || focusedApp->preventsAutoLocking()) {
             autoLockTimer.start();
             return;
         }
@@ -552,7 +556,7 @@ namespace app::manager
 
             LOG_INFO("Starting application %s", app.name().c_str());
             StatusIndicators statusIndicators;
-            statusIndicators.phoneMode        = phoneModeObserver->getCurrentPhoneMode();
+            statusIndicators.phoneMode = phoneModeObserver->getCurrentPhoneMode();
             statusIndicators.tetheringState =
                 phoneModeObserver->isTetheringOn() ? sys::phone_modes::Tethering::On : sys::phone_modes::Tethering::Off;
             statusIndicators.bluetoothMode    = bluetoothMode;

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -42,6 +42,7 @@
 * Fixed Template window clearing after all templates are removed.
 * Fixed wrong notification about multiple unread messages in case there's only one unread left
 * Fixed missing notification about new SMS when phone was locked on application Messages
+* Fixed MTP availability only after phone unlocked
 
 ## [1.7.0 2023-03-23]
 ### Changed / Improved


### PR DESCRIPTION
Fixed file access via MTP even when phone is not unlocked. Now access is granted when the phone is unlocked by the user entering a passcode. If the phone is not passcode protected (passcode is nor set) then access to the files is always possible via MTP.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
