### PR TITLE
[BH-1750] Fix meditation countdown timer

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -21,6 +21,7 @@
 * Fixed the logic in onboarding screens
 * Fixed issues with file uploads with low disk space.
 * Fixed hard fault handling
+* Fixed meditation countdown timer when a deep press is performed
 
 ### Added
 

--- a/products/BellHybrid/apps/application-bell-meditation-timer/CMakeLists.txt
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(application-bell-meditation-timer
         bell::app-common
         bell::app-main
         bell::paths
+        bell::keymap
         service-appmgr
         service-time
     PUBLIC

--- a/products/BellHybrid/apps/application-bell-meditation-timer/presenter/MeditationCountdownPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/presenter/MeditationCountdownPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MeditationCommon.hpp"
@@ -36,11 +36,26 @@ namespace app::meditation
         timer->stop();
     }
 
+    bool MeditationCountdownPresenter::isFinished()
+    {
+        return finished;
+    }
+
+    void MeditationCountdownPresenter::setReady(bool status)
+    {
+        ready = status;
+    }
+
+    bool MeditationCountdownPresenter::isReady()
+    {
+        return ready;
+    }
+
     void MeditationCountdownPresenter::onCountdownFinished()
     {
-        auto data                        = std::make_unique<gui::SwitchData>();
-        data->ignoreCurrentWindowOnStack = true;
-
-        app->switchWindow(meditation::windows::meditationProgress, std::move(data));
+        finished = true;
+        if (ready) {
+            app->switchWindow(meditation::windows::meditationProgress);
+        }
     }
 } // namespace app::meditation

--- a/products/BellHybrid/apps/application-bell-meditation-timer/presenter/MeditationCountdownPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/presenter/MeditationCountdownPresenter.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -38,6 +38,9 @@ namespace app::meditation
             virtual void setTimer(std::unique_ptr<app::TimerWithCallbacks> &&timer) = 0;
             virtual void start()                                                    = 0;
             virtual void stop()                                                     = 0;
+            virtual bool isFinished()                                               = 0;
+            virtual bool isReady()                                                  = 0;
+            virtual void setReady(bool status)                                      = 0;
         };
     };
 
@@ -50,12 +53,17 @@ namespace app::meditation
         std::chrono::seconds duration;
 
         void onCountdownFinished();
+        bool finished{false};
+        bool ready{true};
 
       public:
         MeditationCountdownPresenter(app::ApplicationCommon *app, models::StartDelay &startDelay);
 
         void setTimer(std::unique_ptr<app::TimerWithCallbacks> &&_timer) override;
+        bool isFinished() override;
         void start() override;
         void stop() override;
+        bool isReady() override;
+        void setReady(bool status) override;
     };
 } // namespace app::meditation

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <Arc.hpp>
@@ -8,6 +8,7 @@
 #include "MeditationCountdownWindow.hpp"
 #include "MeditationStyle.hpp"
 
+#include <keymap/KeyMap.hpp>
 #include <apps-common/widgets/ProgressTimerWithBarGraphAndCounter.hpp>
 
 namespace
@@ -90,12 +91,20 @@ namespace gui
         if (mode == ShowMode::GUI_SHOW_INIT) {
             presenter->start();
         }
+        else if (presenter->isFinished()) {
+            application->switchWindow(app::meditation::windows::meditationProgress);
+        }
+        presenter->setReady(true);
     }
 
     bool MeditationCountdownWindow::onInput(const InputEvent &inputEvent)
     {
-        if (inputEvent.isShortRelease(gui::KeyCode::KEY_RF)) {
+        const auto key = mapKey(inputEvent.getKeyCode());
+        if (key == KeyMap::Back) {
             presenter->stop();
+        }
+        if (key == KeyMap::DeepPressUp || key == KeyMap::DeepPressDown) {
+            presenter->setReady(false);
         }
         return AppWindow::onInput(inputEvent);
     }

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -36,9 +36,5 @@ namespace gui
 
         void buildLayout();
         void configureTimer();
-
-        void endSession();
-        void intervalTimeout();
-        void playGong();
     };
 } // namespace gui


### PR DESCRIPTION
When the meditation countdown timer is enabled
and the deep press is performed before this window expired then it displays 0:00 timer.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
