### PR TITLE
[MOS-341] Fixed autofill data during adding previously deleted phone…

### DIFF
--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -283,8 +283,8 @@ namespace app
 
         auto numberView    = utils::PhoneNumber(number).getView();
         auto searchResults = DBServiceAPI::MatchContactByPhoneNumber(this, numberView);
-        if (searchResults != nullptr) {
-            LOG_INFO("Found contact matching search num : contact ID %" PRIu32, searchResults->ID);
+        if (searchResults != nullptr && !searchResults->isTemporary()) {
+            LOG_INFO("Found contact matching (non temporary) search num : contact ID %" PRIu32, searchResults->ID);
             app::manager::Controller::sendAction(this,
                                                  app::manager::actions::EditContact,
                                                  std::make_unique<PhonebookItemData>(std::move(searchResults)));

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -45,6 +45,7 @@
 * Fixed missing notification about new SMS when phone was locked on application Messages
 * Fixed MTP availability only after phone unlocked
 * Fixed a ghost call after quick click back key to end a call after start a call
+* Fixed autofill data during adding previously deleted phone number from dialing window
 
 ## [1.7.0 2023-03-23]
 ### Changed / Improved


### PR DESCRIPTION
… number

Fixed a scenario when the user, after deleting some contact, wont to add this previously deleted number to contact by providing a phone number from home screen and clicking Add button.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
