### PR TITLE
[MOS-999] Provide additional info in log filename

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -35,6 +35,7 @@
 * Added serial number to About section
 * Added possibility to detect device's case colour
 * Added extended information to crashdump filename
+* Added extended information to log filename
 
 ### Changed / Improved
 

--- a/module-services/service-desktop/endpoints/filesystem/FS_Helper.cpp
+++ b/module-services/service-desktop/endpoints/filesystem/FS_Helper.cpp
@@ -48,9 +48,6 @@ namespace sdesktop::endpoints
         }
     } // namespace
 
-    using sender::putToSendQueue;
-    namespace fs = std::filesystem;
-
     auto FS_Helper::processGet(Context &context) -> ProcessResult
     {
         LOG_DEBUG("Handling GET");
@@ -68,7 +65,7 @@ namespace sdesktop::endpoints
             response        = requestListDir(dir);
         }
         else {
-            LOG_ERROR("unknown request");
+            LOG_ERROR("Unknown request");
             response = {.status = http::Code::BadRequest};
         }
 
@@ -116,7 +113,7 @@ namespace sdesktop::endpoints
                 code = requestFileRemoval(fileName) ? http::Code::NoContent : http::Code::NotFound;
             }
             catch (const std::filesystem::filesystem_error &ex) {
-                LOG_ERROR("Can't remove requested file, error: %d", ex.code().value());
+                LOG_ERROR("Can't remove requested file %s, error: %d", fileName.c_str(), ex.code().value());
                 code = http::Code::InternalServerError;
             }
         }
@@ -149,7 +146,7 @@ namespace sdesktop::endpoints
         }
 
         if (!std::filesystem::exists(filePath)) {
-            LOG_ERROR("file not found");
+            LOG_ERROR("File %s not found", filePath.c_str());
 
             json11::Json::object response({{json::reason, json::fs::fileDoesNotExist}});
             return ResponseContext{.status = http::Code::NotFound, .body = response};

--- a/module-utils/CrashdumpMetadataStore/CrashdumpMetadataStore.hpp
+++ b/module-utils/CrashdumpMetadataStore/CrashdumpMetadataStore.hpp
@@ -13,21 +13,21 @@ namespace Store
         CrashdumpMetadata(const CrashdumpMetadata &) = delete;
         CrashdumpMetadata &operator=(const CrashdumpMetadata &) = delete;
 
-        static CrashdumpMetadata &getInstance();
+        [[nodiscard]] static CrashdumpMetadata &getInstance();
 
         void setSerialNumber(const std::string &serialNumber);
-        const std::string &getSerialNumber();
+        [[nodiscard]] const std::string &getSerialNumber();
 
         void setProductName(const std::string &product);
-        const std::string &getProductName();
+        [[nodiscard]] const std::string &getProductName();
 
         void setOsVersion(const std::string &osVersion);
-        const std::string &getOsVersion();
+        [[nodiscard]] const std::string &getOsVersion();
 
         void setCommitHash(const std::string &hash);
-        const std::string &getCommitHash();
+        [[nodiscard]] const std::string &getCommitHash();
 
-        std::string getMetadataString();
+        [[nodiscard]] std::string getMetadataString();
 
       private:
         CrashdumpMetadata();

--- a/module-utils/log/CMakeLists.txt
+++ b/module-utils/log/CMakeLists.txt
@@ -19,10 +19,11 @@ target_link_libraries(log
     PRIVATE
         utility
         purefs-paths
+        crashdump-metadata-store
     PUBLIC
         module-os
         log-api
-        utils-rotator    
+        utils-rotator
         sys-service
 )
 

--- a/module-utils/log/LoggerWorker.cpp
+++ b/module-utils/log/LoggerWorker.cpp
@@ -36,7 +36,7 @@ namespace Log
         case Signal::DumpIntervalBuffer:
         case Signal::DumpDiagnostic:
             LOG_INFO("Received signal: %s", magic_enum::enum_name(command).data());
-            Log::Logger::get().dumpToFile(purefs::dir::getLogsPath() / LOG_FILE_NAME);
+            Log::Logger::get().dumpToFile(purefs::dir::getLogsPath());
             break;
         default:
             LOG_ERROR("Command not valid: %d", static_cast<int>(command));

--- a/module-utils/log/api/log/log.hpp
+++ b/module-utils/log/api/log/log.hpp
@@ -1,35 +1,7 @@
 // Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-/*
- *  This module is wrapper over printf with additional thread safety provided and common logs levels.
- *
- *  USAGE:
- *
- *  Include this header in any file that wishes to write to logger(s).  In
- *  exactly one file (per executable), define LOG_MAIN first (e.g. in your
- *  main .c file).
- *
- *     #define LOG_MAIN
- *     #include "logs/log.h"
- *
- *  This will define the actual objects that all the other units will use.
- *  Then invoke log_Init(VFS_FILE* fp,logger_level level) function to initialize logger utility. If you want
- *additionally store logs into file pass valid file descriptor to init function. By default logger logs info into STDOUT
- *stream. After that logger is ready to use.
- *
- *  Examples:
- *  1)
- *   log_Init(NULL,LOGDEBUG);
- *   Send logs(level higher or equal to LOGDEBUG) to STDOUT stream.
- *
- *  2)
- *   log_Init('valid file pointer',LOGINFO);
- *   Send logs(level higher or equal to LOGINFO) to STDOUT stream and also to file specified by user.
- */
-
-#ifndef LOG_LOG_H_
-#define LOG_LOG_H_
+#pragma once
 
 #include "debug.hpp"
 #include <stdint.h>
