### PR TITLE
[MOS-993] Logger bug fixes and optimizations

### DIFF
--- a/module-cellular/modem/mux/CellularMux.cpp
+++ b/module-cellular/modem/mux/CellularMux.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CellularMux.h"
@@ -554,7 +554,6 @@ void CellularMux::processData(bsp::cellular::CellularDMAResultStruct &result)
             LOG_DEBUG("DMA buffer full");
             [[fallthrough]];
         case bsp::cellular::CellularResultCode::ReceivedAfterFull:
-            [[fallthrough]];
         case bsp::cellular::CellularResultCode::ReceivedAndIdle:
             inst->processData(result);
             break;
@@ -562,9 +561,7 @@ void CellularMux::processData(bsp::cellular::CellularDMAResultStruct &result)
             LOG_DEBUG("DMA uninitialized");
             [[fallthrough]];
         case bsp::cellular::CellularResultCode::ReceivingNotStarted:
-            [[fallthrough]];
         case bsp::cellular::CellularResultCode::TransmittingNotStarted:
-            [[fallthrough]];
         case bsp::cellular::CellularResultCode::CMUXFrameError:
             LOG_DEBUG("CellularResult Error: %s", c_str(result.resultCode));
             inst->processError(result);
@@ -792,7 +789,7 @@ void CellularMux::closeChannels()
 bool CellularMux::searchATCommandResponse(const std::vector<std::string> &response,
                                           const std::string &str,
                                           size_t numberOfExpectedTokens,
-                                          logger_level level)
+                                          LoggerLevel level)
 {
     const size_t numberOfTokens = response.size();
     if (searchForString(response, str) && (numberOfExpectedTokens == 0 || numberOfTokens == numberOfExpectedTokens)) {
@@ -838,7 +835,7 @@ const std::unique_ptr<ATParser> &CellularMux::getParser() const
     return parser;
 }
 
-bool CellularMux::checkATCommandPrompt(const std::vector<std::string> &response, logger_level level)
+bool CellularMux::checkATCommandPrompt(const std::vector<std::string> &response, LoggerLevel level)
 {
     return searchATCommandResponse(response, ">", 0, level);
 }

--- a/module-cellular/modem/mux/CellularMux.h
+++ b/module-cellular/modem/mux/CellularMux.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -323,7 +323,7 @@ class CellularMux
     bool searchATCommandResponse(const std::vector<std::string> &response,
                                  const std::string &str,
                                  size_t numberOfExpectedTokens,
-                                 logger_level level);
+                                 LoggerLevel level);
     bool searchForString(const std::vector<std::string> &response, const std::string &str);
 
     /// @brief It is serching the resposne for ">" string
@@ -333,7 +333,7 @@ class CellularMux
     /// @param response - tokenized resposne
     /// @param level - determine how the errors are logged
     /// @return true - str string is found, false - otherwise
-    bool checkATCommandPrompt(const std::vector<std::string> &response, logger_level level = LOGERROR);
+    bool checkATCommandPrompt(const std::vector<std::string> &response, LoggerLevel level = LOGERROR);
 
     void selectAntenna(bsp::cellular::antenna antenna);
     [[nodiscard]] bsp::cellular::antenna getAntenna();

--- a/module-utils/log/LoggerBuffer.hpp
+++ b/module-utils/log/LoggerBuffer.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -11,11 +11,11 @@ class LoggerBuffer : public StringCircularBuffer
     explicit LoggerBuffer(size_t size) : StringCircularBuffer(size)
     {}
 
-    [[nodiscard]] std::pair<bool, std::string> get();
+    [[nodiscard]] std::optional<std::string> get();
     void put(const std::string &logMsg);
     void put(std::string &&logMsg);
 
-    static constexpr auto lostBytesMessage = "bytes was lost.";
+    static constexpr auto lostBytesMessage = "bytes were lost.";
 
   private:
     void updateNumOfLostBytes();

