### PR TITLE
[BH-1824] Removal of the minus sign in countdown time in Meditation

### DIFF
--- a/products/BellHybrid/apps/application-bell-meditation-timer/data/MeditationStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/data/MeditationStyle.hpp
@@ -51,8 +51,9 @@ namespace app::meditationStyle
 
         namespace timer
         {
-            constexpr inline auto marginTop = 23;
-            constexpr inline auto font      = runningStyle::timer::font;
+            constexpr inline auto marginTop  = 23;
+            constexpr inline auto marginLeft = 43;
+            constexpr inline auto font       = runningStyle::timer::font;
             constexpr inline auto maxSizeX  = runningStyle::timer::maxSizeX;
             constexpr inline auto maxSizeY  = runningStyle::timer::maxSizeY;
         } // namespace timer

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.cpp
@@ -16,6 +16,7 @@ namespace
     constexpr auto meditationCountdownTimerName{"MeditationCountdownTimer"};
     constexpr std::chrono::seconds meditationCountdownTimerPeriod{1};
     constexpr auto meditationCountdownMode{app::ProgressCountdownMode::Increasing};
+    constexpr auto leftBoxSize{1};
 } // namespace
 
 namespace gui
@@ -73,12 +74,12 @@ namespace gui
                                          0,
                                          runningStyle::timer::maxSizeX,
                                          runningStyle::timer::maxSizeY,
-                                         true,
-                                         1,
+                                         false,
+                                         leftBoxSize,
                                          TimeFixedWidget::RightBox::defaultSize);
         timer->setFontAndDimensions(countdownStyle::timer::font);
         timer->setMinimumSize(countdownStyle::timer::maxSizeX, countdownStyle::timer::maxSizeY);
-        timer->setMargins(gui::Margins(0, countdownStyle::timer::marginTop, 0, 0));
+        timer->setMargins(gui::Margins(countdownStyle::timer::marginLeft, countdownStyle::timer::marginTop, 0, 0));
         timer->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
 
         mainVBox->resizeItems();


### PR DESCRIPTION
Removed minus sign in countdown timer in Meditation

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