@@ -68,6 +40,7 @@ extern "C"
 #endif
     int log_Printf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
     void log_WriteToDevice(const uint8_t *pBuffer, unsigned NumBytes);
+    size_t log_getMaxLineLength();
 
 /**
  * Log functions (one per level).
@@ -100,13 +73,3 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-static const size_t LINE_BUFFER_SIZE   = 2048;
-static const char *LOG_FILE_NAME       = "MuditaOS.log";
-static const int MAX_LOG_FILES_COUNT   = 3;
-static const size_t MAX_LOG_FILE_SIZE  = 1024 * 1024 * 15; // 15 MB
-#pragma GCC diagnostic pop
-
-#endif /* LOG_LOG_H_ */

--- a/module-utils/log/log.cpp
+++ b/module-utils/log/log.cpp
@@ -3,7 +3,6 @@
 
 #include <log/log.hpp>
 #include <Logger.hpp>
-#include <ticks.hpp>
 #include <macros.h>
 
 using Log::Logger;
@@ -44,6 +43,11 @@ int log_Log(LoggerLevel level, const char *file, int line, const char *function,
     const int result = Logger::get().log(level, file, line, function, fmt, args);
     va_end(args);
     return result;
+}
+
+size_t log_getMaxLineLength()
+{
+    return Logger::get().getMaxLineLength();
 }
 
 extern "C"

--- a/module-utils/log/tests/CMakeLists.txt
+++ b/module-utils/log/tests/CMakeLists.txt
@@ -36,3 +36,13 @@ add_catch2_executable(
         module-utils
         log
 )
+
+# Logger buffer container tests
+add_catch2_executable(
+    NAME
+        utils-loggerbuffercontainer
+    SRCS
+        test_LoggerBufferContainer.cpp
+    LIBS
+        log
+)

--- a/module-utils/log/tests/test_LoggerBufferContainer.cpp
+++ b/module-utils/log/tests/test_LoggerBufferContainer.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <catch2/catch.hpp>
+#include <LoggerBufferContainer.hpp>
+
+TEST_CASE("Test if proper buffer is chosen")
+{
+    LoggerBufferContainer buffer;
+
+    size_t bufferIndex = buffer.getCurrentIndex();
+    REQUIRE(bufferIndex == 0);
+
+    buffer.nextBuffer();
+    bufferIndex = buffer.getCurrentIndex();
+    REQUIRE(bufferIndex == 1);
+
+    buffer.nextBuffer();
+    bufferIndex = buffer.getCurrentIndex();
+    REQUIRE(bufferIndex == 0);
+
+    buffer.nextBuffer();
+    bufferIndex = buffer.getCurrentIndex();
+    REQUIRE(bufferIndex == 1);
+}

--- a/module-utils/log/tests/test_log.cpp
+++ b/module-utils/log/tests/test_log.cpp
@@ -6,20 +6,20 @@
 #include <log/log.hpp>
 #include <string>
 
