### PR TITLE
[BH-1412] Fix system shutdown procedure

### DIFF
--- a/module-services/service-desktop/include/service-desktop/ServiceDesktopDependencies.hpp
+++ b/module-services/service-desktop/include/service-desktop/ServiceDesktopDependencies.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "ServiceDesktopName.hpp"
-#include <service-eink/ServiceEinkDependencies.hpp>
+#include <service-gui/ServiceGUIDependencies.hpp>
 #include <string>
 #include <vector>
 
@@ -16,7 +16,7 @@ namespace sys::dependencies
     template <>
     inline std::vector<std::string> getDependenciesFor<ServiceDesktop>()
     {
-        return sys::dependencies::getDependenciesTo<service::eink::ServiceEink>();
+        return sys::dependencies::getDependenciesTo<service::gui::ServiceGUI>();
     }
 
     template <>

--- a/module-services/service-gui/service-gui/ServiceGUI.hpp
+++ b/module-services/service-gui/service-gui/ServiceGUI.hpp
@@ -34,10 +34,11 @@ namespace service::gui
 
         enum class ServiceGUIState
         {
-            Displaying,
+            Idle = 0,
             Rendering,
+            Displaying,
             Closing,
-            Idle
+            ReadyToClose
         };
 
       public:

--- a/module-services/service-gui/service-gui/ServiceGUIDependencies.hpp
+++ b/module-services/service-gui/service-gui/ServiceGUIDependencies.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <service-desktop/ServiceDesktopDependencies.hpp>
+#include <service-eink/ServiceEinkDependencies.hpp>
 #include <service-gui/ServiceGUIName.hpp>
 #include <string>
 #include <vector>
@@ -17,7 +17,7 @@ namespace sys::dependencies
     template <>
     inline std::vector<std::string> getDependenciesFor<service::gui::ServiceGUI>()
     {
-        return sys::dependencies::getDependenciesTo<ServiceDesktop>();
+        return sys::dependencies::getDependenciesTo<service::eink::ServiceEink>();
     }
 
     template <>

--- a/module-sys/SystemManager/SystemManagerCommon.cpp
+++ b/module-sys/SystemManager/SystemManagerCommon.cpp
@@ -473,6 +473,10 @@ namespace sys
             serviceCloseTimer.stop();
 
             const auto message = static_cast<ReadyToCloseMessage *>(msg);
+            if (std::find(servicesToClose.begin(), servicesToClose.end(), message->sender) == servicesToClose.end()) {
+                LOG_ERROR("%s is not on the list. Further processing skipped.", message->sender.c_str());
+                return;
+            }
             LOG_INFO("ready to close %s", message->sender.c_str());
             servicesToClose.erase(std::remove(servicesToClose.begin(), servicesToClose.end(), message->sender),
                                   servicesToClose.end());

--- a/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
+++ b/products/BellHybrid/apps/application-bell-main/ApplicationBellMain.cpp
@@ -80,7 +80,9 @@ namespace app
         });
 
         connect(typeid(sdesktop::usb::USBConfigured), [&](sys::Message *msg) -> sys::MessagePointer {
-            homeScreenPresenter->setUSBStatusConnected();
+            if (getCurrentWindow()->getName() == gui::name::window::main_window) {
+                homeScreenPresenter->setUSBStatusConnected();
+            }
             return sys::msgHandled();
         });
         connect(typeid(AlarmDeactivated), [this](sys::Message *request) -> sys::MessagePointer {


### PR DESCRIPTION
Changed startup services order.
Prevent handling multiple "close ready" messages from one service while closing system.
Introduced a new state in ServiceGUI.
Fixed a problem with turning on Harmony with a connected USB cable.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
