### PR TITLE
[BH-1774] Fix frequency lock during user activity

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -9,6 +9,7 @@
 * Fixed uneven screen refresh when turning on the device
 * Fixed not disappearing snooze icon when an alarm is deactivated
 * Fixed incorrect message after new alarm setting in some scenarios
+* Fixed frequency lock during user activity
 
 ### Added
 * Files not fully transferred via Center will be now removed when USB cable is unplugged

--- a/module-services/service-evtmgr/EventManager.cpp
+++ b/module-services/service-evtmgr/EventManager.cpp
@@ -37,7 +37,6 @@
 #include <list>
 #include <ctime>
 #include <apps-common/messages/AppMessage.hpp>
-#include <system/messages/SentinelRegistrationMessage.hpp>
 #include <EventStore.hpp>
 #include <ticks.hpp>
 #include <purefs/filesystem_paths.hpp>
@@ -182,10 +181,6 @@ sys::ReturnCodes EventManagerCommon::InitHandler()
     EventWorker = createEventWorker();
     EventWorker->init(settings, eventManagerParams);
     EventWorker->run();
-
-    cpuSentinel                  = std::make_shared<sys::TimedCpuSentinel>(service::name::evt_manager, this);
-    auto sentinelRegistrationMsg = std::make_shared<sys::SentinelRegistrationMessage>(cpuSentinel);
-    bus.sendUnicast(sentinelRegistrationMsg, service::name::system_manager);
 
     return sys::ReturnCodes::Success;
 }

--- a/module-services/service-evtmgr/service-evtmgr/EventManagerCommon.hpp
+++ b/module-services/service-evtmgr/service-evtmgr/EventManagerCommon.hpp
@@ -14,7 +14,6 @@
 #include <Service/Worker.hpp>
 #include <service-db/DBServiceName.hpp>
 #include <Timers/TimerHandle.hpp>
-#include <SystemManager/CpuSentinel.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -69,7 +68,7 @@ class EventManagerCommon : public sys::Service
 
     std::shared_ptr<settings::Settings> settings;
     std::unique_ptr<WorkerEventCommon> EventWorker;
-    std::shared_ptr<sys::TimedCpuSentinel> cpuSentinel;
+
     // application where key events are sent. This is also only application that is allowed to change keyboard long
     // press settings.
     std::string targetApplication;

--- a/module-sys/SystemManager/PowerManager.cpp
+++ b/module-sys/SystemManager/PowerManager.cpp
@@ -216,5 +216,6 @@ namespace sys
 
         taskStatistics.Update();
         taskStatistics.LogCpuUsage();
+        cpuGovernor->PrintActiveSentinels();
     }
 } // namespace sys

--- a/module-sys/SystemManager/SystemManagerCommon.cpp
+++ b/module-sys/SystemManager/SystemManagerCommon.cpp
@@ -61,6 +61,16 @@ namespace sys
         }
 
     } // namespace
+
+    namespace constants
+    {
+        using namespace std::chrono_literals;
+        inline constexpr std::chrono::milliseconds timerInitInterval{30s};
+        inline constexpr std::chrono::milliseconds timerPeriodInterval{100ms};
+        inline constexpr std::chrono::milliseconds powerManagerLogsTimerInterval{1h};
+        inline constexpr auto restoreTimeout{5000};
+    } // namespace constants
+
     namespace state
     {
         template <typename T>

--- a/module-sys/SystemManager/include/SystemManager/CpuGovernor.hpp
+++ b/module-sys/SystemManager/include/SystemManager/CpuGovernor.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -39,6 +39,7 @@ namespace sys
         auto RemoveSentinel(std::string sentinelName) -> void;
         [[nodiscard]] auto GetNumberOfRegisteredSentinels() const noexcept -> uint32_t;
         void PrintAllSentinels() const noexcept;
+        void PrintActiveSentinels() const noexcept;
 
         void SetCpuFrequencyRequest(const std::string &sentinelName, bsp::CpuFrequencyMHz request);
         void ResetCpuFrequencyRequest(const std::string &sentinelName);
@@ -47,8 +48,6 @@ namespace sys
         void InformSentinelsAboutCpuFrequencyChange(bsp::CpuFrequencyMHz newFrequency) noexcept;
 
       private:
-        static void PrintName(const GovernorSentinelPointer &element);
-
         /// this could be set - set is sorted :)
         GovernorSentinelsVector sentinels;
     };

