### PR TITLE
[MOS-1010] Fix for Alarm disappearance during end of call window

### DIFF
--- a/module-apps/application-call/ApplicationCall.cpp
+++ b/module-apps/application-call/ApplicationCall.cpp
@@ -187,6 +187,10 @@ namespace app
             return sys::MessageNone{};
         });
 
+        connect(typeid(cellular::IsCallActive), [&](sys::Message *request) {
+            return std::make_shared<cellular::IsCallActiveResponse>(callModel->getState() != call::CallState::None);
+        });
+
         connect(typeid(cellular::CallStartedNotification), [&](sys::Message *request) {
             auto message = static_cast<cellular::CallStartedNotification *>(request);
             callModel->setPhoneNumber(message->getNumber());

--- a/module-services/service-cellular/CellularServiceAPI.cpp
+++ b/module-services/service-cellular/CellularServiceAPI.cpp
@@ -4,6 +4,7 @@
 #include "service-cellular/CellularMessage.hpp"
 #include "service-cellular/CellularServiceAPI.hpp"
 #include "service-cellular/ServiceCellular.hpp"
+#include "application-call/include/application-call/ApplicationCall.hpp"
 
 #include <MessageType.hpp>
 #include <modem/mux/CellularMux.h>
@@ -242,6 +243,7 @@ bool CellularServiceAPI::GetAntenna(sys::Service *serv, bsp::cellular::antenna &
 
 bool CellularServiceAPI::IsCallInProgress(sys::Service *serv, bool &response)
 {
+    // Ask cellular is in Active state (any other state than Idle)
     auto msg = std::make_shared<cellular::IsCallActive>();
     auto ret = serv->bus.sendUnicastSync(msg, service::name::cellular, 1000);
     if (ret.first == sys::ReturnCodes::Success) {
@@ -252,6 +254,31 @@ bool CellularServiceAPI::IsCallInProgress(sys::Service *serv, bool &response)
             return true;
         }
     }
+    return false;
+}
+
+bool CellularServiceAPI::IsCallStateForCallApplicationActive(sys::Service *serv, bool &response)
+{
+    // Ask ApplicationCall (if App even exist) about its internal Call State
+    auto msg = std::make_shared<cellular::IsCallActive>();
+    auto ret = serv->bus.sendUnicastSync(msg, app::name_call, 1000);
+    if (ret.first == sys::ReturnCodes::Success) {
+        auto celResponse = std::dynamic_pointer_cast<cellular::IsCallActiveResponse>(ret.second);
+        if ((celResponse != nullptr) && (celResponse->retCode == sys::ReturnCodes::Success)) {
+            LOG_DEBUG("Is Call in active for ApplicationCall: %d", celResponse->active);
+            response = celResponse->active;
+            return true;
+        }
+    }
+    else if (ret.first == sys::ReturnCodes::ServiceDoesntExist) {
+        LOG_DEBUG("App doesn't exist so it cannot have an active call state");
+        response = false;
+        return true; // Tolerant behavior
+    }
+
+    LOG_DEBUG("ApplicationCall doesn't seem to be responding, so we're assuming the app doesn't exist, "
+              "so App can not have active call state");
+    response = false;
     return false;
 }
 

--- a/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
+++ b/module-services/service-cellular/service-cellular/CellularServiceAPI.hpp
@@ -86,6 +86,7 @@ namespace CellularServiceAPI
     bool GetQNWINFO(sys::Service *serv, std::string &response);
     bool GetAntenna(sys::Service *serv, bsp::cellular::antenna &response);
     bool IsCallInProgress(sys::Service *serv, bool &response);
+    bool IsCallStateForCallApplicationActive(sys::Service *serv, bool &response);
     /**
      * @brief Transmits DTMF tone
      * @param serv

--- a/module-services/service-time/ServiceTime.cpp
+++ b/module-services/service-time/ServiceTime.cpp
@@ -50,8 +50,16 @@ namespace stm
         alarmOperations->updateEventsCache(TimePointNow());
         alarmOperations->addCheckIfPhoneCallIsOngoingCallback([this]() -> bool {
             bool isPhoneCallInProgress = false;
+            // Check Call state in Cellular
             if (!CellularServiceAPI::IsCallInProgress(this, isPhoneCallInProgress)) {
-                LOG_ERROR("Unable to check if the Call is in progress");
+                LOG_ERROR("Unable to check if the Call is in progress for Cellular service");
+            }
+
+            // Double check is ApplicationCall (if App exist) has active state of call
+            if (!isPhoneCallInProgress &&
+                !CellularServiceAPI::IsCallStateForCallApplicationActive(this, isPhoneCallInProgress)) {
+                LOG_WARN("Unable to check if the ApplicationCall has Active Call State. "
+                         "Call Status not considered active");
             }
             return isPhoneCallInProgress;
         });

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -33,6 +33,7 @@
 * Fixed hard fault handling
 * Fixed issue with uneven first screen redraw after turning the phone on
 * Fixed issue with bypassing phone lock window after unplugging USB cable on tethering popup
+* Fixed Alarm disappearance during end of call window
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
It was possible to display an Alarm with the appropriate Alarm window exactly when end of call window with call summary are displayed and automatically closed after 3 seconds. This commit will fix this scenario. Now Alarm is snooze in the same way as if there is a phone call going on.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
