### PR TITLE
[MOS-929] Block executing call when phone number empty

### DIFF
--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -33,6 +33,7 @@ namespace gui
         presenter.attachCallbacks();
         buildInterface();
     }
+
     CallWindow::~CallWindow() noexcept
     {
         presenter.clearModel();
@@ -43,6 +44,7 @@ namespace gui
         destroyInterface();
         buildInterface();
     }
+
     void CallWindow::buildInterface()
     {
         AppWindow::buildInterface();
@@ -54,7 +56,6 @@ namespace gui
         navBar->setText(nav_bar::Side::Right, utils::translate(style::strings::common::back));
         navBar->setText(gui::nav_bar::Side::Center, utils::translate(strings::message));
 
-        // top circle image
         imageCircleTop = new gui::Image(this, imageCircleTop::x, imageCircleTop::y, 0, 0, imageCircleTop::name);
         imageCircleBottom =
             new gui::Image(this, imageCircleBottom::x, imageCircleBottom::y, 0, 0, imageCircleBottom::name);
@@ -244,6 +245,7 @@ namespace gui
         navBar->setActive(gui::nav_bar::Side::Center, false);
         navBar->setActive(gui::nav_bar::Side::Right, false);
     }
+
     void CallWindow::setIncomingCallLayout(bool isValidCallerId)
     {
         navBar->setText(gui::nav_bar::Side::Left, utils::translate(strings::answer), true);
@@ -315,5 +317,4 @@ namespace gui
     {
         speakerIcon->set(icon);
     }
-
 } /* namespace gui */

--- a/module-apps/application-call/windows/NumberWindow.cpp
+++ b/module-apps/application-call/windows/NumberWindow.cpp
@@ -6,14 +6,11 @@
 #include "CallSwitchData.hpp"
 #include "NumberWindow.hpp"
 
-#include <ContactRecord.hpp>
-#include <gui/widgets/Image.hpp>
 #include <gui/widgets/text/Label.hpp>
 #include <gui/widgets/Window.hpp>
 #include <i18n/i18n.hpp>
 #include <text/modes/InputMode.hpp>
 #include <service-appmgr/Controller.hpp>
-#include <service-cellular/CellularServiceAPI.hpp>
 
 #include <cassert>
 
@@ -79,15 +76,20 @@ namespace gui
 
     bool NumberWindow::onInput(const InputEvent &inputEvent)
     {
-        auto code = translator.handle(inputEvent.getRawKey(), InputMode({InputMode::phone}).get());
+        const auto code = translator.handle(inputEvent.getRawKey(), InputMode({InputMode::phone}).get());
+
         if (inputEvent.isShortRelease()) {
             // Call function
             if (inputEvent.is(KeyCode::KEY_LF)) {
+                if (enteredNumber.empty()) {
+                    return false;
+                }
                 interface->handleCallEvent(enteredNumber);
                 return true;
             }
+
             // Clear/back function
-            else if (inputEvent.is(KeyCode::KEY_RF)) {
+            if (inputEvent.is(KeyCode::KEY_RF)) {
                 // if there isn't any char in phone number field return to previous application
                 if (enteredNumber.empty()) {
                     formatter->Clear();

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -14,6 +14,7 @@
 * General improvement in Eink display and error handling
 * Change roaming indicator to show domestic roaming as home network
 * Optimized ServiceAudio power management
+* Blocked call execution with empty phone number field
 
 ### Fixed
 


### PR DESCRIPTION
Fix of the issue that when trying to call empty
number when entering number via keypad
on main screen, popup 'Something went wrong'
would appear, while no action should
happen in such case.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
