### PR TITLE
[BH-1801] Fix incorrect calculation of requested CPU frequency

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -10,6 +10,7 @@
 * Fixed incorrect message after new alarm setting in some scenarios
 * Fixed frequency lock during user activity
 * Fixed possibility of OS crash during update package size check
+* Fixed incorrect calculation of requested CPU frequency
 
 ### Added
 * Files not fully transferred via Center will be now removed when USB cable is unplugged

--- a/module-sys/SystemManager/CpuGovernor.cpp
+++ b/module-sys/SystemManager/CpuGovernor.cpp
@@ -163,7 +163,7 @@ namespace sys
             return (*l).GetRequestedFrequency() < (*r).GetRequestedFrequency();
         });
 
-        d.frequency = (*minSentinel)->GetRequestedFrequency();
+        d.minFrequency = (*minSentinel)->GetRequestedFrequency();
         if (auto p = (*minSentinel)->GetSentinel().lock()) {
             d.name   = p->GetName();
             d.reason = p->getReason();

--- a/module-sys/SystemManager/CpuLogPrinter.cpp
+++ b/module-sys/SystemManager/CpuLogPrinter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SystemManager/CpuPrinter.hpp"
@@ -44,7 +44,7 @@ namespace sys::cpu::stats
                    int(ret.frequencySet),
                    ret.data.name.c_str(),
                    ret.data.reason.c_str(),
-                   int(ret.data.frequency),
+                   int(ret.data.minFrequency),
                    CLOCK_GetFreq(0));
     }
 

--- a/module-sys/SystemManager/CpuPackPrinter.cpp
+++ b/module-sys/SystemManager/CpuPackPrinter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SystemManager/CpuPrinter.hpp"
@@ -67,7 +67,7 @@ namespace sys::cpu::stats
                                       {"freq", uint32_t(ret.frequencySet)},
                                       {"name", ret.data.name},
                                       {"reason", ret.data.reason},
-                                      {"requested", uint32_t(ret.data.frequency)},
+                                      {"requested", uint32_t(ret.data.minFrequency)},
                                       {"avgA", int32_t(bsp::battery_charger::getAvgCurrent())},
                                       {"nowA", int32_t(bsp::battery_charger::getCurrentMeasurement())},
                                       {"ts", getTimestamp()}};

--- a/module-sys/SystemManager/PowerManager.cpp
+++ b/module-sys/SystemManager/PowerManager.cpp
@@ -64,7 +64,7 @@ namespace sys
         cpuAlgorithms = std::make_unique<cpu::AlgorithmFactory>();
         cpuAlgorithms->emplace(sys::cpu::AlgoID::ImmediateUpscale, std::make_unique<sys::cpu::ImmediateUpscale>());
         cpuAlgorithms->emplace(sys::cpu::AlgoID::FrequencyStepping,
-                               std::make_unique<sys::cpu::FrequencyStepping>(powerProfile, *cpuGovernor));
+                               std::make_unique<sys::cpu::FrequencyStepping>(powerProfile));
 
         cpuFrequencyMonitor.push_back(CpuFrequencyMonitor(lowestLevelName));
         cpuFrequencyMonitor.push_back(CpuFrequencyMonitor(middleLevelName));
