### PR TITLE
[MOS-1036] Fix song time not updated when returning from list

### DIFF
--- a/module-apps/application-music-player/ApplicationMusicPlayer.cpp
+++ b/module-apps/application-music-player/ApplicationMusicPlayer.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <application-music-player/ApplicationMusicPlayer.hpp>
@@ -75,22 +75,22 @@ namespace app
         lockPolicyHandler.setPreventsAutoLockByStateCallback(std::move(stateLockCallback));
 
         connect(typeid(AudioStopNotification), [&](sys::Message *msg) -> sys::MessagePointer {
-            auto notification = static_cast<AudioStopNotification *>(msg);
+            const auto notification = static_cast<AudioStopNotification *>(msg);
             music_player::AudioNotificationsHandler audioNotificationHandler{priv->songsPresenter};
             return audioNotificationHandler.handleAudioStopNotification(notification);
         });
         connect(typeid(AudioEOFNotification), [&](sys::Message *msg) -> sys::MessagePointer {
-            auto notification = static_cast<AudioStopNotification *>(msg);
+            const auto notification = static_cast<AudioStopNotification *>(msg);
             music_player::AudioNotificationsHandler audioNotificationHandler{priv->songsPresenter};
             return audioNotificationHandler.handleAudioEofNotification(notification);
         });
         connect(typeid(AudioPausedNotification), [&](sys::Message *msg) -> sys::MessagePointer {
-            auto notification = static_cast<AudioPausedNotification *>(msg);
+            const auto notification = static_cast<AudioPausedNotification *>(msg);
             music_player::AudioNotificationsHandler audioNotificationHandler{priv->songsPresenter};
             return audioNotificationHandler.handleAudioPausedNotification(notification);
         });
         connect(typeid(AudioResumedNotification), [&](sys::Message *msg) -> sys::MessagePointer {
-            auto notification = static_cast<AudioResumedNotification *>(msg);
+            const auto notification = static_cast<AudioResumedNotification *>(msg);
             music_player::AudioNotificationsHandler audioNotificationHandler{priv->songsPresenter};
             return audioNotificationHandler.handleAudioResumedNotification(notification);
         });
