### PR TITLE
[MOS-1021] Fix blocked passcode behavior

### DIFF
--- a/module-apps/apps-common/locks/data/PhoneLockMessages.hpp
+++ b/module-apps/apps-common/locks/data/PhoneLockMessages.hpp
@@ -48,13 +48,13 @@ namespace locks
     class SkippedSetPhoneLock : public sys::DataMessage
     {};
 
-    class UnLockPhoneInput : public sys::DataMessage
+    class UnlockPhoneInput : public sys::DataMessage
     {
       private:
-        std::vector<unsigned int> inputData;
+        std::vector<unsigned> inputData;
 
       public:
-        explicit UnLockPhoneInput(std::vector<unsigned int> inputData) : inputData(std::move(inputData))
+        explicit UnlockPhoneInput(std::vector<unsigned> inputData) : inputData(std::move(inputData))
         {}
 
         [[nodiscard]] auto getInputData() const noexcept
@@ -88,10 +88,10 @@ namespace locks
     class NextPhoneUnlockAttemptLockTime : public sys::DataMessage
     {
       private:
-        time_t nextPhoneUnlockAttemptLockTime;
+        std::time_t nextPhoneUnlockAttemptLockTime;
 
       public:
-        explicit NextPhoneUnlockAttemptLockTime(time_t nextPhoneUnlockAttemptLockTime)
+        explicit NextPhoneUnlockAttemptLockTime(std::time_t nextPhoneUnlockAttemptLockTime)
             : nextPhoneUnlockAttemptLockTime(nextPhoneUnlockAttemptLockTime)
         {}
 
@@ -101,10 +101,10 @@ namespace locks
         }
     };
 
-    class ExternalUnLockPhone : public UnLockPhoneInput
+    class ExternalUnlockPhone : public UnlockPhoneInput
     {
       public:
-        explicit ExternalUnLockPhone(std::vector<unsigned int> inputData) : UnLockPhoneInput(std::move(inputData))
+        explicit ExternalUnlockPhone(std::vector<unsigned> inputData) : UnlockPhoneInput(std::move(inputData))
         {}
     };
 
@@ -120,21 +120,6 @@ namespace locks
         [[nodiscard]] auto getAvailability() const noexcept
         {
             return value;
-        }
-    };
-
-    class ExternalUnLockPhoneInfo : public sys::DataMessage
-    {
-      private:
-        unsigned int attemptsLeft;
-
-      public:
-        explicit ExternalUnLockPhoneInfo(unsigned int attemptsLeft) : attemptsLeft(attemptsLeft)
-        {}
-
-        [[nodiscard]] auto getAttemptsLeft() const noexcept
-        {
-            return attemptsLeft;
         }
     };
 } // namespace locks

