### PR TITLE
[MOS-930] Change translations for Old Messages text

### DIFF
--- a/image/system_a/data/lang/Deutsch.json
+++ b/image/system_a/data/lang/Deutsch.json
@@ -301,7 +301,7 @@
     "app_messages_no_messages": "<text align='center' color='4'>Noch keine Nachrichten.<p>Zum Hinzuf\u00fcgen <b>linken Pfeil</b> dr\u00fccken.</p></text>",
     "app_messages_no_sim": "Keine SIM-Karte.\n\nZum Senden einer SMS\nSIM-Karte einsetzen.",
     "app_messages_no_templates": "<text align='center'>Noch keine Vorlagen.<p><b>Erstellen Sie eine neue Vorlage</b></p><p>im Mudita Center, um sie in Ihrem</p><p>Pure zu verwenden.</p></text>",
-    "app_messages_old_messages": "Alte Nachrichten",
+    "app_messages_old_messages": "Vorherige Nachrichten",
     "app_messages_templates": "Vorlagen",
     "app_messages_thread_delete_confirmation": "Dieses Gespr\u00e4ch l\u00f6schen?",
     "app_messages_thread_draft": "Entwurf: ",

--- a/image/system_a/data/lang/English.json
+++ b/image/system_a/data/lang/English.json
@@ -304,7 +304,7 @@
     "app_messages_no_messages": "<text align='center' color='4'>No messages yet.<p>Press <b>left arrow</b> to add new.</p></text>",
     "app_messages_no_sim": "No SIM.\n\nTo send a SMS,\nplease insert a SIM card.",
     "app_messages_no_templates": "<text align='center'>No templates yet.<p><b>Create a new template</b> in Mudita</p><p>Center to use in your Pure.</p></text>",
-    "app_messages_old_messages": "Old Messages",
+    "app_messages_old_messages": "Previous messages",
     "app_messages_templates": "Templates",
     "app_messages_thread_delete_confirmation": "Delete this conversation?",
     "app_messages_thread_draft": "Draft: ",

--- a/image/system_a/data/lang/Espanol.json
+++ b/image/system_a/data/lang/Espanol.json
@@ -300,7 +300,7 @@
     "app_messages_no_messages": "<text align='center' color='4'>No hay mensajes.<p>Pulsa la <b>flecha izquierda</b> para a\u00f1adir uno.</p></text>",
     "app_messages_no_sim": "No hay SIM.\n\nPara enviar un SMS,\ndebes insertar una tarjeta SIM.",
     "app_messages_no_templates": "<text align='center'>A\u00fan no hay plantillas.<p><b>Crea una nueva plantilla</b> en Mudita</p><p>Center para usar en tu Pure.</p></text>",
-    "app_messages_old_messages": "Mensajes antiguos",
+    "app_messages_old_messages": "Mensajes anteriores",
     "app_messages_templates": "Plantillas",
     "app_messages_thread_delete_confirmation": "\u00bfEliminar esta conversaci\u00f3n?",
     "app_messages_thread_draft": "Borrador: ",

--- a/image/system_a/data/lang/Francais.json
+++ b/image/system_a/data/lang/Francais.json
@@ -268,7 +268,7 @@
     "app_messages_no_messages": "<text align = 'center' color = '4'>Aucun message.<p>Appuyez sur la <b>fl\u00e8che gauche</b> pour en composer un nouveau.</p></text>",
     "app_messages_no_sim": "Pas de carte SIM.\n\nPour envoyer un SMS,\nveuillez ins\u00e9rer une carte SIM.",
     "app_messages_no_templates": "<text align='center'>Pas encore de mod\u00e8les.<p><b>Cr\u00e9ez un nouveau mod\u00e8le</b> sur Mudita</p><p>Center \u00e0 utiliser dans votre Pure.</p></text>",
-    "app_messages_old_messages": "Anciens messages",
+    "app_messages_old_messages": "Messages pr\u00e9c\u00e9dents",
     "app_messages_templates": "Mod\u00e8les",
     "app_messages_thread_delete_confirmation": "Supprimer cette conversation ?",
     "app_messages_thread_draft": "Brouillon: ",

--- a/image/system_a/data/lang/Polski.json
+++ b/image/system_a/data/lang/Polski.json
@@ -293,7 +293,7 @@
     "app_messages_no_messages": "<text align='center' color='4'>Nie ma jeszcze \u017cadnych wiadomo\u015bci.<p>Wci\u015bnij <b>lew\u0105 strza\u0142k\u0119</b>, by doda\u0107 now\u0105.</p></text>",
     "app_messages_no_sim": "Brak SIM.\n\nAby wys\u0142a\u0107 SMS,\nw\u0142\u00f3\u017c kart\u0119 SIM.",
     "app_messages_no_templates": "<text align='center'>Nie ma jeszcze \u017cadnych szablon\u00f3w.<p><b>Stw\u00f3rz nowy szablon</b> w Mudita</p><p>Center, aby u\u017cy\u0107 go w swoim Pure.</p></text>",
-    "app_messages_old_messages": "Stare Wiadomo\u015bci",
+    "app_messages_old_messages": "Poprzednie wiadomo\u015bci",
     "app_messages_templates": "Szablony",
     "app_messages_thread_delete_confirmation": "Usun\u0105\u0107 t\u0119 rozmow\u0119?",
     "app_messages_thread_draft": "Wersja robocza: ",

--- a/image/system_a/data/lang/Svenska.json
+++ b/image/system_a/data/lang/Svenska.json
@@ -163,7 +163,7 @@
     "app_messages_no_messages": "<text align='center' color='4'>Inga meddelanden \u00e4n.<p>Tryck <b>v\u00e4nsterpil</b> f\u00f6r att b\u00f6rja skriva ett.</p></text>",
     "app_messages_no_sim": "F\u00f6r att skicka ett SMS,\ns\u00e4tt i ett SIM-kort.",
     "app_messages_no_templates": "<text align='center'>Inga mallar \u00e4nnu.<p><b>Skapa en ny mall</b> i Mudita</p><p>Center som du kan anv\u00e4nda i din Pure.</p></text>",
-    "app_messages_old_messages": "Gamla meddelanden",
+    "app_messages_old_messages": "Tidigare meddelanden",
     "app_messages_templates": "Mallar",
     "app_messages_thread_delete_confirmation": "Radera konversation?",
     "app_messages_thread_draft": "Utkast: ",


### PR DESCRIPTION
Change translations for Old Messages text to Previous Messages text.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
