### PR TITLE
[BH-1728] Fix redundant clock face display while shutting down Harmony

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -13,6 +13,7 @@
 * Fixed problem with displaying some filenames in Relaxation
 * Fixed disabling the alarm on the system shutdown screen
 * Fixed "Next alarm will ring in 24h" popup on shutdown screen
+* Fixed redundant clock face display while shutting down Harmony
 
 ### Added
 

--- a/module-gui/gui/input/Translator.cpp
+++ b/module-gui/gui/input/Translator.cpp
@@ -161,7 +161,6 @@ namespace gui
             return gui::KeyCode::HEADSET_OK;
 
         case bsp::KeyCodes::HeadsetVolUp:
-            void resetPreviousKeyPress();
             return gui::KeyCode::HEADSET_VOLUP;
 
         case bsp::KeyCodes::HeadsetVolDown:

--- a/products/BellHybrid/apps/application-bell-main/windows/BellBatteryStatusWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-main/windows/BellBatteryStatusWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -34,6 +34,7 @@ namespace gui
         void buildInterface() override;
         bool onInput(const InputEvent &inputEvent) override;
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
+        void onClose(CloseReason reason) override;
 
         BellBaseLayout *body{};
         TextFixedSize *topDescription{};

--- a/products/BellHybrid/services/evtmgr/EventManager.cpp
+++ b/products/BellHybrid/services/evtmgr/EventManager.cpp
@@ -165,6 +165,7 @@ void EventManager::buildKeySequences()
 
     auto powerOffSeq      = std::make_unique<PowerOffSequence>(*this);
     powerOffSeq->onAction = [this]() {
+        backlightHandler.handleScreenLight(backlight::Type::Frontlight);
         app::manager::Controller::sendAction(
             this, app::manager::actions::ShowPopup, std::make_unique<PowerOffPopupRequestParams>());
     };


### PR DESCRIPTION
<!-- Please describe your pull request here -->

When the user holds the back button for 10 seconds to display the "turning off" prompt, we  show a redundant clock face display.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