--- a/module-sys/SystemManager/include/SystemManager/CpuSentinel.hpp
+++ b/module-sys/SystemManager/include/SystemManager/CpuSentinel.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -36,6 +36,9 @@ namespace sys
         void ReadRegistrationData(bsp::CpuFrequencyMHz frequencyHz);
         TaskHandle_t getTask();
         std::string getReason();
+
+        TickType_t getHoldTicks() const noexcept;
+
         virtual ~CpuSentinel() = default;
 
       protected:
@@ -43,6 +46,7 @@ namespace sys
         bsp::CpuFrequencyMHz currentFrequencyToHold{bsp::CpuFrequencyMHz::Level_0};
         std::atomic<bsp::CpuFrequencyMHz> currentFrequency{bsp::CpuFrequencyMHz::Level_0};
         sys::Service *owner{nullptr};
+        TickType_t holdTicks;
 
         /// function called from the PowerManager context
         /// to update resources immediately

--- a/module-sys/SystemManager/include/SystemManager/SystemManagerCommon.hpp
+++ b/module-sys/SystemManager/include/SystemManager/SystemManagerCommon.hpp
@@ -29,15 +29,6 @@ namespace app
 
 namespace sys
 {
-    namespace constants
-    {
-        using namespace std::chrono_literals;
-        inline constexpr std::chrono::milliseconds timerInitInterval{30s};
-        inline constexpr std::chrono::milliseconds timerPeriodInterval{100ms};
-        inline constexpr std::chrono::milliseconds powerManagerLogsTimerInterval{1h};
-        inline constexpr auto restoreTimeout{5000};
-    } // namespace constants
-
     enum class Code
     {
         CloseSystem,

--- a/products/BellHybrid/services/evtmgr/EventManager.cpp
+++ b/products/BellHybrid/services/evtmgr/EventManager.cpp
@@ -44,7 +44,7 @@ EventManager::EventManager(LogDumpFunction logDumpFunction, const std::string &n
                           .voltage{.shutdown            = constants::shutdownVoltageThreshold,
                                    .measurementMaxCount = constants::measurementThreshold}},
                          name),
-      backlightHandler(settings, this), userActivityHandler(std::make_shared<sys::CpuSentinel>(name, this), this)
+      backlightHandler(settings, this), userActivityHandler(this)
 {
     buildKeySequences();
 

--- a/products/BellHybrid/services/evtmgr/include/evtmgr/user-activity-handler/UserActivityHandler.hpp
+++ b/products/BellHybrid/services/evtmgr/include/evtmgr/user-activity-handler/UserActivityHandler.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -12,7 +12,7 @@ namespace evm
     class UserActivityHandler
     {
       public:
-        UserActivityHandler(std::shared_ptr<sys::CpuSentinel> cpuSentinel, sys::Service *parent);
+        UserActivityHandler(sys::Service *parent);
 
         void handleUserInput();
 

--- a/products/BellHybrid/services/evtmgr/user-activity-handler/UserActivityHandler.cpp
+++ b/products/BellHybrid/services/evtmgr/user-activity-handler/UserActivityHandler.cpp
@@ -1,8 +1,10 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <evtmgr/user-activity-handler/UserActivityHandler.hpp>
 #include <Timers/TimerFactory.hpp>
+#include <system/messages/SentinelRegistrationMessage.hpp>
+#include <system/Constants.hpp>
 
 namespace evm
 {
@@ -10,15 +12,19 @@ namespace evm
     {
         constexpr auto userActivityTimerTime = std::chrono::seconds(10);
         constexpr auto userActivityCPULevel  = bsp::CpuFrequencyMHz::Level_5;
+        constexpr auto sentinelName          = "UserActivity";
     } // namespace
 
-    UserActivityHandler::UserActivityHandler(std::shared_ptr<sys::CpuSentinel> cpuSentinel, sys::Service *parent)
-        : cpuSentinel{std::move(cpuSentinel)},
+    UserActivityHandler::UserActivityHandler(sys::Service *parent)
+        : cpuSentinel(std::make_shared<sys::CpuSentinel>(sentinelName, parent)),
           activityTimer{sys::TimerFactory::createSingleShotTimer(
               parent, "UserActivityTimer", userActivityTimerTime, [this]([[maybe_unused]] sys::Timer &timer) {
                   onUserActivityTimeout();
               })}
-    {}
+    {
+        auto sentinelRegistrationMsg = std::make_shared<sys::SentinelRegistrationMessage>(cpuSentinel);
+        parent->bus.sendUnicast(std::move(sentinelRegistrationMsg), service::name::system_manager);
+    }
 
     void UserActivityHandler::handleUserInput()
     {

--- a/products/PurePhone/services/evtmgr/include/evtmgr/EventManager.hpp
+++ b/products/PurePhone/services/evtmgr/include/evtmgr/EventManager.hpp
@@ -22,7 +22,7 @@ class EventManager : public EventManagerCommon
                         .measurementMaxCount = constants::measurementThreshold}},
               name),
           vibrator(std::make_unique<vibra_handle::Vibra>(this)), backlightHandler(settings, this),
-          userActivityHandler(std::make_shared<sys::CpuSentinel>(name, this), this)
+          userActivityHandler(this)
     {}
 
   private:

--- a/products/PurePhone/services/evtmgr/include/evtmgr/UserActivityHandler.hpp
+++ b/products/PurePhone/services/evtmgr/include/evtmgr/UserActivityHandler.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -12,7 +12,7 @@ namespace evm
     class UserActivityHandler
     {
       public:
-        UserActivityHandler(std::shared_ptr<sys::CpuSentinel> cpuSentinel, sys::Service *parent);
+        UserActivityHandler(sys::Service *parent);
 
         void handleUserInput();
 

--- a/products/PurePhone/services/evtmgr/user-activity-handler/UserActivityHandler.cpp
+++ b/products/PurePhone/services/evtmgr/user-activity-handler/UserActivityHandler.cpp
@@ -1,8 +1,10 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <evtmgr/UserActivityHandler.hpp>
 #include <Timers/TimerFactory.hpp>
+#include <system/messages/SentinelRegistrationMessage.hpp>
+#include <system/Constants.hpp>
 
 namespace evm
 {
@@ -10,15 +12,19 @@ namespace evm
     {
         constexpr auto userActivityTimerTime = std::chrono::seconds(2);
         constexpr auto userActivityCPULevel  = bsp::CpuFrequencyMHz::Level_4;
+        constexpr auto sentinelName          = "UserActivity";
     } // namespace
 
-    UserActivityHandler::UserActivityHandler(std::shared_ptr<sys::CpuSentinel> cpuSentinel, sys::Service *parent)
-        : cpuSentinel{std::move(cpuSentinel)},
+    UserActivityHandler::UserActivityHandler(sys::Service *parent)
+        : cpuSentinel(std::make_shared<sys::CpuSentinel>(sentinelName, parent)),
           activityTimer{sys::TimerFactory::createSingleShotTimer(
               parent, "UserActivityTimer", userActivityTimerTime, [this]([[maybe_unused]] sys::Timer &timer) {
                   onUserActivityTimeout();
               })}
-    {}
+    {
+        auto sentinelRegistrationMsg = std::make_shared<sys::SentinelRegistrationMessage>(cpuSentinel);
+        parent->bus.sendUnicast(std::move(sentinelRegistrationMsg), service::name::system_manager);
+    }
 
     void UserActivityHandler::handleUserInput()
     {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -50,6 +50,7 @@
 * Fixed phone number input style unification
 * Fixed disappearing selections when setting custom alarm after popup is shown
 * Fixed alarm preview playback behavior
+* Fixed frequency lock during user activity
 
 ## [1.7.2 2023-07-28]
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

- Sentinel locks the frequency when pressing buttons and the encoder.
- The "user activity" sentinel will be properly managed by the system (CpuGovernor) just like other sentinels.
- Adding information about active sentinels in the power management statistics logs

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
