### PR TITLE
[MOS-994] Fix redirection to dial number view by pressing BACK from a…

### DIFF
--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -285,15 +285,16 @@ namespace app
         auto searchResults = DBServiceAPI::MatchContactByPhoneNumber(this, numberView);
         if (searchResults != nullptr && !searchResults->isTemporary()) {
             LOG_INFO("Found contact matching (non temporary) search num : contact ID %" PRIu32, searchResults->ID);
-            app::manager::Controller::sendAction(this,
-                                                 app::manager::actions::EditContact,
-                                                 std::make_unique<PhonebookItemData>(std::move(searchResults)));
+            auto data                     = std::make_unique<PhonebookItemData>(std::move(searchResults));
+            data->nameOfSenderApplication = GetName();
+            app::manager::Controller::sendAction(this, app::manager::actions::EditContact, std::move(data));
         }
         else {
             auto contactRecord = std::make_shared<ContactRecord>();
             contactRecord->numbers.emplace_back(std::move(numberView));
 
             auto data                        = std::make_unique<PhonebookItemData>(std::move(contactRecord));
+            data->nameOfSenderApplication    = GetName();
             data->ignoreCurrentWindowOnStack = true;
             app::manager::Controller::sendAction(
                 this, manager::actions::AddContact, std::move(data), manager::OnSwitchBehaviour::RunInBackground);

--- a/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
@@ -132,6 +132,7 @@ namespace gui
 
             newContactModel->saveData(contact);
             verifyAndSave();
+            return true;
         }
         else if (!inputEvent.isShortRelease(KeyCode::KEY_RF) || !shouldCurrentAppBeIgnoredOnSwitchBack()) {
             return AppWindow::onInput(inputEvent);

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -46,6 +46,7 @@
 * Fixed MTP availability only after phone unlocked
 * Fixed a ghost call after quick click back key to end a call after start a call
 * Fixed autofill data during adding previously deleted phone number from dialing window
+* Fixed redirection to dial number view by pressing BACK from add new number view
 
 ## [1.7.0 2023-03-23]
 ### Changed / Improved


### PR DESCRIPTION
…dd new number view

Fix for inconsistent redirection when the user dial number from home screen and want to save it but instead of save the user click BACK to go to screen with dialed number

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
