### PR TITLE
[MOS-938] Fix EULA multiline scrolling

### DIFF
--- a/module-apps/application-onboarding/windows/EULALicenseWindow.cpp
+++ b/module-apps/application-onboarding/windows/EULALicenseWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "EULALicenseWindow.hpp"
@@ -52,7 +52,7 @@ namespace app::onBoarding
         eulaText->setPenWidth(::style::window::default_border_rect_no_focus);
         eulaText->setEditMode(gui::EditMode::Scroll);
         eulaText->setCursorStartPosition(gui::CursorStartPosition::DocumentBegin);
-        eulaText->setScrollLeap(4);
+        eulaText->setScrollStep(4);
 
         navBar->setActive(gui::nav_bar::Side::Left, true);
 

--- a/module-gui/gui/widgets/text/Text.cpp
+++ b/module-gui/gui/widgets/text/Text.cpp
@@ -34,10 +34,10 @@ namespace gui
     }
 
     Text::Text(Item *parent,
-               const uint32_t &x,
-               const uint32_t &y,
-               const uint32_t &w,
-               const uint32_t &h,
+               const std::uint32_t &x,
+               const std::uint32_t &y,
+               const std::uint32_t &w,
+               const std::uint32_t &h,
                ExpandMode expandMode,
                TextType textType)
         : Rect(parent, x, y, w, h), expandMode{expandMode}, textType{textType},
@@ -591,21 +591,25 @@ namespace gui
                 return false;
             }
 
-            auto scroll_ = [this](auto activity) {
-                bool notAtEdge = true;
-                for (size_t ii = 0; ii < scrollLeap && notAtEdge; ++ii) {
-                    notAtEdge &= activity();
+            const auto applyMultilineScrolling = [this](const auto scrollFn) {
+                std::size_t scrollStepsPerformed;
+                for (scrollStepsPerformed = 0; scrollStepsPerformed < scrollStep; ++scrollStepsPerformed) {
+                    const auto atTextEnd = !scrollFn();
+                    if (atTextEnd) {
+                        break;
+                    }
                 }
-                return notAtEdge;
+                return (scrollStepsPerformed != 0);
             };
-            auto cursor_ = static_cast<TextLinesCursor *>(cursor);
 
-            if (inputEvent.is(KeyCode::KEY_DOWN)) {
-                return scroll_(std::bind(&TextLinesCursor::displayNextLine, cursor_));
-            }
+            const auto textLinesCursor = static_cast<TextLinesCursor *>(cursor);
 
             if (inputEvent.is(KeyCode::KEY_UP)) {
-                return scroll_(std::bind(&TextLinesCursor::displayPreviousLine, cursor_));
+                return applyMultilineScrolling(std::bind(&TextLinesCursor::displayPreviousLine, textLinesCursor));
+            }
+
+            if (inputEvent.is(KeyCode::KEY_DOWN)) {
+                return applyMultilineScrolling(std::bind(&TextLinesCursor::displayNextLine, textLinesCursor));
             }
         }
 
@@ -722,7 +726,7 @@ namespace gui
         return false;
     }
 
-    auto Text::makePreDrawLines(const uint32_t utfVal) -> std::unique_ptr<Lines>
+    auto Text::makePreDrawLines(const std::uint32_t utfVal) -> std::unique_ptr<Lines>
     {
         auto preDrawLines = std::make_unique<Lines>(this);
         auto documentCopy = *cursor->getDocument();
@@ -793,7 +797,7 @@ namespace gui
         }
     }
 
-    auto Text::checkMaxSizeLimit(uint32_t utfVal) -> AdditionBound
+    auto Text::checkMaxSizeLimit(std::uint32_t utfVal) -> AdditionBound
     {
         auto returnValue = AdditionBound::CanAddAll;
 
@@ -870,7 +874,7 @@ namespace gui
         return {AdditionBound::CanAddAll, textBlock};
     }
 
-    auto Text::checkMaxLinesLimit(uint32_t utfVal, unsigned int limitVal) -> AdditionBound
+    auto Text::checkMaxLinesLimit(std::uint32_t utfVal, unsigned int limitVal) -> AdditionBound
     {
         auto returnValue = AdditionBound::CanAddAll;
 
@@ -947,7 +951,7 @@ namespace gui
         return {AdditionBound::CanAddAll, textBlock};
     }
 
