### PR TITLE
[BH-1791] Add CPU frequency lock during log dump

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -11,6 +11,7 @@
 * Fixed frequency lock during user activity
 * Fixed possibility of OS crash during update package size check
 * Fixed incorrect calculation of requested CPU frequency
+* Fixed CPU frequency setting when dumping logs to a file
 
 ### Added
 * Files not fully transferred via Center will be now removed when USB cable is unplugged

--- a/module-sys/SystemManager/CMakeLists.txt
+++ b/module-sys/SystemManager/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(sys-manager
     PRIVATE
         CpuGovernor.cpp
         CpuSentinel.cpp
+        LogSentinel.cpp
         GovernorSentinelOperations.cpp
         CpuStatistics.cpp
         TaskStatistics.cpp

--- a/module-sys/SystemManager/LogSentinel.cpp
+++ b/module-sys/SystemManager/LogSentinel.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include <SystemManager/LogSentinel.hpp>
+#include <log/log.hpp>
+
+namespace sys
+{
+    namespace
+    {
+        constexpr std::uint32_t holdMutexTimeoutMs{100000};
+        constexpr auto sentinelName{"LoggerSentinel"};
+        constexpr auto holdFrequencyReason{"LogDump"};
+    } // namespace
+
+    LogSentinel::LogSentinel(bsp::CpuFrequencyMHz frequencyToLock) : requestedFrequency(frequencyToLock)
+    {
+        mutex = xSemaphoreCreateMutex();
+        if (mutex == NULL) {
+            LOG_ERROR("Failed to create mutex for logger!");
+        }
+    }
+
+    void LogSentinel::HoldMinimumFrequency()
+    {
+        frequencyRequest = true;
+        if (mutex != NULL) {
+            if (xSemaphoreTake(mutex, pdMS_TO_TICKS(holdMutexTimeoutMs)) != pdTRUE) {
+                LOG_ERROR("Failed to get mutex for the logger!");
+            }
+        }
+        frequencyRequest = false;
+    }
+
+    void LogSentinel::ReleaseMinimumFrequency()
+    {
+        if (mutex != NULL) {
+            xSemaphoreGive(mutex);
+        }
+    }
+
+    void LogSentinel::UpdateCurrentFrequency(bsp::CpuFrequencyMHz newFrequency)
+    {
+        const bool newPermission = newFrequency >= requestedFrequency;
+        if (mutex != NULL && dumpPermission != newPermission) {
+            if (newPermission) {
+                xSemaphoreGive(mutex);
+            }
+            else if (xSemaphoreTake(mutex, 0) != pdTRUE) {
+                LOG_ERROR("Failed to get mutex when reducing the CPU frequency!");
+                return;
+            }
+        }
+        dumpPermission = newPermission;
+    }
+
+    [[nodiscard]] auto LogSentinel::GetRequestedFrequency() const noexcept -> sentinel::View
+    {
+        sentinel::View view{.ownerTCBNumber = 0,
+                            .name           = sentinelName,
+                            .minFrequency   = (frequencyRequest ||
+                                             ((mutex != NULL) && dumpPermission && (uxSemaphoreGetCount(mutex) == 0)))
+                                                  ? requestedFrequency
+                                                  : bsp::CpuFrequencyMHz::Level_0,
+                            .reason         = holdFrequencyReason};
+        return view;
+    }
+
+} // namespace sys

--- a/module-sys/SystemManager/include/SystemManager/LogSentinel.hpp
+++ b/module-sys/SystemManager/include/SystemManager/LogSentinel.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <mutex.hpp>
+#include <bsp/common.hpp>
+#include "SentinelView.hpp"
+
+namespace sys
+{
+    class LogSentinel
+    {
+      public:
+        explicit LogSentinel(bsp::CpuFrequencyMHz frequencyToLock);
+
+        void HoldMinimumFrequency();
+        void ReleaseMinimumFrequency();
+        void UpdateCurrentFrequency(bsp::CpuFrequencyMHz newFrequency);
+        [[nodiscard]] auto GetRequestedFrequency() const noexcept -> sentinel::View;
+
+      private:
+        xSemaphoreHandle mutex;
+        bsp::CpuFrequencyMHz requestedFrequency{bsp::CpuFrequencyMHz::Level_0};
+        bool dumpPermission{true};
+        bool frequencyRequest{false};
+    };
+
+} // namespace sys

--- a/module-sys/SystemManager/include/SystemManager/PowerManager.hpp
+++ b/module-sys/SystemManager/include/SystemManager/PowerManager.hpp
@@ -9,6 +9,7 @@
 #include "drivers/semc/DriverSEMC.hpp"
 #include "SysCpuUpdateResult.hpp"
 #include "CpuGovernor.hpp"
+#include "LogSentinel.hpp"
 #include "TaskStatistics.hpp"
 #include <bsp/lpm/PowerProfile.hpp>
 #include <vector>
@@ -75,6 +76,7 @@ namespace sys
         void SetCpuFrequency(bsp::CpuFrequencyMHz freq);
 
         void UpdateCpuFrequencyMonitor(bsp::CpuFrequencyMHz currentFreq);
+        [[nodiscard]] auto GetMinimumCpuFrequencyRequested() const noexcept -> sentinel::View;
 
         TickType_t lastCpuFrequencyChangeTimestamp{0};
         TickType_t lastLogStatisticsTimestamp{0};
@@ -84,6 +86,7 @@ namespace sys
         std::shared_ptr<drivers::DriverSEMC> driverSEMC;
         std::unique_ptr<bsp::LowPowerMode> lowPowerControl;
         std::unique_ptr<CpuGovernor> cpuGovernor;
+        std::unique_ptr<LogSentinel> logSentinel;
         const bsp::PowerProfile powerProfile;
 
         std::unique_ptr<sys::cpu::AlgorithmFactory> cpuAlgorithms;

--- a/module-utils/log/CMakeLists.txt
+++ b/module-utils/log/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(log
         utility
         purefs-paths
         crashdump-metadata-store
+        Microsoft.GSL::GSL
     PUBLIC
         module-os
         log-api

--- a/module-utils/log/Logger.cpp
+++ b/module-utils/log/Logger.cpp
@@ -7,6 +7,7 @@
 #include <purefs/filesystem_paths.hpp>
 #include <fstream>
 #include <CrashdumpMetadataStore.hpp>
+#include <gsl/util>
 
 namespace
 {
@@ -187,6 +188,15 @@ namespace Log
     /// @return:   1 - log flush successflul
     int Logger::dumpToFile(const std::filesystem::path &logDirectoryPath, LoggerState loggerState)
     {
+        if (preDumpToFile != nullptr) {
+            preDumpToFile();
+        }
+        auto _ = gsl::finally([this] {
+            if (postDumpToFile != nullptr) {
+                postDumpToFile();
+            }
+        });
+
         if (logFileName.empty()) {
             const auto &osMetadata = Store::CrashdumpMetadata::getInstance().getMetadataString();
             logFileName = std::string(logFileNamePrefix) + logFileNameSeparator + osMetadata + logFileNameExtension;

--- a/module-utils/log/Logger.hpp
+++ b/module-utils/log/Logger.hpp
@@ -56,6 +56,11 @@ namespace Log
         int flushLogs();
         [[nodiscard]] std::size_t getMaxLineLength();
 
+        /// functions called immediately before and after dumping logs to a file
+        /// created to synchronize necessary peripherals with the CPU frequency
+        std::function<void()> preDumpToFile;
+        std::function<void()> postDumpToFile;
+
         static constexpr auto CRIT_STR = "CRIT";
         static constexpr auto IRQ_STR  = "IRQ";
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -14,6 +14,7 @@
 
 * Fixed possible crash when entering phone number
 * Fixed incorrect calculation of requested CPU frequency
+* Fixed CPU frequency setting when dumping logs to a file
 
 ## [1.9.0 2023-10-19]
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

This will improve security and peripheral stabilization when downloading logs to a file.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
