### PR TITLE
[MOS-1032] Fix double return to previous window in onboarding

### DIFF
--- a/module-apps/application-onboarding/windows/OnBoardingChangeDateAndTimeWindow.cpp
+++ b/module-apps/application-onboarding/windows/OnBoardingChangeDateAndTimeWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "OnBoardingChangeDateAndTimeWindow.hpp"
@@ -13,13 +13,6 @@ namespace app::onBoarding
 
     bool OnBoardingChangeDateAndTimeWindow::onInput(const gui::InputEvent &inputEvent)
     {
-        if (inputEvent.isKeyRelease(gui::KeyCode::KEY_ENTER)) {
-            auto ret = ChangeDateAndTimeWindow::onInput(inputEvent);
-            application->returnToPreviousWindow();
-            return ret;
-        }
-
         return ChangeDateAndTimeWindow::onInput(inputEvent);
     }
-
 } // namespace app::onBoarding


### PR DESCRIPTION
Fix of the regression created by previous
commit - saving manually set time resulted
in switching two windows back instead of
just one.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
