### PR TITLE
[BH-000] Fix simulator in vsc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -93,5 +93,8 @@
         "semaphore": "cpp",
         "byte": "cpp"
     },
-    "favorites.sortDirection": "ASC",
+    "terminal.integrated.env.linux": {
+        "GTK_PATH": ""
+    },
+    "favorites.sortDirection": "ASC"
 }


### PR DESCRIPTION
This fix is due to a bug in Ubuntu. The GTK path
must be changed in order to run the simulator window.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
