### PR TITLE
[BH-1764] Fix GridLayoutTesting Border Callback Test

### DIFF
--- a/module-gui/gui/widgets/Item.cpp
+++ b/module-gui/gui/widgets/Item.cpp
@@ -93,6 +93,7 @@ namespace gui
         }
         if (item == focusItem) {
             focusItem = nullptr;
+            focus     = false;
         }
 
         auto fi = std::find(children.begin(), children.end(), item);

--- a/module-gui/test/test-google/test-gui-gridlayout.cpp
+++ b/module-gui/test/test-google/test-gui-gridlayout.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "gtest/gtest.h"
@@ -267,7 +267,7 @@ TEST_F(GridLayoutTesting, Navigate_Test_ActiveItems_2_BorderCallback)
 }
 
 ///> TODO: Enable this test when issue with setFocus will be resolved
-TEST_F(GridLayoutTesting, DISABLED_Border_Callback_Test)
+TEST_F(GridLayoutTesting, Border_Callback_Test)
 {
     ///> Test for grid layout with 46 elements
     ///> | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 | 11 | 12 |


### PR DESCRIPTION
Fix not seting focus to false when all items where removed from parent

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [x] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
