### PR TITLE
[BH-1822] Disable Address Sanitizer

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -40,9 +40,33 @@
         },
         {
             "type": "shell",
+            "label": "Run PurePhone (Linux + Valgrind)",
+            "command": "valgrind",
+            "args": [
+                "./PurePhone.elf"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-PurePhone-linux-Debug"
+            },
+            "group": {
+                "kind": "build",
+                //"isDefault": true
+            },
+            "detail": "Build dir has to be configured with Cmake using Ninja",
+        },
+        {
+            "type": "shell",
             "label": "Configure and Build PurePhone (Linux)",
             "group": "build",
             "dependsOn": ["Configure PurePhone (Linux)", "Build PurePhone (Linux)"],
+            "dependsOrder": "sequence",
+            "detail": "Configure cmake project and build with Ninja",
+        },
+        {
+            "type": "shell",
+            "label": "Build and Run PurePhone (Linux + Valgrind)",
+            "group": "build",
+            "dependsOn": ["Build PurePhone (Linux)", "Run PurePhone (Linux + Valgrind)"],
             "dependsOrder": "sequence",
             "detail": "Configure cmake project and build with Ninja",
         },
@@ -81,6 +105,19 @@
         },
         {
             "type": "shell",
+            "label": "Run BellHybrid (Linux + Valgrind)",
+            "command": "valgrind",
+            "args": [
+                "./BellHybrid.elf"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-BellHybrid-linux-Debug"
+            },
+            "group": "build",
+            "detail": "Build dir has to be configured with Cmake using Ninja",
+        },
+        {
+            "type": "shell",
             "label": "Build BellHybrid Disk Image (Linux)",
             "command": "ninja",
             "args": [
@@ -97,6 +134,14 @@
             "label": "Configure and Build BellHybrid (Linux)",
             "group": "build",
             "dependsOn": ["Configure BellHybrid (Linux)", "Build BellHybrid (Linux)", "Build BellHybrid Disk Image (Linux)"],
+            "dependsOrder": "sequence",
+            "detail": "Configure cmake project and build with Ninja",
+        },
+        {
+            "type": "shell",
+            "label": "Build and Run BellHybrid (Linux + Valgrind)",
+            "group": "build",
+            "dependsOn": ["Build BellHybrid (Linux)", "Run BellHybrid (Linux + Valgrind)"],
             "dependsOrder": "sequence",
             "detail": "Configure cmake project and build with Ninja",
         },

--- a/Target_Linux.cmake
+++ b/Target_Linux.cmake
@@ -9,7 +9,7 @@ set(TARGET_LIBRARIES
 
 link_libraries(pthread rt)
 
-option (LINUX_ENABLE_SANITIZER "Enable address sanitizer for Linux" ON)
+option (LINUX_ENABLE_SANITIZER "Enable address sanitizer for Linux" OFF)
 if (LINUX_ENABLE_SANITIZER)
     add_compile_options(-fsanitize=address)
     add_link_options(-fsanitize=address)

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -195,7 +195,7 @@ This can be done manually, by editing the `.cmake` files (not recommended though
 | `MUDITA_USB_ID`               | Enable using Mudita registered USB Vendor ID and Pure Phone USB Product ID| OFF           |
 | `ENABLE_APP_X`                | Build and enable application X                                            | ON            |
 | `OPTIMIZE_APP_X`              | Optimize application X in debug build                                     | ON            |
-| `LINUX_ENABLE_SANITIZER`      | Enable address sanitizer for Linux                                        | ON            |
+| `LINUX_ENABLE_SANITIZER`      | Enable address sanitizer for Linux                                        | OFF           |
 | `ENABLE_SECURE_BOOT`          | Build signed binary for Secure Boot                                       | OFF           |
 | `THIRD_PARTY_DEBUG_OPTIMIZE`  | Optimize third party in debug                                             | ON            |
 | `ENABLE_TEST_LOGS`            | Enable logs in unit tests                                                 | OFF           |

--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -12,6 +12,7 @@
 
 ### Changed / Improved
 * Optimize the way Relaxation is loading music files
+* Disabled Address Sanitizer for the Linux simulator
 
 ## [2.2.2 2023-11-14]
 


### PR DESCRIPTION
Due to using wrappers for the glibc syscalls, the ASAN doesn't work well. We also had trouble integrating this tool with GCC12.
The ASAN is still available but is turned off by default. Use -DLINUX_ENABLE_SANITIZER=ON to turn on.
Our recommendation is to use Valgrind as the runtime profiling tool. It's added for visual studio code.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [x] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
