### PR TITLE
[BH-1842] Fix dependabot alerts

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,1 +1,1 @@
-gitpython==3.1.11
+gitpython>=3.1.41

--- a/docker/assets/requirements.txt
+++ b/docker/assets/requirements.txt
@@ -3,12 +3,12 @@ dataclasses==0.6
 dataclasses_json==0.5.4
 eyed3==0.9.6
 ghapi
-gitpython==3.1.11
+gitpython>=3.1.41
 iniconfig==1.1.1
 inotify==0.2.10
 packaging==20.4
 pluggy==0.13.1
-py==1.10.0
+py<=1.11.0
 pyparsing==2.4.7
 pyserial==3.5
 pytest==6.1.2

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,12 +1,12 @@
-certifi==2021.5.30
+certifi>=2023.7.22
 charset-normalizer==2.0.4
 gitdb==4.0.7
-GitPython==3.1.18
+gitpython>=3.1.41
 idna==3.2
-requests==2.26.0
+requests>=2.31.0
 smmap==4.0.0
 tqdm==4.62.2
-urllib3==1.26.6
+urllib3>=1.26.18
 ghapi
 pylink
 matplotlib


### PR DESCRIPTION
GitHub's dependabot suggests we might be using outdated and vulnerable python libraries. This commit updates our requirements to use more recent verions of some of the libraries.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