@@ -106,7 +106,7 @@ namespace sys
     {
         uint32_t cpuLoad = cpuStatistics.GetPercentageCpuLoad();
         cpu::UpdateResult retval;
-        cpu::AlgorithmData data{
+        const cpu::AlgorithmData data{
             cpuLoad, lowPowerControl->GetCurrentFrequencyLevel(), cpuGovernor->GetMinimumFrequencyRequested()};
 
         auto _ = gsl::finally([&retval, this, data] {

--- a/module-sys/SystemManager/cpu/AlgorithmFactory.cpp
+++ b/module-sys/SystemManager/cpu/AlgorithmFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlgorithmFactory.hpp"
@@ -32,7 +32,7 @@ namespace sys::cpu
     }
 
     AlgorithmResult AlgorithmFactory::calculate(const std::list<sys::cpu::AlgoID> &algorithms,
-                                                cpu::AlgorithmData &data,
+                                                const cpu::AlgorithmData &data,
                                                 AlgoID *used)
     {
         for (auto id : algorithms) {

--- a/module-sys/SystemManager/cpu/AlgorithmFactory.hpp
+++ b/module-sys/SystemManager/cpu/AlgorithmFactory.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -27,7 +27,7 @@ namespace sys::cpu
         /// use algorithms from factory depending on list to calculate frequency
         /// return used algorithm in used paramter
         AlgorithmResult calculate(const std::list<sys::cpu::AlgoID> &algorithms,
-                                  cpu::AlgorithmData &data,
+                                  const cpu::AlgorithmData &data,
                                   AlgoID *used = nullptr);
         /// reset internal algorithms data
         void reset(const std::list<sys::cpu::AlgoID> &algorithms);

--- a/module-sys/SystemManager/cpu/algorithm/FrequencyStepping.hpp
+++ b/module-sys/SystemManager/cpu/algorithm/FrequencyStepping.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -16,13 +16,12 @@ namespace sys::cpu
     class FrequencyStepping : public Algorithm
     {
         const bsp::PowerProfile &powerProfile;
-        CpuGovernor &cpuGovernor;
         unsigned int aboveThresholdCounter    = 0;
         unsigned int belowThresholdCounter    = 0;
         bool isFrequencyDownscalingInProgress = true;
 
       public:
-        FrequencyStepping(const bsp::PowerProfile &powerProfile, CpuGovernor &cpuGovernor);
+        explicit FrequencyStepping(const bsp::PowerProfile &powerProfile);
         [[nodiscard]] AlgorithmResult calculateImplementation(const AlgorithmData &data) override;
         void resetImplementation() override;
     };

--- a/module-sys/SystemManager/cpu/algorithm/ImmediateUpscale.cpp
+++ b/module-sys/SystemManager/cpu/algorithm/ImmediateUpscale.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ImmediateUpscale.hpp"
@@ -7,7 +7,7 @@ namespace sys::cpu
 {
     AlgorithmResult ImmediateUpscale::calculateImplementation(const AlgorithmData &data)
     {
-        const auto now = data.sentinel.frequency;
+        const auto now = data.sentinel.minFrequency;
         const auto was = data.curentFrequency;
         if (now > was) {
             return {algorithm::Change::UpScaled, now};

--- a/module-sys/SystemManager/include/SystemManager/SentinelView.hpp
+++ b/module-sys/SystemManager/include/SystemManager/SentinelView.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -19,7 +19,7 @@ namespace sys
             /// name of sentinel thread responsible for curent minimum load
             std::string name;
             /// curent minimum frequency set in sentinel
-            bsp::CpuFrequencyMHz frequency = bsp::CpuFrequencyMHz::Level_0;
+            bsp::CpuFrequencyMHz minFrequency = bsp::CpuFrequencyMHz::Level_0;
             /// textual information on what actually happens
             std::string reason;
         };

--- a/module-sys/SystemManager/tests/test-cpu-algorithms.cpp
+++ b/module-sys/SystemManager/tests/test-cpu-algorithms.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <catch2/catch.hpp>
@@ -34,7 +34,7 @@ namespace mockup
         auto cpuAlgorithms = std::make_unique<sys::cpu::AlgorithmFactory>();
         cpuAlgorithms->emplace(sys::cpu::AlgoID::ImmediateUpscale, std::make_unique<sys::cpu::ImmediateUpscale>());
         cpuAlgorithms->emplace(sys::cpu::AlgoID::FrequencyStepping,
-                               std::make_unique<sys::cpu::FrequencyStepping>(powerProfile, cpuGovernor));
+                               std::make_unique<sys::cpu::FrequencyStepping>(powerProfile));
         cpuAlgorithms->emplace(sys::cpu::AlgoID::FrequencyHold,
                                std::make_unique<sys::cpu::FrequencyHold>(freq, powerProfile));
         return cpuAlgorithms;

--- a/module-sys/SystemManager/tests/unittest_CpuSentinelsGovernor.cpp
+++ b/module-sys/SystemManager/tests/unittest_CpuSentinelsGovernor.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "SystemManager/GovernorSentinelOperations.hpp"
@@ -68,28 +68,28 @@ TEST_CASE("Power Manager CPU sentinels governor test")
         governor->RegisterNewSentinel(testSentinel_1);
         governor->RegisterNewSentinel(testSentinel_2);
 
-        REQUIRE(governor->GetMinimumFrequencyRequested().frequency == bsp::CpuFrequencyMHz::Level_0);
+        REQUIRE(governor->GetMinimumFrequencyRequested().minFrequency == bsp::CpuFrequencyMHz::Level_0);
 
         governor->SetCpuFrequencyRequest("testSentinel_1", bsp::CpuFrequencyMHz::Level_4);
-        REQUIRE(governor->GetMinimumFrequencyRequested().frequency == bsp::CpuFrequencyMHz::Level_4);
+        REQUIRE(governor->GetMinimumFrequencyRequested().minFrequency == bsp::CpuFrequencyMHz::Level_4);
 
         governor->SetCpuFrequencyRequest("testSentinel_2", bsp::CpuFrequencyMHz::Level_6);
-        REQUIRE(governor->GetMinimumFrequencyRequested().frequency == bsp::CpuFrequencyMHz::Level_6);
+        REQUIRE(governor->GetMinimumFrequencyRequested().minFrequency == bsp::CpuFrequencyMHz::Level_6);
 
         governor->SetCpuFrequencyRequest("testSentinel_1", bsp::CpuFrequencyMHz::Level_2);
-        REQUIRE(governor->GetMinimumFrequencyRequested().frequency == bsp::CpuFrequencyMHz::Level_6);
+        REQUIRE(governor->GetMinimumFrequencyRequested().minFrequency == bsp::CpuFrequencyMHz::Level_6);
 
         governor->ResetCpuFrequencyRequest("testSentinel_2");
-        REQUIRE(governor->GetMinimumFrequencyRequested().frequency == bsp::CpuFrequencyMHz::Level_2);
+        REQUIRE(governor->GetMinimumFrequencyRequested().minFrequency == bsp::CpuFrequencyMHz::Level_2);
 
         governor->SetCpuFrequencyRequest("badNameSentinel", bsp::CpuFrequencyMHz::Level_6);
-        REQUIRE(governor->GetMinimumFrequencyRequested().frequency == bsp::CpuFrequencyMHz::Level_2);
+        REQUIRE(governor->GetMinimumFrequencyRequested().minFrequency == bsp::CpuFrequencyMHz::Level_2);
 
         governor->SetCpuFrequencyRequest("testSentinel_1", bsp::CpuFrequencyMHz::Level_1);
-        REQUIRE(governor->GetMinimumFrequencyRequested().frequency == bsp::CpuFrequencyMHz::Level_1);
+        REQUIRE(governor->GetMinimumFrequencyRequested().minFrequency == bsp::CpuFrequencyMHz::Level_1);
 
         governor->ResetCpuFrequencyRequest("testSentinel_1");
-        REQUIRE(governor->GetMinimumFrequencyRequested().frequency == bsp::CpuFrequencyMHz::Level_0);
+        REQUIRE(governor->GetMinimumFrequencyRequested().minFrequency == bsp::CpuFrequencyMHz::Level_0);
     }
 }
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 * Fixed possible crash when entering phone number
+* Fixed incorrect calculation of requested CPU frequency
 
 ## [1.9.0 2023-10-19]
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

Sometimes when the frequency is locked, e.g. at 132 MHz, the algorithm still calculated a lower frequency, e.g. 66 MHz.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
