### PR TITLE
[BH-1720] Changed GDB python to python 3

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -e
-# Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+# Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 # For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 source config/common.sh
 
 BIN_DIR="build-rt1051-Debug"
-GDB_ARM=$( hash arm-none-eabi-gdb-py 2> /dev/null && echo "arm-none-eabi-gdb-py" || echo "arm-none-eabi-gdb" )
+GDB_ARM=$( hash arm-none-eabi-gdb-py3 2> /dev/null && echo "arm-none-eabi-gdb-py3" || echo "arm-none-eabi-gdb" )
 
 help() 
 {


### PR DESCRIPTION
If the debug session was started using the run.sh script, the python version is now python 3.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [X] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
