### PR TITLE
[MOS-184] Fix unit tests not failing on duplicate test case

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 	branch = 703bd9caab50b139428cea1aaff9974ebee5742e
 [submodule "Catch2"]
 	path = test/Catch2
-	url = https://github.com/catchorg/Catch2
+	url = ../Catch2.git
 [submodule "date"]
 	path = third-party/date
 	url = ../date.git

--- a/doc/build_targets.md
+++ b/doc/build_targets.md
@@ -21,20 +21,20 @@ Some build targets are enabled/disabled based on the selected target architectur
 For each product there are targets:
 
 
-| Arch | Name | Alias | Description |
-|------|------|-------|-------------|
-|common| doc                            |                                                   | Target to build doxygen documentation, [documentation](generate_doxygen.md) |
-|common| \<Product\>                    |                                                   | Binary target for the product |
-|common| \<Product\>-disk-img           | \<Product\>.img                                   | Disk image for the product    |
-|RT1051| \<Product\>-StandaloneImage    | PurePhone-\<version\>-RT1051-package-standalone   | Creates image that can be `dd` or `pureflash` to the device|
-|RT1051| \<Product>\-UpdatePackage      | PurePhone-\<version\>-RT1051-Update.tar           | Creates Update package, that can be used by Mudita Center or an update script|
-|linux | check                          |                                                   | build and run unittests |
-|common| json-common-target             |                                                   | Mudita company public assets common between community and proprietary builds |
-|common| json-community-target          |                                                   | Mudita company public assets for community build |
-|common| json-proprietary-target        |                                                   | Mudita company private assets proprietary build |
-|RT1051| json-rt1051-assets             |                                                   | Mudita company RT1051 specific assets |
-|RT1051| ecoboot.bin                    |                                                   | OS bootloader |
-|RT1051| updater.bin                    |                                                   | OS updater |
+| Arch   | Name                        | Alias                                           | Description                                                                   |
+|--------|-----------------------------|-------------------------------------------------|-------------------------------------------------------------------------------|
+| common | doc                         |                                                 | Target to build doxygen documentation, [documentation](generate_doxygen.md)   |
+| common | \<Product\>                 |                                                 | Binary target for the product                                                 |
+| common | \<Product\>-disk-img        | \<Product\>.img                                 | Disk image for the product                                                    |
+| RT1051 | \<Product\>-StandaloneImage | PurePhone-\<version\>-RT1051-package-standalone | Creates image that can be `dd` or `pureflash` to the device                   |
+| RT1051 | \<Product>\-UpdatePackage   | PurePhone-\<version\>-RT1051-Update.tar         | Creates Update package, that can be used by Mudita Center or an update script |
+| linux  | check                       |                                                 | build and run unittests                                                       |
+| common | json-common-target          |                                                 | Mudita company public assets common between community and proprietary builds  |
+| common | json-community-target       |                                                 | Mudita company public assets for community build                              |
+| common | json-proprietary-target     |                                                 | Mudita company private assets proprietary build                               |
+| RT1051 | json-rt1051-assets          |                                                 | Mudita company RT1051 specific assets                                         |
+| RT1051 | ecoboot.bin-target          |                                                 | OS bootloader                                                                 |
+| RT1051 | recovery.bin-target         |                                                 | OS recovery utility                                                           |
 
 ## Product binary target
 
@@ -110,15 +110,14 @@ These are distributed with the image and update targets available for each produ
 Downloads Mudita private RT1051 specific assets with [download_assets](./download_assets.md) that company is either not eligible or capable of sharing publicly.
 These are distributed with the image and update targets available for each product.
 
-## ecoboot.bin
+## ecoboot.bin-target
 
 Downloads the bootloader with [download_assets](download_assets.md).
 
-OS bootloader, used to pre-init hardware and launch either OS or updater utility.
+OS bootloader, used to pre-init hardware and launch either OS or recovery utility.
 
-## updater.bin
+## recovery.bin-target
 
 Downloads the updater with [download_assets](download_assets.md).
 
