### PR TITLE
[MOS-1028] Fix possibility to copy text from empty note

### DIFF
--- a/module-apps/application-messages/windows/OptionsMessages.cpp
+++ b/module-apps/application-messages/windows/OptionsMessages.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SMSdata.hpp"
@@ -113,7 +113,7 @@ std::list<gui::Option> newMessageWindowOptions(app::ApplicationMessages *app,
         return true;
     });
 
-    if (Clipboard::getInstance().gotData()) {
+    if (Clipboard::getInstance().hasData()) {
         options.emplace_back(utils::translate("sms_paste"), [=](gui::Item &item) {
             text->addText(Clipboard::getInstance().paste(), gui::AdditionType::perBlock);
             app->returnToPreviousWindow();

--- a/module-apps/application-notes/ApplicationNotes.cpp
+++ b/module-apps/application-notes/ApplicationNotes.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <application-notes/ApplicationNotes.hpp>
@@ -20,18 +20,19 @@
 
 #include <utility>
 
+namespace
+{
+    constexpr auto applicationNotesStackSize = 1024 * 4;
+}
+
 namespace app
 {
-    namespace
-    {
-        constexpr auto NotesStackSize = 4096U;
-    } // namespace
-
     ApplicationNotes::ApplicationNotes(std::string name,
                                        std::string parent,
                                        StatusIndicators statusIndicators,
                                        StartInBackground startInBackground)
-        : Application(std::move(name), std::move(parent), statusIndicators, startInBackground, NotesStackSize)
+        : Application(
+              std::move(name), std::move(parent), statusIndicators, startInBackground, applicationNotesStackSize)
     {
         bus.channels.push_back(sys::BusChannel::ServiceDBNotifications);
     }

--- a/module-apps/application-notes/windows/NoteCreateWindow.cpp
+++ b/module-apps/application-notes/windows/NoteCreateWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "NoteCreateWindow.hpp"
@@ -25,6 +25,6 @@ namespace app::notes
     void NoteCreateWindow::onCharactersCountChanged(std::uint32_t count)
     {
         NoteEditWindow::onCharactersCountChanged(count);
-        navBar->setActive(gui::nav_bar::Side::Center, count != 0U);
+        navBar->setActive(gui::nav_bar::Side::Center, count != 0);
     }
 } // namespace app::notes

--- a/module-apps/application-notes/windows/NoteEditWindow.hpp
+++ b/module-apps/application-notes/windows/NoteEditWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -45,7 +45,7 @@ namespace app::notes
 
         std::unique_ptr<NoteEditWindowContract::Presenter> presenter;
         std::shared_ptr<NotesRecord> notesRecord;
-        gui::Label *charactersCounter;
-        gui::Text *edit;
+        gui::Label *charactersCounter = nullptr;
+        gui::Text *edit               = nullptr;
     };
 } // namespace app::notes

--- a/module-apps/application-notes/windows/NotesOptions.hpp
+++ b/module-apps/application-notes/windows/NotesOptions.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -22,7 +22,5 @@ namespace app::notes
                                               const NotesRecord &record,
                                               AbstractNotesRepository &notesRepository,
                                               gui::Text *textWidget);
-    std::list<gui::Option> noteEditOptions(ApplicationCommon *application,
-                                           const NotesRecord &record,
-                                           gui::Text *textWidget);
+    std::list<gui::Option> noteEditOptions(ApplicationCommon *application, gui::Text *textWidget);
 } // namespace app::notes

--- a/module-apps/application-phonebook/widgets/InputLinesWithLabelWidget.cpp
+++ b/module-apps/application-phonebook/widgets/InputLinesWithLabelWidget.cpp
@@ -75,7 +75,7 @@ namespace gui
                 inputText->setFont(style::window::font::mediumbold);
 
                 if (this->navBarSetOptionsLabel) {
-                    const auto optionsLabelState = !inputText->isEmpty() || Clipboard::getInstance().gotData();
+                    const auto optionsLabelState = !inputText->isEmpty() || Clipboard::getInstance().hasData();
                     this->navBarSetOptionsLabel(utils::translate(style::strings::common::options), optionsLabelState);
                 }
             }
@@ -95,12 +95,12 @@ namespace gui
             const auto result = inputText->onInput(event);
 
             if (!event.is(KeyCode::KEY_AST) && this->navBarSetOptionsLabel) {
-                const auto optionsLabelState = !inputText->isEmpty() || Clipboard::getInstance().gotData();
+                const auto optionsLabelState = !inputText->isEmpty() || Clipboard::getInstance().hasData();
                 this->navBarSetOptionsLabel(utils::translate(style::strings::common::options), optionsLabelState);
             }
 
             if (event.isShortRelease(gui::KeyCode::KEY_LF) &&
-                (!inputText->isEmpty() || Clipboard::getInstance().gotData())) {
+                (!inputText->isEmpty() || Clipboard::getInstance().hasData())) {
                 if (this->inputOptions) {
                     this->inputOptions(inputText);
                 }

--- a/module-apps/application-phonebook/windows/PhonebookInputOptions.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookInputOptions.cpp
@@ -33,7 +33,7 @@ namespace gui
             });
         }
 
