### PR TITLE
[MOS-1038] Fix CPU frequency hanging after SMS received

### DIFF
--- a/module-services/service-audio/include/service-audio/ServiceAudio.hpp
+++ b/module-services/service-audio/include/service-audio/ServiceAudio.hpp
@@ -39,6 +39,14 @@ class ServiceAudio : public sys::Service
         Continuous
     };
 
+    enum class InternalOperationState
+    {
+        AudioIdle,
+        OperationIdle,
+        Paused,
+        Active
+    };
+
     audio::AudioMux audioMux;
     std::shared_ptr<sys::CpuSentinel> cpuSentinel;
     audio::AudioMux::VibrationStatus vibrationMotorStatus = audio::AudioMux::VibrationStatus::Off;
@@ -96,7 +104,7 @@ class ServiceAudio : public sys::Service
     std::string GetSound(const audio::PlaybackType &plType);
     constexpr auto IsResumable(const audio::PlaybackType &type) const -> bool;
     constexpr auto ShouldLoop(const std::optional<audio::PlaybackType> &type) const -> bool;
-    auto GetOperationState() -> audio::Operation::State;
+    auto GetOperationState() -> InternalOperationState;
     auto IsSystemSound(const audio::PlaybackType &type) -> bool;
     audio::PlaybackType generatePlayback(const audio::PlaybackType &type,
                                          const audio::Setting &setting = audio::Setting::Volume);
@@ -128,7 +136,7 @@ class ServiceAudio : public sys::Service
     auto handleSingleVibrationStart() -> sys::MessagePointer;
 
     void notifyAboutNewRoutingIfRouterAvailable();
-    void updateMinimumCpuFrequency(audio::Operation::State operationState);
+    void updateMinimumCpuFrequency(ServiceAudio::InternalOperationState operationState);
 };
 
 namespace sys


### PR DESCRIPTION
Fix of the issue that in some cases (e.g. after
text message was received) ServiceAudio would
not release CPU sentinel, what resulted in
quick battery discharge.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
