### PR TITLE
[BH-1695] Fix Harmony crash on startup

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -18,6 +18,7 @@
 * Fixed problem with an unresponsive device after playing specific WAV files.
 * Fixed USB charging port detection.
 * Fixed problem with deleting files during Relaxation session.
+* Fixed occasional crash on system startup.
 
 ### Added
 

--- a/module-bsp/drivers/pwm/DriverPWM.hpp
+++ b/module-bsp/drivers/pwm/DriverPWM.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -9,10 +9,10 @@
 
 namespace drivers
 {
-
     enum class PWMInstances
     {
-        PWM_1 = 1,
+        OFFSET = 1,
+        PWM_1  = OFFSET,
         PWM_2,
         PWM_3,
         PWM_4,
@@ -34,6 +34,7 @@ namespace drivers
         B,
         X
     };
+
     struct DriverPWMParams
     {
         PWMChannel channel;


### PR DESCRIPTION
Fix of the bug in PWM driver that
resulted in accessing array out of
bounds, what caused occasional
system crash on startup.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
