### PR TITLE
[BH-1705] Fixed back button power off timer 10s

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -20,6 +20,7 @@
 * Fixed problem with deleting files during Relaxation session.
 * Fixed occasional crash on system startup.
 * Fixed occasional USB crash when USB cable was disconnected during files upload
+* Fixed back button power off timer changed to 10s 
 
 ### Added
 

--- a/products/BellHybrid/services/evtmgr/internal/key_sequences/PowerOffSequence.hpp
+++ b/products/BellHybrid/services/evtmgr/internal/key_sequences/PowerOffSequence.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -11,6 +11,6 @@ class PowerOffSequence : public GenericLongPressSequence<KeyMap::Back>
   public:
     explicit PowerOffSequence(sys::Service &service)
         : GenericLongPressSequence<KeyMap::Back>{sys::TimerFactory::createSingleShotTimer(
-              &service, "poffseq", std::chrono::milliseconds{5000}, [this](auto &) { handleTimer(); })}
+              &service, "poffseq", std::chrono::milliseconds{9000}, [this](auto &) { handleTimer(); })}
     {}
 };


### PR DESCRIPTION
When holding the back button the device would promt to power off after 5s. This was not inline with the manual. Now the prompt will come up after 10s which is correct by the manual. In the code the actual time is set to 9s because an additional 1s delay is caused by the OS and screen refreash rate.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [X] Has changelog entry added

<!-- Thanks for your work ♥ -->
