### PR TITLE
[BH-1870] Fix displaying the menu after deep press on main screen

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -7,6 +7,7 @@
 * Fixed initial watchdog configuration
 * Fixed alarm rings when deactivated during snooze
 * Fixed popup about file deletion showing in Relaxation app even if no file was deleted
+* Fixed displaying the menu after deep press on main screen
 
 ### Added
 * Added setting onboarding year to build date year


### PR DESCRIPTION
<!-- Please describe your pull request here -->

Add double checking debouncing timer with reference GPT timer to eliminate incorrect behavior on deep press after exiting WFI

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
