### PR TITLE
[BH-1700] Add date and time to logs at the startup

### DIFF
--- a/module-bsp/board/rt1051/bsp/rtc/rtc.cpp
+++ b/module-bsp/board/rt1051/bsp/rtc/rtc.cpp
@@ -63,8 +63,23 @@ namespace bsp::rtc
         /* Enable HP RTC */
         SNVS_HP_RTC_StartTimer(SNVS);
 
+        printCurrentDataTime();
+
         LOG_INFO("RTC configured successfully");
         return ErrorCode::OK;
+    }
+
+    void printCurrentDataTime()
+    {
+        struct tm datatime;
+        getCurrentDateTime(&datatime);
+        LOG_INFO("Startup RTC date: %04d/%02d/%02d time: %02d:%02d:%02d",
+                 1900 + datatime.tm_year,
+                 1 + datatime.tm_mon,
+                 datatime.tm_mday,
+                 datatime.tm_hour,
+                 datatime.tm_min,
+                 datatime.tm_sec);
     }
 
     ErrorCode setDateTimeFromTimestamp(time_t timestamp)

--- a/module-bsp/bsp/rtc/rtc.hpp
+++ b/module-bsp/bsp/rtc/rtc.hpp
@@ -37,4 +37,5 @@ namespace bsp::rtc
 	ErrorCode setAlarmInSecondsFromNow(std::uint32_t secs);
 	ErrorCode getAlarmTimestamp(std::uint32_t* secs);
 	ErrorCode setMinuteAlarm(time_t timestamp);
+	void printCurrentDataTime();
 }


### PR DESCRIPTION
Save date and time at the startup of the system for analysis purposes.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
