### PR TITLE
[BH-1830] Fix eink crash while refreshing

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -6,6 +6,7 @@
 * Fixed eink errors in logs
 * Fixed alarm when the onboarding is in progress
 * Fixed relaxation start delay when trying to play MP3 files with large metadata
+* Fixed eink crash while refreshing
 
 ### Added
 * Added shortcuts instruction to settings

--- a/module-services/service-eink/ServiceEink.cpp
+++ b/module-services/service-eink/ServiceEink.cpp
@@ -343,7 +343,7 @@ namespace service::eink
                 previousContext->insert(0, 0, ctx);
             }
         }
-        if (previousRefreshStatus == RefreshStatus::Failed) {
+        if ((previousRefreshStatus == RefreshStatus::Failed) && !updateFrames.empty()) {
             updateFrames.front() = {0, 0, BOARD_EINK_DISPLAY_RES_X, BOARD_EINK_DISPLAY_RES_Y};
         }
 


### PR DESCRIPTION
If the previous refresh failed the driver tried to add a new frame in the front of the vector. In some cases, the updateFrames could be empty, and adding a frame caused a system crash.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
