### PR TITLE
[BH-1706] Fix inaccessible MTP on Harmony

### DIFF
--- a/module-bsp/bsp/usb/usb.hpp
+++ b/module-bsp/bsp/usb/usb.hpp
@@ -38,6 +38,7 @@ namespace bsp
         std::string serialNumber;
         std::uint16_t deviceVersion;
         std::string rootPath;
+        bool mtpLockedAtInit;
     };
 
     int usbInit(const usbInitParams &initParams);

--- a/module-services/service-desktop/ServiceDesktop.cpp
+++ b/module-services/service-desktop/ServiceDesktop.cpp
@@ -172,9 +172,9 @@ auto ServiceDesktop::usbWorkerInit() -> sys::ReturnCodes
     if (initialized) {
         return sys::ReturnCodes::Success;
     }
+
     auto serialNumber = getSerialNumber();
     auto caseColour   = getCaseColour();
-
     LOG_DEBUG("usbWorkerInit Serial Number: %s, Case Colour: %s", serialNumber.c_str(), caseColour.c_str());
 
     desktopWorker = std::make_unique<WorkerDesktop>(this,

--- a/module-services/service-desktop/WorkerDesktop.cpp
+++ b/module-services/service-desktop/WorkerDesktop.cpp
@@ -48,8 +48,12 @@ bool WorkerDesktop::init(std::list<sys::WorkerQueueInfo> queues)
     auto sentinelRegistrationMsg = std::make_shared<sys::SentinelRegistrationMessage>(cpuSentinel);
     ownerService->bus.sendUnicast(sentinelRegistrationMsg, service::name::system_manager);
 
-    const bsp::usbInitParams initParams = {
-        receiveQueue, irqQueue, serialNumber, device_colour::getColourVersion(caseColour), rootPath};
+    const bsp::usbInitParams initParams = {receiveQueue,
+                                           irqQueue,
+                                           serialNumber,
+                                           device_colour::getColourVersion(caseColour),
+                                           rootPath,
+                                           securityModel.isSecurityEnabled()};
 
     initialized = bsp::usbInit(initParams) == 0;
 
@@ -96,9 +100,15 @@ void WorkerDesktop::reset()
     usbStatus   = bsp::USBDeviceStatus::Disconnected;
     bsp::usbDeinit();
 
-    bsp::usbInitParams initParams = {
-        receiveQueue, irqQueue, serialNumber, device_colour::getColourVersion(caseColour), rootPath};
-    initialized = bsp::usbInit(initParams) >= 0;
+    const bsp::usbInitParams initParams = {receiveQueue,
+                                           irqQueue,
+                                           serialNumber,
+                                           device_colour::getColourVersion(caseColour),
+                                           rootPath,
+                                           securityModel.isSecurityEnabled()};
+
+    initialized = bsp::usbInit(initParams) == 0;
+
     if (initialized) {
         usbStatus = bsp::USBDeviceStatus::Connected;
         ownerService->bus.sendMulticast(std::make_shared<sdesktop::usb::USBConnected>(),

--- a/module-services/service-desktop/WorkerDesktop.hpp
+++ b/module-services/service-desktop/WorkerDesktop.hpp
@@ -44,7 +44,6 @@ class WorkerDesktop : public sys::Worker
 
   private:
     void reset();
-    void suspendUsb();
 
     bool handleReceiveQueueMessage(std::shared_ptr<sys::WorkerQueue> &queue);
     bool handleSendQueueMessage(std::shared_ptr<sys::WorkerQueue> &queue);


### PR DESCRIPTION
Fix of the issue that Harmony's MTP
was constantly locked after MOS-686
fix, as the mechanics of unlocking
was not handled for Harmony at all.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
