### PR TITLE
[BH-1702] Fix RTWDOG main DCDC reset

### DIFF
--- a/module-bsp/board/rt1051/bsp/watchdog/watchdog.cpp
+++ b/module-bsp/board/rt1051/bsp/watchdog/watchdog.cpp
@@ -1,26 +1,25 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "bsp/watchdog/watchdog.hpp"
-extern "C"
-{
-#include "fsl_rtwdog.h"
-}
+#include <fsl_rtwdog.h>
 #include <limits>
+#include <cstdint>
 
 namespace bsp::watchdog
 {
-    bool init(unsigned int timeoutMs)
+    bool init(unsigned timeoutMs)
     {
         // 32.768kHz source clock divided by 256 prescaler
-        static constexpr unsigned int clockFreqHz = 32768 / 256;
+        constexpr unsigned clockFreqHz = 32768 / 256;
 
-        const unsigned int timeoutValueTicks = timeoutMs * clockFreqHz / 1000;
-        if (timeoutValueTicks > std::numeric_limits<uint16_t>::max()) {
+        const unsigned timeoutValueTicks = timeoutMs * clockFreqHz / 1000;
+        if (timeoutValueTicks > std::numeric_limits<std::uint16_t>::max()) {
             return false;
         }
 
-        rtwdog_config_t config      = {};
+        rtwdog_config_t config;
+        RTWDOG_GetDefaultConfig(&config);
         config.enableRtwdog         = true;
         config.clockSource          = kRTWDOG_ClockSource1;            // LPO_CLK clock (32.768kHz)
         config.prescaler            = kRTWDOG_ClockPrescalerDivide256; // 256 prescaler (effectively 128Hz clock)
@@ -32,7 +31,7 @@ namespace bsp::watchdog
         config.enableInterrupt      = true;
         config.enableWindowMode     = false;
         config.windowValue          = 0;
-        config.timeoutValue         = static_cast<uint16_t>(timeoutValueTicks);
+        config.timeoutValue         = static_cast<std::uint16_t>(timeoutValueTicks);
         RTWDOG_Init(RTWDOG, &config);
 
         return true;

--- a/module-bsp/bsp/watchdog/watchdog.hpp
+++ b/module-bsp/bsp/watchdog/watchdog.hpp
@@ -5,6 +5,6 @@
 
 namespace bsp::watchdog
 {
-    bool init(unsigned int timeoutMs);
+    bool init(unsigned timeoutMs);
     void refresh();
 }


### PR DESCRIPTION
Fix of the issue that RTWDOG performed
only CPU reset in case of timeout due
to IRQ misconfiguration resulting in
RTWDOG handler not being called.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