-using namespace std;
-
 TEST_CASE("Log tests")
 {
+    const auto lineBufferSize = log_getMaxLineLength();
+
     const int value                   = -423;
     const char *carray            = "carray";
-    const string str                  = "string";
+    const std::string str             = "string";
     const double double_value         = 6.5323;
     const unsigned int unsigned_value = 7821;
-    char big_array[LINE_BUFFER_SIZE + 2];
+    char big_array[lineBufferSize + 2];
     memset(big_array, 'X', sizeof(big_array));
     big_array[sizeof(big_array) - 1] = '\0';
 
-    const auto loggerBufferSize = static_cast<int>(LINE_BUFFER_SIZE);
+    const auto loggerBufferSize = static_cast<int>(lineBufferSize);
     int result           = LOG_TRACE("value: %d", value);
     REQUIRE(0 < result);
     REQUIRE(result <= loggerBufferSize);

--- a/module-utils/log/tests/test_logDumps.cpp
+++ b/module-utils/log/tests/test_logDumps.cpp
@@ -1,15 +1,23 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
-
 #include <string>
-
 #include <log/Logger.hpp>
-#include <log/LoggerBufferContainer.hpp>
+#include <CrashdumpMetadataStore/CrashdumpMetadataStore.hpp>
 
 namespace
 {
+    inline constexpr auto productName       = "TestProduct";
+    inline constexpr auto osVersion         = "6.6.6";
+    inline constexpr auto commitHash        = "baadf00d";
+    inline constexpr auto serialNumber      = "141120222134";
+    inline constexpr auto filenamePrefix    = "MuditaOS";
+    inline constexpr auto filenameExtension = ".log";
+    inline constexpr auto filenameSeparator = "_";
+
+    const std::filesystem::path logsDir = "./ut_logs";
+
     int countFiles(const std::filesystem::path &dir)
     {
         int sum = 0;
@@ -32,106 +40,104 @@ namespace
         }
         return true;
     }
+
+    void prepareCrashdumpStore()
+    {
+        Store::CrashdumpMetadata::getInstance().setProductName(productName);
+        Store::CrashdumpMetadata::getInstance().setOsVersion(osVersion);
+        Store::CrashdumpMetadata::getInstance().setCommitHash(commitHash);
+        Store::CrashdumpMetadata::getInstance().setSerialNumber(serialNumber);
+    }
+
 } // namespace
 
 TEST_CASE("Test if logs are dumped to a file without rotation")
 {
-    auto app                            = Log::Application{"TestApp", "rev", "tag", "branch"};
-    constexpr auto MaxFileSize          = 1024 * 1024; // 1 MB
-    constexpr auto TestLog              = "12345678";
-    const std::filesystem::path logsDir = "./ut_logs";
-    const auto testLogFile              = logsDir / "TestApp.log";
+    static constexpr auto maxFileSize   = 1024 * 1024; // 1 MB
+    static constexpr auto testLogString = "12345678";
 
-    // Prepare the environment.
+    auto app = Log::Application{"TestApp", "rev", "tag", "branch"};
+
+    /* Prepare the environment */
+    prepareCrashdumpStore();
+
+    const auto &osMetadata = Store::CrashdumpMetadata::getInstance().getMetadataString();
+    const auto logFilename = std::string(filenamePrefix) + filenameSeparator + osMetadata + filenameExtension;
+    const auto logFilePath = logsDir / logFilename;
+
     if (std::filesystem::exists(logsDir)) {
         std::filesystem::remove_all(logsDir);
     }
     std::filesystem::create_directory(logsDir);
 
-    // Initialize the logger with test parameters.
-    Log::Logger::get().init(std::move(app), MaxFileSize);
+    /* Initialize the logger with test parameters */
+    Log::Logger::get().init(std::move(app), maxFileSize);
     REQUIRE(countFiles(logsDir) == 0);
 
-    // Dump logs.
-    LOG_ERROR(TestLog);
-    Log::Logger::get().dumpToFile(testLogFile);
+    /* Dump logs */
+    LOG_ERROR("%s", testLogString);
+    Log::Logger::get().dumpToFile(logsDir);
     REQUIRE(countFiles(logsDir) == 1);
-    REQUIRE(checkIfLogFilesExist(testLogFile, 1));
+    REQUIRE(checkIfLogFilesExist(logFilePath, 1) == true);
 
-    LOG_ERROR(TestLog);
-    Log::Logger::get().dumpToFile(testLogFile);
+    LOG_ERROR("%s", testLogString);
+    Log::Logger::get().dumpToFile(logsDir);
     REQUIRE(countFiles(logsDir) == 1);
-    REQUIRE(checkIfLogFilesExist(testLogFile, 1));
+    REQUIRE(checkIfLogFilesExist(logFilePath, 1) == true);
 
-    // Clean-up the environment
+    /* Clean-up the environment */
     std::filesystem::remove_all(logsDir);
 }
 
 TEST_CASE("Test if log files rotate")
 {
-    auto app                            = Log::Application{"TestApp", "rev", "tag", "branch"};
-    constexpr auto MaxFileSize          = 10; // 10 bytes
-    constexpr auto TestLog              = "12345678";
-    const std::filesystem::path logsDir = "./ut_logs";
-    const auto testLogFile              = logsDir / "TestApp.log";
+    static constexpr auto maxFileSize   = 10; // 10 bytes
+    static constexpr auto testLogString = "12345678";
 
-    // Prepare the environment.
+    auto app = Log::Application{"TestApp", "rev", "tag", "branch"};
+
+    /* Prepare the environment */
+    prepareCrashdumpStore();
+
+    const auto &osMetadata = Store::CrashdumpMetadata::getInstance().getMetadataString();
+    const auto logFilename = std::string(filenamePrefix) + filenameSeparator + osMetadata + filenameExtension;
+    const auto logFilePath = logsDir / logFilename;
+
     if (std::filesystem::exists(logsDir)) {
         std::filesystem::remove_all(logsDir);
     }
     std::filesystem::create_directory(logsDir);
 
     // Initialize the logger with test parameters.
-    Log::Logger::get().init(std::move(app), MaxFileSize);
+    Log::Logger::get().init(std::move(app), maxFileSize);
     REQUIRE(countFiles(logsDir) == 0);
 
-    // Dump logs.
-    // Dumping logs to a file causes a log rotation.
-    LOG_ERROR(TestLog);
-    Log::Logger::get().dumpToFile(testLogFile);
+    /* Dump logs. Dumping logs to a file causes files rotation. */
+    LOG_ERROR("%s", testLogString);
+    Log::Logger::get().dumpToFile(logsDir);
     REQUIRE(countFiles(logsDir) == 1);
-    REQUIRE(checkIfLogFilesExist(testLogFile, 1));
+    REQUIRE(checkIfLogFilesExist(logFilePath, 1) == true);
 
-    LOG_ERROR(TestLog);
-    Log::Logger::get().dumpToFile(testLogFile);
+    LOG_ERROR("%s", testLogString);
+    Log::Logger::get().dumpToFile(logsDir);
     REQUIRE(countFiles(logsDir) == 2);
-    REQUIRE(checkIfLogFilesExist(testLogFile, 2));
+    REQUIRE(checkIfLogFilesExist(logFilePath, 2) == true);
 
-    LOG_ERROR(TestLog);
-    Log::Logger::get().dumpToFile(testLogFile);
+    LOG_ERROR("%s", testLogString);
+    Log::Logger::get().dumpToFile(logsDir);
     REQUIRE(countFiles(logsDir) == 3);
-    REQUIRE(checkIfLogFilesExist(testLogFile, 3));
+    REQUIRE(checkIfLogFilesExist(logFilePath, 3) == true);
 
-    LOG_ERROR(TestLog);
-    Log::Logger::get().dumpToFile(testLogFile);
+    LOG_ERROR("%s", testLogString);
+    Log::Logger::get().dumpToFile(logsDir);
     REQUIRE(countFiles(logsDir) == 3);
-    REQUIRE(checkIfLogFilesExist(testLogFile, 3));
+    REQUIRE(checkIfLogFilesExist(logFilePath, 3) == true);
 
-    LOG_ERROR(TestLog);
-    Log::Logger::get().dumpToFile(testLogFile);
+    LOG_ERROR("%s", testLogString);
+    Log::Logger::get().dumpToFile(logsDir);
     REQUIRE(countFiles(logsDir) == 3);
-    REQUIRE(checkIfLogFilesExist(testLogFile, 3));
+    REQUIRE(checkIfLogFilesExist(logFilePath, 3) == true);
 
     // Clean-up the environment
     std::filesystem::remove_all(logsDir);
-}
-
-TEST_CASE("Test if choose proper buffer")
-{
-    LoggerBufferContainer buffer;
-
-    size_t bufferIndex = buffer.getCurrentIndex();
-    REQUIRE(bufferIndex == 0);
-
-    buffer.nextBuffer();
-    bufferIndex = buffer.getCurrentIndex();
-    REQUIRE(bufferIndex == 1);
-
-    buffer.nextBuffer();
-    bufferIndex = buffer.getCurrentIndex();
-    REQUIRE(bufferIndex == 0);
-
-    buffer.nextBuffer();
-    bufferIndex = buffer.getCurrentIndex();
-    REQUIRE(bufferIndex == 1);
 }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -9,6 +9,7 @@
 * Added translations for Bluetooth conenction status label
 * Added WCDMA recognition as 3G in status bar
 * Added extended information to crashdump filename
+* Added extended information to log filename
 
 ### Changed / Improved
 


### PR DESCRIPTION
Added info about product, OS version, commit hash
and serial number to log filename to simplify
triage and quick sanity check of the logs in
cases many log files have to be analyzed.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
