### PR TITLE
[BH-1717] Fix no clock update

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -24,6 +24,7 @@
 * Fixed alarm problems when it was re-set while snooze was still active
 * Fixed the problem with the not appearing system closing window in some cases
 * Fixed the buttons sometimes don't respond on press or release
+* Fixed no clock update
 
 ### Added
 

--- a/module-bsp/board/linux/rtc/rtc.cpp
+++ b/module-bsp/board/linux/rtc/rtc.cpp
@@ -46,6 +46,11 @@ namespace bsp::rtc
         return ErrorCode::OK;
     }
 
+    ErrorCode enableLpSrtc()
+    {
+        return ErrorCode::OK;
+    }
+
     void printCurrentDataTime()
     {
         struct tm datatime;

--- a/module-bsp/bsp/rtc/rtc.hpp
+++ b/module-bsp/bsp/rtc/rtc.hpp
@@ -28,6 +28,7 @@ namespace bsp::rtc
 	ErrorCode disableAlarmIrq();
 	ErrorCode maskAlarmIrq();
 	ErrorCode unmaskAlarmIrq();
+	ErrorCode enableLpSrtc();
 	ErrorCode setDateTimeFromTimestamp(time_t timestamp);
 	ErrorCode setDateTime(struct tm* time);
 	ErrorCode getCurrentDateTime(struct tm* datetime);


### PR DESCRIPTION
The secure RTC can lock and the clock is not updated. To prevent this situation we reset LP registers (except for timestamps and alarms) and clear the LVD flag. Then we enable again LP SRTC.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
