### PR TITLE
[MOS-930] Fix for for misunderstanding holes in sms conversations

### DIFF
--- a/image/system_a/data/lang/Deutsch.json
+++ b/image/system_a/data/lang/Deutsch.json
@@ -308,6 +308,7 @@
     "app_messages_thread_not_sent": "Nicht gesendet: ",
     "app_messages_thread_you": "Sie: ",
     "app_messages_title_main": "Nachrichten",
+    "app_messages_old_messages": "Alte Nachrichten",
     "app_music_player_albums": "<text color='9'>Alben</text>",
     "app_music_player_all_songs": "Alle Lieder",
     "app_music_player_artists": "<text color='9'>K\u00fcnstler</text>",

--- a/image/system_a/data/lang/English.json
+++ b/image/system_a/data/lang/English.json
@@ -311,6 +311,7 @@
     "app_messages_thread_not_sent": "Not sent: ",
     "app_messages_thread_you": "You: ",
     "app_messages_title_main": "Messages",
+    "app_messages_old_messages": "Old Messages",
     "app_music_player_albums": "<text color='9'>Albums</text>",
     "app_music_player_all_songs": "<text><b>All songs</b></text>",
     "app_music_player_artists": "<text color='9'>Artists</text>",

--- a/image/system_a/data/lang/Espanol.json
+++ b/image/system_a/data/lang/Espanol.json
@@ -307,6 +307,7 @@
     "app_messages_thread_not_sent": "No enviado: ",
     "app_messages_thread_you": "T\u00fa: ",
     "app_messages_title_main": "Mensajes",
+    "app_messages_old_messages": "Mensajes antiguos",
     "app_music_player_albums": "<text color = '9'> \u00c1lbumes </text>",
     "app_music_player_all_songs": "Todas las canciones",
     "app_music_player_artists": "<text color = '9'> Artistas </text>",

--- a/image/system_a/data/lang/Francais.json
+++ b/image/system_a/data/lang/Francais.json
@@ -275,6 +275,7 @@
     "app_messages_thread_not_sent": "Pas envoy\u00e9: ",
     "app_messages_thread_you": "Vous: ",
     "app_messages_title_main": "Messages",
+    "app_messages_old_messages": "Anciens messages",
     "app_music_player_albums": "<text color='9'>Albums</text>",
     "app_music_player_all_songs": "Toutes les chansons",
     "app_music_player_artists": "<text color='9'>Artistes</text>",

--- a/image/system_a/data/lang/Polski.json
+++ b/image/system_a/data/lang/Polski.json
@@ -300,6 +300,7 @@
     "app_messages_thread_not_sent": "Niewys\u0142ane: ",
     "app_messages_thread_you": "Ty: ",
     "app_messages_title_main": "Wiadomo\u015bci",
+    "app_messages_old_messages": "Stare Wiadomo\u015bci",
     "app_music_player_albums": "<text color='9'>Albumy</text>",
     "app_music_player_all_songs": "Wszystkie utwory",
     "app_music_player_artists": "<text color='9'>Wykonawcy</text>",

--- a/image/system_a/data/lang/Svenska.json
+++ b/image/system_a/data/lang/Svenska.json
@@ -170,6 +170,7 @@
     "app_messages_thread_not_sent": "Ej skickat: ",
     "app_messages_thread_you": "Du: ",
     "app_messages_title_main": "Meddelanden",
+    "app_messages_old_messages": "Gamla meddelanden",
     "app_music_player_albums": "<text color='9'>Album</text>",
     "app_music_player_all_songs": "Alla l\u00e5tar",
     "app_music_player_artists": "<text color='9'>Artister</text>",

--- a/module-apps/application-messages/data/MessagesStyle.hpp
+++ b/module-apps/application-messages/data/MessagesStyle.hpp
@@ -106,6 +106,14 @@ namespace style
             inline constexpr uint32_t w = style::listview::body_width_with_scroll;
         } // namespace smsList
 
