### PR TITLE
[MOS-1003] Fix automatically marking new message as read

### DIFF
--- a/module-apps/application-messages/models/SMSThreadModel.cpp
+++ b/module-apps/application-messages/models/SMSThreadModel.cpp
@@ -53,7 +53,7 @@ unsigned int SMSThreadModel::requestRecordsCount()
     return recordsCount;
 }
 
-void SMSThreadModel::requestRecords(uint32_t offset, uint32_t limit)
+void SMSThreadModel::requestRecords(std::uint32_t offset, std::uint32_t limit)
 {
     auto query = std::make_unique<db::query::SMSGetForList>(smsThreadID, offset, limit, numberID);
     auto task  = app::AsyncQuery::createFromQuery(std::move(query), db::Interface::Name::SMS);
@@ -80,8 +80,6 @@ auto SMSThreadModel::handleQueryResponse(db::QueryResult *queryResult) -> bool
         // Additional one element for SMSInputWidget.
         recordsCount = msgResponse->getCount() + 1;
         list->reSendLastRebuildRequest();
-
-        markCurrentThreadAsRead();
         return false;
     }
 
@@ -129,6 +127,7 @@ void SMSThreadModel::resetInputWidget()
     smsInput->clearNavigationItem(gui::NavigationDirection::UP);
     smsInput->clearNavigationItem(gui::NavigationDirection::DOWN);
 }
+
 void SMSThreadModel::markCurrentThreadAsRead()
 {
     const auto [code, msg] = DBServiceAPI::GetQueryWithReply(application,

--- a/module-apps/application-messages/models/SMSThreadModel.hpp
+++ b/module-apps/application-messages/models/SMSThreadModel.hpp
@@ -32,7 +32,7 @@ class SMSThreadModel : public app::DatabaseModel<SMSRecord>,
 
     unsigned int requestRecordsCount() override;
     bool updateRecords(std::vector<SMSRecord> records) override;
-    void requestRecords(uint32_t offset, uint32_t limit) override;
+    void requestRecords(std::uint32_t offset, std::uint32_t limit) override;
     unsigned int getMinimalItemSpaceRequired() const override;
     gui::ListItem *getItem(gui::Order order) override;
 };

--- a/module-apps/application-messages/windows/SMSThreadViewWindow.hpp
+++ b/module-apps/application-messages/windows/SMSThreadViewWindow.hpp
@@ -22,10 +22,10 @@ namespace gui
         std::shared_ptr<SMSThreadModel> smsModel;
         gui::ListView *smsList = nullptr;
 
-        auto requestContact(unsigned int numberID) -> void;
-        auto handleContactQueryResponse(db::QueryResult *) -> bool;
+        void requestContact(unsigned int numberID);
+        bool handleContactQueryResponse(db::QueryResult *);
         void requestNumber(unsigned int numberID);
-        auto handleNumberQueryResponse(db::QueryResult *) -> bool;
+        bool handleNumberQueryResponse(db::QueryResult *);
 
       public:
         explicit SMSThreadViewWindow(app::ApplicationCommon *app);

--- a/module-db/Interface/ThreadRecord.hpp
+++ b/module-db/Interface/ThreadRecord.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -13,14 +13,15 @@
 #include <utf8/UTF8.hpp>
 
 #include <cstdint>
+
 struct ThreadRecord : Record
 {
-    uint32_t date           = 0;
-    uint32_t msgCount       = 0;
-    uint32_t unreadMsgCount = 0;
+    std::uint32_t date           = 0;
+    std::uint32_t msgCount       = 0;
+    std::uint32_t unreadMsgCount = 0;
     UTF8 snippet;
     SMSType type      = SMSType::UNKNOWN;
-    uint32_t numberID = DB_ID_NONE;
+    std::uint32_t numberID = DB_ID_NONE;
 
     ThreadRecord() = default;
     ThreadRecord(const ThreadsTableRow &rec)
@@ -47,19 +48,18 @@ class ThreadRecordInterface : public RecordInterface<ThreadRecord, ThreadRecordF
     ~ThreadRecordInterface() = default;
 
     bool Add(const ThreadRecord &rec) override final;
-    bool RemoveByID(uint32_t id) override final;
+    bool RemoveByID(std::uint32_t id) override final;
     bool Update(const ThreadRecord &rec) override final;
-    ThreadRecord GetByID(uint32_t id) override final;
-    ThreadRecord GetByContact(uint32_t contact_id);
+    ThreadRecord GetByID(std::uint32_t id) override final;
     ThreadRecord GetByNumber(const utils::PhoneNumber::View &phoneNumber);
 
-    uint32_t GetCount() override final;
-    uint32_t GetCount(EntryState state);
+    std::uint32_t GetCount() override final;
+    std::uint32_t GetCount(EntryState state);
 
-    std::unique_ptr<std::vector<ThreadRecord>> GetLimitOffset(uint32_t offset, uint32_t limit) override final;
+    std::unique_ptr<std::vector<ThreadRecord>> GetLimitOffset(std::uint32_t offset, std::uint32_t limit) override final;
 
-    std::unique_ptr<std::vector<ThreadRecord>> GetLimitOffsetByField(uint32_t offset,
-                                                                     uint32_t limit,
+    std::unique_ptr<std::vector<ThreadRecord>> GetLimitOffsetByField(std::uint32_t offset,
+                                                                     std::uint32_t limit,
                                                                      ThreadRecordField field,
                                                                      const char *str) override final;
 


### PR DESCRIPTION
Fix of the issue that after entering messages
app, opening one of the threads and returning
to main messages app window, new messages in
this thread were automatically marked as read.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