-Updater is used to perform the firmware upgrade via update packages. 
-
+PureRecovery is an auxiliary application which is responsible for various tasks including performing update process, backup, restore, etc. 

--- a/module-platform/linux/tests/unittest_filesystem_core.cpp
+++ b/module-platform/linux/tests/unittest_filesystem_core.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -316,7 +316,7 @@ TEST_CASE("Corefs: Read only filesystem")
         {};
         ret = fscore.stat("/sys/assets", st);
         REQUIRE(ret == 0);
-        REQUIRE(st.st_mode & S_IFDIR);
+        REQUIRE((st.st_mode & S_IFDIR) != 0);
         REQUIRE((st.st_mode & (S_IWGRP | S_IWUSR | S_IWOTH)) == 0);
     }
     REQUIRE(fscore.umount("/sys") == 0);
@@ -353,8 +353,8 @@ TEST_CASE("Corefs: Remount filesystem from RO to RW and to RO")
         {};
         ret = fscore->stat("/sys/assets", st);
         REQUIRE(ret == 0);
-        REQUIRE(st.st_mode & S_IFDIR);
-        REQUIRE(st.st_mode & (S_IWGRP | S_IWUSR | S_IWOTH));
+        REQUIRE((st.st_mode & S_IFDIR) != 0);
+        REQUIRE((st.st_mode & (S_IWGRP | S_IWUSR)) == (S_IWGRP | S_IWUSR));
     }
     REQUIRE(fscore->umount("/sys") == 0);
 }
@@ -412,7 +412,7 @@ TEST_CASE("Corefs: stat extended")
     REQUIRE(fs_core.stat("/sys", st) == 0);
     REQUIRE(S_ISFIFO(st.st_mode) == 0);
     REQUIRE(S_ISCHR(st.st_mode) == 0);
-    REQUIRE(S_ISDIR(st.st_mode));
+    REQUIRE(S_ISDIR(st.st_mode) != 0);
     REQUIRE(S_ISBLK(st.st_mode) == 0);
     REQUIRE(S_ISLNK(st.st_mode) == 0);
     REQUIRE(S_ISSOCK(st.st_mode) == 0);
@@ -422,7 +422,7 @@ TEST_CASE("Corefs: stat extended")
     REQUIRE(fs_core.stat(dir, st) == 0);
     REQUIRE(S_ISFIFO(st.st_mode) == 0);
     REQUIRE(S_ISCHR(st.st_mode) == 0);
-    REQUIRE(S_ISDIR(st.st_mode));
+    REQUIRE(S_ISDIR(st.st_mode) != 0);
     REQUIRE(S_ISBLK(st.st_mode) == 0);
     REQUIRE(S_ISLNK(st.st_mode) == 0);
     REQUIRE(S_ISSOCK(st.st_mode) == 0);
@@ -437,7 +437,7 @@ TEST_CASE("Corefs: stat extended")
     REQUIRE(S_ISBLK(st.st_mode) == 0);
     REQUIRE(S_ISLNK(st.st_mode) == 0);
     REQUIRE(S_ISSOCK(st.st_mode) == 0);
-    REQUIRE(S_ISREG(st.st_mode));
+    REQUIRE(S_ISREG(st.st_mode) != 0);
 
     // Final cleanup
     REQUIRE(0 == fs_core.unlink(fil));

--- a/module-platform/linux/tests/unittest_filesystem_ext4.cpp
+++ b/module-platform/linux/tests/unittest_filesystem_ext4.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -61,7 +61,8 @@ TEST_CASE("ext4: Basic mount and functionality")
     REQUIRE(fscore.umount("/ala") == -ENOENT);
     REQUIRE(fscore.mount("emmc0part0", "/sys", "vfat") == -EBUSY);
     REQUIRE(fscore.mount("emmc0part0", "/path", "vfat") == -EBUSY);
-    struct statvfs ssv;
+    struct statvfs ssv
+    {};
     REQUIRE(fscore.stat_vfs("/sys/", ssv) == 0);
     REQUIRE(fscore.stat_vfs("/sys", ssv) == 0);
 
