### PR TITLE
[MOS-1047] Fix calling abort() in EnterNumberWindow

### DIFF
--- a/module-apps/application-call/data/CallSwitchData.hpp
+++ b/module-apps/application-call/data/CallSwitchData.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -6,12 +6,10 @@
 #include "SwitchData.hpp"
 
 #include <PhoneNumber.hpp>
-
 #include <string>
 
 namespace app
 {
-
     class CallSwitchData : public gui::SwitchData
     {
       public:
@@ -28,7 +26,7 @@ namespace app
         utils::PhoneNumber::View phoneNumber;
 
       public:
-        CallSwitchData(const utils::PhoneNumber::View &phoneNumber, Type type = Type::UNDEFINED)
+        explicit CallSwitchData(const utils::PhoneNumber::View &phoneNumber, Type type = Type::UNDEFINED)
             : SwitchData(descriptionStr), type(type), phoneNumber(phoneNumber){};
 
         const Type &getType() const
@@ -48,7 +46,7 @@ namespace app
       public:
         static constexpr auto descriptionStr = "EnterNumberSwitchData";
 
-        EnterNumberData(const std::string &phoneNumber) : SwitchData(descriptionStr), phoneNumber(phoneNumber)
+        explicit EnterNumberData(const std::string &phoneNumber) : SwitchData(descriptionStr), phoneNumber(phoneNumber)
         {}
 
         const std::string &getPhoneNumber() const
@@ -60,7 +58,7 @@ namespace app
     class ExecuteCallData : public CallSwitchData
     {
       public:
-        ExecuteCallData(const utils::PhoneNumber::View &phoneNumber)
+        explicit ExecuteCallData(const utils::PhoneNumber::View &phoneNumber)
             : CallSwitchData(phoneNumber, app::CallSwitchData::Type::EXECUTE_CALL){};
     };
 } /* namespace app */

--- a/module-apps/application-call/include/application-call/ApplicationCall.hpp
+++ b/module-apps/application-call/include/application-call/ApplicationCall.hpp
@@ -5,6 +5,7 @@
 
 #include <application-call/model/CallModel.hpp>
 #include <application-call/presenter/CallPresenter.hpp>
+#include <application-call/windows/WindowNames.hpp>
 #include <Timers/TimerHandle.hpp>
 #include <service-cellular/CellularMessage.hpp>
 #include <service-evtmgr/ServiceEventManagerName.hpp>
@@ -17,18 +18,7 @@
 
 namespace app
 {
-    inline constexpr auto name_call       = "ApplicationCall";
-    inline constexpr auto call_stack_size = 8192U;
-
-    namespace window
-    {
-        inline constexpr auto name_enterNumber       = gui::name::window::main_window;
-        inline constexpr auto name_call              = "CallWindow";
-        inline constexpr auto name_emergencyCall     = "EmergencyCallWindow";
-        inline constexpr auto name_duplicatedContact = "DuplicatedContactWindow";
-        inline constexpr auto name_dialogConfirm     = "DialogConfirm";
-        inline constexpr auto name_number            = "NumberWindow";
-    } // namespace window
+    inline constexpr auto name_call = "ApplicationCall";
 
     class EnterNumberWindowInterface
     {
@@ -56,7 +46,7 @@ namespace app
         sys::ReturnCodes InitHandler() override;
         sys::MessagePointer handleAppClose(sys::Message *msgl) override;
 
-        sys::ReturnCodes SwitchPowerModeHandler(const sys::ServicePowerMode mode) override final
+        sys::ReturnCodes SwitchPowerModeHandler([[maybe_unused]] const sys::ServicePowerMode mode) override final
         {
             return sys::ReturnCodes::Success;
         }

--- a/module-apps/application-call/windows/CallWindow.cpp
+++ b/module-apps/application-call/windows/CallWindow.cpp
@@ -27,7 +27,7 @@ namespace gui
     using namespace app::call;
 
     CallWindow::CallWindow(app::ApplicationCommon *app, app::call::CallWindowContract::Presenter &presenter)
-        : gui::AppWindow{app, app::window::name_call}, presenter{presenter}
+        : gui::AppWindow{app, gui::window::name::call}, presenter{presenter}
     {
         presenter.attach(this);
         presenter.attachCallbacks();
@@ -79,7 +79,7 @@ namespace gui
         iconsBox->setEdges(RectangleEdge::None);
 
         microphoneIcon                    = new MicrophoneIcon(iconsBox);
-        microphoneIcon->activatedCallback = [=](gui::Item &item) {
+        microphoneIcon->activatedCallback = [=]([[maybe_unused]] gui::Item &item) {
             microphoneIcon->setNext();
             LOG_INFO("Microphone %s", static_cast<bool>(microphoneIcon->get()) ? "activated" : "deactivated");
 
@@ -89,7 +89,7 @@ namespace gui
         };
 
         speakerIcon                    = new SpeakerIcon(iconsBox);
-        speakerIcon->activatedCallback = [=](gui::Item &item) {
+        speakerIcon->activatedCallback = [=]([[maybe_unused]] gui::Item &item) {
             speakerIcon->setNext();
             LOG_INFO("Speaker %s", static_cast<bool>(speakerIcon->get()) ? "activated" : "deactivated");
 
@@ -154,11 +154,11 @@ namespace gui
         }
     }
 
-    void CallWindow::onBeforeShow(ShowMode mode, SwitchData *data)
+    void CallWindow::onBeforeShow([[maybe_unused]] ShowMode mode, SwitchData *data)
     {
         presenter.buildLayout();
 
-        if (auto switchData = dynamic_cast<SMSTemplateSent *>(data); switchData != nullptr) {
+        if (const auto switchData = dynamic_cast<SMSTemplateSent *>(data); switchData != nullptr) {
             presenter.hangUpCall();
             presenter.sendSms(switchData->getText());
             return;
@@ -208,7 +208,7 @@ namespace gui
 
     void CallWindow::connectTimerOnExit()
     {
-        timerCallback = [this](Item &, sys::Timer &timer) {
+        timerCallback = [this]([[maybe_unused]] Item &item, [[maybe_unused]] sys::Timer &timer) {
             LOG_DEBUG("Delayed exit timer callback");
             presenter.handleDelayedViewClose();
             application->popCurrentWindow();

--- a/module-apps/application-call/windows/CallWindow.hpp
+++ b/module-apps/application-call/windows/CallWindow.hpp
@@ -69,5 +69,4 @@ namespace gui
         gui::SpeakerIconState getSpeakerIconState() override;
         void setSpeakerIconState(const gui::SpeakerIconState &icon) override;
     };
-
 } /* namespace gui */

--- a/module-apps/application-call/windows/EmergencyCallWindow.cpp
+++ b/module-apps/application-call/windows/EmergencyCallWindow.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "CallAppStyle.hpp"
@@ -10,7 +10,7 @@ namespace gui
 {
 
     EmergencyCallWindow::EmergencyCallWindow(app::ApplicationCommon *app, app::EnterNumberWindowInterface *interface)
-        : NumberWindow(app, interface, app::window::name_emergencyCall)
+        : NumberWindow(app, interface, gui::window::name::emergency_call)
     {
         buildInterface();
     }

--- a/module-apps/application-call/windows/EmergencyCallWindow.hpp
+++ b/module-apps/application-call/windows/EmergencyCallWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -7,7 +7,6 @@
 
 namespace gui
 {
-
     class EmergencyCallWindow : public NumberWindow
     {
       public:
@@ -19,5 +18,4 @@ namespace gui
         void buildInterface() override;
         status_bar::Configuration configureStatusBar(status_bar::Configuration appConfiguration) override;
     };
-
 } /* namespace gui */

--- a/module-apps/application-call/windows/EnterNumberWindow.cpp
+++ b/module-apps/application-call/windows/EnterNumberWindow.cpp
@@ -30,13 +30,13 @@ namespace gui
         navBar->setText(nav_bar::Side::Center, utils::translate("common_add"));
         navBar->setText(nav_bar::Side::Right, utils::translate("app_call_clear"));
 
-        auto iconsBox = new HBox(
+        const auto iconsBox = new HBox(
             this, style::window::default_left_margin, iconsBox::y, style::window::default_body_width, iconsBox::h);
         iconsBox->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
         iconsBox->setEdges(RectangleEdge::None);
 
         newContactIcon                    = new gui::AddContactIcon(iconsBox);
-        newContactIcon->activatedCallback = [=](gui::Item &item) { return addNewContact(); };
+        newContactIcon->activatedCallback = [=]([[maybe_unused]] gui::Item &item) { return addNewContact(); };
         setFocusItem(newContactIcon);
 
         iconsBox->resizeItems();
@@ -62,7 +62,7 @@ namespace gui
         }
 
         if (data->getDescription() == app::EnterNumberData::descriptionStr) {
-            auto *callData = dynamic_cast<app::EnterNumberData *>(data);
+            const auto callData = dynamic_cast<app::EnterNumberData *>(data);
             assert(callData != nullptr);
 
             initFormatterInput(callData->getPhoneNumber());
@@ -70,10 +70,10 @@ namespace gui
             application->refreshWindow(RefreshModes::GUI_REFRESH_FAST);
         }
         else if (data->getDescription() == app::CallSwitchData::descriptionStr) {
-            auto *callData = dynamic_cast<app::CallSwitchData *>(data);
+            const auto callData = dynamic_cast<app::CallSwitchData *>(data);
             assert(callData != nullptr);
 
-            auto &phoneNumber = callData->getPhoneNumber();
+            const auto &phoneNumber = callData->getPhoneNumber();
 
             initFormatterInput(phoneNumber.getEntered());
             setNumberLabel(phoneNumber.getFormatted());
@@ -84,8 +84,7 @@ namespace gui
             }
         }
         else {
-            LOG_ERROR("Unhandled switch data");
-            abort();
+            LOG_ERROR("Unhandled switch data: %s", data->getDescription().c_str());
         }
 
         return true;

--- a/module-apps/application-call/windows/EnterNumberWindow.hpp
+++ b/module-apps/application-call/windows/EnterNumberWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -15,7 +15,7 @@ namespace gui
       public:
         EnterNumberWindow(app::ApplicationCommon *app,
                           app::EnterNumberWindowInterface *interface,
-                          std::string windowName = app::window::name_enterNumber);
+                          std::string windowName = gui::window::name::enter_number);
         ~EnterNumberWindow() override = default;
 
         auto handleSwitchData(SwitchData *data) -> bool override;
@@ -26,5 +26,4 @@ namespace gui
 
         auto addNewContact() -> bool;
     };
-
 } /* namespace gui */

--- a/module-apps/application-call/windows/NumberWindow.hpp
+++ b/module-apps/application-call/windows/NumberWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -26,7 +26,7 @@ namespace gui
 
         NumberWindow(app::ApplicationCommon *app,
                      app::EnterNumberWindowInterface *interface,
-                     std::string windowName = app::window::name_number);
+                     std::string windowName = gui::window::name::number);
 
         auto onInput(const InputEvent &inputEvent) -> bool override;
         [[nodiscard]] auto getEnteredNumber() const noexcept -> const std::string &;

--- a/module-apps/application-call/windows/WindowNames.hpp
+++ b/module-apps/application-call/windows/WindowNames.hpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <AppWindowConstants.hpp>
+
+namespace gui::window::name
+{
+    inline constexpr auto enter_number        = gui::name::window::main_window;
+    inline constexpr auto call                = "CallWindow";
+    inline constexpr auto emergency_call      = "EmergencyCallWindow";
+    inline constexpr auto call_dialog_confirm = "DialogConfirm";
+    inline constexpr auto number              = "NumberWindow";
+} // namespace gui::window::name

--- a/module-apps/application-calllog/include/application-calllog/ApplicationCallLog.hpp
+++ b/module-apps/application-calllog/include/application-calllog/ApplicationCallLog.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -9,13 +9,12 @@
 
 namespace app
 {
-
-    inline constexpr auto CallLogAppStr = "ApplicationCallLog";
+    inline constexpr auto name_calllog = "ApplicationCallLog";
 
     class ApplicationCallLog : public Application
     {
       public:
-        ApplicationCallLog(std::string name                    = CallLogAppStr,
+        ApplicationCallLog(std::string name                    = name_calllog,
                            std::string parent                  = {},
                            StatusIndicators statusIndicators   = StatusIndicators{},
                            StartInBackground startInBackground = {false});
@@ -25,7 +24,7 @@ namespace app
         sys::ReturnCodes InitHandler() override;
         sys::ReturnCodes DeinitHandler() override;
 
-        sys::ReturnCodes SwitchPowerModeHandler(const sys::ServicePowerMode mode) override final
+        sys::ReturnCodes SwitchPowerModeHandler([[maybe_unused]] const sys::ServicePowerMode mode) override final
         {
             return sys::ReturnCodes::Success;
         }

--- a/module-apps/application-desktop/windows/DesktopMainWindow.cpp
+++ b/module-apps/application-desktop/windows/DesktopMainWindow.cpp
@@ -16,6 +16,12 @@
 
 #include <memory>
 
+namespace
+{
+    constexpr auto pageFirstNotificationIdx = 0;
+    constexpr auto pageLastNotificationIdx  = style::notifications::model::maxNotificationsPerPage - 1;
+} // namespace
+
 namespace gui
 {
     void DesktopMainWindow::buildInterface()
@@ -88,7 +94,7 @@ namespace gui
 
     void DesktopMainWindow::onBeforeShow(ShowMode mode, SwitchData *data)
     {
-        if (auto notificationData = dynamic_cast<app::manager::actions::NotificationsChangedParams *>(data)) {
+        if (const auto notificationData = dynamic_cast<app::manager::actions::NotificationsChangedParams *>(data)) {
             notificationsModel->updateData(notificationData);
         }
         else {
@@ -112,15 +118,9 @@ namespace gui
         return AppWindow::onInput(inputEvent);
     }
 
-    namespace
-    {
-        constexpr auto pageFirstNotificationIdx = 0;
-        constexpr auto pageLastNotificationIdx  = style::notifications::model::maxNotificationsPerPage - 1;
-    } // namespace
-
     bool DesktopMainWindow::processShortReleaseEvent(const InputEvent &inputEvent)
     {
-        auto code = translator.handle(inputEvent.getRawKey(), InputMode({InputMode::phone}).get());
+        const auto code = translator.handle(inputEvent.getRawKey(), InputMode({InputMode::phone}).get());
         // if numeric key was pressed record that key and send it to call application
         if (code != 0) {
             const auto &number = std::string(1, static_cast<char>(code));
@@ -200,7 +200,7 @@ namespace gui
 
     app::ApplicationDesktop *DesktopMainWindow::getAppDesktop() const
     {
-        auto *app = dynamic_cast<app::ApplicationDesktop *>(application);
+        const auto app = dynamic_cast<app::ApplicationDesktop *>(application);
         assert(app);
         return app;
     }
@@ -220,5 +220,4 @@ namespace gui
         return app::manager::Controller::sendAction(
             application, app::manager::actions::Dial, std::make_unique<app::EnterNumberData>(number));
     }
-
 } /* namespace gui */

--- a/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
+++ b/module-apps/application-messages/windows/SMSTemplatesWindow.cpp
@@ -90,7 +90,7 @@ namespace gui
 
         auto requestingWindow  = switchData->requestingWindow;
         app->templatesCallback = [=](std::shared_ptr<SMSTemplateRecord> templ) {
-            LOG_DEBUG("SMS template id = %" PRIu32 "chosen", templ->ID);
+            LOG_DEBUG("SMS template id = %" PRIu32 " chosen", templ->ID);
             auto data = std::make_unique<SMSTextData>(templ->text, SMSTextData::Concatenate::True);
             application->switchWindow(requestingWindow, std::move(data));
             return true;
@@ -105,7 +105,7 @@ namespace gui
         assert(app != nullptr);
 
         app->templatesCallback = [=](std::shared_ptr<SMSTemplateRecord> templ) {
-            LOG_DEBUG("SMS template id = %" PRIu32 "sent", templ->ID);
+            LOG_DEBUG("SMS template id = %" PRIu32 " sent", templ->ID);
             app::manager::Controller::switchBack(
                 app,
                 std::make_unique<app::manager::SwitchBackRequest>(application->GetName(),

--- a/module-apps/application-special-input/include/application-special-input/ApplicationSpecialInput.hpp
+++ b/module-apps/application-special-input/include/application-special-input/ApplicationSpecialInput.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -9,8 +9,7 @@
 
 namespace app
 {
-
-    inline constexpr auto special_input = "ApplicationSpecialInput";
+    inline constexpr auto name_special_input = "ApplicationSpecialInput";
     inline constexpr auto char_select   = gui::name::window::main_window;
 
     // app just to provide input selection on UI
@@ -19,7 +18,7 @@ namespace app
       public:
         std::string requester = "";
 
-        ApplicationSpecialInput(std::string name                    = special_input,
+        ApplicationSpecialInput(std::string name                    = name_special_input,
                                 std::string parent                  = {},
                                 StatusIndicators statusIndicators   = StatusIndicators{},
                                 StartInBackground startInBackground = {true});

--- a/module-services/service-cellular/CellularServiceAPI.cpp
+++ b/module-services/service-cellular/CellularServiceAPI.cpp
@@ -261,7 +261,7 @@ bool CellularServiceAPI::IsCallStateForCallApplicationActive(sys::Service *serv,
 {
     // Ask ApplicationCall (if App even exist) about its internal Call State
     auto msg = std::make_shared<cellular::IsCallActive>();
-    auto ret = serv->bus.sendUnicastSync(msg, app::name_call, 1000);
+    const auto ret = serv->bus.sendUnicastSync(std::move(msg), app::name_call, 1000);
     if (ret.first == sys::ReturnCodes::Success) {
         auto celResponse = std::dynamic_pointer_cast<cellular::IsCallActiveResponse>(ret.second);
         if ((celResponse != nullptr) && (celResponse->retCode == sys::ReturnCodes::Success)) {

--- a/products/PurePhone/PurePhoneMain.cpp
+++ b/products/PurePhone/PurePhoneMain.cpp
@@ -220,7 +220,7 @@ int main()
             applications.push_back(app::CreateLauncher<app::ApplicationNotes>(app::name_notes));
 #endif
 #ifdef ENABLE_APP_CALLLOG
-            applications.push_back(app::CreateLauncher<app::ApplicationCallLog>(app::CallLogAppStr));
+            applications.push_back(app::CreateLauncher<app::ApplicationCallLog>(app::name_calllog));
 #endif
 #ifdef ENABLE_APP_PHONEBOOK
             applications.push_back(app::CreateLauncher<app::ApplicationPhonebook>(app::name_phonebook));
@@ -230,7 +230,7 @@ int main()
 #endif
 #ifdef ENABLE_APP_SPECIAL_INPUT
             applications.push_back(
-                app::CreateLauncher<app::ApplicationSpecialInput>(app::special_input, app::Closeable::False));
+                app::CreateLauncher<app::ApplicationSpecialInput>(app::name_special_input, app::Closeable::False));
 #endif
 #ifdef ENABLE_APP_ANTENNA
             applications.push_back(app::CreateLauncher<app::ApplicationAntenna>(app::name_antenna));

--- a/products/PurePhone/services/appmgr/RunAppsInBackground.cpp
+++ b/products/PurePhone/services/appmgr/RunAppsInBackground.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <appmgr/ApplicationManager.hpp>
@@ -6,10 +6,9 @@
 
 namespace app::manager
 {
-
     void ApplicationManager::runAppsInBackground()
     {
-        for (const auto &name : std::vector<ApplicationName>{app::special_input}) {
+        for (const auto &name : std::vector<ApplicationName>{app::name_special_input}) {
             if (auto app = getApplication(name); app != nullptr) {
                 StatusIndicators statusIndicators;
                 statusIndicators.phoneMode        = phoneModeObserver->getCurrentPhoneMode();

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -27,6 +27,7 @@
 * Fixed frequency lock during user activity
 * Fixed crash on transferring audio file with big metadata
 * Fixed possibility of OS crash during update package size check
+* Fixed possible crash when entering phone number
 
 ## [1.8.0 2023-09-27]
 


### PR DESCRIPTION
* Removed call to abort() method in case 
EnterNumberWindow's SwitchData handler
receives message that can't be handled,
what caused the phone to crash.
* Unify ApplicationCall window names definitions.
* Code cleanup.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
