### PR TITLE
[MOS-1007] Fix for add/update contact with 2 same phone numbers

### DIFF
--- a/module-db/Interface/ContactRecord.hpp
+++ b/module-db/Interface/ContactRecord.hpp
@@ -319,4 +319,6 @@ class ContactRecordInterface : public RecordInterface<ContactRecord, ContactReco
      */
     auto changeNumberRecordInPlaceIfCountryCodeIsOnlyDifferent(const std::vector<std::uint32_t> &oldNumberIDs,
                                                                std::vector<ContactRecord::Number> &newNumbers) -> bool;
+
+    auto hasContactRecordSameNumbers(const ContactRecord &rec) -> bool;
 };

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -22,6 +22,7 @@
 * Fixed missing contact entries when scrolling through the contact list
 * Fixed misunderstanding holes in sms conversations
 * Fixed occasional crash when unplugging Pure from PC when connected with Mudita Center
+* Fixed ability to create contact with 2 same numbers
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
There was possibility to add contact, or edit some contact, with have 2 same phone numbers (exactly the same or witch/without country code). Now this has been fixed and is not possible to create, even by editing, contact with 2 exactly the same numbers or 2 same numbers and one of them with a country code

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
