### PR TITLE
[MOS-1024] Fix unlocking phone after locked with tethering popup

### DIFF
--- a/module-apps/apps-common/ApplicationCommon.hpp
+++ b/module-apps/apps-common/ApplicationCommon.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -23,7 +23,6 @@
 #include <list>     // for list
 #include <map>      // for allocator, map
 #include <memory>   // for make_shared
-#include <stdint.h> // for uint32_t
 #include <string>   // for string
 #include <utility>  // for move, pair
 #include <vector>   // for vector
@@ -189,8 +188,7 @@ namespace app
         std::unique_ptr<gui::popup::Filter> popupFilter;
         std::unique_ptr<WindowsStack> windowsStackImpl;
         std::string default_window;
-        State state        = State::DEACTIVATED;
-        bool phoneIsLocked = false;
+        State state = State::DEACTIVATED;
 
         sys::MessagePointer handleSignalStrengthUpdate(sys::Message *msgl);
         sys::MessagePointer handleNetworkAccessTechnologyUpdate(sys::Message *msgl);
@@ -224,7 +222,7 @@ namespace app
                                    std::string parent                  = "",
                                    StatusIndicators statusIndicators   = StatusIndicators{},
                                    StartInBackground startInBackground = {false},
-                                   uint32_t stackDepth                 = 4096,
+                                   std::uint32_t stackDepth            = 1024 * 4,
                                    sys::ServicePriority priority       = sys::ServicePriority::Idle);
 
         virtual ~ApplicationCommon() noexcept;
@@ -328,13 +326,13 @@ namespace app
                                   manager::actions::ActionId actionId,
                                   manager::actions::ActionParamsPtr &&data);
         static void messageSwitchApplication(sys::Service *sender,
-                                             std::string application,
-                                             std::string window,
+                                             const std::string &application,
+                                             const std::string &window,
                                              std::unique_ptr<gui::SwitchData> data,
                                              StartupReason startupReason);
-        static void messageCloseApplication(sys::Service *sender, std::string application);
-        static void messageRebuildApplication(sys::Service *sender, std::string application);
-        static void messageApplicationLostFocus(sys::Service *sender, std::string application);
+        static void messageCloseApplication(sys::Service *sender, const std::string &application);
+        static void messageRebuildApplication(sys::Service *sender, const std::string &application);
+        static void messageApplicationLostFocus(sys::Service *sender, const std::string &application);
         static void messageSwitchBack(sys::Service *sender, const std::string &application);
         /// @}
 
@@ -368,7 +366,7 @@ namespace app
         bool userInterfaceDBNotification(sys::Message *msg, const UiNotificationFilter &filter = nullptr);
         virtual gui::popup::Filter &getPopupFilter() const;
 
-        void requestShutdownWindow(std::string windowName);
+        void requestShutdownWindow(const std::string &windowName);
 
       public:
         /// push window to the top of windows stack
@@ -377,9 +375,6 @@ namespace app
         /// getter for previous window name
         /// @ingrup AppWindowStack
         std::optional<std::string> getPreviousWindow(std::uint32_t count = 1) const;
-        /// clears windows stack
-        /// @ingrup AppWindowStack
-        void cleanPrevWindw();
         /// getter for current wisible window in application
         /// if there is none - returns default window
         /// @ingrup AppWindowStack
@@ -418,7 +413,7 @@ namespace app
         /// informs self that there was key press
         /// used to provide a way for long press/multipress handling in application
         static void messageInputEventApplication(sys::Service *sender,
-                                                 std::string application,
+                                                 const std::string &application,
                                                  const gui::InputEvent &event);
 
         void addActionReceiver(manager::actions::ActionId actionId, OnActionReceived &&callback);

--- a/module-apps/apps-common/popups/TetheringConfirmationPopup.cpp
+++ b/module-apps/apps-common/popups/TetheringConfirmationPopup.cpp
@@ -6,7 +6,6 @@
 #include "ApplicationCommon.hpp"
 
 #include <system/messages/TetheringQuestionRequest.hpp>
-#include <service-appmgr/Controller.hpp>
 
 namespace gui
 {

--- a/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
+++ b/module-services/service-appmgr/model/ApplicationManagerCommon.cpp
@@ -458,7 +458,6 @@ namespace app::manager
         case actions::Launch:
             return handleLaunchAction(action);
         case actions::ShowPopup:
-            [[fallthrough]];
         case actions::AbortPopup:
             return handleActionOnFocusedApp(action);
         case actions::NotificationsChanged:

--- a/products/PurePhone/sys/SystemManager.cpp
+++ b/products/PurePhone/sys/SystemManager.cpp
@@ -90,7 +90,6 @@ namespace sys
                 CellularServiceAPI::ChangeModulePowerState(this, cellular::service::State::PowerState::On);
                 break;
             case Store::Battery::LevelState::CriticalCharging:
-                [[fallthrough]];
             case Store::Battery::LevelState::CriticalNotCharging:
                 CellularServiceAPI::ChangeModulePowerState(this, cellular::service::State::PowerState::Off);
                 break;
@@ -146,7 +145,7 @@ namespace sys
                 bus.sendUnicast(std::make_shared<TetheringQuestionAbort>(), service::name::appmgr);
             }
             else {
-                // Turned on, disabling...
+                // Turned on, disabling
                 LOG_INFO("Disabling tethering");
                 bus.sendUnicast(std::make_shared<sevm::RequestPhoneModeForceUpdate>(), service::name::evt_manager);
             }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -32,6 +32,7 @@
 * Fixed data losing because switching tethering via tethering popup
 * Fixed hard fault handling
 * Fixed issue with uneven first screen redraw after turning the phone on
+* Fixed issue with bypassing phone lock window after unplugging USB cable on tethering popup
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
Fix of the issue that after phone has locked
on tethering confirmation popup, unplugging
USB cable would result in bypassing phone
lock screen without providing password.
Minor ApplicationCommon cleanup.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
