### PR TITLE
[MOS-1028] Fix corner case with input mode in Notes app

### DIFF
--- a/module-apps/application-notes/windows/NoteEditWindow.cpp
+++ b/module-apps/application-notes/windows/NoteEditWindow.cpp
@@ -83,8 +83,8 @@ namespace app::notes
             }));
         edit->setTextChangedCallback([this](Item &, const UTF8 &text) {
             const auto textLength        = text.length();
-            const auto optionsLabelState = (textLength != 0) || Clipboard::getInstance().hasData();
-            navBar->setActive(gui::nav_bar::Side::Left, optionsLabelState);
+            optionsLabelEnabled          = (textLength != 0) || Clipboard::getInstance().hasData();
+            navBar->setActive(gui::nav_bar::Side::Left, optionsLabelEnabled);
 
             setCharactersCount(textLength);
             onCharactersCountChanged(textLength);
@@ -143,13 +143,13 @@ namespace app::notes
     bool NoteEditWindow::onInput(const gui::InputEvent &inputEvent)
     {
         if (inputEvent.isShortRelease()) {
-            if (inputEvent.is(gui::KeyCode::KEY_ENTER)) {
+            if (inputEvent.is(gui::KeyCode::KEY_ENTER) && !edit->getText().empty()) {
                 saveNote();
                 auto switchData                        = std::make_unique<NoteSwitchData>(notesRecord);
                 switchData->ignoreCurrentWindowOnStack = true;
                 application->switchWindow(gui::name::window::note_preview, std::move(switchData));
             }
-            if (inputEvent.is(gui::KeyCode::KEY_LF) && navBar->isActive(gui::nav_bar::Side::Left)) {
+            if (inputEvent.is(gui::KeyCode::KEY_LF) && optionsLabelEnabled) {
                 application->switchWindow(
                     window::name::option_window,
                     std::make_unique<gui::OptionsWindowOptions>(noteEditOptions(application, edit)));

--- a/module-apps/application-notes/windows/NoteEditWindow.hpp
+++ b/module-apps/application-notes/windows/NoteEditWindow.hpp
@@ -47,5 +47,6 @@ namespace app::notes
         std::shared_ptr<NotesRecord> notesRecord;
         gui::Label *charactersCounter = nullptr;
         gui::Text *edit               = nullptr;
+        bool optionsLabelEnabled      = false;
     };
 } // namespace app::notes


### PR DESCRIPTION
Fix of minor corner case bug in previous
implementation - pressing left functional
button when selecting input mode would
display empty options menu even if note
and clipboard were empty.
Additionally fixed the same bug for
'Save' button.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
