### PR TITLE
[BH-1708] Fix buttons behavior

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -23,6 +23,7 @@
 * Fixed back button power off timer changed to 10s
 * Fixed alarm problems when it was re-set while snooze was still active
 * Fixed the problem with the not appearing system closing window in some cases
+* Fixed the buttons sometimes don't respond on press or release
 
 ### Added
 


### PR DESCRIPTION
When the button is pressed/released we get an interrupt which falls or rises edge. We read the gpio state a bit later so in case of debouncing we can register the wrong pin state. After the debounce interval the state is stable.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
