### PR TITLE
[MOS-948] Fix for tethering popup was losing app context

### DIFF
--- a/module-apps/apps-common/popups/TetheringConfirmationPopup.cpp
+++ b/module-apps/apps-common/popups/TetheringConfirmationPopup.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TetheringConfirmationPopup.hpp"
@@ -23,7 +23,7 @@ namespace gui
         metadata.action = [this]() {
             application->bus.sendUnicast(std::make_shared<sys::TetheringEnabledResponse>(),
                                          service::name::system_manager);
-            app::manager::Controller::sendAction(application, app::manager::actions::Home);
+            application->returnToPreviousWindow();
             return true;
         };
         auto msg = std::make_unique<DialogMetadataMessage>(std::move(metadata));

--- a/module-apps/apps-common/popups/TetheringOffPopup.cpp
+++ b/module-apps/apps-common/popups/TetheringOffPopup.cpp
@@ -34,7 +34,7 @@ namespace gui
         metadata.action = [this]() {
             application->bus.sendUnicast(std::make_shared<sys::TetheringStateRequest>(sys::phone_modes::Tethering::Off),
                                          service::name::system_manager);
-            app::manager::Controller::sendAction(application, app::manager::actions::Home);
+            application->returnToPreviousWindow();
             return true;
         };
         metadata.title = utils::translate("tethering");

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -27,6 +27,7 @@
 * Fixed ability to create contact with 2 same numbers
 * Fixed diacritics in translations
 * Fixed issues with file uploads with low disk space.
+* Fixed data losing because switching tethering via tethering popup
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
Fixed data loss when creating or editing a note/contact after connecting the USB cable and selecting the option to enable tetering in the popup window that appears. Now when tethering is enabled via the popup, the user will return to Application without data loss.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