@@ -89,9 +90,10 @@ TEST_CASE("ext4: Read tests")
     REQUIRE(fs_core->seek(fd, 4, SEEK_SET) == 4);
     REQUIRE(fs_core->read(fd, buf, 8) == 8);
     REQUIRE(memcmp(buf, "456789AB", 8) == 0);
-    struct stat st;
+    struct stat st
+    {};
     REQUIRE(fs_core->fstat(fd, st) == 0);
-    REQUIRE(st.st_mode & S_IFREG);
+    REQUIRE((st.st_mode & S_IFREG) != 0);
     REQUIRE((st.st_mode & (S_IRUSR | S_IRGRP | S_IROTH)) == (S_IRUSR | S_IRGRP | S_IROTH));
 
     REQUIRE(fs_core->close(fd) == 0);
@@ -130,9 +132,10 @@ TEST_CASE("ext4: Write tests")
     REQUIRE(fd >= 3);
     REQUIRE(fs_core->ftruncate(fd, trunc_fsize) == 0);
     REQUIRE(fs_core->close(fd) == 0);
-    struct stat st;
+    struct stat st
+    {};
     REQUIRE(fs_core->stat(trunc_fname, st) == 0);
-    REQUIRE(st.st_mode & S_IFREG);
+    REQUIRE((st.st_mode & S_IFREG) != 0);
     REQUIRE(st.st_size == trunc_fsize);
     REQUIRE(fs_core->unlink(trunc_fname) == 0);
 
@@ -148,9 +151,10 @@ TEST_CASE("ext4: Read-only filesystem tests")
     const auto fd = fs_core->open("/sys/test_read_1.txt", O_RDONLY, 0);
     REQUIRE(fd >= 3);
 
-    struct stat st;
+    struct stat st
+    {};
     REQUIRE(fs_core->fstat(fd, st) == 0);
-    REQUIRE(st.st_mode & S_IFREG);
+    REQUIRE((st.st_mode & S_IFREG) != 0);
     REQUIRE((st.st_mode & (S_IRUSR | S_IRGRP | S_IROTH)) == (S_IRUSR | S_IRGRP | S_IROTH));
     REQUIRE((st.st_mode & (S_IWUSR | S_IWGRP | S_IWOTH)) == 0);
 
