### PR TITLE
[BH-1826] Fix corner case for new progress bar design

### DIFF
--- a/module-gui/gui/widgets/ProgressBar.cpp
+++ b/module-gui/gui/widgets/ProgressBar.cpp
@@ -245,6 +245,7 @@ namespace gui
         const auto absoluteValue = std::lround(static_cast<float>(maxValue) * percent);
         setValue(absoluteValue);
     }
+
     int ArcProgressBar::getMaximum() const noexcept
     {
         return maxValue;
@@ -271,6 +272,11 @@ namespace gui
         }
         progressStartIndicator->setCenter(calculateStartIndicatorCenter());
         progressEndIndicator->setCenter(calculateEndIndicatorCenter());
+
+        const auto progressItemsVisible = ((dTheta != 0) || (change == ProgressChange::IncrementFromZero));
+        progressArc->setVisible(progressItemsVisible);
+        progressStartIndicator->setVisible(progressItemsVisible);
+        progressEndIndicator->setVisible(progressItemsVisible);
 
         Arc::buildDrawListImplementation(commands);
     }


### PR DESCRIPTION
Fix minor corner case so that current progress
bar implementation fully matches the design -
after the bar has decremented to zero, there
should be no start or end indicator visible.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
