### PR TITLE
[BH-1756] Fix "turn off" window display time

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -22,6 +22,7 @@
 * Fixed issues with file uploads with low disk space.
 * Fixed hard fault handling
 * Fixed meditation countdown timer when a deep press is performed
+* Fixed "turn off" window display time
 
 ### Added
 

--- a/products/BellHybrid/apps/Application.cpp
+++ b/products/BellHybrid/apps/Application.cpp
@@ -71,7 +71,8 @@ namespace app
                 break;
             case ID::PowerOff:
                 windowsFactory.attach(window::power_off_window, [](ApplicationCommon *app, const std::string &name) {
-                    return std::make_unique<gui::BellTurnOffOptionWindow>(app, window::power_off_window);
+                    return std::make_unique<gui::BellTurnOffOptionWindow>(
+                        app, gui::turnOffPopupTimeout, window::power_off_window);
                 });
                 windowsFactory.attach(gui::BellTurnOffWindow::name,
                                       [](ApplicationCommon *app, const std::string &name) {

--- a/products/BellHybrid/apps/common/include/common/popups/BellTurnOffOptionWindow.hpp
+++ b/products/BellHybrid/apps/common/include/common/popups/BellTurnOffOptionWindow.hpp
@@ -8,11 +8,16 @@
 
 namespace gui
 {
+    constexpr std::chrono::seconds turnOffPopupTimeout{10};
+    constexpr std::chrono::milliseconds defaultWindowTimeout{0};
+
     class BellTurnOffOptionWindow : public BellShortOptionWindow
     {
       public:
         static constexpr auto defaultName = "BellTurnOffOptionWindow";
-        explicit BellTurnOffOptionWindow(app::ApplicationCommon *app, const char *name = defaultName);
+        explicit BellTurnOffOptionWindow(app::ApplicationCommon *app,
+                                         std::chrono::milliseconds duration = defaultWindowTimeout,
+                                         const char *name                   = defaultName);
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
         void onClose(CloseReason reason) override;
 

--- a/products/BellHybrid/apps/common/src/popups/BellTurnOffOptionWindow.cpp
+++ b/products/BellHybrid/apps/common/src/popups/BellTurnOffOptionWindow.cpp
@@ -16,20 +16,23 @@
 
 namespace
 {
-    using namespace std::chrono_literals;
-    constexpr auto windowTimeout{10s};
     constexpr auto timerName{"BellTurnOffPopupTimer"};
 } // namespace
 
 namespace gui
 {
-    BellTurnOffOptionWindow::BellTurnOffOptionWindow(app::ApplicationCommon *app, const char *name)
+    BellTurnOffOptionWindow::BellTurnOffOptionWindow(app::ApplicationCommon *app,
+                                                     std::chrono::milliseconds duration,
+                                                     const char *name)
         : BellShortOptionWindow(app, name), yesStr{utils::translate("common_yes")}, noStr{utils::translate("common_no")}
     {
         addOptions(settingsOptionsList());
         setListTitle(utils::translate("app_bell_turn_off_question"));
 
-        popupTimer    = app::GuiTimerFactory::createSingleShotTimer(application, this, timerName, windowTimeout);
+        if (duration > std::chrono::milliseconds::zero()) {
+            popupTimer = app::GuiTimerFactory::createSingleShotTimer(application, this, timerName, duration);
+        }
+
         timerCallback = [this, name](Item &, sys::Timer &timer) {
             if (application->getCurrentWindow()->getName() == name) {
                 application->returnToPreviousWindow();


### PR DESCRIPTION
<!-- Please describe your pull request here -->

"Turn off" window should be displayed for 10 seconds triggered by pressing the buttons "light" and "back" or 180 seconds triggered from the menu->settings

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