-        if (Clipboard::getInstance().gotData()) {
+        if (Clipboard::getInstance().hasData()) {
             options.emplace_back(utils::translate("common_text_paste"), [=](gui::Item &item) {
                 /* Single line text ellipsis implementation doesn't properly support
                  * text that consists of multiple blocks - use character addition

--- a/module-utils/Clipboard/Clipboard.cpp
+++ b/module-utils/Clipboard/Clipboard.cpp
@@ -1,21 +1,21 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Clipboard.hpp"
+
 cpp_freertos::MutexStandard Clipboard::mutex;
 
 Clipboard &Clipboard::getInstance()
 {
     static Clipboard clipboard;
-
     return clipboard;
 }
 
-void Clipboard::copy(const std::string &data)
+void Clipboard::copy(const std::string &newData)
 {
     cpp_freertos::LockGuard lock(mutex);
-    this->data      = data;
-    this->validData = true;
+    data      = newData;
+    validData = true;
 }
 
 std::string Clipboard::paste()

--- a/module-utils/Clipboard/Clipboard.hpp
+++ b/module-utils/Clipboard/Clipboard.hpp
@@ -1,10 +1,9 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include <mutex.hpp>
-
 #include <string>
 
 class Clipboard
@@ -25,7 +24,7 @@ class Clipboard
     void copy(const std::string &);
     std::string paste();
 
-    bool gotData() const
+    bool hasData() const
     {
         return validData;
     }

--- a/module-utils/Clipboard/test/unittest_clipboard.cpp
+++ b/module-utils/Clipboard/test/unittest_clipboard.cpp
@@ -9,17 +9,17 @@ TEST_CASE("Clipboard")
     SECTION("No data")
     {
         // It is guaranted to have no data only during 1st call to singleton getInstance()
-        REQUIRE(Clipboard::getInstance().gotData() == false);
-        REQUIRE(Clipboard::getInstance().paste() == "");
+        REQUIRE(Clipboard::getInstance().hasData() == false);
+        REQUIRE(Clipboard::getInstance().paste().empty() == true);
     }
 
     SECTION("Single copy")
     {
         const std::string test1 = "test1";
         Clipboard::getInstance().copy(test1);
-        REQUIRE(Clipboard::getInstance().gotData() == true);
+        REQUIRE(Clipboard::getInstance().hasData() == true);
         REQUIRE(Clipboard::getInstance().paste() == test1);
-        REQUIRE(Clipboard::getInstance().gotData() == true);
+        REQUIRE(Clipboard::getInstance().hasData() == true);
     }
 
     SECTION("Double copy")
@@ -27,19 +27,19 @@ TEST_CASE("Clipboard")
         const std::string test1 = "test1";
         const std::string test2 = "test2";
         Clipboard::getInstance().copy(test1);
-        REQUIRE(Clipboard::getInstance().gotData() == true);
+        REQUIRE(Clipboard::getInstance().hasData() == true);
         Clipboard::getInstance().copy(test2);
-        REQUIRE(Clipboard::getInstance().gotData() == true);
+        REQUIRE(Clipboard::getInstance().hasData() == true);
         REQUIRE(Clipboard::getInstance().paste() == test2);
-        REQUIRE(Clipboard::getInstance().gotData() == true);
+        REQUIRE(Clipboard::getInstance().hasData() == true);
     }
 
     SECTION("Copy empty string")
     {
         const std::string test1 = "";
         Clipboard::getInstance().copy(test1);
-        REQUIRE(Clipboard::getInstance().gotData() == true);
+        REQUIRE(Clipboard::getInstance().hasData() == true);
         REQUIRE(Clipboard::getInstance().paste() == test1);
-        REQUIRE(Clipboard::getInstance().gotData() == true);
+        REQUIRE(Clipboard::getInstance().hasData() == true);
     }
 }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -35,6 +35,7 @@
 * Fixed Alarm disappearance during end of call window
 * Fixed passcode behavior when blocked from Mudita Center
 * Fixed missing tethering icon on "Tethering is on" window
+* Fixed showing "Copy text" option in empty note
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
Fix of the issue that in Notes app 'Copy text'
option was shown in 'Options' menu even if
the note didn't contain any text.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
