### PR TITLE
[MOS-1052] Change VoLTE label from 'beta' to 'experimental'

### DIFF
--- a/image/system_a/data/lang/Deutsch.json
+++ b/image/system_a/data/lang/Deutsch.json
@@ -577,6 +577,7 @@
     "common_disconnect": "TRENNEN",
     "common_edit": "\u00c4NDERN",
     "common_emoji": "EMOJI",
+    "common_experimental": "(experimentell)",
     "common_february": "Februar",
     "common_forget": "VERGESSEN",
     "common_fr": "FR",

--- a/image/system_a/data/lang/English.json
+++ b/image/system_a/data/lang/English.json
@@ -579,6 +579,7 @@
     "common_disconnect": "DISCONNECT",
     "common_edit": "EDIT",
     "common_emoji": "EMOJI",
+    "common_experimental": "(experimental)",
     "common_february": "February",
     "common_forget": "FORGET",
     "common_fr": "FR",

--- a/image/system_a/data/lang/Espanol.json
+++ b/image/system_a/data/lang/Espanol.json
@@ -577,6 +577,7 @@
     "common_disconnect": "DESCONECTAR",
     "common_edit": "EDITAR",
     "common_emoji": "EMOJI",
+    "common_experimental": "(experimental)",
     "common_february": "Febrero",
     "common_forget": "OLVIDAR",
     "common_fr": "V",

--- a/image/system_a/data/lang/Francais.json
+++ b/image/system_a/data/lang/Francais.json
@@ -544,6 +544,7 @@
     "common_disconnect": "D\u00c9CONNECTER",
     "common_edit": "MODIFIER",
     "common_emoji": "EMOJI",
+    "common_experimental": "(expérimental)",
     "common_february": "F\u00e9vrier",
     "common_forget": "OUBLIER",
     "common_fr": "VE",

--- a/image/system_a/data/lang/Polski.json
+++ b/image/system_a/data/lang/Polski.json
@@ -571,6 +571,7 @@
     "common_disconnect": "ROZ\u0141\u0104CZ SI\u0118",
     "common_edit": "EDYTUJ",
     "common_emoji": "EMOJI",
+    "common_experimental": "(eksperymentalne)",
     "common_february": "Luty",
     "common_forget": "ZAPOMNIJ",
     "common_fr": "PT",

--- a/image/system_a/data/lang/Svenska.json
+++ b/image/system_a/data/lang/Svenska.json
@@ -401,6 +401,7 @@
     "common_december": "December",
     "common_edit": "REDIGERA",
     "common_emoji": "EMOJI",
+    "common_experimental": "(experimentell)",
     "common_february": "Februari",
     "common_fr": "FR",
     "common_fri": "Fre",

--- a/module-apps/application-settings/windows/network/NetworkWindow.cpp
+++ b/module-apps/application-settings/windows/network/NetworkWindow.cpp
@@ -46,7 +46,7 @@ namespace gui
             false));
 
         optionsList.emplace_back(std::make_unique<gui::option::OptionSettings>(
-            getVolteLabel(),
+            getVoltePrimaryLabel(),
             [this]([[maybe_unused]] gui::Item &item) {
                 const auto volteState = getVolteStateFromSettingsApp(application);
                 if (!volteState.permitted) {
@@ -80,7 +80,11 @@ namespace gui
                 return true;
             },
             nullptr,
-            getRightItemSetting()));
+            getRightItemSetting(),
+            false,
+            UTF8(),
+            true,
+            getVolteSecondaryLabel()));
 
 #if DISABLED_SETTINGS_OPTIONS == 1
         auto operatorsOn = operatorsSettings->getOperatorsOn();
@@ -124,7 +128,7 @@ namespace gui
         return optionsList;
     }
 
-    auto NetworkWindow::getVolteLabel() -> std::string
+    auto NetworkWindow::getVoltePrimaryLabel() -> std::string
     {
         const auto &volteState = getVolteStateFromSettingsApp(application);
 
@@ -136,12 +140,18 @@ namespace gui
             labelText += ": ";
             labelText += utils::translate("app_settings_network_volte_not_available");
         }
-        else if (volteState.beta) {
-            labelText += " <b>" + utils::translate("common_beta") + "</b>";
-        }
         labelText += "</text>";
 
         return labelText;
+    }
+
+    auto NetworkWindow::getVolteSecondaryLabel() -> std::string
+    {
+        const auto &volteState = getVolteStateFromSettingsApp(application);
+        if (volteState.permitted && volteState.beta) {
+            return "<text><b>" + utils::translate("common_experimental") + "</b><text>";
+        }
+        return {};
     }
 
     auto NetworkWindow::getRightItemSetting() -> option::SettingRightItem

--- a/module-apps/application-settings/windows/network/NetworkWindow.hpp
+++ b/module-apps/application-settings/windows/network/NetworkWindow.hpp
@@ -20,7 +20,8 @@ namespace gui
 
       private:
         auto buildOptionsList() -> std::list<Option> override;
