### PR TITLE
[MOS-1046] Update module-services/service-cellular/call/doc/README.md

### DIFF
--- a/module-services/service-cellular/call/doc/README.md
+++ b/module-services/service-cellular/call/doc/README.md
@@ -37,7 +37,7 @@ CellularCall.hpp is written such as:
     - any API has to first define a virtual interface
     - then define platform implementation
 
-State machine is written using [boost::stm](https://boost-ext.github.io/sml/index.html)
+State machine is written using [boost::sml](https://boost-ext.github.io/sml/index.html)
 
 **NOTE** API catalog should and can be further split into API header and platform implementation.
 


### PR DESCRIPTION
             
Typo in documentation module-services/service-cellular/call/doc/README.md
The state machine library is called `sml`, not `stm`.
The link is correct.
When searching on Github, it was difficult to find that **MuditaOS** uses this library.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [x] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->