### PR TITLE
[BH-1765] Added missing python requirement

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -14,3 +14,4 @@ dataclasses_json==0.5.4
 tqdm==4.62.2
 eyed3==0.9.6
 ghapi
+requests


### PR DESCRIPTION
while setting up MuditaOS toolchain in a virtual environment I noticed a requirement was missing. Probably it comes preinstalled on Ubuntu so no one noticed until now.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
