### PR TITLE
[BH-1691] Change the layout of the battery status

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -29,6 +29,7 @@
 * Changed order in which files are displayed in Relaxation
 * Optimized E-Ink energy consumption
 * Information about device memory is now sent to MC in floating points numbers
+* Changed the layout of the battery status
 
 ## [1.9.0 2023-04-03]
 

--- a/products/BellHybrid/apps/common/include/common/widgets/BellBattery.hpp
+++ b/products/BellHybrid/apps/common/include/common/widgets/BellBattery.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -6,7 +6,6 @@
 #include <Units.hpp>
 #include <gui/widgets/BoxLayout.hpp>
 #include <gui/widgets/Image.hpp>
-#include <gui/widgets/text/TextFixedSize.hpp>
 
 namespace gui
 {
@@ -14,7 +13,7 @@ namespace gui
     namespace battery
     {
         constexpr auto font_small         = style::window::font::largelight;
-        constexpr auto image_right_margin = 5U;
+        constexpr auto image_left_margin  = 8U;
         constexpr auto percent_h          = 102U;
         constexpr auto percent_w          = 106U;
         constexpr auto battery_widget_h   = 64U;

--- a/products/BellHybrid/apps/common/src/widgets/BellBattery.cpp
+++ b/products/BellHybrid/apps/common/src/widgets/BellBattery.cpp
@@ -1,9 +1,9 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <common/data/BatteryUtils.hpp>
 #include <common/widgets/BellBattery.hpp>
-#include <Image.hpp>
+#include <gui/widgets/text/TextFixedSize.hpp>
 
 namespace
 {
@@ -22,9 +22,6 @@ namespace gui
 {
     BellBattery::BellBattery(Item *parent, BatteryWidthMode widthMode) : HBox(parent), widthMode(widthMode)
     {
-        img = new Image(this, battery_low, gui::ImageTypeSpecifier::W_M);
-        img->setAlignment(Alignment(Alignment::Horizontal::Left, Alignment::Vertical::Center));
-
         percentText = new Text(this);
         percentText->setMaximumSize(battery::percent_w, battery::percent_h);
         percentText->setFont(battery::font_small);
@@ -35,6 +32,9 @@ namespace gui
         percentText->drawUnderline(false);
         percentText->setText("000%");
         percentText->setVisible(false);
+
+        img = new Image(this, battery_low, gui::ImageTypeSpecifier::W_M);
+        img->setAlignment(Alignment(Alignment::Horizontal::Right, Alignment::Vertical::Center));
     }
 
     void BellBattery::setFont(const UTF8 &fontName)
@@ -70,7 +70,7 @@ namespace gui
     {
         batteryPercentMode = mode;
         if (batteryPercentMode == BatteryPercentMode::Show) {
-            img->setMargins(gui::Margins(0, 0, battery::image_right_margin, 0));
+            img->setMargins(gui::Margins(battery::image_left_margin, 0, 0, 0));
             percentText->setVisible(true);
         }
         else {
@@ -86,7 +86,7 @@ namespace gui
 
     void BellBattery::setWidthsToFitContent()
     {
-        auto width = img->widgetMinimumArea.w + img->getMargins().right;
+        auto width = img->widgetMinimumArea.w + img->getMargins().left;
         if (percentText->visible) {
             percentText->setMinimumWidthToFitText();
             width += percentText->widgetMinimumArea.w;


### PR DESCRIPTION
The new layout of battery status has the battery
SOC on the left side and battery image on the right.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
