### PR TITLE
[BH-1726] Fix unwanted popup on shutdown screen

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -12,6 +12,7 @@
 * Fixed the problem with the not appearing system closing window in some cases
 * Fixed problem with displaying some filenames in Relaxation
 * Fixed disabling the alarm on the system shutdown screen
+* Fixed "Next alarm will ring in 24h" popup on shutdown screen
 
 ### Added
 

--- a/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
+++ b/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
@@ -52,6 +52,7 @@ namespace app
         bus.channels.push_back(sys::BusChannel::AlarmNotifications);
 
         addActionReceiver(manager::actions::ShowAlarm, [this](auto &&data) {
+            clearPendingPopups();
             switchWindow(gui::name::window::main_window, std::move(data));
             return actionHandled();
         });


### PR DESCRIPTION
<!-- Please describe your pull request here -->

During the alarm occurrence and the system turn-off screen
- selecting "No" option causes the "Next alarm will ring in 24h" prompt to be displayed

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