-    auto Text::checkAdditionBounds(const uint32_t utfVal) -> AdditionBound
+    auto Text::checkAdditionBounds(const std::uint32_t utfVal) -> AdditionBound
     {
         auto returnValue = AdditionBound::CanAddAll;
 
@@ -1009,7 +1013,7 @@ namespace gui
         return {std::get<0>(returnValue), shortestProcessedBlock};
     }
 
-    bool Text::addChar(uint32_t utf_value)
+    bool Text::addChar(std::uint32_t utf_value)
     {
         cursor->addChar(utf_value);
         auto block = document->getBlock(cursor);

--- a/module-gui/gui/widgets/text/Text.hpp
+++ b/module-gui/gui/widgets/text/Text.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -97,15 +97,15 @@ namespace gui
         [[nodiscard]] auto getSizeMinusPadding(Axis axis, Area val) -> Length;
         auto applyParentSizeRestrictions() -> void;
         auto calculateAndRequestSize() -> void;
-        auto makePreDrawLines(uint32_t utfVal) -> std::unique_ptr<Lines>;
+        auto makePreDrawLines(std::uint32_t utfVal) -> std::unique_ptr<Lines>;
         auto makePreDrawLines(const TextBlock &textBlock) -> std::unique_ptr<Lines>;
 
         auto checkMaxSignsLimit(unsigned int limitVal) -> AdditionBound;
         auto checkMaxSignsLimit(const TextBlock &textBlock, unsigned int limitVal)
             -> std::tuple<AdditionBound, TextBlock>;
-        auto checkMaxSizeLimit(uint32_t utfVal) -> AdditionBound;
+        auto checkMaxSizeLimit(std::uint32_t utfVal) -> AdditionBound;
         auto checkMaxSizeLimit(const TextBlock &textBlock) -> std::tuple<AdditionBound, TextBlock>;
-        auto checkMaxLinesLimit(uint32_t utfVal, unsigned int limitVal) -> AdditionBound;
+        auto checkMaxLinesLimit(std::uint32_t utfVal, unsigned int limitVal) -> AdditionBound;
         auto checkMaxLinesLimit(const TextBlock &textBlock, unsigned int limitVal)
             -> std::tuple<AdditionBound, TextBlock>;
 
@@ -119,12 +119,12 @@ namespace gui
       public:
         Text();
         Text(Item *parent,
-             const uint32_t &x     = 0,
-             const uint32_t &y     = 0,
-             const uint32_t &w     = 0,
-             const uint32_t &h     = 0,
-             ExpandMode expandMode = ExpandMode::None,
-             TextType textType     = TextType::MultiLine);
+             const std::uint32_t &x = 0,
+             const std::uint32_t &y = 0,
+             const std::uint32_t &w = 0,
+             const std::uint32_t &h = 0,
+             ExpandMode expandMode  = ExpandMode::None,
+             TextType textType      = TextType::MultiLine);
         ~Text() override;
 
         void setEditMode(EditMode mode);
@@ -134,13 +134,13 @@ namespace gui
         void setTextLimitType(TextLimitType limitType, unsigned int val = 0);
         void clearTextLimits();
         void drawUnderline(bool val);
-        size_t getScrollLeap() const
+        std::size_t getScrollStep() const noexcept
         {
-            return scrollLeap;
+            return scrollStep;
         }
-        void setScrollLeap(size_t leap)
+        void setScrollStep(std::size_t step) noexcept
         {
-            scrollLeap = leap;
+            scrollStep = step;
         }
 
         TextBackup backupText() const;
@@ -190,7 +190,9 @@ namespace gui
 
       private:
         gui::KeyInputMappedTranslation translator;
-        size_t scrollLeap = 1;
+
+        /// Default scroll step is one line
+        std::size_t scrollStep = 1;
 
       public:
         /// Callback when text changed
@@ -200,12 +202,12 @@ namespace gui
 
         TextChangedCallback textChangedCallback;
 
-        auto checkAdditionBounds(uint32_t utfVal) -> AdditionBound;
+        auto checkAdditionBounds(std::uint32_t utfVal) -> AdditionBound;
         auto checkAdditionBounds(const TextBlock &textBlock) -> std::tuple<AdditionBound, TextBlock>;
 
         auto setCursorStartPosition(CursorStartPosition val) -> void;
 
-        bool addChar(uint32_t utf8);
+        bool addChar(std::uint32_t utf8);
         bool removeChar();
         void onTextChanged();
         void setTextChangedCallback(TextChangedCallback &&callback);


### PR DESCRIPTION
Fix of the issue that EULA would not refresh
during scrolling at the end of document.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