--- a/module-apps/apps-common/locks/handlers/PhoneLockHandler.hpp
+++ b/module-apps/apps-common/locks/handlers/PhoneLockHandler.hpp
@@ -14,14 +14,14 @@
 namespace locks
 {
     constexpr auto phoneLockTimerName                    = "PhoneLockTimer";
-    constexpr unsigned int initialNoLockTimeAttemptsLeft = 3;
-    constexpr time_t initialLockTime                     = 15;
-    constexpr unsigned int phoneLockTimeMultiplier       = 2;
+    constexpr unsigned initialNoLockTimeAttemptsLeft     = 3;
+    constexpr std::time_t initialLockTime                = 15;
+    constexpr unsigned phoneLockTimeMultiplier           = 2;
 
     class PhoneLockHandler
     {
       public:
-        enum class ReasonForRequest
+        enum class RequestReason
         {
             Default = 0, // For default behaviors
             MTPUnlock
@@ -31,17 +31,17 @@ namespace locks
         enum class PhoneState
         {
             Locked,
-            Unlocked,
+            Unlocked
         };
 
         enum class LockTimerState
         {
             Start,
             Counting,
-            Stop,
+            Stop
         };
 
-        sys::Service *owner;
+        sys::Service *owner = nullptr;
         std::shared_ptr<settings::Settings> settings;
         Lock lock;
         bool phoneLockEnabled = true;
@@ -49,12 +49,12 @@ namespace locks
         PhoneState phoneState                             = PhoneState::Locked;
         PhoneLockInputTypeAction phoneLockInputTypeAction = PhoneLockInputTypeAction::Unlock;
 
-        unsigned int phoneLockHash = std::numeric_limits<unsigned>::max();
-        std::vector<unsigned int> storedInputData;
+        unsigned phoneLockHash = std::numeric_limits<unsigned>::max();
+        std::vector<unsigned> storedInputData;
 
         sys::TimerHandle phoneLockTimer;
-        time_t lockedFor                 = 0;
-        time_t nextUnlockAttemptLockTime = 0;
+        std::time_t lockedFor                 = 0;
+        std::time_t nextUnlockAttemptLockTime = 0;
 
         void setPhoneLockInputTypeAction(PhoneLockInputTypeAction _phoneLockInputTypeAction);
         bool checkPhoneLockInputTypeAction(PhoneLockInputTypeAction _phoneLockInputTypeAction);
@@ -72,24 +72,24 @@ namespace locks
         void phoneLockDisableAction();
         void phoneLockChangeAction();
         void phoneLockSetAction();
-        void phoneInputRequiredAction(ReasonForRequest reqReason = ReasonForRequest::Default);
+        void phoneInputRequiredAction(RequestReason reqReason = RequestReason::Default);
         void phoneUnlockPopupsCloseAction();
+        void phoneBlockedPopupsCloseAction();
         void phoneLockChangeInfoAction();
-        void phoneExternalUnlockInfoAction();
         void phoneLockTimeUpdateInfoAction(LockTimerState state);
 
         void checkNewPhoneLock();
         void resolvePhoneLockAction();
 
-        void comparePhoneLockHashCode(LockInput inputData);
+        void processPhoneLockHashCode(LockInput inputData);
         sys::MessagePointer verifyPhoneUnlockInput(LockInput inputData);
         sys::MessagePointer verifyPhoneLockChangeInput(LockInput inputData);
 
       public:
-        explicit PhoneLockHandler(sys::Service *owner, std::shared_ptr<settings::Settings> settings);
+        PhoneLockHandler(sys::Service *owner, std::shared_ptr<settings::Settings> settings);
 
         sys::MessagePointer handleLockRequest();
-        sys::MessagePointer handleUnlockRequest(ReasonForRequest reqReason = ReasonForRequest::Default);
+        sys::MessagePointer handleUnlockRequest(RequestReason reqReason = RequestReason::Default);
         sys::MessagePointer handleUnlockCancelRequest();
         sys::MessagePointer handleEnablePhoneLock();
         sys::MessagePointer handleDisablePhoneLock();
@@ -104,13 +104,12 @@ namespace locks
         void setPhoneLockHash(const std::string &value);
         [[nodiscard]] bool isPhoneLocked() const noexcept;
 
-        void setPhoneLockTime(time_t time);
-        void setNextUnlockAttemptLockTime(time_t time);
-        void setNoLockTimeAttemptsLeft(unsigned int attemptsNumber);
+        void setPhoneLockTime(std::time_t time);
+        void setNextUnlockAttemptLockTime(std::time_t time);
+        void setNoLockTimeAttemptsLeft(unsigned attemptsNumber);
         void increaseLockTime() noexcept;
         void setNextUnlockAttemptFormattedTime() noexcept;
         void resetLockTime() noexcept;
         void broadcastLockTime() noexcept;
     };
-
 } // namespace locks

--- a/module-apps/apps-common/locks/handlers/PhoneLockSubject.cpp
+++ b/module-apps/apps-common/locks/handlers/PhoneLockSubject.cpp
@@ -54,6 +54,6 @@ namespace locks
 
     void PhoneLockSubject::verifyInput(LockInput inputData)
     {
-        owner->bus.sendUnicast(std::make_shared<UnLockPhoneInput>(inputData), service::name::appmgr);
+        owner->bus.sendUnicast(std::make_shared<UnlockPhoneInput>(inputData), service::name::appmgr);
     }
 } // namespace locks

--- a/module-apps/apps-common/locks/widgets/Lock.cpp
+++ b/module-apps/apps-common/locks/widgets/Lock.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Lock.hpp"
@@ -18,7 +18,7 @@ namespace locks
         }
     }
 
