### PR TITLE
[MOS-973] Fix for a ghost call after quick click back key to end a call

### DIFF
--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -205,6 +205,12 @@ namespace app
         return ret;
     }
 
+    sys::MessagePointer ApplicationCall::handleAppClose(sys::Message *msgl)
+    {
+        callModel->hangUpCall();
+        return ApplicationCommon::handleAppClose(msgl);
+    }
+
     void ApplicationCall::createUserInterface()
     {
         windowsFactory.attach(app::window::name_enterNumber, [](ApplicationCommon *app, const std::string &name) {

--- a/module-apps/application-call/include/application-call/ApplicationCall.hpp
+++ b/module-apps/application-call/include/application-call/ApplicationCall.hpp
@@ -54,6 +54,7 @@ namespace app
                                  StartInBackground startInBackground = {false});
         sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;
         sys::ReturnCodes InitHandler() override;
+        sys::MessagePointer handleAppClose(sys::Message *msgl) override;
 
         sys::ReturnCodes SwitchPowerModeHandler(const sys::ServicePowerMode mode) override final
         {

--- a/module-apps/apps-common/ApplicationCommon.cpp
+++ b/module-apps/apps-common/ApplicationCommon.cpp
@@ -180,6 +180,11 @@ namespace app
 #if DEBUG_APPLICATION_MANAGEMENT == 1
         LOG_DEBUG("[%s] (%s) -> (%s)", GetName().c_str(), stateStr(state), stateStr(st));
 #endif
+        // To prevent handling of key presses event from other state of application as a longPress
+        if (state != st) {
+            keyTranslator->resetPreviousKeyPress();
+            longPressTimer.stop();
+        }
         state = st;
     }
 

--- a/module-gui/gui/input/Translator.cpp
+++ b/module-gui/gui/input/Translator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Translator.hpp"
@@ -71,6 +71,7 @@ namespace gui
     void KeyBaseTranslation::resetPreviousKeyPress()
     {
         previousKeyPress = {};
+        isPreviousKeyPressed = false;
     }
 
     void KeyBaseTranslation::setPreviousKeyTimedOut(bool status)

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -43,6 +43,7 @@
 * Fixed wrong notification about multiple unread messages in case there's only one unread left
 * Fixed missing notification about new SMS when phone was locked on application Messages
 * Fixed MTP availability only after phone unlocked
+* Fixed a ghost call after quick click back key to end a call after start a call
 
 ## [1.7.0 2023-03-23]
 ### Changed / Improved


### PR DESCRIPTION
Fixed a scenario where the user click to make a call to some contact and then quickly click BACK (right function button) to end the call and despite that Pure was still calling without showing any information. This fix prevent to handle key press event as a key longpress even after application lose a focus, or change a state.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
