### PR TITLE
[MOS-552] Fix alarm clock input behavior

### DIFF
--- a/module-apps/application-alarm-clock/widgets/AlarmTimeItem.hpp
+++ b/module-apps/application-alarm-clock/widgets/AlarmTimeItem.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -10,6 +10,11 @@ namespace gui
 {
     class AlarmTimeItem : public AlarmInternalListItem
     {
+      public:
+        explicit AlarmTimeItem(std::function<void(const UTF8 &text)> navBarTemporaryMode = nullptr,
+                               std::function<void()> navBarRestoreFromTemporaryMode      = nullptr);
+
+      private:
         gui::HBox *hBox          = nullptr;
         gui::Label *colonLabel   = nullptr;
         gui::Text *hourInput     = nullptr;
@@ -25,14 +30,7 @@ namespace gui
         void onInputCallback(gui::Text &textItem);
         void prepareForTimeMode();
         [[nodiscard]] bool isPm(const std::string &text) const;
-        void validateHour();
 
-        template <typename T>
-        UTF8 timeValueToPaddedString(const T &value);
-
-      public:
-        AlarmTimeItem(std::function<void(const UTF8 &text)> navBarTemporaryMode = nullptr,
-                      std::function<void()> navBarRestoreFromTemporaryMode      = nullptr);
+        void clearTimeFieldsIfFull(Item *focusedItem);
     };
-
 } /* namespace gui */

--- a/module-apps/apps-common/widgets/DateAndTimeStyle.hpp
+++ b/module-apps/apps-common/widgets/DateAndTimeStyle.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -11,7 +11,7 @@ namespace style::window::date_and_time
     inline constexpr auto separator        = 30;
     inline constexpr auto time_input_12h_w = 120;
     inline constexpr auto time_input_24h_w = 195;
-    inline constexpr auto hBox_h           = height - 1.25 * topMargin;
+    inline constexpr auto hBox_h           = static_cast<int>(height - 1.25f * topMargin);
     inline constexpr auto listView_x       = style::window::default_left_margin;
     inline constexpr auto listView_y       = style::window::default_vertical_pos;
     inline constexpr auto listView_w       = style::listview::body_width_with_scroll;

--- a/module-audio/tags_fetcher/TagsFetcher.cpp
+++ b/module-audio/tags_fetcher/TagsFetcher.cpp
@@ -2,9 +2,9 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TagsFetcher.hpp"
-#include <Utils.hpp>
 #include <riff/wav/wavproperties.h>
 #include "fileref.h"
+#include <time/time_constants.hpp>
 
 namespace tags::fetcher
 {
@@ -60,9 +60,9 @@ namespace tags::fetcher
                 }
 
                 const uint32_t total_duration_s = properties->length();
-                const uint32_t duration_min     = total_duration_s / utils::secondsInMinute;
-                const uint32_t duration_hour    = duration_min / utils::secondsInMinute;
-                const uint32_t duration_sec     = total_duration_s % utils::secondsInMinute;
+                const uint32_t duration_min     = total_duration_s / utils::time::secondsInMinute;
+                const uint32_t duration_hour    = duration_min / utils::time::secondsInMinute;
+                const uint32_t duration_sec     = total_duration_s % utils::time::secondsInMinute;
                 const uint32_t sample_rate      = properties->sampleRate();
                 const uint32_t num_channel      = properties->channels();
                 const uint32_t bitrate          = properties->bitrate();

--- a/module-utils/utility/Utils.hpp
+++ b/module-utils/utility/Utils.hpp
@@ -2,6 +2,7 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
+
 #include "Split.hpp"
 #include <log/log.hpp>
 #include <magic_enum.hpp>
@@ -16,8 +17,7 @@
 
 namespace utils
 {
-    inline constexpr auto WHITESPACE       = " \n\r\t\f\v";
-    constexpr unsigned int secondsInMinute = 60;
+    inline constexpr auto WHITESPACE = " \n\r\t\f\v";
 
     template <typename T>
     inline constexpr bool is_byte_v = std::is_integral_v<T> && sizeof(T) == sizeof(std::uint8_t);
@@ -126,6 +126,12 @@ namespace utils
         }
         constexpr auto leadingDigit = '0';
         base.insert(0, minStringLength - base.length(), leadingDigit);
+        return base;
+    }
+
+    static inline std::string removeLeadingZeros(std::string base)
+    {
+        base.erase(0, std::min(base.find_first_not_of('0'), base.size() - 1));
         return base;
     }
 
@@ -324,7 +330,9 @@ namespace utils
     static inline std::string stringToLowercase(const std::string &inputString)
     {
         std::string outputString;
-        std::for_each(inputString.begin(), inputString.end(), [&](char ch) { outputString += std::tolower(ch); });
+        std::transform(inputString.cbegin(), inputString.cend(), std::back_inserter(outputString), [](const auto ch) {
+            return std::tolower(ch);
+        });
         return outputString;
     }
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -39,6 +39,7 @@
 * Fixed "Copy" option missing from the options list in "New message" window
 * Fixed losing unsaved data on go back
 * Fixed disabled screen autolock in meditation app
+* Fixed multiple issues with input fields in "New alarm" window
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
Fix of multiple issues that manifested in
input fields of alarm clock, i.e. value
not erasing automatically, redundant
double-zero filling of hours field,
lack of zero-filling of minutes field
when navigating to AM/PM field in
12h mode.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
