### PR TITLE
[BH-1739] Fix problem with charging the device

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -13,6 +13,7 @@
 * Fixed problem with displaying some filenames in Relaxation
 * Fixed disabling the alarm on the system shutdown screen
 * Fixed "Next alarm will ring in 24h" popup on shutdown screen
+* Fixed problem with charging the device after powering on
 
 ### Added
 

--- a/module-bsp/CMakeLists.txt
+++ b/module-bsp/CMakeLists.txt
@@ -14,7 +14,7 @@ target_sources(
         bsp/lpm/bsp_lpm.cpp
         devices/Device.cpp
         devices/power/CW2015.cpp
-        devices/power/MP2639B.cpp
+        devices/power/MP2615GQ.cpp
         devices/temperature/CT7117.cpp
         drivers/dma/DriverDMA.cpp
         drivers/dmamux/DriverDMAMux.cpp

--- a/module-bsp/board/rt1051/bellpx/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/rt1051/bellpx/hal/battery_charger/BatteryCharger.cpp
@@ -10,7 +10,7 @@
 #include "timers.h"
 
 #include <hal/battery_charger/AbstractBatteryCharger.hpp>
-#include <devices/power/MP2639B.hpp>
+#include <devices/power/MP2615GQ.hpp>
 #include <devices/power/CW2015.hpp>
 #include <board/BoardDefinitions.hpp>
 #include <log/log.hpp>
@@ -91,7 +91,7 @@ namespace hal::battery
         void pollFuelGauge();
 
         void handleIrqEvents(IrqEvents event);
-        void handleChargerEvents(MP2639B::ChargingStatus status);
+        void handleChargerEvents(MP2615GQ::ChargingStatus status);
 
         xTimerHandle reinit_timer;
         xQueueHandle notification_channel;
@@ -100,7 +100,7 @@ namespace hal::battery
         std::shared_ptr<drivers::DriverI2C> i2c;
         std::shared_ptr<drivers::DriverGPIO> charger_gpio_chgok;
         std::shared_ptr<drivers::DriverGPIO> charger_gpio;
-        mutable bsp::devices::power::MP2639B charger;
+        mutable bsp::devices::power::MP2615GQ charger;
 
         std::shared_ptr<drivers::DriverGPIO> fuel_gauge_gpio;
         mutable bsp::devices::power::CW2015 fuel_gauge;
@@ -109,7 +109,7 @@ namespace hal::battery
     BellBatteryCharger::BellBatteryCharger(xQueueHandle irqQueueHandle)
         : notification_channel{irqQueueHandle}, i2c{drivers::DriverI2C::Create(i2c_instance, i2c_params)},
           charger_gpio_chgok{drivers::DriverGPIO::Create(charger_irq_gpio_chgok, {})},
-          charger_gpio{drivers::DriverGPIO::Create(charger_irq_gpio, {})}, charger{MP2639B::Configuration{
+          charger_gpio{drivers::DriverGPIO::Create(charger_irq_gpio, {})}, charger{MP2615GQ::Configuration{
                                                                                charger_gpio,
                                                                                charger_irq_pin_mode,
                                                                                charger_gpio,
@@ -167,26 +167,26 @@ namespace hal::battery
 
     AbstractBatteryCharger::ChargingStatus BellBatteryCharger::getChargingStatus() const
     {
-        /// Charger status fetched from MP2639B alone is not enough to be 100% sure what state we are currently in. For
-        /// more info check the Table 2 (page 26) from the MP2639B datasheet. It is required to also take into account
+        /// Charger status fetched from MP2615GQ alone is not enough to be 100% sure what state we are currently in. For
+        /// more info check the Table 2 (page 26) from the MP2615GQ datasheet. It is required to also take into account
         /// the current state of SOC.
 
         const auto charger_status = charger.get_charge_status();
         const auto current_soc    = getSOC();
 
-        if (charger_status == MP2639B::ChargingStatus::Complete && current_soc >= 100) {
+        if (charger_status == MP2615GQ::ChargingStatus::Complete && current_soc >= 100) {
             return ChargingStatus::ChargingDone;
         }
-        else if (charger_status == MP2639B::ChargingStatus::Discharging) {
+        else if (charger_status == MP2615GQ::ChargingStatus::Discharging) {
             return ChargingStatus::Discharging;
         }
-        else if (charger_status == MP2639B::ChargingStatus::Charging && current_soc < 100) {
+        else if (charger_status == MP2615GQ::ChargingStatus::Charging && current_soc < 100) {
             return ChargingStatus::Charging;
         }
-        else if (charger_status == MP2639B::ChargingStatus::Complete && current_soc < 100) {
+        else if (charger_status == MP2615GQ::ChargingStatus::Complete && current_soc < 100) {
             return ChargingStatus::PluggedNotCharging;
         }
-        else if (charger_status == MP2639B::ChargingStatus::Charging && current_soc >= 100) {
+        else if (charger_status == MP2615GQ::ChargingStatus::Charging && current_soc >= 100) {
             LOG_INFO("The charger reports 'Charging state', but the battery SOC is 100");
             return ChargingStatus::ChargingDone;
         }
@@ -245,6 +245,15 @@ namespace hal::battery
                                       LOG_INFO("Valid charger detected, enabling charging");
                                       charger.enable_charging(true);
                                       break;
+                                  case events::DCD::Error: {
+                                      // For some chargers, the USB can't detect plug events and returns an error code.
+                                      // Maybe it is a hardware issue or the charger is not USB-compliant. However, we
+                                      // can try to check the voltage. If the voltage is valid it means that the charger
+                                      // is connected and we can enable charging.
+                                      const auto canCharge = charger.is_valid_voltage();
+                                      charger.enable_charging(canCharge);
+                                      break;
+                                  }
                                   case events::DCD::CDP:
                                   case events::DCD::SDP:
                                   default:
@@ -253,7 +262,7 @@ namespace hal::battery
                               }},
                    event);
     }
-    void BellBatteryCharger::handleChargerEvents(const MP2639B::ChargingStatus)
+    void BellBatteryCharger::handleChargerEvents(const MP2615GQ::ChargingStatus)
     {
         sendNotification(Events::Charger);
     }

--- a/module-bsp/devices/power/CW2015.hpp
+++ b/module-bsp/devices/power/CW2015.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -10,7 +10,7 @@
 
 namespace bsp::devices::power
 {
-    /// MP2639B fuel gauge driver
+    /// CW2015 fuel gauge driver
     /// To enable interrupts support call \ref init_irq_pin and then invoke \ref handle_irq in the corresponding IRQ
     /// routine.
     class CW2015

--- a/module-bsp/devices/power/MP2615GQ.hpp
+++ b/module-bsp/devices/power/MP2615GQ.hpp
@@ -12,10 +12,10 @@
 
 namespace bsp::devices::power
 {
-    /// MP2639B charger driver
+    /// MP2615GQ charger driver
     /// To enable interrupts support call \ref enable_irq and then invoke \ref handle_irq in the corresponding IRQ
     /// routine.
-    class MP2639B
+    class MP2615GQ
     {
       public:
         enum class ChargingStatus : std::uint8_t
@@ -30,13 +30,13 @@ namespace bsp::devices::power
         struct Configuration
         {
             std::shared_ptr<drivers::DriverGPIO> mode_gpio;
-            uint32_t mode_pin;
+            std::uint32_t mode_pin;
 
             std::shared_ptr<drivers::DriverGPIO> acok_gpio;
-            uint32_t acok_pin;
+            std::uint32_t acok_pin;
 
             std::shared_ptr<drivers::DriverGPIO> chgok_gpio;
-            uint32_t chgok_pin;
+            std::uint32_t chgok_pin;
 
             /// User defined notification handler called when the driver wants to inform that charging state has
             /// changed. Notifications are called from the software timer context hence it is not allowed to perform
@@ -44,13 +44,13 @@ namespace bsp::devices::power
             std::function<void(const ChargingStatus)> notification;
         };
 
-        explicit MP2639B(const Configuration &conf);
-        ~MP2639B();
+        explicit MP2615GQ(const Configuration &conf);
+        ~MP2615GQ();
 
-        MP2639B(const MP2639B &) = delete;
-        MP2639B &operator=(const MP2639B &) = delete;
-        MP2639B(MP2639B &&)                 = default;
-        MP2639B &operator=(MP2639B &&) = delete;
+        MP2615GQ(const MP2615GQ &) = delete;
+        MP2615GQ &operator=(const MP2615GQ &) = delete;
+        MP2615GQ(MP2615GQ &&)                 = default;
+        MP2615GQ &operator=(MP2615GQ &&) = delete;
 
         ChargingStatus get_charge_status();
         void enable_charging(bool ctrl);
@@ -58,10 +58,11 @@ namespace bsp::devices::power
         void enable_irq();
         void handle_irq();
 
-      private:
-        bool is_charging() const;
-        bool is_valid_voltage() const;
         bool is_charging_enabled() const;
+        bool is_valid_voltage() const;
+        bool is_charging() const;
+
+      private:
         Configuration configuration;
         xTimerHandle irq_filter_timer;
     };


### PR DESCRIPTION
For some chargers, the USB can't detect plug events and returns an error code. Maybe it is a hardware issue or the charger is not USB-compliant. However, we can try to check the voltage. If the voltage is valid it means that the charger is connected and we can enable charging. Also changed the name of the charging driver and did a small refactor.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
