### PR TITLE
[CP-2032] Unplugging the cable during file upload leaves partially se…

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -31,6 +31,7 @@
 * Added extended information to log filename
 * Added Harmony version information in about section
 * Added system shutdown if there is no user activity for 180 seconds on the language selection screen
+* Files not fully transferred via Center will be now removed when USB cable is unplugged
 
 ### Changed / Improved
 

--- a/module-services/service-desktop/endpoints/filesystem/FileOperations.cpp
+++ b/module-services/service-desktop/endpoints/filesystem/FileOperations.cpp
@@ -67,7 +67,7 @@ void FileOperations::cancelTimedOutWriteTransfer()
 
     fileCtxEntry->second.reset();
 
-    LOG_DEBUG("Canceling timed out rxID %u", static_cast<unsigned>(timedOutXfer));
+    LOG_DEBUG("Canceling timed out txID %u", static_cast<unsigned>(timedOutXfer));
     writeTransfers.erase(timedOutXfer);
 }
 
@@ -175,7 +175,6 @@ auto FileOperations::createTransmitIDForFile(const std::filesystem::path &file,
 
     createFileWriteContextFor(file, size, Crc32, txID);
     fileData = std::make_unique<std::vector<uint8_t>>(SingleChunkSize, 0);
-
     return txID;
 }
 
@@ -225,4 +224,18 @@ auto FileOperations::sendDataForTransmitID(transfer_id txID, std::uint32_t chunk
     }
 
     return returnCode;
+}
+
+auto FileOperations::cleanUpUndeliveredTransfers() -> void
+{
+    if (writeTransfers.empty()) {
+        return;
+    }
+
+    LOG_INFO("Clean up after undelivered transfers");
+    for (auto &wt : writeTransfers) {
+        wt.second->removeFile();
+        wt.second.reset();
+        writeTransfers.erase(wt.first);
+    }
 }

--- a/module-services/service-desktop/endpoints/include/endpoints/filesystem/FileOperations.hpp
+++ b/module-services/service-desktop/endpoints/include/endpoints/filesystem/FileOperations.hpp
@@ -5,6 +5,7 @@
 
 #include "FileContext.hpp"
 
+#include <log/log.hpp>
 #include <filesystem>
 #include <vector>
 #include <map>
@@ -26,7 +27,6 @@ class FileOperations
     std::atomic<transfer_id> runningRxId{0};
     std::atomic<transfer_id> runningTxId{0};
     std::unique_ptr<std::vector<std::uint8_t>> fileData{};
-
     auto createFileReadContextFor(const std::filesystem::path &file, std::size_t fileSize, transfer_id xfrId) -> void;
 
     auto createFileWriteContextFor(const std::filesystem::path &file,
@@ -71,4 +71,6 @@ class FileOperations
         -> transfer_id;
 
     auto sendDataForTransmitID(transfer_id, std::uint32_t chunkNo, const std::string &data) -> sys::ReturnCodes;
+
+    auto cleanUpUndeliveredTransfers() -> void;
 };

--- a/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
@@ -120,6 +120,8 @@ class ServiceDesktop : public sys::Service
 
     void checkChargingCondition();
 
+    void cleanFileSystemEndpointUndeliveredTransfers();
+
     template <typename T>
     auto connectHandler() -> bool
     {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -8,6 +8,7 @@
 * Added extended information to crashdump filename
 * Added extended information to log filename
 * Added GUI screens informing about failed MMI/USSD request
+* Files not fully transferred via Center will be now removed when USB cable is unplugged
 
 ### Changed / Improved
 


### PR DESCRIPTION
…nt file

Files not completely sent will be deleted after the USB cable is removed from device to not leave any partially sent file

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
