### PR TITLE
[BH-1814] Fix EInk errors in logs

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 * Fixed frequency lock during user activity
 * Fixed boot error screen text alignment
+* Fixed eink errors in logs
 
 ### Added
 * Added notification when charger is connected

--- a/module-bsp/board/rt1051/bsp/eink/ED028TC1.cpp
+++ b/module-bsp/board/rt1051/bsp/eink/ED028TC1.cpp
@@ -491,7 +491,7 @@ void EinkChangeDisplayUpdateTimings(EinkDisplayTimingsMode_e timingsMode)
     } break;
     }
 
-    if (BSP_EinkWriteData(tmpbuf, 4, SPI_AUTOMATIC_CS) != 0) {
+    if (BSP_EinkWriteData(tmpbuf, sizeof(tmpbuf), SPI_AUTOMATIC_CS) != 0) {
         return;
     }
 }
@@ -530,7 +530,6 @@ EinkStatus_e EinkPowerOff()
 
     std::uint8_t cmd = EinkPowerOFF; // 0x02
     if (BSP_EinkWriteData(&cmd, sizeof(cmd), SPI_AUTOMATIC_CS) != 0) {
-        EinkPowerDown();
         return EinkDMAErr;
     }
 

--- a/module-bsp/board/rt1051/common/fsl_drivers/fsl_lpspi.c
+++ b/module-bsp/board/rt1051/common/fsl_drivers/fsl_lpspi.c
@@ -200,8 +200,6 @@ void LPSPI_MasterInit(LPSPI_Type *base, const lpspi_master_config_t *masterConfi
 
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
-    /* Reset to known status */
-    LPSPI_Reset(base);
 
     /* Set LPSPI to master */
     LPSPI_SetMasterSlaveMode(base, kLPSPI_Master);


### PR DESCRIPTION
According to the newest fsl library, the LPSPI_Reset function shouldn't be invoked in the LPSPI_MasterInit function.
As a result, the LPSPI module can't work after calling this API.

Fix the system crash when an EInk error occurs. If the display returns the error the driver could invoke the EinkPowerDown function recursively which causes a crash.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
