### PR TITLE
[BH-1807] Fix missing AM/PM label in apps clock

### DIFF
--- a/module-apps/apps-common/widgets/TimeSetFmtSpinner.cpp
+++ b/module-apps/apps-common/widgets/TimeSetFmtSpinner.cpp
@@ -10,7 +10,6 @@
 
 namespace gui
 {
-
     TimeSetFmtSpinner::TimeSetFmtSpinner(Item *parent) : HBox{parent}
     {
         using namespace utils;
@@ -27,7 +26,6 @@ namespace gui
         updateFmtFont(noFocusFontName);
         fmt->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
         fmt->setMargins(getFmtMargins(noFocusFontName));
-        fmt->setEdges(RectangleEdge::None);
         fmt->setVisible(false);
         fmt->setPenFocusWidth(style::time_set_spinner::focus::size);
         fmt->setEdges(RectangleEdge::Bottom);
@@ -85,6 +83,7 @@ namespace gui
             }
 
         } break;
+
         case utils::time::Locale::TimeFormat::FormatTime24H: {
             fmt->setVisible(false);
             auto hours = std::chrono::hours(timeSetSpinner->getHour());
@@ -98,6 +97,7 @@ namespace gui
                 }
             }
         } break;
+
         default:
             break;
         }
@@ -138,7 +138,13 @@ namespace gui
 
     auto TimeSetFmtSpinner::getFmtMargins(const std::string &fmtFont) const noexcept -> Margins
     {
-        return fmtMarginsMap.find(fmtFont)->second;
+        const auto fmtMargin = fmtMarginsMap.find(fmtFont);
+        if (fmtMargin == fmtMarginsMap.end()) {
+            LOG_ERROR("Missing margins map entry for font '%s', update margins map! Fallback value (zero) will be set.",
+                      fmtFont.c_str());
+            return Margins();
+        }
+        return fmtMargin->second;
     }
 
     auto TimeSetFmtSpinner::setHour(int value) noexcept -> void
@@ -291,11 +297,13 @@ namespace gui
 
         HBox::handleContentChanged();
     }
+
     auto TimeSetFmtSpinner::set12HPeriod(const Period period) -> void
     {
         period == Period::AM ? fmt->set_value(utils::time::Locale::getAM())
                              : fmt->set_value(utils::time::Locale::getPM());
     }
+
     auto TimeSetFmtSpinner::getHour24Format() const noexcept -> int
     {
         using namespace utils::time;
@@ -305,5 +313,4 @@ namespace gui
         auto hours = std::chrono::hours(timeSetSpinner->getHour());
         return date::make24(hours, isPM()).count();
     }
-
 } // namespace gui

--- a/module-apps/apps-common/widgets/TimeSetFmtSpinner.hpp
+++ b/module-apps/apps-common/widgets/TimeSetFmtSpinner.hpp
@@ -69,19 +69,23 @@ namespace gui
 
         auto setTimeFormat(utils::time::Locale::TimeFormat fmt, bool informContentChanged) noexcept -> void;
 
-        std::map<std::string, Margins> fmtMarginsMap = {
+        // clang-format off
+        const std::map<std::string, Margins> fmtMarginsMap = {
             {style::window::font::verybiglight, {style::time_set_fmt_spinner::small_margin, 0, 0, 0}},
             {style::window::font::veryverybiglight, {style::time_set_fmt_spinner::small_margin, 0, 0, 0}},
             {style::window::font::largelight, {style::time_set_fmt_spinner::small_margin, 0, 0, 0}},
+            {style::window::font::large, {style::time_set_fmt_spinner::small_margin, 0, style::time_set_fmt_spinner::small_margin, 0}},
+            {style::window::font::supersizeme, {style::time_set_fmt_spinner::big_margin, 0, style::time_set_fmt_spinner::big_margin, 0}},
             {style::window::font::supersizemelight, {style::time_set_fmt_spinner::big_margin, 0, 0, 0}},
             {style::window::font::huge, {style::time_set_fmt_spinner::big_margin, 0, 0, 0}},
             {style::window::font::gargantuan, {style::time_set_fmt_spinner::big_margin, 0, 0, 0}}};
-        [[nodiscard]] auto getFmtMargins(const std::string &fmtFont) const noexcept -> Margins;
+        // clang-format on
 
         auto onInput(const InputEvent &inputEvent) -> bool override;
         auto handleEnterKey() -> bool;
         auto handleRightFunctionKey() -> bool;
         void handleContentChanged() override;
+        [[nodiscard]] auto getFmtMargins(const std::string &fmtFont) const noexcept -> Margins;
 
         TimeSetSpinner *timeSetSpinner{nullptr};
         StringSpinner *fmt{nullptr};
@@ -91,5 +95,4 @@ namespace gui
 
         utils::time::Locale::TimeFormat timeFormat{utils::time::Locale::TimeFormat::FormatTime12H};
     };
