### PR TITLE
[BH-1625] The shutdown window doesn't appear while closing the system

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -22,6 +22,7 @@
 * Fixed occasional USB crash when USB cable was disconnected during files upload
 * Fixed back button power off timer changed to 10s
 * Fixed alarm problems when it was re-set while snooze was still active
+* Fixed the problem with the not appearing system closing window in some cases
 
 ### Added
 

--- a/module-services/service-gui/ServiceGUI.cpp
+++ b/module-services/service-gui/ServiceGUI.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ServiceGUI.hpp"
@@ -234,15 +234,13 @@ namespace service::gui
         contextPool->returnContext(contextId);
         contextReleaseTimer.stop();
 
-        if (isClosing) {
-            sendCloseReadyMessage(this);
+        // Even if the next render is already cached, if any context in the pool is currently being processed, then
+        // we better wait for it.
+        if (isNextFrameReady() and not isAnyFrameBeingRenderedOrDisplayed()) {
+            trySendNextFrame();
         }
-        else {
-            // Even if the next render is already cached, if any context in the pool is currently being processed, then
-            // we better wait for it.
-            if (isNextFrameReady() and not isAnyFrameBeingRenderedOrDisplayed()) {
-                trySendNextFrame();
-            }
+        else if (isClosing) {
+            sendCloseReadyMessage(this);
         }
         return sys::MessageNone{};
     }


### PR DESCRIPTION
Fixed the problem with the not appearing system closing window in some cases

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