-    void Lock::putNextChar(unsigned int c)
+    void Lock::putNextChar(unsigned c)
     {
         if (maxInputSize > inputValue.size()) {
             inputValue.push_back(c);
@@ -41,5 +41,4 @@ namespace locks
     {
         nextUnlockAttemptFormattedTime = time;
     }
-
 } // namespace locks

--- a/module-apps/apps-common/locks/widgets/Lock.hpp
+++ b/module-apps/apps-common/locks/widgets/Lock.hpp
@@ -1,7 +1,8 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
+
 #include <vector>
 #include <string>
 #include <functional>
@@ -31,12 +32,12 @@ namespace locks
         {
             return lockState;
         }
-        [[nodiscard]] unsigned int getMaxInputSize() const noexcept
+        [[nodiscard]] unsigned getMaxInputSize() const noexcept
         {
             return maxInputSize;
         }
         /// returns current position of a Input character to be inserted
-        [[nodiscard]] unsigned int getCharCount() const noexcept
+        [[nodiscard]] unsigned getCharCount() const noexcept
         {
             return inputValue.size();
         }
@@ -48,11 +49,11 @@ namespace locks
         {
             return getCharCount() >= minInputSize;
         }
-        [[nodiscard]] std::vector<unsigned int> getInput() const
+        [[nodiscard]] std::vector<unsigned> getInput() const
         {
             return inputValue;
         }
-        [[nodiscard]] unsigned int getAttemptsLeft() const noexcept
+        [[nodiscard]] unsigned getAttemptsLeft() const noexcept
         {
             return attemptsLeft;
         }
@@ -70,7 +71,7 @@ namespace locks
         }
         void setNextUnlockAttemptFormattedTime(const std::string &time);
 
-        void putNextChar(unsigned int c);
+        void putNextChar(unsigned c);
         /// removes a last character passed to Lock via putNextChar. The last character can not be popped
         void popChar();
         /// clear all characters passed to the Lock
@@ -78,24 +79,24 @@ namespace locks
         /// consumes LockState::InputInvalid state and LockState::NewInputInvalid
         void consumeState() noexcept;
 
-        explicit Lock(LockState state, unsigned int attemptsLeft = unlimitedNumOfAttempts)
+        explicit Lock(LockState state, unsigned attemptsLeft = unlimitedNumOfAttempts)
             : lockState{state}, attemptsLeft{attemptsLeft}
         {}
 
       private:
         std::string lockName;
         LockState lockState       = LockState::Unlocked;
-        unsigned int attemptsLeft = 0;
+        unsigned attemptsLeft     = 0;
         std::string nextUnlockAttemptFormattedTime;
 
-        std::vector<unsigned int> inputValue;
-        unsigned int maxInputSize = defaultInputSize;
-        unsigned int minInputSize = defaultInputSize;
+        std::vector<unsigned> inputValue;
+        unsigned maxInputSize = defaultInputSize;
+        unsigned minInputSize = defaultInputSize;
 
-        static constexpr unsigned int defaultInputSize       = 4;
-        static constexpr unsigned int unlimitedNumOfAttempts = std::numeric_limits<unsigned int>::max();
+        static constexpr unsigned defaultInputSize       = 4;
+        static constexpr unsigned unlimitedNumOfAttempts = std::numeric_limits<unsigned>::max();
 
-        void setInputSizeBounds(unsigned int _minInputSize, unsigned int _maxInputSize)
+        void setInputSizeBounds(unsigned _minInputSize, unsigned _maxInputSize)
         {
             minInputSize = _minInputSize;
             maxInputSize = _maxInputSize;
@@ -104,5 +105,4 @@ namespace locks
         friend class PhoneLockHandler;
         friend class SimLockHandler;
     };
-
 } // namespace locks

