### PR TITLE
[BH-1780] Fix uncaught std::filesystem::file_size exception

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -9,6 +9,7 @@
 * Fixed not disappearing snooze icon when an alarm is deactivated
 * Fixed incorrect message after new alarm setting in some scenarios
 * Fixed frequency lock during user activity
+* Fixed possibility of OS crash during update package size check
 
 ### Added
 * Files not fully transferred via Center will be now removed when USB cable is unplugged

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -27,6 +27,7 @@
 * Fixed alarm preview playback behavior
 * Fixed frequency lock during user activity
 * Fixed crash on transferring audio file with big metadata
+* Fixed possibility of OS crash during update package size check
 
 ## [1.8.0 2023-09-27]
 


### PR DESCRIPTION
Fix of the issue that exceptions thrown
by file_size method were not caught
at all, what resulted in system crashing.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