-
 } // namespace gui

--- a/module-apps/apps-common/widgets/TimeSetSpinner.cpp
+++ b/module-apps/apps-common/widgets/TimeSetSpinner.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "TimeSetSpinner.hpp"
@@ -8,13 +8,15 @@
 #include <gui/widgets/ImageBox.hpp>
 #include <gui/widgets/text/Label.hpp>
 
-static constexpr auto hourMin         = 0;
-static constexpr auto hourMax         = 23;
-static constexpr auto hourDoubleDigit = 10;
-static constexpr auto hourStep        = 1;
-static constexpr auto minuteMin       = 0;
-static constexpr auto minuteMax       = 59;
-static constexpr auto minuteStep      = 1;
+namespace
+{
+    constexpr auto hourMin    = 0;
+    constexpr auto hourMax    = 23;
+    constexpr auto hourStep   = 1;
+    constexpr auto minuteMin  = 0;
+    constexpr auto minuteMax  = 59;
+    constexpr auto minuteStep = 1;
+} // namespace
 
 namespace gui
 {
@@ -231,7 +233,13 @@ namespace gui
 
     auto TimeSetSpinner::getColonMargins(const std::string &colonFont) const noexcept -> Margins
     {
-        return colonMarginsMap.find(colonFont)->second;
+        const auto colonMargins = colonMarginsMap.find(colonFont);
+        if (colonMargins == colonMarginsMap.end()) {
+            LOG_ERROR("Missing margins map entry for font '%s', update margins map! Fallback value (zero) will be set.",
+                      colonFont.c_str());
+            return Margins();
+        }
+        return colonMargins->second;
     }
 
     auto TimeSetSpinner::applySizeRestrictions() -> void

--- a/module-apps/apps-common/widgets/TimeSetSpinner.hpp
+++ b/module-apps/apps-common/widgets/TimeSetSpinner.hpp
@@ -21,7 +21,7 @@ namespace style::time_set_spinner
     inline constexpr auto big_margin   = 6U;
     inline constexpr auto gargantuan_margin_left  = 14U;
     inline constexpr auto gargantuan_margin_right = 7U;
-    inline constexpr auto align_margin            = -12;
+    inline constexpr auto bottom_align_margin     = -12;
 } // namespace style::time_set_spinner
 
 namespace gui
@@ -47,7 +47,7 @@ namespace gui
         [[nodiscard]] auto getMinute() const noexcept -> int;
 
       private:
-        std::map<std::string, std::string> colonFontMap = {
+        const std::map<std::string, std::string> colonFontMap = {
             {style::window::font::verybiglight, "alarm_colon_W_M"},
             {style::window::font::veryverybiglight, "alarm_colon_W_M"},
             {style::window::font::largelight, "alarm_colon_W_M"},
@@ -57,29 +57,17 @@ namespace gui
             {style::window::font::huge, "alarm_colon_clock_W_M"},
             {style::window::font::gargantuan, "alarm_colon_clock_W_M"}};
 
-        std::map<std::string, Margins> colonMarginsMap = {
-            {style::window::font::verybiglight,
-             {style::time_set_spinner::very_small_margin, 0, style::time_set_spinner::very_small_margin, 0}},
-            {style::window::font::veryverybiglight,
-             {style::time_set_spinner::very_small_margin, 0, style::time_set_spinner::very_small_margin, 0}},
-            {style::window::font::largelight,
-             {style::time_set_spinner::small_margin, 0, style::time_set_spinner::small_margin, 0}},
-            {style::window::font::large,
-             {style::time_set_spinner::small_margin,
-              0,
-              style::time_set_spinner::small_margin,
-              style::time_set_spinner::align_margin}},
-            {style::window::font::supersizeme,
-             {style::time_set_spinner::big_margin, 0, style::time_set_spinner::big_margin, 0}},
-            {style::window::font::supersizemelight,
-             {style::time_set_spinner::big_margin, 0, style::time_set_spinner::big_margin, 0}},
-            {style::window::font::huge,
-             {style::time_set_spinner::big_margin, 0, style::time_set_spinner::big_margin, 0}},
-            {style::window::font::gargantuan,
-             {style::time_set_spinner::gargantuan_margin_left,
-              0,
-              style::time_set_spinner::gargantuan_margin_right,
-              0}}};
+        // clang-format off
+        const std::map<std::string, Margins> colonMarginsMap = {
+            {style::window::font::verybiglight, {style::time_set_spinner::very_small_margin, 0, style::time_set_spinner::very_small_margin, 0}},
+            {style::window::font::veryverybiglight, {style::time_set_spinner::very_small_margin, 0, style::time_set_spinner::very_small_margin, 0}},
+            {style::window::font::largelight, {style::time_set_spinner::small_margin, 0, style::time_set_spinner::small_margin, 0}},
+            {style::window::font::large, {style::time_set_spinner::small_margin, 0, style::time_set_spinner::small_margin, style::time_set_spinner::bottom_align_margin}},
+            {style::window::font::supersizeme, {style::time_set_spinner::big_margin, 0, style::time_set_spinner::big_margin, 0}},
+            {style::window::font::supersizemelight, {style::time_set_spinner::big_margin, 0, style::time_set_spinner::big_margin, 0}},
+            {style::window::font::huge, {style::time_set_spinner::big_margin, 0, style::time_set_spinner::big_margin, 0}},
+            {style::window::font::gargantuan, {style::time_set_spinner::gargantuan_margin_left, 0, style::time_set_spinner::gargantuan_margin_right, 0}}};
+        // clang-format on
 
         U8IntegerSpinner *hour        = nullptr;
         ImageBox *colon              = nullptr;

--- a/products/BellHybrid/apps/application-bell-relaxation/data/RelaxationStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/data/RelaxationStyle.hpp
@@ -11,7 +11,7 @@ namespace gui::relaxationStyle
     inline constexpr auto titleFont       = style::window::font::largelight;
     inline constexpr auto clockFont       = style::window::font::largelight;
     inline constexpr auto timerValueFont  = style::window::font::supersizemelight;
-    inline constexpr auto valumeValueFont = style::window::font::supersizemelight;
+    inline constexpr auto volumeValueFont = style::window::font::supersizemelight;
 
     namespace ended
     {

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationVolumeWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationVolumeWindow.cpp
@@ -62,7 +62,7 @@ namespace gui
                                         static_cast<U8IntegerSpinner::value_type>(data.step)},
                                        Boundaries::Fixed);
         spinner->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::center_layout_h);
