### PR TITLE
[MOS-1013] Fix missing audio files in simulator after rebuilding image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,13 @@ add_directories(
         DIRECTORIES log assets crash_dumps data bin db scripts var
 )
 
+# Remove 'var' directory to delete all files created during simulator operation
+add_custom_target(
+        remove_var_directory
+        COMMAND rm -rf ${SYSROOT_PATH}/system_a/var
+        COMMENT "Removing 'var' directory"
+)
+
 # Create and initialize product-specific databases
 add_databases_target(
         TARGET create_product_databases
@@ -198,6 +205,7 @@ add_databases_target(
         DEST_DIR ${SYSROOT_PATH}/system_a/db
         DEVEL ${WITH_DEVELOPMENT_FEATURES}
 )
+
 # Install scripts
 add_scripts_target(
         TARGET install_scripts

--- a/products/BellHybrid/CMakeLists.txt
+++ b/products/BellHybrid/CMakeLists.txt
@@ -120,6 +120,7 @@ else()
         DEPENDS
             install_scripts
             create_product_databases
+            remove_var_directory
             create_user_directories
             assets
             BellHybrid-version.json-target

--- a/products/PurePhone/CMakeLists.txt
+++ b/products/PurePhone/CMakeLists.txt
@@ -137,6 +137,7 @@ else()
         DEPENDS
             install_scripts
             create_product_databases
+            remove_var_directory
             create_user_directories
             assets
             PurePhone-version.json-target


### PR DESCRIPTION
Fix of the issue that rebuilding simulator
image after multimedia files have been
indexed resulted in no files visible in
Music Player app.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
