### PR TITLE
[MOS-1031] Fix Meditation app screen lock

### DIFF
--- a/module-apps/application-meditation/include/application-meditation/ApplicationMeditation.hpp
+++ b/module-apps/application-meditation/include/application-meditation/ApplicationMeditation.hpp
@@ -42,8 +42,7 @@ namespace app
             return {{manager::actions::Launch,
                      manager::actions::PhoneModeChanged,
                      manager::actions::BluetoothModeChanged,
-                     manager::actions::AlarmClockStatusChanged},
-                    locks::AutoLockPolicy::PreventPermanently};
+                     manager::actions::AlarmClockStatusChanged}};
         }
     };
 } // namespace app

--- a/module-apps/application-meditation/windows/MeditationWindow.cpp
+++ b/module-apps/application-meditation/windows/MeditationWindow.cpp
@@ -16,7 +16,7 @@
 
 namespace gui
 {
-    MeditationWindow::MeditationWindow(app::ApplicationCommon *app, const MeditationParams params)
+    MeditationWindow::MeditationWindow(app::ApplicationCommon *app, const MeditationParams &params)
         : AppWindow{app, name::window::main_window}, meditationParams(params)
     {
         MeditationWindow::buildInterface();

--- a/module-apps/application-meditation/windows/MeditationWindow.hpp
+++ b/module-apps/application-meditation/windows/MeditationWindow.hpp
@@ -14,7 +14,7 @@ namespace gui
     class MeditationWindow : public AppWindow
     {
       public:
-        MeditationWindow(app::ApplicationCommon *app, const MeditationParams params);
+        MeditationWindow(app::ApplicationCommon *app, const MeditationParams &params);
 
         auto onInput(const InputEvent &inputEvent) -> bool override;
 

--- a/module-apps/apps-common/locks/handlers/LockPolicyHandler.cpp
+++ b/module-apps/apps-common/locks/handlers/LockPolicyHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "LockPolicyHandler.hpp"
@@ -47,10 +47,12 @@ void LockPolicyHandler::setPreventsAutoLockByStateCallback(
 {
     preventsAutoLockByStateCallback = std::move(_preventsAutoLockByStateCallback);
 }
+
 bool LockPolicyHandler::preventsAutoLockByWindow()
 {
     return owner->getCurrentWindow()->preventsAutoLocking();
 }
+
 bool LockPolicyHandler::preventsAutoLockByState() const
 {
     Expects(preventsAutoLockByStateCallback != nullptr);

--- a/module-gui/gui/core/FontManager.cpp
+++ b/module-gui/gui/core/FontManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "FontManager.hpp"
@@ -167,7 +167,6 @@ namespace gui
 
     FontManager &FontManager::getInstance()
     {
-
         static FontManager instance;
         if (!instance.initialized) {
             LOG_WARN("Using uninitialized font manager will result in no font loaded");

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -38,6 +38,7 @@
 * Fixed showing "Copy text" option in empty note
 * Fixed "Copy" option missing from the options list in "New message" window
 * Fixed losing unsaved data on go back
+* Fixed disabled screen autolock in meditation app
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
Fix of the issue that Meditation app
would prevent phone from locking on
every screen, though it should do
so only on timer screen.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
