### PR TITLE
[MOS-948] Revert: Fix for tethering popup was losing app context

### DIFF
--- a/module-apps/apps-common/popups/TetheringConfirmationPopup.cpp
+++ b/module-apps/apps-common/popups/TetheringConfirmationPopup.cpp
@@ -6,6 +6,7 @@
 #include "ApplicationCommon.hpp"
 
 #include <system/messages/TetheringQuestionRequest.hpp>
+#include <service-appmgr/Controller.hpp>
 
 namespace gui
 {
@@ -22,7 +23,7 @@ namespace gui
         metadata.action = [this]() {
             application->bus.sendUnicast(std::make_shared<sys::TetheringEnabledResponse>(),
                                          service::name::system_manager);
-            application->returnToPreviousWindow();
+            app::manager::Controller::sendAction(application, app::manager::actions::Home);
             return true;
         };
         auto msg = std::make_unique<DialogMetadataMessage>(std::move(metadata));

--- a/module-apps/apps-common/popups/TetheringOffPopup.cpp
+++ b/module-apps/apps-common/popups/TetheringOffPopup.cpp
@@ -6,6 +6,7 @@
 #include <messages/DialogMetadataMessage.hpp>
 #include <apps-common/ApplicationCommon.hpp>
 #include <system/messages/TetheringStateRequest.hpp>
+#include <service-appmgr/Controller.hpp>
 
 namespace gui
 {
@@ -32,7 +33,7 @@ namespace gui
         metadata.action = [this]() {
             application->bus.sendUnicast(std::make_shared<sys::TetheringStateRequest>(sys::phone_modes::Tethering::Off),
                                          service::name::system_manager);
-            application->returnToPreviousWindow();
+            app::manager::Controller::sendAction(application, app::manager::actions::Home);
             return true;
         };
         metadata.title = utils::translate("tethering");

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -29,7 +29,6 @@
 * Fixed ability to create contact with 2 same numbers
 * Fixed diacritics in translations
 * Fixed issues with file uploads with low disk space.
-* Fixed data losing because switching tethering via tethering popup
 * Fixed hard fault handling
 * Fixed issue with uneven first screen redraw after turning the phone on
 * Fixed issue with bypassing phone lock window after unplugging USB cable on tethering popup


### PR DESCRIPTION
**Reverting** previous fix because when tethering is switched on the user are not able to use phone features, and we this fix make the user to pass this block and it would make their confuse.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
