### PR TITLE
[BH-1865] Remove redundant cursor in alarm edit mode

### DIFF
--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
@@ -157,9 +157,9 @@ namespace gui
             setTextDescription(utils::translate("app_bellmain_home_screen_bottom_desc_dp"));
             break;
         case app::home_screen::ViewState::AlarmEdit:
-            alarm->setEditMode(EditMode::Edit);
             setHeaderViewMode(HeaderViewMode::AlarmIconAndTime);
             setScreenMode(ScreenViewMode::Main);
+            alarm->setEditMode(EditMode::Edit);
             removeTextDescription();
             break;
         case app::home_screen::ViewState::ActivatedLowBattery:


### PR DESCRIPTION
Fix for the issue that after BH-1636
hour value in alarm edit mode was
displayed with a cursor below it,
which was inconsistent with the
design.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