@@ -189,7 +193,8 @@ TEST_CASE("ext4: Directory tests")
             int dir_status = 0;
             for (;;) {
                 std::string fn;
-                struct stat st;
+                struct stat st
+                {};
                 dir_status = fs_core->dirnext(dh, fn, st);
 
                 if (dir_status == 0) {
@@ -209,12 +214,12 @@ TEST_CASE("ext4: Directory tests")
         {
             const auto dh = fs_core->diropen(path);
             REQUIRE(dh);
-            struct stat st;
+            struct stat st
+            {};
             std::string first_fn;
             REQUIRE(fs_core->dirnext(dh, first_fn, st) == 0);
 
-            for (std::string tmp_fn; fs_core->dirnext(dh, tmp_fn, st) == 0;)
-                ;
+            for (std::string tmp_fn; fs_core->dirnext(dh, tmp_fn, st) == 0;) {}
             REQUIRE(fs_core->dirreset(dh) == 0);
 
             std::string reset_fn;
@@ -283,7 +288,8 @@ TEST_CASE("ext4: stat extended")
     REQUIRE(fs_core);
     REQUIRE(fs_core->mount("emmc0part0", "/sys", "ext4") == 0);
     // Check if it is a directory
-    struct stat st;
+    struct stat st
+    {};
     REQUIRE(fs_core->stat("/sys", st) == 0);
     REQUIRE(S_ISDIR(st.st_mode));
     REQUIRE(fs_core->stat("/sys/", st) == 0);

--- a/module-platform/linux/tests/unittest_filesystem_littlefs.cpp
+++ b/module-platform/linux/tests/unittest_filesystem_littlefs.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -113,7 +113,7 @@ TEST_CASE("littlefs: Read tests")
     {
         struct stat st;
         REQUIRE(fs_core->fstat(fd, st) == 0);
-        REQUIRE(st.st_mode & S_IFREG);
+        REQUIRE((st.st_mode & S_IFREG) != 0);
         REQUIRE((st.st_mode & (S_IRUSR | S_IRGRP | S_IROTH)) == (S_IRUSR | S_IRGRP | S_IROTH));
     }
 
@@ -165,7 +165,7 @@ TEST_CASE("littlefs: Read-only filesystem tests")
 
         struct stat st;
         REQUIRE(fs_core->fstat(fd, st) == 0);
-        REQUIRE(st.st_mode & S_IFREG);
+        REQUIRE((st.st_mode & S_IFREG) != 0);
         REQUIRE((st.st_mode & (S_IRUSR | S_IRGRP | S_IROTH)) == (S_IRUSR | S_IRGRP | S_IROTH));
         REQUIRE((st.st_mode & (S_IWUSR | S_IWGRP | S_IWOTH)) == 0);
 

--- a/module-platform/linux/tests/unittest_filesystem_reedgefs.cpp
+++ b/module-platform/linux/tests/unittest_filesystem_reedgefs.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #define CATCH_CONFIG_MAIN
@@ -74,7 +74,8 @@ TEST_CASE("reedgefs: Basic API test")
     ret = fscore.mount("emmc0part0", "/sys", "reedgefs");
     REQUIRE(ret == 0);
     {
-        struct statvfs ssv;
+        struct statvfs ssv
+        {};
         ret = fscore.stat_vfs("/sys/", ssv);
         REQUIRE(ret == 0);
     }
@@ -95,7 +96,8 @@ TEST_CASE("reedgefs: Basic API test")
         int hwnd = fscore.open("/sys/.boot.json", 0, 0);
         REQUIRE(hwnd >= 3);
         std::cout << "File open handle " << hwnd << std::endl;
-        struct stat st;
+        struct stat st
+        {};
         ret = fscore.fstat(hwnd, st);
         REQUIRE(ret == 0);
         std::cout << "File size " << st.st_size << std::endl;
@@ -242,7 +244,8 @@ TEST_CASE("reedgefs: Directory operations")
 
     SECTION("Null pointer handle dirnext")
     {
-        struct stat st;
+        struct stat st
+        {};
         std::string fnm;
         REQUIRE(fscore.dirnext(nullptr, fnm, st) == -ENXIO);
         REQUIRE(fscore.dirclose(dirhandle) == 0);
@@ -258,7 +261,8 @@ TEST_CASE("reedgefs: Directory operations")
 
     SECTION("Directory reset")
     {
-        struct stat st;
+        struct stat st
+        {};
         std::vector<std::tuple<std::string, struct stat>> vec;
         for (std::string fnm;;) {
             if (fscore.dirnext(dirhandle, fnm, st) != 0) {
@@ -310,16 +314,18 @@ TEST_CASE("reedgefs: Read only filesystem")
     }
     SECTION("Check function which not modify fs")
     {
-        struct statvfs ssv;
+        struct statvfs ssv
+        {};
         ret = fscore.stat_vfs("/sys/", ssv);
         REQUIRE(ret == 0);
     }
     SECTION("Check stat to not set S_IW...")
     {
-        struct stat st;
+        struct stat st
+        {};
         ret = fscore.stat("/sys", st);
         REQUIRE(ret == 0);
-        REQUIRE(st.st_mode & S_IFDIR);
+        REQUIRE((st.st_mode & S_IFDIR) != 0);
         REQUIRE((st.st_mode & (S_IWGRP | S_IWUSR | S_IWOTH)) == 0);
     }
     REQUIRE(fscore.umount("/sys") == 0);
@@ -353,27 +359,13 @@ TEST_CASE("reedgefs: Remount filesystem from RO to RW and to RO")
     }
     {
         REQUIRE(fscore->mkdir("/sys/current", 0660) == 0);
-        struct stat st;
+        struct stat st
+        {};
         ret = fscore->stat("/sys", st);
         REQUIRE(ret == 0);
-        REQUIRE(st.st_mode & S_IFDIR);
-        REQUIRE(st.st_mode & (S_IWGRP | S_IWUSR | S_IWOTH));
+        REQUIRE((st.st_mode & S_IFDIR) != 0);
+        REQUIRE((st.st_mode & (S_IWGRP | S_IWUSR | S_IWOTH)) == (S_IWGRP | S_IWUSR | S_IWOTH));
     }
     REQUIRE(fscore->umount("/sys") == 0);
 }
 
-// TEST_CASE("reedgefs: Autodetect filesystems")
-// {
-//     using namespace purefs;
-//     auto dm   = std::make_shared<blkdev::disk_manager>();
-//     auto disk = std::make_shared<blkdev::disk_image>(::testing::vfs::disk_image);
-//     REQUIRE(disk);
-//     REQUIRE(dm->register_device(disk, "emmc0") == 0);
-//     auto fscore         = std::make_shared<purefs::fs::filesystem>(dm);
-//     const auto vfs_reedgefs = std::make_shared<fs::drivers::filesystem_reedgefs>();
-//     REQUIRE(vfs_reedgefs->mount_count() == 0);
-//     auto ret = fscore->register_filesystem("reedgefs", vfs_reedgefs);
-//     REQUIRE(ret == 0);
-//     REQUIRE(fscore->mount("emmc0part0", "/sys", "auto") == 0);
-//     REQUIRE(fscore->umount("/sys") == 0);
-// }

--- a/third-party/json/test/json11-test.cpp
+++ b/third-party/json/test/json11-test.cpp
@@ -6,7 +6,8 @@ TEST_CASE("json11 - custom types test")
     std::string err{};
     std::string dumpString{};
 
-    SECTION("signed"){
+    SECTION("signed")
+    {
         SECTION("intmax_t - max")
         {
             intmax_t value = INTMAX_MAX;
@@ -20,6 +21,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("intmax_t - min")
         {
             intmax_t value = INTMAX_MIN;
@@ -33,6 +35,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("int64_t - max")
         {
             int64_t value = INT64_MAX;
@@ -46,6 +49,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("int64_t - min")
         {
             int64_t value = INT64_MIN;
@@ -59,6 +63,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("int32_t - max")
         {
             int32_t value = INT32_MAX;
@@ -72,6 +77,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("int32_t - min")
         {
             int32_t value = INT32_MIN;
@@ -85,6 +91,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("int16_t - min")
         {
             int16_t value = INT16_MAX;
@@ -98,6 +105,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("int16_t - max")
         {
             int16_t value = INT16_MIN;
@@ -111,6 +119,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("int8_t - min")
         {
             int8_t value = INT8_MAX;
@@ -124,6 +133,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("int8_t - max")
         {
             int8_t value = INT8_MIN;
@@ -139,7 +149,8 @@ TEST_CASE("json11 - custom types test")
         }
     }
 
-    SECTION("unsigned"){
+    SECTION("unsigned")
+    {
         SECTION("uintmax_t")
         {
             uintmax_t value = UINTMAX_MAX;
@@ -153,6 +164,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("uint64_t")
         {
             uint64_t value = UINT64_MAX;
@@ -179,6 +191,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("uint16_t")
         {
             uint16_t value = UINT16_MAX;
@@ -192,6 +205,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("uint8_t")
         {
             uint8_t value = UINT8_MAX;
@@ -205,6 +219,7 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson == json);
             REQUIRE(newJson["test"] == value);
         }
+
         SECTION("size_t")
         {
             size_t value = SIZE_MAX;
@@ -219,6 +234,4 @@ TEST_CASE("json11 - custom types test")
             REQUIRE(newJson["test"] == value);
         }
     }
-
 }
-


### PR DESCRIPTION
Fix of the issue that unit tests build would not
fail when unit test contained 2 test cases with
identical name.
Changed Catch2 submodule to local fork.
Minor unit tests and build target docs cleanup.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
