### PR TITLE
[MOS-1060] Fix memory leak in contacts list view

### DIFF
--- a/module-apps/application-phonebook/widgets/PhonebookListView.cpp
+++ b/module-apps/application-phonebook/widgets/PhonebookListView.cpp
@@ -61,7 +61,6 @@ namespace gui
         ListItem *previousListItem = nullptr;
 
         while ((item = provider->getItem(getOrderFromDirection())) != nullptr) {
-
             /* If direction is top-to-bottom, add label mark before adding phonebook item. */
             if (direction == listview::Direction::Bottom) {
                 addLabelMarker(dynamic_cast<gui::PhonebookItem *>(item));
@@ -73,6 +72,7 @@ namespace gui
                 body->addWidget(item);
             }
             else {
+                delete item; // Item has not been added to any GUI element - delete it manually
                 if (direction == listview::Direction::Top) {
                     if (previousItemIsLabel) {
                         break;
@@ -97,7 +97,7 @@ namespace gui
         recalculateStartIndex();
 
         // Add element on top for first page purpose
-        if (startIndex == 0 && direction == listview::Direction::Top) {
+        if ((startIndex == 0) && (direction == listview::Direction::Top)) {
             body->addWidget(new PhonebookMarkItem(labelMark));
         }
     }

--- a/module-gui/gui/widgets/ListItemProvider.hpp
+++ b/module-gui/gui/widgets/ListItemProvider.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -28,7 +28,6 @@ namespace gui
 
         virtual ListItem *getItem(Order order) = 0;
 
-        virtual void requestRecords(uint32_t offset, uint32_t limit) = 0;
+        virtual void requestRecords(std::uint32_t offset, std::uint32_t limit) = 0;
     };
-
 } // namespace gui

--- a/module-gui/gui/widgets/ListViewEngine.cpp
+++ b/module-gui/gui/widgets/ListViewEngine.cpp
@@ -64,7 +64,7 @@ namespace gui
             setup(rebuildType, dataOffset);
 
             // If deletion operation caused last page to be removed request previous one.
-            if ((startIndex != 0 && startIndex == elementsCount)) {
+            if (startIndex != 0 && startIndex == elementsCount) {
                 requestPreviousPage();
             }
             else {
@@ -178,9 +178,7 @@ namespace gui
         body->setFocusItem(nullptr);
 
         while (const auto el = body->children.back()) {
-
             if (el->type == ItemType::LIST_ITEM) {
-
                 if (!dynamic_cast<ListItem *>(el)->deleteByList) {
                     body->removeWidget(el);
                 }
@@ -319,7 +317,8 @@ namespace gui
             if (!item->visible) {
                 // In case model is tracking internal indexes -> undo last get.
                 if (requestFullListRender) {
-                    provider->getItem(getOppositeOrderFromDirection());
+                    const auto prevItem = provider->getItem(getOppositeOrderFromDirection());
+                    delete prevItem; // Remove created item to prevent memory leak
                 }
                 break;
             }

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -13,7 +13,8 @@
 
 ### Fixed
 
-* Fixed playback start delay when trying to play MP3 files with large metadata
+* Fixed playback start delay when trying to play MP3 files with large metadata.
+* Fixed memory leak in contacts list view.
 
 ## [1.10.0 2023-11-24]
 


### PR DESCRIPTION
Fix of the memory leak that happened in
contacts list view due to not deleting
unused heap-allocated object.

Coauthored by @lukasmas.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
