### PR TITLE
[MOS-1037] Fix disappearing 'Call' label in phonebook

### DIFF
--- a/module-apps/application-phonebook/windows/PhonebookMainWindow.hpp
+++ b/module-apps/application-phonebook/windows/PhonebookMainWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -16,14 +16,13 @@
 
 namespace gui
 {
-
     class PhonebookMainWindow : public AppWindow
     {
       private:
-        std::shared_ptr<SearchRequestModel> model = nullptr;
+        std::shared_ptr<SearchRequestModel> model;
 
       protected:
-        std::shared_ptr<PhonebookModel> phonebookModel = nullptr;
+        std::shared_ptr<PhonebookModel> phonebookModel;
         ListView *contactsList                         = nullptr;
         gui::Icon *emptyListIcon                       = nullptr;
 
@@ -52,5 +51,4 @@ namespace gui
 
         void HandleFilteringByLetter(const InputEvent &inputEvent);
     };
-
 } /* namespace gui */

--- a/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
+++ b/module-apps/application-phonebook/windows/PhonebookNewContact.cpp
@@ -115,7 +115,7 @@ namespace gui
         return true;
     }
 
-    void PhonebookNewContact::showDialogUnsavedChanges(std::function<bool()> whereToGoOnYes)
+    void PhonebookNewContact::showDialogUnsavedChanges(const std::function<bool()> &whereToGoOnYes)
     {
         // Show a popup warning about possible data loss
         auto metaData = std::make_unique<gui::DialogMetadataMessage>(

--- a/module-apps/application-phonebook/windows/PhonebookNewContact.hpp
+++ b/module-apps/application-phonebook/windows/PhonebookNewContact.hpp
@@ -39,7 +39,7 @@ namespace gui
                                         const std::uint32_t duplicatedNumberContactID = 0u);
         void showDialogDuplicatedSpeedDialNumber();
         void showDialogPrimaryAndSecondaryNumberAreTheSame();
-        void showDialogUnsavedChanges(std::function<bool()> whereToGoOnYes = nullptr);
+        void showDialogUnsavedChanges(const std::function<bool()> &whereToGoOnYes = nullptr);
         void setSaveButtonVisible(bool visible);
         void showContactDeletedNotification();
         bool checkIfContactWasDeletedDuringEditProcess() const;

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -46,6 +46,7 @@
 * Fixed misleading "Save" button behavior in "Date and time" window
 * Fixed losing unsaved user data when tethering is switching on
 * Fixed invalid elapsed time in music player after playing and pausing track from songs list view
+* Fixed disappearing "Call" label in Phonebook app
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
Fix of the issue that 'Call' label would
disappear or show as 'Options' label
when switching through the windows in
particular scenarios.
Additionally fixed possibility to
call to contact when selecting it
via messages app by pressing
unlabeled left functional.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
