### PR TITLE
[BH-1817] Fix alarm when the onboarding is active

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -6,6 +6,7 @@
 * Fixed frequency lock during user activity
 * Fixed boot error screen text alignment
 * Fixed eink errors in logs
+* Fixed alarm when the onboarding is in progress
 
 ### Added
 * Added notification when charger is connected

--- a/products/BellHybrid/apps/application-bell-onboarding/include/application-bell-onboarding/ApplicationBellOnBoarding.hpp
+++ b/products/BellHybrid/apps/application-bell-onboarding/include/application-bell-onboarding/ApplicationBellOnBoarding.hpp
@@ -44,7 +44,7 @@ namespace app
                                            std::string parent                  = "",
                                            StatusIndicators statusIndicators   = StatusIndicators{},
                                            StartInBackground startInBackground = {false},
-                                           std::uint32_t stackDepth            = 1024 * 8);
+                                           std::uint32_t stackDepth            = 1024 * 11);
         ~ApplicationBellOnBoarding();
 
         sys::ReturnCodes InitHandler() override;

--- a/products/BellHybrid/services/time/include/time/AlarmOperations.hpp
+++ b/products/BellHybrid/services/time/include/time/AlarmOperations.hpp
@@ -6,7 +6,7 @@
 #include <AlarmOperations.hpp>
 #include <db/SystemSettings.hpp>
 #include <common/models/BedtimeModel.hpp>
-
+#include <service-db/Settings.hpp>
 namespace alarms
 {
     class AlarmOperationsFactory : public IAlarmOperationsFactory
@@ -43,6 +43,13 @@ namespace alarms
 
         virtual ~SnoozeChimeSettingsProvider() noexcept = default;
         virtual auto getSettings() -> Settings          = 0;
+    };
+
+    class OnboardingSettingsProvider
+    {
+      public:
+        virtual ~OnboardingSettingsProvider() noexcept = default;
+        virtual auto isDone() -> bool                  = 0;
     };
 
     class AbstractBedtimeSettingsProvider
@@ -95,6 +102,7 @@ namespace alarms
                         GetCurrentTime getCurrentTimeCallback,
                         std::unique_ptr<PreWakeUpSettingsProvider> &&preWakeUpSettingsProvider,
                         std::unique_ptr<SnoozeChimeSettingsProvider> &&snoozeChimeSettingsProvider,
+                        std::unique_ptr<OnboardingSettingsProvider> &&onboardingSettingsProvider,
                         std::unique_ptr<AbstractBedtimeSettingsProvider> &&BedtimeModel);
 
       private:
@@ -117,9 +125,11 @@ namespace alarms
                               bool newStateOn) override;
 
         bool isBedtimeAllowed() const;
+        bool isOnboardingDone();
 
         PreWakeUp preWakeUp;
         std::unique_ptr<SnoozeChimeSettingsProvider> snoozeChimeSettings;
+        std::unique_ptr<OnboardingSettingsProvider> onboardingSettings;
         Bedtime bedtime;
     };
 } // namespace alarms


### PR DESCRIPTION
The alarm shouldn't activate itself when the onboarding is in progress. So now we check the onboarding status before checking alarms.
Increased size of the onboarding application stack. This should resolve the issue when somehow, the alarm is set but there is no stack that causes the application to crash.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
