### PR TITLE
[BH-1718] Add extra logs to the RTC module

### DIFF
--- a/module-bsp/board/rt1051/bsp/rtc/rtc.cpp
+++ b/module-bsp/board/rt1051/bsp/rtc/rtc.cpp
@@ -50,6 +50,9 @@ namespace bsp::rtc
         while ((SNVS->LPCR & SNVS_LPCR_SRTC_ENV_MASK) == 0) {
             if ((cpp_freertos::Ticks::GetTicks() - initialTicks) > cpp_freertos::Ticks::MsToTicks(timeoutMs)) {
                 LOG_ERROR("RTC init timeout!");
+                LOG_ERROR("SSM state: 0x%02lX", static_cast<std::uint32_t>(SNVS_HP_GetSSMState(SNVS)));
+                LOG_ERROR("LPCR: 0x%08lX LPLR: 0x%08lX LPSR: 0x%08lX", SNVS->LPCR, SNVS->LPLR, SNVS->LPSR);
+                LOG_ERROR("HPCR: 0x%08lX HPLR: 0x%08lX HPSR: 0x%08lX", SNVS->HPCR, SNVS->HPLR, SNVS->HPSR);
                 return ErrorCode::Error;
             }
             vTaskDelay(retryDelayMs);


### PR DESCRIPTION
Add extra logs when the RTC timeout error occurs.
In that, we can find reason in registers of what happened.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
