### PR TITLE
[MOS-1004] Fix autolock on SMS template call rejection

### DIFF
--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -110,10 +110,10 @@ namespace gui
         };
 
         sendSmsIcon                    = new gui::SendSmsIcon(iconsBox);
-        sendSmsIcon->activatedCallback = [=](gui::Item &item) {
+        sendSmsIcon->activatedCallback = [=]([[maybe_unused]] gui::Item &item) {
             LOG_INFO("Send message template and reject the call");
-            constexpr auto preventAutoLock = true;
-            auto msg = std::make_unique<SMSSendTemplateRequest>(presenter.getPhoneNumber().getView(), preventAutoLock);
+            auto msg = std::make_unique<SMSSendTemplateRequest>(presenter.getPhoneNumber().getView(),
+                                                                SMSSendTemplateRequest::AutolockBehavior::Prevent);
             msg->ignoreCurrentWindowOnStack = true;
             msg->nameOfSenderApplication    = application->GetName();
             return app::manager::Controller::sendAction(application,

--- a/module-apps/application-messages/ApplicationMessages.cpp
+++ b/module-apps/application-messages/ApplicationMessages.cpp
@@ -157,11 +157,11 @@ namespace app
             gui::name::window::thread_sms_search,
             [](ApplicationCommon *app, const std::string &name) { return std::make_unique<gui::SMSSearch>(app); });
         windowsFactory.attach(gui::name::window::sms_templates, [](ApplicationCommon *app, const std::string &name) {
-            return std::make_unique<gui::SMSTemplatesWindow>(app);
+            return std::make_unique<gui::SMSTemplatesWindow>(app, name);
         });
         windowsFactory.attach(gui::name::window::call_sms_templates,
                               [](ApplicationCommon *app, const std::string &name) {
-                                  return std::make_unique<gui::SMSTemplatesWindow>(app);
+                                  return std::make_unique<gui::SMSTemplatesWindow>(app, name);
                               });
         windowsFactory.attach(gui::name::window::search_results, [](ApplicationCommon *app, const std::string &name) {
             return std::make_unique<gui::SearchResults>(app);

--- a/module-apps/application-messages/data/SMSdata.hpp
+++ b/module-apps/application-messages/data/SMSdata.hpp
@@ -72,18 +72,25 @@ class SMSSendRequest : public SMSRequest
 class SMSSendTemplateRequest : public SMSRequest
 {
   public:
-    explicit SMSSendTemplateRequest(const utils::PhoneNumber::View &phoneNumber, bool preventAutoLock = false)
-        : SMSRequest(phoneNumber), preventAutoLock(preventAutoLock)
+    enum class AutolockBehavior
+    {
+        Allow,
+        Prevent
+    };
+
+    explicit SMSSendTemplateRequest(const utils::PhoneNumber::View &phoneNumber,
+                                    AutolockBehavior autolockBehavior = AutolockBehavior::Allow)
+        : SMSRequest(phoneNumber), autolockBehavior(autolockBehavior)
     {}
     ~SMSSendTemplateRequest() override = default;
 
-    [[nodiscard]] bool isAutoLockPrevented() const
+    [[nodiscard]] AutolockBehavior getAutolockBehavior() const noexcept
     {
-        return preventAutoLock;
+        return autolockBehavior;
     }
 
   private:
-    bool preventAutoLock;
+    AutolockBehavior autolockBehavior;
 };
 
 class SMSTemplateSent : public gui::SwitchData

--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -91,8 +91,7 @@ namespace gui
         auto requestingWindow  = switchData->requestingWindow;
         app->templatesCallback = [=](std::shared_ptr<SMSTemplateRecord> templ) {
             LOG_DEBUG("SMS template id = %" PRIu32 "chosen", templ->ID);
-            std::unique_ptr<gui::SwitchData> data =
-                std::make_unique<SMSTextData>(templ->text, SMSTextData::Concatenate::True);
+            auto data = std::make_unique<SMSTextData>(templ->text, SMSTextData::Concatenate::True);
             application->switchWindow(requestingWindow, std::move(data));
             return true;
         };
@@ -100,7 +99,8 @@ namespace gui
 
     void SMSTemplatesWindow::smsSendTemplateRequestHandler(const SMSSendTemplateRequest *const switchData)
     {
-        preventsAutoLock = switchData->isAutoLockPrevented();
+        preventsAutoLock = (switchData->getAutolockBehavior() == SMSSendTemplateRequest::AutolockBehavior::Prevent);
+
         auto app         = dynamic_cast<app::ApplicationMessages *>(application);
         assert(app != nullptr);
 
@@ -115,10 +115,8 @@ namespace gui
         };
     }
 
-    void SMSTemplatesWindow::onBeforeShow(ShowMode mode, SwitchData *data)
+    void SMSTemplatesWindow::onBeforeShow([[maybe_unused]] ShowMode mode, SwitchData *data)
     {
-        preventsAutoLock = false;
-
         if (auto switchData = dynamic_cast<SMSTemplateRequest *>(data)) {
             smsTemplateRequestHandler(switchData);
         }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -51,6 +51,7 @@
 * Fixed occasional USB crash when USB cable was disconnected during files upload
 * Fixed unsupported character in several quotes
 * Fixed marking new message as read in Messages app main window
+* Fixed unwanted autolock on template selection window while rejecting call
 
 ## [1.7.0 2023-03-23]
 ### Changed / Improved


### PR DESCRIPTION
Fix of the issue that unlocked phone would
automatically lock after user tried to reject
incoming call via SMS and stayed on the
templates window.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