+        namespace oldSmsLabel
+        {
+            inline constexpr std::uint32_t x = style::messages::smsList::x;
+            inline constexpr std::uint32_t y = style::messages::smsList::y;
+            inline constexpr std::uint32_t h = 25;
+            inline constexpr std::uint32_t w = style::messages::smsList::w;
+        } // namespace oldSmsLabel
+
         namespace templates
         {
             namespace list

--- a/module-apps/application-messages/windows/SMSThreadViewWindow.cpp
+++ b/module-apps/application-messages/windows/SMSThreadViewWindow.cpp
@@ -35,6 +35,33 @@ namespace gui
                                     listview::ScrollBarType::Proportional);
         smsList->setOrientation(listview::Orientation::BottomTop);
 
+        // Text for Old Messages
+        oldMessagesText = new gui::Text(this, 0, 0, 0, 0, ExpandMode::None);
+        oldMessagesText->setText(utils::translate("app_messages_old_messages"));
+        oldMessagesText->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
+        oldMessagesText->setMaximumSize(style::window::default_body_width, style::messages::oldSmsLabel::h);
+        oldMessagesText->setFont(style::window::font::verysmall);
+
+        // Arrow sign for Old Messages
+        oldMessagesArrow = new gui::Image("old_messages_arrow_24px_W_M");
+
+        // HBox for Old Messages
+        oldMessagesHBox = new gui::HBox(this,
+                                        style::messages::oldSmsLabel::x,
+                                        style::messages::oldSmsLabel::y,
+                                        style::messages::oldSmsLabel::w,
+                                        style::messages::oldSmsLabel::h);
+        oldMessagesHBox->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
+        oldMessagesHBox->setEdges(gui::RectangleEdge::None);
+        oldMessagesHBox->addWidget(oldMessagesText);
+        oldMessagesHBox->addWidget(oldMessagesArrow);
+        oldMessagesHBox->visible = false;
+
+        // Set callback to switch on/off visible of Old Message Label
+        smsList->onElementsAboveOfCurrentPageChangeCallback = [this](const signed int elementsAboveOfCurrentPageCount) {
+            oldMessagesHBox->visible = (elementsAboveOfCurrentPageCount > 0);
+        };
+
         setFocusItem(smsList);
     }
 

--- a/module-apps/application-messages/windows/SMSThreadViewWindow.hpp
+++ b/module-apps/application-messages/windows/SMSThreadViewWindow.hpp
@@ -20,7 +20,10 @@ namespace gui
     {
       private:
         std::shared_ptr<SMSThreadModel> smsModel;
-        gui::ListView *smsList = nullptr;
+        gui::ListView *smsList       = nullptr;
+        gui::HBox *oldMessagesHBox   = nullptr;
+        gui::Text *oldMessagesText   = nullptr;
+        gui::Image *oldMessagesArrow = nullptr;
 
         void requestContact(unsigned int numberID);
         bool handleContactQueryResponse(db::QueryResult *);

--- a/module-gui/gui/widgets/ListViewEngine.cpp
+++ b/module-gui/gui/widgets/ListViewEngine.cpp
@@ -154,7 +154,7 @@ namespace gui
 
         if (direction == listview::Direction::Top) {
             const int position = currentPageSize - 1 - index;
-            index        = std::abs(position);
+            index              = std::abs(position);
         }
 
         return index;
@@ -229,6 +229,8 @@ namespace gui
             rebuildRequests.pop_back();
             rebuildList(request.first, request.second);
         }
+
+        updateCountOfElementsAboveCurrentPage();
 
         fillFirstPage();
     }
@@ -382,6 +384,8 @@ namespace gui
                 }
             }
 
+            updateCountOfElementsAboveCurrentPage();
+
             reSendLastRebuildRequest();
             return false;
         }
@@ -438,7 +442,7 @@ namespace gui
             const unsigned diff = currentPageSize < body->getVisibleChildrenCount()
                                       ? 0
                                       : currentPageSize - body->getVisibleChildrenCount();
