### PR TITLE
[BH-1412] Improve system shutdown procedure

### DIFF
--- a/module-sys/Service/Worker.cpp
+++ b/module-sys/Service/Worker.cpp
@@ -265,9 +265,16 @@ namespace sys
     {
         assert(getState() == State::Running || getState() == State::Stopped);
         if (xSemaphoreTake(joinSemaphore, timeout) != pdTRUE) {
+            LOG_ERROR("Failed to take semaphore!");
             return false;
         }
-        while (eTaskGetState(taskHandle) != eDeleted) {}
+        const auto waitDeleteTaskTick = xTaskGetTickCount();
+        while (eTaskGetState(taskHandle) != eDeleted) {
+            if ((xTaskGetTickCount() - waitDeleteTaskTick) > timeout) {
+                LOG_ERROR("Task waiting aborted (timeout). TaskState != eDeleted");
+                return false;
+            }
+        }
         return true;
     }
 

--- a/module-sys/Service/include/Service/Worker.hpp
+++ b/module-sys/Service/include/Service/Worker.hpp
@@ -103,7 +103,7 @@ namespace sys
 
         static constexpr std::size_t controlMessagesCount = static_cast<std::size_t>(ControlMessage::MessageCount);
         static constexpr std::size_t defaultStackSize     = 8192;
-        static constexpr TickType_t defaultJoinTimeout    = portMAX_DELAY;
+        static constexpr TickType_t defaultJoinTimeout    = pdMS_TO_TICKS(500);
         static constexpr auto controlQueueNamePrefix      = "wctrl";
 
         xSemaphoreHandle joinSemaphore = nullptr;


### PR DESCRIPTION
Changed default Worker join timeout to a more realistic value
 in case of system shutdown procedure.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
