### PR TITLE
[BH-1825] Remove minus sign in countdown timers of progress

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -19,6 +19,7 @@
 * Time setting updated
 * Factory reset removes user files
 * Changed countdown progress bar design in Relaxation, Meditation and Power Nap apps
+* Removed minus sign in progress countdown timers in Relaxation, Meditation and Power Nap apps
 
 ## [2.2.3 2023-11-30]
 

--- a/module-apps/apps-common/widgets/TimeFixedWidget.cpp
+++ b/module-apps/apps-common/widgets/TimeFixedWidget.cpp
@@ -1,13 +1,10 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TimeFixedWidget.hpp"
 #include <ListView.hpp>
 #include <Style.hpp>
-#include <time/time_conversion.hpp>
 #include <time/time_date_validation.hpp>
-#include "DateAndTimeStyle.hpp"
-#include <time/TimeZone.hpp>
 #include <service-time/api/TimeSettingsApi.hpp>
 
 namespace
@@ -30,8 +27,6 @@ namespace
 
 namespace gui
 {
-    namespace date_and_time = style::window::date_and_time;
-
     TimeFixedWidget::LeftBox::LeftBox(uint32_t digitsCount) : container{digitsCount}
     {}
 
@@ -177,12 +172,12 @@ namespace gui
         info.minusWidth    = minusVisible ? leftBox.minus->getTextFormat().getFont()->getPixelWidth(minusSign) : 0;
 
         auto maximumWidthNeededForLeftBox = (info.digitMaxWidth * leftBox.container.digits.size()) + info.minusWidth;
-        auto avaliableEvenWidth           = (info.mainBoxWidth - info.colonWidth) / 2;
+        auto availableEvenWidth           = (info.mainBoxWidth - info.colonWidth) / 2;
 
-        info.leftBoxWidth  = avaliableEvenWidth;
-        info.rightBoxWidth = avaliableEvenWidth;
+        info.leftBoxWidth  = availableEvenWidth;
+        info.rightBoxWidth = availableEvenWidth;
 
-        if (avaliableEvenWidth < maximumWidthNeededForLeftBox) {
+        if (availableEvenWidth < maximumWidthNeededForLeftBox) {
 
             info.leftBoxWidth  = maximumWidthNeededForLeftBox;
             info.rightBoxWidth = info.mainBoxWidth - info.minusWidth - info.leftBoxWidth;
@@ -190,5 +185,4 @@ namespace gui
 
         return info;
     }
-
 } /* namespace gui */

--- a/products/BellHybrid/apps/application-bell-meditation-timer/presenter/MeditationProgressPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/presenter/MeditationProgressPresenter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MeditationTimer.hpp"
@@ -55,7 +55,7 @@ namespace app::meditation
 
     void MeditationProgressPresenter::start()
     {
-        reinterpret_cast<app::Application *>(app)->suspendIdleTimer();
+        static_cast<app::Application *>(app)->suspendIdleTimer();
         timer->reset(std::chrono::seconds(duration), interval);
         timer->start();
     }

--- a/products/BellHybrid/apps/application-bell-powernap/data/PowerNapStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/data/PowerNapStyle.hpp
@@ -13,41 +13,40 @@ namespace gui::powerNapStyle
     {
         namespace progress
         {
-            constexpr inline auto radius                   = 192;
-            constexpr inline auto penWidth                 = 3;
-            constexpr inline auto verticalDeviationDegrees = 38;
+            inline constexpr auto radius                   = 192;
+            inline constexpr auto penWidth                 = 3;
+            inline constexpr auto verticalDeviationDegrees = 38;
         } // namespace progress
 
         namespace timer
         {
-            constexpr inline auto marginTop   = 41;
-            constexpr inline auto marginRight = 32;
-            constexpr inline auto font        = style::window::font::supersizeme;
-            constexpr inline auto maxSizeX    = 340;
-            constexpr inline auto maxSizeY    = 198;
+            inline constexpr auto marginTop = 41;
+            inline constexpr auto font      = style::window::font::supersizeme;
+            inline constexpr auto maxSizeX  = 340;
+            inline constexpr auto maxSizeY  = 198;
         } // namespace timer
 
         namespace pauseIcon
         {
-            constexpr inline auto image     = "big_pause";
-            constexpr inline auto marginTop = 39;
-            constexpr inline auto maxSizeX  = 203;
-            constexpr inline auto maxSizeY  = 203;
+            inline constexpr auto image     = "big_pause";
+            inline constexpr auto marginTop = 39;
+            inline constexpr auto maxSizeX  = 203;
+            inline constexpr auto maxSizeY  = 203;
         } // namespace pauseIcon
 
         namespace ringIcon
         {
-            constexpr inline auto image     = "big_bell_ringing";
-            constexpr inline auto marginTop = 39;
-            constexpr inline auto maxSizeX  = 210;
-            constexpr inline auto maxSizeY  = 203;
+            inline constexpr auto image     = "big_bell_ringing";
+            inline constexpr auto marginTop = 39;
+            inline constexpr auto maxSizeX  = 210;
+            inline constexpr auto maxSizeY  = 203;
         } // namespace ringIcon
 
         namespace clock
         {
-            constexpr inline auto marginTop = 17;
-            constexpr inline auto maxSizeX  = 340;
-            constexpr inline auto maxSizeY  = 84;
+            inline constexpr auto marginTop = 17;
+            inline constexpr auto maxSizeX  = 340;
+            inline constexpr auto maxSizeY  = 84;
         } // namespace clock
     }
 } // namespace gui::powerNapStyle

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
@@ -67,11 +67,11 @@ namespace gui
         clock->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
         clock->setMargins(gui::Margins(0, progressStyle::clock::marginTop, 0, 0));
 
