### PR TITLE
[BH-1833] Enable RTWDOG in WFI mode

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Fixed source clock frequency computation for PWM module
+* Fixed initial watchdog configuration
 
 ### Added
 * Added setting onboarding year to build date year
@@ -11,6 +12,7 @@
 * Added low battery notification before using the application
 * Added entering WFI when CPU is idle to reduce power consumption
 * Added switching SDRAM to self-refresh before entering WFI for further power consumption reduction
+* Added watchdog protection to WFI mode
 
 ### Changed / Improved
 

--- a/module-bsp/board/rt1051/bellpx/bsp/lpm/WfiController.cpp
+++ b/module-bsp/board/rt1051/bellpx/bsp/lpm/WfiController.cpp
@@ -4,12 +4,12 @@
 #include "WfiController.hpp"
 #include "EnterSleepMode.h"
 #include <fsl_gpc.h>
-#include <fsl_rtwdog.h>
 #include <fsl_runtimestat_gpt.h>
 #include <Utils.hpp>
 #include <time/time_constants.hpp>
 #include <ticks.hpp>
 #include <timers.h>
+#include <watchdog/watchdog.hpp>
 
 namespace bsp
 {
@@ -19,8 +19,8 @@ namespace bsp
          * trigger after more than minute - this way no event will ever be missed */
         constexpr auto timersInactivityTimeMs{60 * utils::time::milisecondsInSecond};
 
-        bool wfiModeAllowed = false;
-        std::uint32_t timeSpentInWFI;
+        bool wfiModeAllowed{false};
+        std::uint32_t timeSpentInWFI{0};
 
         bool isTimerTaskScheduledSoon()
         {
@@ -137,7 +137,7 @@ namespace bsp
             return 0;
         }
 
-        RTWDOG_Refresh(RTWDOG);
+        watchdog::refresh();
         setWaitModeConfig();
         peripheralEnterDozeMode();
 
@@ -163,7 +163,7 @@ namespace bsp
         enableSystick();
 
         peripheralExitDozeMode();
-        RTWDOG_Refresh(RTWDOG);
+        watchdog::refresh();
         EnableGlobalIRQ(savedPrimask);
 
         blockEnteringWfiMode();

--- a/module-bsp/board/rt1051/bsp/watchdog/watchdog.cpp
+++ b/module-bsp/board/rt1051/bsp/watchdog/watchdog.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "bsp/watchdog/watchdog.hpp"
@@ -23,7 +23,7 @@ namespace bsp::watchdog
         config.enableRtwdog         = true;
         config.clockSource          = kRTWDOG_ClockSource1;            // LPO_CLK clock (32.768kHz)
         config.prescaler            = kRTWDOG_ClockPrescalerDivide256; // 256 prescaler (effectively 128Hz clock)
-        config.workMode.enableWait  = false;
+        config.workMode.enableWait  = true;                            // Keep RTWDOG enabled in WFI
         config.workMode.enableStop  = false;
         config.workMode.enableDebug = false; // If true, RTWDOG will run when target is halted
         config.testMode             = kRTWDOG_TestModeDisabled;

--- a/module-sys/SystemWatchdog/include/SystemWatchdog/SystemWatchdog.hpp
+++ b/module-sys/SystemWatchdog/include/SystemWatchdog/SystemWatchdog.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -41,22 +41,11 @@ namespace sys
 
       private:
         SystemWatchdog();
-
-        // Timeout period for refresh
-        static constexpr TickType_t refreshTimeoutPeriod = pdMS_TO_TICKS(90000);
-        // Timeout period for the actual watchdog
-        static constexpr TickType_t watchdogTimeoutPeriod = pdMS_TO_TICKS(16000);
-        // Period of actual watchdog refresh
-        static constexpr TickType_t checkPeriod = pdMS_TO_TICKS(8000);
-        // Timeout period for watchdog thread closure
-        static constexpr TickType_t closurePeriod = pdMS_TO_TICKS(2000);
-
         void Run() final;
 
         TickType_t lastRefreshTimestamp{0};
-        bool timeout_occurred{false};
+        bool timeoutOccurred{false};
         bool enableRunLoop{false};
         cpp_freertos::BinarySemaphore taskEndedSem{false};
     };
-
 } // namespace sys


### PR DESCRIPTION
* Fixed initial RTWDOG config procedure, which 
put watchdog module in some non-deterministic
state due to not waiting after unlock request
and config change, what prevented the watchdog
to be reconfigured later in the OS.
* Configured RTWDOG to continue running in WFI 
to prevent potential freezes caused by
CPU not being woken up by periodic RTC
interrupt.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