--- a/module-apps/apps-common/locks/widgets/PhoneLockBox.cpp
+++ b/module-apps/apps-common/locks/widgets/PhoneLockBox.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Lock.hpp"
@@ -69,14 +69,12 @@ namespace gui
         LockWindow->pinLabelsBox->setVisible(true);
 
         switch (type) {
-        case LockBox::InputActionType::ProvideInput: {
+        case LockBox::InputActionType::ProvideInput:
             LockWindow->setText(textForInputRequired, LockInputWindow::TextType::Primary);
             break;
-        }
-        case LockBox::InputActionType::ProvideNewInput: {
+        case LockBox::InputActionType::ProvideNewInput:
             LockWindow->setText(textForProvideNewInput, LockInputWindow::TextType::Primary);
             break;
-        }
         case LockBox::InputActionType::ConfirmNewInput:
             LockWindow->setText(textForConfirmNewInput, LockInputWindow::TextType::Primary);
             break;
@@ -90,7 +88,6 @@ namespace gui
     {
         switch (type) {
         case LockBox::InputErrorType::InvalidInput:
-
             LockWindow->setText(textForInvalidInput,
                                 LockInputWindow::TextType::Primary,
                                 {{LockWindow->getToken(LockInputWindow::Token::Attempts), static_cast<int>(value)}});

--- a/module-apps/apps-common/notifications/NotificationsModel.cpp
+++ b/module-apps/apps-common/notifications/NotificationsModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "NotificationsModel.hpp"
@@ -8,7 +8,6 @@ using namespace gui;
 
 namespace
 {
-
     bool hasTetheringNotification(app::manager::actions::NotificationsChangedParams *params)
     {
         const auto &notifications = params->getNotifications();
@@ -38,7 +37,7 @@ NotificationsModel::NotificationsModel(NotificationsListPlacement listPlacement)
 
 void NotificationsModel::attachPresenter(std::shared_ptr<NotificationsPresenter> notificationsPresenter)
 {
-    this->notificationsPresenter = notificationsPresenter;
+    this->notificationsPresenter = std::move(notificationsPresenter);
 }
 
 bool NotificationsModel::hasDismissibleNotification() const noexcept

--- a/module-services/service-desktop/endpoints/security/SecurityEndpointHelper.cpp
+++ b/module-services/service-desktop/endpoints/security/SecurityEndpointHelper.cpp
@@ -107,7 +107,7 @@ namespace sdesktop::endpoints
 
         if (passCode.size() == PasscodeLength) {
             try {
-                auto msg = std::make_shared<locks::ExternalUnLockPhone>(passCodeArrayToVecOfInts(passCode));
+                auto msg = std::make_shared<locks::ExternalUnlockPhone>(passCodeArrayToVecOfInts(passCode));
                 status   = owner->bus.sendUnicast(std::move(msg), service::name::appmgr)
                                ? http::Code::NoContent
                                : http::Code::InternalServerError;

--- a/products/PurePhone/services/appmgr/ApplicationManager.cpp
+++ b/products/PurePhone/services/appmgr/ApplicationManager.cpp
@@ -181,51 +181,56 @@ namespace app::manager
         });
 
         // PhoneLock connects
-        connect(typeid(locks::LockPhone),
-                [&](sys::Message *request) -> sys::MessagePointer { return phoneLockHandler.handleLockRequest(); });
-        connect(typeid(locks::UnlockPhone),
-                [&](sys::Message *request) -> sys::MessagePointer { return phoneLockHandler.handleUnlockRequest(); });
-        connect(typeid(locks::UnlockPhoneForMTP), [&](sys::Message *request) -> sys::MessagePointer {
-            return phoneLockHandler.handleUnlockRequest(locks::PhoneLockHandler::ReasonForRequest::MTPUnlock);
+        connect(typeid(locks::LockPhone), [&]([[maybe_unused]] sys::Message *request) -> sys::MessagePointer {
+            return phoneLockHandler.handleLockRequest();
         });
-        connect(typeid(locks::CancelUnlockPhone), [&](sys::Message *request) -> sys::MessagePointer {
+        connect(typeid(locks::UnlockPhone), [&]([[maybe_unused]] sys::Message *request) -> sys::MessagePointer {
+            return phoneLockHandler.handleUnlockRequest();
+        });
+        connect(typeid(locks::UnlockPhoneForMTP), [&]([[maybe_unused]] sys::Message *request) -> sys::MessagePointer {
+            return phoneLockHandler.handleUnlockRequest(locks::PhoneLockHandler::RequestReason::MTPUnlock);
+        });
+        connect(typeid(locks::CancelUnlockPhone), [&]([[maybe_unused]] sys::Message *request) -> sys::MessagePointer {
             return phoneLockHandler.handleUnlockCancelRequest();
         });
-        connect(typeid(locks::UnLockPhoneInput), [&](sys::Message *request) -> sys::MessagePointer {
-            auto data = static_cast<locks::UnLockPhoneInput *>(request);
+        connect(typeid(locks::UnlockPhoneInput), [&](sys::Message *request) -> sys::MessagePointer {
+            const auto data = static_cast<locks::UnlockPhoneInput *>(request);
             return phoneLockHandler.handlePhoneLockInput(data->getInputData());
         });
-        connect(typeid(locks::EnablePhoneLock),
-                [&](sys::Message *request) -> sys::MessagePointer { return phoneLockHandler.handleEnablePhoneLock(); });
-        connect(typeid(locks::DisablePhoneLock), [&](sys::Message *request) -> sys::MessagePointer {
+        connect(typeid(locks::EnablePhoneLock), [&]([[maybe_unused]] sys::Message *request) -> sys::MessagePointer {
+            return phoneLockHandler.handleEnablePhoneLock();
+        });
+        connect(typeid(locks::DisablePhoneLock), [&]([[maybe_unused]] sys::Message *request) -> sys::MessagePointer {
             return phoneLockHandler.handleDisablePhoneLock();
         });
-        connect(typeid(locks::UnlockedPhone), [&](sys::Message *request) -> sys::MessagePointer {
+        connect(typeid(locks::UnlockedPhone), [&]([[maybe_unused]] sys::Message *request) -> sys::MessagePointer {
             autoLockTimer.start();
             return simLockHandler.askForSimUnlocking();
         });
-        connect(typeid(locks::ChangePhoneLock),
-                [&](sys::Message *request) -> sys::MessagePointer { return phoneLockHandler.handleChangePhoneLock(); });
-        connect(typeid(locks::SetPhoneLock),
-                [&](sys::Message *request) -> sys::MessagePointer { return phoneLockHandler.handleSetPhoneLock(); });
-        connect(typeid(locks::SkipSetPhoneLock), [&](sys::Message *request) -> sys::MessagePointer {
+        connect(typeid(locks::ChangePhoneLock), [&]([[maybe_unused]] sys::Message *request) -> sys::MessagePointer {
+            return phoneLockHandler.handleChangePhoneLock();
+        });
+        connect(typeid(locks::SetPhoneLock), [&]([[maybe_unused]] sys::Message *request) -> sys::MessagePointer {
+            return phoneLockHandler.handleSetPhoneLock();
+        });
+        connect(typeid(locks::SkipSetPhoneLock), [&]([[maybe_unused]] sys::Message *request) -> sys::MessagePointer {
             return phoneLockHandler.handleSkipSetPhoneLock();
         });
         connect(typeid(locks::PhoneLockTimeUpdate), [&](sys::Message *request) -> sys::MessagePointer {
-            auto req = static_cast<locks::PhoneLockTimeUpdate *>(request);
+            const auto req = static_cast<locks::PhoneLockTimeUpdate *>(request);
             notificationProvider.handle(req);
             return sys::msgHandled();
         });
         connect(typeid(SetAutoLockTimeoutRequest), [&](sys::Message *request) -> sys::MessagePointer {
-            auto req = static_cast<SetAutoLockTimeoutRequest *>(request);
+            const auto req = static_cast<SetAutoLockTimeoutRequest *>(request);
             return handleAutoLockSetRequest(req);
         });
-        connect(typeid(locks::ExternalUnLockPhone), [&](sys::Message *request) -> sys::MessagePointer {
-            auto data = static_cast<locks::ExternalUnLockPhone *>(request);
+        connect(typeid(locks::ExternalUnlockPhone), [&](sys::Message *request) -> sys::MessagePointer {
+            const auto data = static_cast<locks::ExternalUnlockPhone *>(request);
             return phoneLockHandler.handleExternalUnlockRequest(data->getInputData());
         });
         connect(typeid(locks::ExternalPhoneLockAvailabilityChange), [&](sys::Message *request) -> sys::MessagePointer {
-            auto data = static_cast<locks::ExternalPhoneLockAvailabilityChange *>(request);
+            const auto data = static_cast<locks::ExternalPhoneLockAvailabilityChange *>(request);
             return phoneLockHandler.handleExternalAvailabilityChange(data->getAvailability());
         });
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -34,6 +34,7 @@
 * Fixed issue with uneven first screen redraw after turning the phone on
 * Fixed issue with bypassing phone lock window after unplugging USB cable on tethering popup
 * Fixed Alarm disappearance during end of call window
+* Fixed passcode behavior when blocked from Mudita Center
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
Fix of the issue that after blocking
passcode from Center, Pure would still
display passcode input popup; providing
valid passcode there would result in
phone entering invalid state, where it
behaved as if it was unlocked, but
with blocked passcode.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