@@ -101,7 +101,7 @@ namespace app
     sys::MessagePointer ApplicationMusicPlayer::DataReceivedHandler(sys::DataMessage *msgl,
                                                                     [[maybe_unused]] sys::ResponseMessage *resp)
     {
-        auto retMsg = Application::DataReceivedHandler(msgl);
+        const auto retMsg = Application::DataReceivedHandler(msgl);
         // if message was handled by application's template there is no need to process further.
         if (static_cast<sys::ResponseMessage *>(retMsg.get())->retCode == sys::ReturnCodes::Success) {
             return retMsg;
@@ -113,7 +113,7 @@ namespace app
     // Invoked during initialization
     sys::ReturnCodes ApplicationMusicPlayer::InitHandler()
     {
-        auto ret = Application::InitHandler();
+        const auto ret = Application::InitHandler();
         if (ret != sys::ReturnCodes::Success) {
             return ret;
         }

--- a/module-apps/application-music-player/presenters/SongsPresenter.hpp
+++ b/module-apps/application-music-player/presenters/SongsPresenter.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -50,6 +50,7 @@ namespace app::music_player
             virtual bool playPrevious()                    = 0;
 
             virtual void songsStateRequest()                                      = 0;
+            virtual void progressStateRequest()                                   = 0;
             virtual void setPlayingStateCallback(OnPlayingStateChangeCallback cb) = 0;
             virtual bool handleAudioStopNotifiaction(audio::Token token)          = 0;
             virtual bool handleAudioEofNotification(audio::Token token)           = 0;
@@ -78,6 +79,7 @@ namespace app::music_player
         bool playPrevious() override;
 
         void songsStateRequest() override;
+        void progressStateRequest() override;
         void setPlayingStateCallback(std::function<void(app::music::SongState)> cb) override;
         bool handleAudioStopNotifiaction(audio::Token token) override;
         bool handleAudioEofNotification(audio::Token token) override;
@@ -90,8 +92,7 @@ namespace app::music_player
 
       private:
         void updateViewSongState();
-        void updateViewProgresState();
-        void updateViewSongTitleAndArtist(const std::string &title, const std::string &artist);
+        void updateViewProgressState();
         void refreshView();
         void updateTrackProgressRatio();
         void resetTrackProgressRatio();

--- a/module-apps/application-music-player/windows/MusicPlayerAllSongsWindow.cpp
+++ b/module-apps/application-music-player/windows/MusicPlayerAllSongsWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MusicPlayerAllSongsWindow.hpp"
@@ -6,18 +6,15 @@
 #include <data/MusicPlayerStyle.hpp>
 
 #include <Style.hpp>
-#include <cassert>
 #include <i18n/i18n.hpp>
-#include <service-audio/AudioServiceAPI.hpp>
 #include <gui/widgets/ListView.hpp>
 #include <gui/widgets/Icon.hpp>
 
 namespace gui
 {
-
     MusicPlayerAllSongsWindow::MusicPlayerAllSongsWindow(
         app::ApplicationCommon *app, std::shared_ptr<app::music_player::SongsContract::Presenter> windowPresenter)
-        : AppWindow(app, gui::name::window::all_songs_window), presenter{windowPresenter}
+        : AppWindow(app, gui::name::window::all_songs_window), presenter{std::move(windowPresenter)}
     {
         buildInterface();
     }
@@ -64,11 +61,15 @@ namespace gui
         presenter->createData();
     }
 
-    void MusicPlayerAllSongsWindow::updateSongsState(std::optional<db::multimedia_files::MultimediaFilesRecord> record,
-                                                     RecordState state)
+    void MusicPlayerAllSongsWindow::updateSongsState(
+        [[maybe_unused]] std::optional<db::multimedia_files::MultimediaFilesRecord> record,
+        [[maybe_unused]] RecordState state)
     {
         songsList->rebuildList(gui::listview::RebuildType::InPlace);
     }
+
+    void MusicPlayerAllSongsWindow::updateSongProgress([[maybe_unused]] float progress)
+    {}
 
     void MusicPlayerAllSongsWindow::refreshWindow()
     {
@@ -87,10 +88,6 @@ namespace gui
 
     bool MusicPlayerAllSongsWindow::onInput(const InputEvent &inputEvent)
     {
-        if (AppWindow::onInput(inputEvent)) {
-            return true;
-        }
-
-        return false;
+        return AppWindow::onInput(inputEvent);
     }
 } /* namespace gui */

--- a/module-apps/application-music-player/windows/MusicPlayerAllSongsWindow.hpp
+++ b/module-apps/application-music-player/windows/MusicPlayerAllSongsWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -17,15 +17,14 @@ namespace gui
         explicit MusicPlayerAllSongsWindow(app::ApplicationCommon *app,
                                            std::shared_ptr<app::music_player::SongsContract::Presenter> presenter);
 
-        void onBeforeShow([[maybe_unused]] ShowMode mode, [[maybe_unused]] SwitchData *data) override;
+        void onBeforeShow(ShowMode mode, SwitchData *data) override;
 
         void buildInterface() override;
         bool onInput(const InputEvent &inputEvent) override;
 
         void updateSongsState(std::optional<db::multimedia_files::MultimediaFilesRecord> record,
                               RecordState state) override;
-        void updateSongProgress(float progres) override
-        {}
+        void updateSongProgress(float progress) override;
         void refreshWindow() override;
         void setNavBarTemporaryMode(const std::string &text) override;
         void restoreFromNavBarTemporaryMode() override;
@@ -35,5 +34,4 @@ namespace gui
         ListView *songsList = nullptr;
         Icon *emptyListIcon = nullptr;
     };
-
 } /* namespace gui */

--- a/module-apps/application-music-player/windows/MusicPlayerMainWindow.hpp
+++ b/module-apps/application-music-player/windows/MusicPlayerMainWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -23,7 +23,7 @@ namespace gui
     {
       public:
         /// number of vertical items in track's progress bar
-        static constexpr uint8_t progressBarSize = 27;
+        static constexpr std::uint8_t progressBarSize = 27;
 
         /// current view mode (switching with up / down arrow)
         enum class ViewMode
@@ -36,7 +36,7 @@ namespace gui
         explicit MusicPlayerMainWindow(app::ApplicationCommon *app,
                                        std::shared_ptr<app::music_player::SongsContract::Presenter> presenter);
 
-        void onBeforeShow([[maybe_unused]] ShowMode mode, [[maybe_unused]] SwitchData *data) override;
+        void onBeforeShow(ShowMode mode, SwitchData *data) override;
 
         void rebuild() override;
         void buildInterface() override;
@@ -81,9 +81,9 @@ namespace gui
         Label *descriptionText                   = nullptr;
         Image *progressBarItems[progressBarSize] = {nullptr};
 
-        float currentProgress            = 0.f;
-        uint32_t currentTotalTime        = 0;
-        uint8_t currentProgressBarsBlack = 0;
+        float currentProgress                 = 0.0f;
+        std::uint32_t currentTotalTime        = 0;
+        std::uint8_t currentProgressBarsBlack = 0;
         std::string currentTitle;
         std::string currentArtist;
         std::string currentTimeString;
@@ -91,5 +91,4 @@ namespace gui
         bool isPermissionToChangeViewMode = false;
         bool needToDeepRedrawScreen       = false;
     };
-
 } /* namespace gui */

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -45,6 +45,7 @@
 * Fixed losing drafted message and recipient number in new message windows
 * Fixed misleading "Save" button behavior in "Date and time" window
 * Fixed losing unsaved user data when tethering is switching on
+* Fixed invalid elapsed time in music player after playing and pausing track from songs list view
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
* Fix of the issue that switching from songs list to main view after playing and stopping
some track resulted in elapsed time counter
not being updated until the song is unpaused;
* cleanups.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
