### PR TITLE
 [BH-1705] Adjusted power off timer to >=10s

### DIFF
--- a/products/BellHybrid/services/evtmgr/internal/key_sequences/PowerOffSequence.hpp
+++ b/products/BellHybrid/services/evtmgr/internal/key_sequences/PowerOffSequence.hpp
@@ -11,6 +11,6 @@ class PowerOffSequence : public GenericLongPressSequence<KeyMap::Back>
   public:
     explicit PowerOffSequence(sys::Service &service)
         : GenericLongPressSequence<KeyMap::Back>{sys::TimerFactory::createSingleShotTimer(
-              &service, "poffseq", std::chrono::milliseconds{9000}, [this](auto &) { handleTimer(); })}
+              &service, "poffseq", std::chrono::milliseconds{10000}, [this](auto &) { handleTimer(); })}
     {}
 };


### PR DESCRIPTION
When holding the back button, the device would prompt to power off after ~9-10s. This was not inline with the manual. Now the prompt will come up just after 10s. Previously the timer was set to 9s to account for delays caused be the OS and display, however it is now decided that the only thing that should matter is the time you actually have to hold the button for the prompt to show. This time is more or less exactly the same as the time set in the code.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