-        spinner->setFont(relaxationStyle::valumeValueFont);
+        spinner->setFont(relaxationStyle::volumeValueFont);
         spinner->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
         spinner->setFocusEdges(RectangleEdge::None);
         spinner->set_value(static_cast<U8IntegerSpinner::value_type>(presenter->getVolume()));

--- a/products/BellHybrid/apps/common/include/common/data/StyleCommon.hpp
+++ b/products/BellHybrid/apps/common/include/common/data/StyleCommon.hpp
@@ -10,8 +10,7 @@ namespace gui::bell_style
 {
     inline constexpr auto font            = ::style::window::font::supersizemelight;
     inline constexpr auto font_center     = ::style::window::font::largelight;
-    inline constexpr auto font_top        = ::style::window::font::largelight;
-    inline constexpr auto statusClockFont = style::window::font::large;
+    inline constexpr auto font_status_clock = ::style::window::font::large;
 
     inline constexpr auto popup_icon_top_margin    = 120;
     inline constexpr auto popup_icon_bottom_margin = 30;
@@ -22,14 +21,13 @@ namespace itStyle
 {
     namespace icon
     {
-        constexpr inline auto imageLogo         = "bell_big_logo";
-        constexpr inline auto imagePause        = "big_pause";
-        constexpr inline auto imageTopMargin    = 112;
-        constexpr inline auto imageBottomMargin = 30;
+        inline constexpr auto imagePause        = "big_pause";
+        inline constexpr auto imageTopMargin    = 112;
+        inline constexpr auto imageBottomMargin = 30;
     } // namespace icon
 
     namespace text
     {
-        constexpr inline auto font = style::window::font::verybiglight;
+        inline constexpr auto font = ::style::window::font::verybiglight;
     } // namespace text
 } // namespace itStyle

--- a/products/BellHybrid/apps/common/include/common/widgets/BellStatusClock.hpp
+++ b/products/BellHybrid/apps/common/include/common/widgets/BellStatusClock.hpp
@@ -12,5 +12,4 @@ namespace gui
       public:
         explicit BellStatusClock(Item *parent = nullptr);
     };
-
 } // namespace gui

--- a/products/BellHybrid/apps/common/src/widgets/BellStatusClock.cpp
+++ b/products/BellHybrid/apps/common/src/widgets/BellStatusClock.cpp
@@ -2,18 +2,15 @@
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <common/widgets/BellStatusClock.hpp>
-
 #include <common/data/StyleCommon.hpp>
 
 namespace gui
 {
-
     BellStatusClock::BellStatusClock(Item *parent) : TimeSetFmtSpinner{parent}
     {
-        setFont(bell_style::statusClockFont);
+        setFont(bell_style::font_status_clock);
         setEditMode(EditMode::Browse);
         activeItem = false;
         setTimeFormatSpinnerVisibility(true);
     }
-
 } // namespace gui


### PR DESCRIPTION
* Fix of the issue that after changing font size of the 
clock presented in Relaxation, Meditation and 
Power Nap apps, AM/PM label was not shown
in 12h mode.
* Added logs informing about missing margins map 
entry so that such issue is easier to debug if it 
should happen in the future.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
