### PR TITLE
[BH-1722] Fix unswitchable alarm audio

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -26,6 +26,7 @@
 * Fixed the buttons sometimes don't respond on press or release
 * Fixed no clock update
 * Fixed problem with displaying some filenames in Relaxation
+* Fixed disabling the alarm on the system shutdown screen
 
 ### Added
 

--- a/module-sys/common/include/system/Common.hpp
+++ b/module-sys/common/include/system/Common.hpp
@@ -26,7 +26,8 @@ namespace sys
         PhoneModeChanges,
         PhoneLockChanges,
         BluetoothModeChanges,
-        BluetoothNotifications
+        BluetoothNotifications,
+        AlarmNotifications
     };
 
     enum class ServicePriority
@@ -135,6 +136,8 @@ inline const char *c_str(sys::BusChannel channel)
         return "BluetoothNotifications";
     case sys::BusChannel::PhoneLockChanges:
         return "PhoneLockChanges";
+    case sys::BusChannel::AlarmNotifications:
+        return "AlarmNotifications";
     }
     return "";
 }

--- a/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
+++ b/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
@@ -26,6 +26,7 @@
 #include <WindowsStack.hpp>
 #include <popups/Popups.hpp>
 #include <service-desktop/DesktopMessages.hpp>
+#include <appmgr/messages/AlarmMessage.hpp>
 
 namespace app
 {
@@ -48,6 +49,7 @@ namespace app
 
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
         bus.channels.push_back(sys::BusChannel::USBNotifications);
+        bus.channels.push_back(sys::BusChannel::AlarmNotifications);
 
         addActionReceiver(manager::actions::ShowAlarm, [this](auto &&data) {
             switchWindow(gui::name::window::main_window, std::move(data));
@@ -77,6 +79,10 @@ namespace app
 
         connect(typeid(sdesktop::usb::USBConfigured), [&](sys::Message *msg) -> sys::MessagePointer {
             homeScreenPresenter->setUSBStatusConnected();
+            return sys::msgHandled();
+        });
+        connect(typeid(AlarmDeactivated), [this](sys::Message *request) -> sys::MessagePointer {
+            alarmModel->turnOff();
             return sys::msgHandled();
         });
     }

--- a/products/BellHybrid/sys/SystemManager.cpp
+++ b/products/BellHybrid/sys/SystemManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <sys/SystemManager.hpp>
@@ -35,7 +35,7 @@ namespace sys
             bus.sendUnicast(std::make_shared<AlarmActivated>(), service::name::appmgr);
             break;
         case AlarmActivationStatus::DEACTIVATED:
-            bus.sendUnicast(std::make_shared<AlarmDeactivated>(), service::name::appmgr);
+            bus.sendMulticast(std::make_shared<AlarmDeactivated>(), sys::BusChannel::AlarmNotifications);
             break;
         }
         return MessageNone{};


### PR DESCRIPTION
<!-- Please describe your pull request here -->

Disabling the alarm by clicking "deep press" on the system shutdown screen only visually deactivated the alarm
but the alarm sound continued to ring.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
