### PR TITLE
[BH-1694] Increase CPU core voltage from 900mV to 975mV

### DIFF
--- a/module-bsp/board/rt1051/bsp/lpm/CpuFreqLPM.cpp
+++ b/module-bsp/board/rt1051/bsp/lpm/CpuFreqLPM.cpp
@@ -1,8 +1,7 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CpuFreqLPM.hpp"
-#include <log/log.hpp>
 #include "fsl_dcdc.h"
 
 namespace bsp
@@ -21,7 +20,7 @@ namespace bsp
             /* Set AHB_PODF. */
             CLOCK_SetDiv(kCLOCK_AhbDiv, 1); // CBCDR
 
-            DCDC_AdjustTargetVoltage(DCDC, VDDRun_900_mV, VDDStandby_925_mV);
+            DCDC_AdjustTargetVoltage(DCDC, VDDRun_975_mV, VDDStandby_925_mV);
             break;
         case CpuClock::CpuClock_Osc_12_Mhz:
             /* Set PERIPH_CLK2_PODF. */
@@ -29,7 +28,7 @@ namespace bsp
             /* Set AHB_PODF. */
             CLOCK_SetDiv(kCLOCK_AhbDiv, 1); // CBCDR
 
-            DCDC_AdjustTargetVoltage(DCDC, VDDRun_900_mV, VDDStandby_925_mV);
+            DCDC_AdjustTargetVoltage(DCDC, VDDRun_975_mV, VDDStandby_925_mV);
             break;
         case CpuClock::CpuClock_Osc_24_Mhz:
             /* Set PERIPH_CLK2_PODF. */

--- a/module-bsp/board/rt1051/bsp/lpm/CpuFreqLPM.hpp
+++ b/module-bsp/board/rt1051/bsp/lpm/CpuFreqLPM.hpp
@@ -1,22 +1,21 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#ifndef PUREPHONE_CPUFREQLPM_HPP
-#define PUREPHONE_CPUFREQLPM_HPP
+#pragma once
 
 #include <cstdint>
 
 namespace bsp
 {
-    inline constexpr uint32_t VDDRun_900_mV  = 0x4;
-    inline constexpr uint32_t VDDRun_1050_mV = 0xa;
-    inline constexpr uint32_t VDDRun_1075_mV = 0xb;
-    inline constexpr uint32_t VDDRun_1100_mV = 0xc;
-    inline constexpr uint32_t VDDRun_1125_mV = 0xd;
-    inline constexpr uint32_t VDDRun_1150_mV = 0xe;
-    inline constexpr uint32_t VDDRun_1275_mV = 0x13;
+    inline constexpr std::uint32_t VDDRun_975_mV  = 0x07;
+    inline constexpr std::uint32_t VDDRun_1050_mV = 0x0A;
+    inline constexpr std::uint32_t VDDRun_1075_mV = 0x0B;
+    inline constexpr std::uint32_t VDDRun_1100_mV = 0x0C;
+    inline constexpr std::uint32_t VDDRun_1125_mV = 0x0D;
+    inline constexpr std::uint32_t VDDRun_1150_mV = 0x0E;
+    inline constexpr std::uint32_t VDDRun_1275_mV = 0x13;
 
-    inline constexpr uint32_t VDDStandby_925_mV = 0x1;
+    inline constexpr std::uint32_t VDDStandby_925_mV = 0x01;
 
     class CpuFreqLPM
     {
@@ -38,4 +37,3 @@ namespace bsp
     };
 } // namespace bsp
 
-#endif // PUREPHONE_CPUFREQLPM_HPP


### PR DESCRIPTION
Previous voltage setting was lower than the one
suggested in RT1051 RM and would lead to CPU
instability in certain conditions.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
