### PR TITLE
[BH-1761] Add a log when manual reset is performed

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -31,6 +31,7 @@
 * Added extended information to log filename
 * Added Harmony version information in about section
 * Added system shutdown if there is no user activity for 180 seconds on the language selection screen
+* Added a log when manual reset is performed
 
 ### Changed / Improved
 

--- a/module-services/service-evtmgr/service-evtmgr/EventManagerCommon.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/EventManagerCommon.hpp
@@ -61,11 +61,6 @@ class EventManagerCommon : public sys::Service
 
     LogDumpFunction logDumpFunction;
 
-    /// @return: < 0 - error occured during log flush
-    /// @return:   0 - log flush did not happen
-    /// @return:   1 - log flush successflul
-    int dumpLogsToFile();
-
   protected:
     std::function<void(const time_t)> onMinuteTick;
     virtual void handleKeyEvent(sys::Message *msg);
@@ -83,4 +78,9 @@ class EventManagerCommon : public sys::Service
     // ID of alarm waiting to trigger
     uint32_t alarmID;
     const EventManagerParams eventManagerParams;
+
+    /// @return: < 0 - error occured during log flush
+    /// @return:   0 - log flush did not happen
+    /// @return:   1 - log flush successflul
+    int dumpLogsToFile();
 };

--- a/products/BellHybrid/services/evtmgr/EventManager.cpp
+++ b/products/BellHybrid/services/evtmgr/EventManager.cpp
@@ -173,8 +173,8 @@ void EventManager::buildKeySequences()
 
     auto resetSeq      = std::make_unique<ResetSequence>(*this);
     resetSeq->onAction = [this]() {
-        app::manager::Controller::sendAction(
-            this, app::manager::actions::ShowPopup, std::make_unique<RebootPopupRequestParams>());
+        LOG_INFO("Incoming manual reset caused by user!");
+        EventManagerCommon::dumpLogsToFile();
     };
     collection.emplace_back(std::move(resetSeq));
 

--- a/products/BellHybrid/services/evtmgr/internal/key_sequences/ResetSequence.hpp
+++ b/products/BellHybrid/services/evtmgr/internal/key_sequences/ResetSequence.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -11,7 +11,7 @@ class ResetSequence : public GenericLongPressSequence<KeyMap::Back, KeyMap::Fron
   public:
     explicit ResetSequence(sys::Service &service)
         : GenericLongPressSequence<KeyMap::Back, KeyMap::Frontlight>{sys::TimerFactory::createSingleShotTimer(
-              &service, "rseq", std::chrono::milliseconds{10000}, [this](auto &) { handleTimer(); })}
+              &service, "rseq", std::chrono::milliseconds{5500}, [this](auto &) { handleTimer(); })}
 
     {}
 };


### PR DESCRIPTION
If the user performs a manual reset there is no information in the logs. It can be treated as software resets.
So the best solution is to add a log about incoming manual reset and dump all logs to the file.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