-        auto getVolteLabel() -> std::string;
+        auto getVoltePrimaryLabel() -> std::string;
+        auto getVolteSecondaryLabel() -> std::string;
         auto getRightItemSetting() -> option::SettingRightItem;
 
         app::settingsInterface::OperatorsSettings *operatorsSettings = nullptr;

--- a/module-apps/apps-common/options/OptionStyle.hpp
+++ b/module-apps/apps-common/options/OptionStyle.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -48,6 +48,7 @@ namespace gui::option
         inline constexpr gui::Length option_left_margin   = 10;
         inline constexpr gui::Length option_right_margin  = 10;
         inline constexpr gui::Length option_bottom_margin = style::margins::big;
+        inline constexpr gui::Length option_label_spacer  = style::margins::small;
         inline constexpr uint32_t optionsListTopMargin    = 10U;
         inline constexpr uint32_t optionsListX            = style::window::default_left_margin;
         inline constexpr uint32_t optionsListY            = style::window::default_vertical_pos + optionsListTopMargin;

--- a/module-apps/apps-common/options/type/OptionSetting.hpp
+++ b/module-apps/apps-common/options/type/OptionSetting.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -10,33 +10,28 @@ namespace gui::option
 {
     class OptionSettings : public option::Base
     {
-      protected:
-        UTF8 text;
+      public:
+        OptionSettings(const UTF8 &primaryText,
+                       std::function<bool(Item &)> activatedCallback,
+                       std::function<bool(Item &)> focusChangedCallback,
+                       AppWindow *app,
+                       SettingRightItem rightItem = SettingRightItem::Disabled,
+                       bool indent                = false,
+                       const UTF8 &textOnRight    = UTF8(),
+                       bool isTextOnRightSmall    = true,
+                       const UTF8 &secondaryText  = UTF8());
+        [[nodiscard]] auto build() const -> ListItem * override;
+        [[nodiscard]] auto str() const -> std::string override;
+
+      private:
+        UTF8 primaryText;
+        UTF8 secondaryText;
         std::function<bool(Item &)> activatedCallback    = nullptr;
         std::function<bool(Item &)> focusChangedCallback = nullptr;
         AppWindow *app                                   = nullptr;
         SettingRightItem rightItem                       = SettingRightItem::Disabled;
         bool indent                                      = false;
         UTF8 textOnRight;
-        bool textOnRightIsSmall = true;
-
-      public:
-        OptionSettings(UTF8 text,
-                       std::function<bool(Item &)> activatedCallback,
-                       std::function<bool(Item &)> focusChangedCallback,
-                       AppWindow *app,
-                       SettingRightItem rightItem = SettingRightItem::Disabled,
-                       bool indent                = false,
-                       UTF8 textOnRight           = UTF8(),
-                       bool textOnRightIsSmall    = true)
-            : text(std::move(text)), activatedCallback(std::move(activatedCallback)),
-              focusChangedCallback(std::move(focusChangedCallback)), app(app), rightItem(rightItem), indent(indent),
-              textOnRight(std::move(textOnRight)), textOnRightIsSmall(textOnRightIsSmall)
-        {}
-        [[nodiscard]] auto build() const -> ListItem * override;
-        [[nodiscard]] auto str() const -> std::string override
-        {
-            return text;
-        }
+        bool isTextOnRightSmall = true;
     };
 } // namespace gui::option

--- a/module-apps/apps-common/widgets/ButtonTriState.cpp
+++ b/module-apps/apps-common/widgets/ButtonTriState.cpp
@@ -16,10 +16,10 @@ namespace gui
 
     void ButtonTriState::switchState(State requestedState)
     {
-        setFont(style::window::font::small);
         setPenWidth(style::buttonTriState::penWidth);
 
         const auto setRectangleStyle = [this](State state) {
+            setFont(style::window::font::small);
             setAlignment(Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center));
             setEdges(RectangleEdge::All);
             setCorners(RectangleRoundedCorner::All);
@@ -30,6 +30,7 @@ namespace gui
         };
 
         const auto setTextOnlyStyle = [this](const std::string &text) {
+            setFont(style::window::font::verysmall);
             setAlignment(Alignment(gui::Alignment::Horizontal::Right, gui::Alignment::Vertical::Center));
             setEdges(RectangleEdge::None);
             setCorners(RectangleRoundedCorner::None);

--- a/products/PurePhone/PurePhoneMain.cpp
+++ b/products/PurePhone/PurePhoneMain.cpp
@@ -131,7 +131,7 @@ int main()
     if (!sys::SystemWatchdog::getInstance().init()) {
         LOG_ERROR("System watchdog failed to initialize");
         // wait for the hardware watchdog (initialized in reset ISR) to reset the system
-        while (1)
+        while (true)
             ;
     }
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -10,6 +10,7 @@
 
 * Disabled USB MTP protocol
 * Changed UI flow on discharged device window.
+* Changed VoLTE label from 'beta' to 'experimental'.
 
 ### Fixed
 


### PR DESCRIPTION
Changed VoLTE label from 'beta' to
'experimental'.
Fixed transition state label font
size to match the design.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