-        timer = new gui::TimeFixedWidget(
-            mainVBox, 0, 0, progressStyle::timer::maxSizeX, progressStyle::timer::maxSizeY, true);
+        timer =
+            new gui::TimeFixedWidget(mainVBox, 0, 0, progressStyle::timer::maxSizeX, progressStyle::timer::maxSizeY);
         timer->setFontAndDimensions(progressStyle::timer::font);
         timer->setMinimumSize(progressStyle::timer::maxSizeX, progressStyle::timer::maxSizeY);
-        timer->setMargins(gui::Margins(0, progressStyle::timer::marginTop, progressStyle::timer::marginRight, 0));
+        timer->setMargins(gui::Margins(0, progressStyle::timer::marginTop, 0, 0));
         timer->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
 
         iconPause = new Icon(mainVBox, 0, 0, 0, 0, {}, {});

--- a/products/BellHybrid/apps/application-bell-relaxation/data/RelaxationStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/data/RelaxationStyle.hpp
@@ -15,14 +15,12 @@ namespace gui::relaxationStyle
 
     namespace ended
     {
-        static constexpr auto image_top_margin    = 170U;
-        static constexpr auto image_bottom_margin = 30U;
+        inline constexpr auto image_top_margin    = 170U;
+        inline constexpr auto image_bottom_margin = 30U;
     } // namespace ended
 
     namespace title
     {
-        inline constexpr auto bottomDescTopMargin = 15U;
-        inline constexpr auto maxProgressValue    = 16U;
         inline constexpr auto maxLines            = 2U;
         inline constexpr auto width               = 400U;
     } // namespace title
@@ -33,49 +31,42 @@ namespace gui::relaxationStyle
         inline constexpr auto minWidth = 300U;
     } // namespace text
 
-    namespace pause
-    {
-        inline constexpr auto textH = 200U;
-    }
-
     namespace relStyle
     {
         namespace progress
         {
-            constexpr inline auto radius                   = 192U;
-            constexpr inline auto penWidth                 = 3U;
-            constexpr inline auto verticalDeviationDegrees = 38U;
+            inline constexpr auto radius                   = 192U;
+            inline constexpr auto penWidth                 = 3U;
+            inline constexpr auto verticalDeviationDegrees = 38U;
         } // namespace progress
 
         namespace timer
         {
-            constexpr inline auto marginTop   = 41U;
-            constexpr inline auto marginRight = 32U;
-            constexpr inline auto font        = style::window::font::supersizeme;
-            constexpr inline auto maxSizeX    = 340U;
-            constexpr inline auto maxSizeY    = 198U;
+            inline constexpr auto marginTop = 41U;
+            inline constexpr auto font      = style::window::font::supersizeme;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 198U;
         } // namespace timer
 
         namespace pauseIcon
         {
-            constexpr inline auto image     = "big_pause";
-            constexpr inline auto marginTop = 39U;
-            constexpr inline auto maxSizeX  = 203U;
-            constexpr inline auto maxSizeY  = 203U;
+            inline constexpr auto image     = "big_pause";
+            inline constexpr auto marginTop = 39U;
+            inline constexpr auto maxSizeX  = 203U;
+            inline constexpr auto maxSizeY  = 203U;
         } // namespace pauseIcon
 
         namespace clock
         {
-            constexpr inline auto marginTop = 17U;
-            constexpr inline auto maxSizeX  = 340U;
-            constexpr inline auto maxSizeY  = 84U;
+            inline constexpr auto marginTop = 17U;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 84U;
         } // namespace clock
     }     // namespace relStyle
 
     namespace error
     {
-        constexpr inline auto imageMarginTop = 122U;
-        constexpr inline auto textPaddingTop = 30U;
+        inline constexpr auto imageMarginTop = 122U;
+        inline constexpr auto textPaddingTop = 30U;
     } // namespace error
-
 } // namespace gui::relaxationStyle

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.cpp
@@ -70,10 +70,10 @@ namespace gui
         clock->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
         clock->setMargins(Margins(0, relStyle::clock::marginTop, 0, 0));
 
-        timer = new TimeFixedWidget(mainVBox, 0, 0, relStyle::timer::maxSizeX, relStyle::timer::maxSizeY, true);
+        timer = new TimeFixedWidget(mainVBox, 0, 0, relStyle::timer::maxSizeX, relStyle::timer::maxSizeY);
         timer->setFontAndDimensions(relStyle::timer::font);
         timer->setMinimumSize(relStyle::timer::maxSizeX, relStyle::timer::maxSizeY);
-        timer->setMargins(Margins(0, relStyle::timer::marginTop, relStyle::timer::marginRight, 0));
+        timer->setMargins(Margins(0, relStyle::timer::marginTop, 0, 0));
         timer->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
 
         icon = new Icon(mainVBox, 0, 0, 0, 0, {}, {});


### PR DESCRIPTION
Removed minus sign shown next to the remaining
time value for timers showing progress in
Meditation, Relaxation and Power Nap apps.
Style constants cleanup.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
