### PR TITLE
[BH-1729] Changed the "Turn off Harmony" popup display time to 10 sec…

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -26,6 +26,7 @@
 
 * Information about device memory is now sent to MC in floating points numbers
 * General improvement in Eink display and error handling
+* Changed the "Turn off Harmony" popup display time to 10 seconds
 
 ## [2.0.0 2023-06-29]
 

--- a/products/BellHybrid/apps/common/include/common/popups/BellTurnOffOptionWindow.hpp
+++ b/products/BellHybrid/apps/common/include/common/popups/BellTurnOffOptionWindow.hpp
@@ -1,9 +1,10 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include <common/options/BellShortOptionWindow.hpp>
+#include <Timers/TimerHandle.hpp>
 
 namespace gui
 {
@@ -12,10 +13,12 @@ namespace gui
       public:
         static constexpr auto defaultName = "BellTurnOffOptionWindow";
         explicit BellTurnOffOptionWindow(app::ApplicationCommon *app, const char *name = defaultName);
+        void onBeforeShow(ShowMode mode, SwitchData *data) override;
+        void onClose(CloseReason reason) override;
 
       private:
         std::list<Option> settingsOptionsList();
-
+        sys::TimerHandle popupTimer;
         const UTF8 yesStr;
         const UTF8 noStr;
     };


### PR DESCRIPTION
…onds

<!-- Please describe your pull request here -->

When the user activates the prompt to turn off Harmony, it has been displayed for more than 3 minutes.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
