### PR TITLE
[MOS-1048] Fix not fitting VoLTE button label

### DIFF
--- a/module-apps/apps-common/widgets/ButtonTriState.cpp
+++ b/module-apps/apps-common/widgets/ButtonTriState.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ButtonTriState.hpp"
@@ -17,22 +17,30 @@ namespace gui
     void ButtonTriState::switchState(State requestedState)
     {
         setFont(style::window::font::small);
-        setRadius(4);
-        setPenWidth(2);
+        setPenWidth(style::buttonTriState::penWidth);
 
-        auto setRectangleStyle = [this]() {
+        const auto setRectangleStyle = [this](State state) {
             setAlignment(Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center));
-            setMinimumSize(style::buttonTriState::w, style::buttonTriState::h);
             setEdges(RectangleEdge::All);
             setCorners(RectangleRoundedCorner::All);
+            setRadius(style::buttonTriState::cornerRadiusRectangleView);
+            setMinimumSize(style::buttonTriState::w, style::buttonTriState::h);
+            setFillColor(state == State::On ? ColorFullBlack : ColorFullWhite);
+            setColor(state == State::On ? ColorFullWhite : ColorFullBlack);
         };
 
-        auto setTextOnlyStyle = [this]() {
+        const auto setTextOnlyStyle = [this](const std::string &text) {
             setAlignment(Alignment(gui::Alignment::Horizontal::Right, gui::Alignment::Vertical::Center));
-            setMinimumSize(120,
-                           style::buttonTriState::h); // unfortunately, setMinimumWidthToFitText() doesn't work here
             setEdges(RectangleEdge::None);
             setCorners(RectangleRoundedCorner::None);
+
+            /* This needs to be changed even though the corners aren't visible
+             * here - it seems setMinimumWidthToFitText() completely ignores radius
+             * setting, what causes the text to not fit properly when radius != 0. */
+            setRadius(style::buttonTriState::cornerRadiusTextView);
+
+            setMinimumHeight(style::buttonTriState::h);
+            setMinimumWidthToFitText(text);
             setColor(ColorFullBlack);
         };
 
@@ -40,13 +48,11 @@ namespace gui
 
         switch (currentState) {
         case State::On:
-            setRectangleStyle();
-            setFillColor(ColorFullBlack);
-            setColor(ColorFullWhite);
+            setRectangleStyle(State::On);
             setText(utils::translate("app_settings_toggle_on"));
             break;
         case State::Transiting:
-            setTextOnlyStyle();
+            setTextOnlyStyle(transitingText);
             setText(transitingText);
             break;
         default:
@@ -54,9 +60,7 @@ namespace gui
                       magic_enum::enum_name(currentState).data());
             [[fallthrough]];
         case State::Off:
-            setRectangleStyle();
-            setFillColor(ColorFullWhite);
-            setColor(ColorFullBlack);
+            setRectangleStyle(State::Off);
             setText(utils::translate("app_settings_toggle_off"));
             break;
         }

--- a/module-apps/apps-common/widgets/ButtonTriState.hpp
+++ b/module-apps/apps-common/widgets/ButtonTriState.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -9,8 +9,11 @@ namespace style
 {
     namespace buttonTriState
     {
-        constexpr uint32_t w = 56;
-        constexpr uint32_t h = 32;
+        inline constexpr std::uint32_t w                         = 56;
+        inline constexpr std::uint32_t h                         = 32;
+        inline constexpr std::uint32_t penWidth                  = 2;
+        inline constexpr std::uint32_t cornerRadiusRectangleView = 4;
+        inline constexpr std::uint32_t cornerRadiusTextView      = 0;
     } // namespace buttonTriState
 } // namespace style
 
@@ -30,7 +33,7 @@ namespace gui
         void switchState(State requestedState);
 
       private:
-        std::string const transitingText;
+        const std::string transitingText;
         State currentState;
     };
 } // namespace gui

--- a/module-gui/gui/widgets/text/Text.cpp
+++ b/module-gui/gui/widgets/text/Text.cpp
@@ -156,7 +156,7 @@ namespace gui
         drawLines();
     }
 
-    void Text::addText(TextBlock text)
+    void Text::addText(const TextBlock &text)
     {
         *cursor << text;
         onTextChanged();
@@ -171,10 +171,9 @@ namespace gui
 
     void Text::addRichText(const UTF8 &text, text::RichTextParser::TokenMap &&tokenMap)
     {
-        auto tmp_document = text::RichTextParser().parse(text, &format, std::move(tokenMap));
+        const auto tmp_document = text::RichTextParser().parse(text, &format, std::move(tokenMap));
 
         if (!tmp_document || tmp_document->isEmpty()) {
-
             debug_text("Nothing to parse/parser error in rich text: %s", text.c_str());
             return addText(text); // fallback
         }
@@ -238,13 +237,13 @@ namespace gui
 
     void Text::setMinimumWidthToFitText(const UTF8 &text)
     {
-        if (!text.empty()) {
-            auto textToFit = !text::RichTextParser().parse(text, &format)->getText().empty()
-                                 ? text::RichTextParser().parse(text, &format)->getText()
-                                 : text;
-
-            setMinimumWidth(format.getFont()->getPixelWidth(textToFit) + getCursorDrawSpace());
+        if (text.empty()) {
+            return;
         }
+
+        const auto &parsedText = text::RichTextParser().parse(text, &format)->getText();
+        const auto &textToFit  = !parsedText.empty() ? parsedText : text;
+        setMinimumWidth(format.getFont()->getPixelWidth(textToFit) + getCursorDrawSpace());
     }
 
     void Text::setMinimumHeightToFitText(unsigned int linesCount)

--- a/module-gui/gui/widgets/text/Text.hpp
+++ b/module-gui/gui/widgets/text/Text.hpp
@@ -149,7 +149,7 @@ namespace gui
         virtual void setText(const UTF8 &text);
         void setText(std::unique_ptr<TextDocument> &&document);
         void addText(const UTF8 &text, AdditionType additionType = AdditionType::perChar);
-        void addText(TextBlock text);
+        void addText(const TextBlock &text);
         /// @defgroup richtext can be virtualized by parametrized RichTextParser virtual api ( as second param )
         /// @{
         /// set rich text with default RichTextParser - please see RichTextParser documentation on how to use format

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -28,6 +28,7 @@
 * Fixed crash on transferring audio file with big metadata
 * Fixed possibility of OS crash during update package size check
 * Fixed possible crash when entering phone number
+* Fixed cut off VoLTE checking label in some languages
 
 ## [1.8.0 2023-09-27]
 


### PR DESCRIPTION
Fix of the issue that VoLTE checking
state label was cut off due to
improper setMinimumWidthToFitText()
method behavior when text is placed
in box with rounded corners.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
