### PR TITLE
[BH-1867][BH-1868] Fix alarm rings after deactivation

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 * Fixed source clock frequency computation for PWM module
 * Fixed initial watchdog configuration
+* Fixed alarm rings when deactivated during snooze
 
 ### Added
 * Added setting onboarding year to build date year

--- a/products/BellHybrid/apps/common/src/AlarmModel.cpp
+++ b/products/BellHybrid/apps/common/src/AlarmModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "models/AlarmModel.hpp"
@@ -80,11 +80,14 @@ namespace app
             return;
         }
         alarmEventPtr->enabled = value;
-        if (isSnoozeActive()) {
+        updateAlarm(*alarmEventPtr);
+        if (value) {
+            alarmStatus = alarms::AlarmStatus::Activated;
+        }
+        else {
+            alarmStatus = alarms::AlarmStatus::Deactivated;
             disableSnooze(*alarmEventPtr);
         }
-        updateAlarm(*alarmEventPtr);
-        alarmStatus = value ? alarms::AlarmStatus::Activated : alarms::AlarmStatus::Deactivated;
     }
     void AlarmModel::updateAlarm(AlarmEventRecord &alarm)
     {


### PR DESCRIPTION
Fix the function that it's responsible for disabling the snooze alarm. After snoozing the alarm
and deactivating the alarm device shouldn't ring.

Collaborated with: @Maciej-Mudita @Lefucjusz @rrandomsky @patrycja-paczkowska

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
