### PR TITLE
[MOS-1032] Fix misleading 'Save' button behavior when setting time

### DIFF
--- a/module-apps/application-settings/windows/system/ChangeDateAndTimeWindow.cpp
+++ b/module-apps/application-settings/windows/system/ChangeDateAndTimeWindow.cpp
@@ -12,7 +12,7 @@
 namespace gui
 {
     ChangeDateAndTimeWindow::ChangeDateAndTimeWindow(app::ApplicationCommon *app, std::string name)
-        : AppWindow(app, name), dateAndTimeModel{std::make_shared<DateAndTimeModel>(this->application)}
+        : AppWindow(app, std::move(name)), dateAndTimeModel{std::make_shared<DateAndTimeModel>(this->application)}
     {
         buildInterface();
     }
@@ -50,6 +50,7 @@ namespace gui
         if (inputEvent.isShortRelease(gui::KeyCode::KEY_ENTER)) {
             dateAndTimeModel->saveData(fromTillDate);
             sendRtcUpdateTimeMessage();
+            application->returnToPreviousWindow();
             return true;
         }
 

--- a/module-apps/application-settings/windows/system/SystemMainWindow.cpp
+++ b/module-apps/application-settings/windows/system/SystemMainWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SystemMainWindow.hpp"
@@ -8,7 +8,6 @@
 #include <DialogMetadataMessage.hpp>
 #include <OptionSetting.hpp>
 #include <service-desktop/DesktopMessages.hpp>
-#include <service-desktop/ServiceDesktop.hpp>
 
 namespace gui
 {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -42,6 +42,7 @@
 * Fixed multiple issues with input fields in "New alarm" window
 * Fixed the ability to create a contact with the same primary and secondary phone number, which resulted in mismatching
 * Fixed losing drafted message and recipient number in new message windows
+* Fixed misleading "Save" button behavior in "Date and time" window
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
Fix of the issue that pressing 'Save' when setting 
time would set the time indeed, but the UI would
not return to previous window, what might look
as if saving failed.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