-            currentPageSize   = body->getVisibleChildrenCount();
+            currentPageSize     = body->getVisibleChildrenCount();
 
             if (direction == listview::Direction::Top) {
                 startIndex += diff;
@@ -537,5 +541,13 @@ namespace gui
         provider->requestRecords(topFetchIndex, limit);
 
         return true;
+    }
+
+    void ListViewEngine::updateCountOfElementsAboveCurrentPage()
+    {
+        unsigned countOfElementsAboveCurrentPage = startIndex;
+        if (onElementsAboveOfCurrentPageChangeCallback) {
+            onElementsAboveOfCurrentPageChangeCallback(countOfElementsAboveCurrentPage);
+        }
     }
 } /* namespace gui */

--- a/module-gui/gui/widgets/ListViewEngine.hpp
+++ b/module-gui/gui/widgets/ListViewEngine.hpp
@@ -200,6 +200,11 @@ namespace gui
         [[nodiscard]] bool isEmpty() const noexcept;
         std::function<void()> emptyListCallback;
         std::function<void()> notEmptyListCallback;
+
+        /// Update the number of items above the current page
+        void updateCountOfElementsAboveCurrentPage();
+        /// Callback on update the number of items above the current page
+        std::function<void(const unsigned elementsAboveOfCurrentPageCount)> onElementsAboveOfCurrentPageChangeCallback;
     };
 
 } /* namespace gui */

--- a/products/PurePhone/CMakeLists.txt
+++ b/products/PurePhone/CMakeLists.txt
@@ -160,14 +160,14 @@ download_asset_release_json(json-common-target
                             ${CMAKE_CURRENT_SOURCE_DIR}/assets/assets_common.json
                             ${SYSROOT_PATH}/
                             MuditaOSPublicAssets
-                            0.0.9
+                            0.0.10
                             ${MUDITA_CACHE_DIR}
     )
 download_asset_release_json(json-community-target
                             ${CMAKE_CURRENT_SOURCE_DIR}/assets/assets_community.json
                             ${SYSROOT_PATH}/system_a/
                             MuditaOSPublicAssets
-                            0.0.8
+                            0.0.10
                             ${MUDITA_CACHE_DIR}
     )
 download_asset_json(json-rt1051-target

--- a/products/PurePhone/assets/assets_common.json
+++ b/products/PurePhone/assets/assets_common.json
@@ -171,6 +171,7 @@
         {"name":"release.tgz", "tarfile": "./image/assets/images/logo_W_G.vpi", "output": "system_a/assets/images/logo_W_G.vpi" },
         {"name":"release.tgz", "tarfile": "./image/assets/images/quote_W_G.vpi", "output": "system_a/assets/images/quote_W_G.vpi" },
         {"name":"release.tgz", "tarfile" :"./image/assets/images/common/alarm_colon_select_W_M.vpi", "output": "system_a/assets/images/alarm_colon_select_W_M.vpi"},
+        {"name":"release.tgz", "tarfile": "./image/assets/images/messages/old_messages_arrow_24px_W_M.vpi", "output": "system_a/assets/images/messages/old_messages_arrow_24px_W_M.vpi" },
 
         {"name" : "release_audio.tgz", "tarfile": "./image/assets/audio/pure/meditation/gong.mp3", "output": "system_a/assets/audio/meditation/gong.mp3"},
         {"name" : "release_audio.tgz", "tarfile": "./image/assets/audio/pure/sms/sms_drum.mp3", "output": "system_a/assets/audio/sms/sms_drum.mp3"},

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -20,6 +20,7 @@
 * Fixed scenario when Alarm not being handled properly during a phone call
 * Fixed handsfree device still ringing after caller has hung up
 * Fixed missing contact entries when scrolling through the contact list
+* Fixed misunderstanding holes in sms conversations
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
Not all messages can fit on the current screen in sms conversation windows, so there may be some holes that might suggest that  there are no more messages to display. Now, when there are more SMS to see by scrolling up, the Old Messages label will indicate this fact.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