--- a/module-utils/log/LoggerWorker.cpp
+++ b/module-utils/log/LoggerWorker.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "LoggerWorker.hpp"
@@ -9,7 +9,7 @@
 
 namespace Log
 {
-    LoggerWorker::LoggerWorker(const std::string name) : Worker(name, priority)
+    LoggerWorker::LoggerWorker(const std::string &name) : Worker(name, priority)
     {}
 
     void LoggerWorker::notify(Signal command)

--- a/module-utils/log/LoggerWorker.hpp
+++ b/module-utils/log/LoggerWorker.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -21,9 +21,9 @@ namespace Log
 
         static constexpr auto SignalQueueName   = "LoggerSignal";
         static constexpr auto SignalSize        = sizeof(Signal);
-        static constexpr auto SignalQueueLenght = 1;
+        static constexpr auto SignalQueueLength = 1;
 
-        explicit LoggerWorker(const std::string name);
+        explicit LoggerWorker(const std::string &name);
         void notify(Signal command);
         bool handleMessage(std::uint32_t queueID) override;
         void handleCommand(Signal command);

--- a/module-utils/log/StringCircularBuffer.cpp
+++ b/module-utils/log/StringCircularBuffer.cpp
@@ -1,20 +1,21 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "StringCircularBuffer.hpp"
 
-std::pair<bool, std::string> StringCircularBuffer::get()
+std::optional<std::string> StringCircularBuffer::get()
 {
     if (isEmpty()) {
-        return {false, ""};
+        return std::nullopt;
     }
 
-    const std::string val = buffer[tail];
+    const auto val = buffer[tail];
+
     full                  = false;
     tail                  = (tail + 1) % capacity;
     --size;
 
-    return {true, val};
+    return val;
 }
 
 void StringCircularBuffer::put(const std::string &item)

--- a/module-utils/log/StringCircularBuffer.hpp
+++ b/module-utils/log/StringCircularBuffer.hpp
@@ -1,10 +1,11 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include <memory>
 #include <string>
+#include <optional>
 
 class StringCircularBuffer
 {
@@ -19,7 +20,7 @@ class StringCircularBuffer
     {
         return size == 0;
     }
-    [[nodiscard]] virtual std::pair<bool, std::string> get();
+    [[nodiscard]] virtual std::optional<std::string> get();
     [[nodiscard]] size_t getSize() const noexcept
     {
         return size;

--- a/module-utils/log/api/log/log.hpp
+++ b/module-utils/log/api/log/log.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 /*
@@ -53,14 +53,14 @@ extern "C"
         LOGWARN,
         LOGERROR,
         LOGFATAL
-    } logger_level;
+    } LoggerLevel;
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
     /**
      * Forward declarations
      */
-    int log_Log(logger_level level, const char *file, int line, const char *function, const char *fmt, ...)
+    int log_Log(LoggerLevel level, const char *file, int line, const char *function, const char *fmt, ...)
         __attribute__((format(printf, 5, 6)));
 #ifdef LOG_IGNORE_ALL
     int log_ignore(logger_level level, const char *file, int line, const char *function, const char *fmt, ...)
@@ -103,7 +103,7 @@ extern "C"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
-static const size_t LOGGER_BUFFER_SIZE = 8192;
+static const size_t LINE_BUFFER_SIZE   = 2048;
 static const char *LOG_FILE_NAME       = "MuditaOS.log";
 static const int MAX_LOG_FILES_COUNT   = 3;
 static const size_t MAX_LOG_FILE_SIZE  = 1024 * 1024 * 15; // 15 MB

--- a/module-utils/log/board/linux/log_linux.cpp
+++ b/module-utils/log/board/linux/log_linux.cpp
@@ -1,10 +1,8 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include <log/log.hpp>
 #include <Logger.hpp>
 #include <iostream>
-#include <string_view>
 #include <ticks.hpp>
 
 namespace Log
@@ -14,7 +12,7 @@ namespace Log
         assert(false && "Not implemented");
     }
 
-    void Logger::logToDevice(Device, std::string_view logMsg, size_t)
+    void Logger::logToDevice(Device, const char *logMsg, size_t)
     {
         std::cout << logMsg;
     }

--- a/module-utils/log/log.cpp
+++ b/module-utils/log/log.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <log/log.hpp>
@@ -23,7 +23,7 @@ int log_Printf(const char *fmt, ...)
     return result;
 }
 
-int log_ignore(logger_level level, const char *file, int line, const char *function, const char *fmt, ...)
+int log_ignore(LoggerLevel level, const char *file, int line, const char *function, const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
@@ -31,7 +31,7 @@ int log_ignore(logger_level level, const char *file, int line, const char *funct
     return 0;
 }
 
-int log_Log(logger_level level, const char *file, int line, const char *function, const char *fmt, ...)
+int log_Log(LoggerLevel level, const char *file, int line, const char *function, const char *fmt, ...)
 {
     va_list args;
 

--- a/module-utils/log/tests/test_LoggerBuffer.cpp
+++ b/module-utils/log/tests/test_LoggerBuffer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -38,39 +38,39 @@ TEST_CASE("LoggerBuffer tests")
 
     auto putMsgFunc = [&](const auto &msg) { buffer.put(msg); };
     auto getMsgFunc = [&](const auto &originalMsg) {
-        const auto [result, msg] = buffer.get();
-        REQUIRE(result);
-        REQUIRE(msg == originalMsg);
+        const auto msg = buffer.get();
+        REQUIRE(msg.has_value());
+        REQUIRE(msg.value() == originalMsg);
     };
     auto putAllMsgsFunc = [&](const vector<string> &msgs) { for_each(msgs.begin(), msgs.end(), putMsgFunc); };
     auto getAllMsgsFunc = [&](const vector<string> &msgs) { for_each(msgs.begin(), msgs.end(), getMsgFunc); };
     auto checkLostBytes = [&](size_t numOfBytes, const string &originalMsg) {
-        const auto [result, msg] = buffer.get();
-        REQUIRE(result);
-        REQUIRE(msg.find(originalMsg) != string::npos);
-        REQUIRE(msg.find(to_string(numOfBytes)) != string::npos);
-        REQUIRE(msg.find(LoggerBuffer::lostBytesMessage) != string::npos);
+        const auto msg = buffer.get();
+        REQUIRE(msg.has_value());
+        REQUIRE(msg.value().find(originalMsg) != string::npos);
+        REQUIRE(msg.value().find(to_string(numOfBytes)) != string::npos);
+        REQUIRE(msg.value().find(LoggerBuffer::lostBytesMessage) != string::npos);
     };
 
     SECTION("calling get on empty buffer should return false")
     {
-        const auto [result, _] = buffer.get();
-        REQUIRE(!result);
+        const auto msg = buffer.get();
+        REQUIRE(!msg.has_value());
         TestBuffer(buffer, capacity, 0);
     }
 
     SECTION("after putting one msg in buffer, get should return this msg")
     {
-        const string originalMsg = randomStringGenerator.getRandomString();
+        const auto originalMsg = randomStringGenerator.getRandomString();
         buffer.put(originalMsg);
         TestBuffer(buffer, capacity, 1);
-        const auto [result, msg] = buffer.get();
-        REQUIRE(result);
-        REQUIRE(msg == originalMsg);
+        const auto msg = buffer.get();
+        REQUIRE(msg.has_value());
+        REQUIRE(msg.value() == originalMsg);
         TestBuffer(buffer, capacity, 0);
     }
 
-    SECTION("after filling whole buffer with msgs, caliling get repeatedly should return all these msgs back")
+    SECTION("after filling whole buffer with msgs, calling get repeatedly should return all these msgs back")
     {
         const auto msgs = randomStringGenerator.createRandomStringVector(capacity);
         putAllMsgsFunc(msgs);

--- a/module-utils/log/tests/test_log.cpp
+++ b/module-utils/log/tests/test_log.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -10,17 +10,16 @@ using namespace std;
 
 TEST_CASE("Log tests")
 {
-    int value                     = -423;
+    const int value                   = -423;
     const char *carray            = "carray";
-    string str                    = "string";
-    double double_value           = 6.5323;
-    unsigned int unsigned_value   = 7821;
-    constexpr auto big_array_size = LOGGER_BUFFER_SIZE + 2;
-    char big_array[big_array_size];
-    memset(big_array, 'X', big_array_size);
-    big_array[big_array_size - 1] = '\0';
+    const string str                  = "string";
+    const double double_value         = 6.5323;
+    const unsigned int unsigned_value = 7821;
+    char big_array[LINE_BUFFER_SIZE + 2];
+    memset(big_array, 'X', sizeof(big_array));
+    big_array[sizeof(big_array) - 1] = '\0';
 
-    int loggerBufferSize = static_cast<int>(LOGGER_BUFFER_SIZE);
+    const auto loggerBufferSize = static_cast<int>(LINE_BUFFER_SIZE);
     int result           = LOG_TRACE("value: %d", value);
     REQUIRE(0 < result);
     REQUIRE(result <= loggerBufferSize);

--- a/test/mock-logs.cpp
+++ b/test/mock-logs.cpp
@@ -4,7 +4,7 @@
 #include <log/log.hpp>
 #include <cstdarg>
 __attribute__((weak)) int log_Log(
-    logger_level level, const char *file, int line, const char *function, const char *fmt, ...)
+    LoggerLevel level, const char *file, int line, const char *function, const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);


### PR DESCRIPTION
Fixes and optimizations in logger:

* fixed possible buffer overflow when logging logs over line buffer size;
* reduced max log line length to 2048;
* moved pubsetbuf before file opening;
* log file stream buffer created once in logger ctor;
* additional minor cleanup.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
