### PR TITLE
[CP-2040] Character sequence causes file being displayed as empty lin…

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -25,6 +25,7 @@
 * Fixed the problem with the not appearing system closing window in some cases
 * Fixed the buttons sometimes don't respond on press or release
 * Fixed no clock update
+* Fixed problem with displaying some filenames in Relaxation
 
 ### Added
 

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationMainWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationMainWindow.cpp
@@ -11,8 +11,9 @@
 
 namespace
 {
-    constexpr auto maxDisplayedTitleLength = 30U;
-}
+    constexpr auto maxDisplayedTitleLength    = 30U;
+    constexpr auto incompleteSequenceCharCode = '\342';
+} // namespace
 
 namespace gui
 {
@@ -28,10 +29,18 @@ namespace gui
 
     void RelaxationMainWindow::setSoundsList(std::vector<db::multimedia_files::MultimediaFilesRecord> sounds)
     {
+        auto trimTittle = [](const std::string &title) {
+            std::string shortTittle = title.substr(0, maxDisplayedTitleLength);
+            if (shortTittle.back() == incompleteSequenceCharCode) {
+                shortTittle.pop_back();
+            }
+            return shortTittle;
+        };
+
         std::list<gui::Option> menuOptionList;
         auto addRecord = [&](const db::multimedia_files::MultimediaFilesRecord &sound) {
             menuOptionList.emplace_back(std::make_unique<gui::option::OptionBellMenu>(
-                sound.tags.title.substr(0, maxDisplayedTitleLength),
+                trimTittle(sound.tags.title),
                 [=](gui::Item &item) {
                     onActivated(sound);
                     return true;

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningLoopWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningLoopWindow.cpp
@@ -18,6 +18,7 @@ namespace
     inline constexpr units::SOC dischargingLevelShowTop = 20;
     inline constexpr units::SOC dischargingLowBattery   = 10;
     inline constexpr auto maxPossibleCharsToDisplay     = 25U;
+    inline constexpr auto incompleteSequenceCharCode    = '\342';
 
     bool isBatteryCharging(const Store::Battery::State state)
     {
@@ -77,6 +78,9 @@ namespace
             return title;
         }
         std::string newTittle = title.substr(0, maxPossibleCharsToDisplay - 2);
+        if (newTittle.back() == incompleteSequenceCharCode) {
+            newTittle.pop_back();
+        }
         newTittle.append("...");
 
         return newTittle;


### PR DESCRIPTION
…e in relaxation app

Fixed problem with displaying some filenames in Relaxation

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
