### PR TITLE
[BH-1874] Fix underline appearing when setting alarm time

### DIFF
--- a/module-apps/apps-common/widgets/AlarmSetSpinner.cpp
+++ b/module-apps/apps-common/widgets/AlarmSetSpinner.cpp
@@ -1,9 +1,8 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "AlarmSetSpinner.hpp"
 #include <FontManager.hpp>
-#include <RawFont.hpp>
 #include <gui/widgets/text/Label.hpp>
 #include <gui/widgets/ImageBox.hpp>
 #include <apps-common/widgets/TimeSetFmtSpinner.hpp>

--- a/module-gui/gui/widgets/Item.cpp
+++ b/module-gui/gui/widgets/Item.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "Item.hpp"
@@ -9,6 +9,7 @@
 #include <list>            // for list<>::iterator, list, operator!=, _List...
 #include <memory>
 #include <DrawCommand.hpp>
+
 namespace gui
 {
 
@@ -558,5 +559,4 @@ namespace gui
     {
         visitor.visit(*this);
     }
-
-} /* namespace gui */
+} // namespace gui

--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
@@ -252,20 +252,24 @@ namespace gui
     {
         switch (mode) {
         case ScreenViewMode::Main:
-            lowBatteryWarning->setVisible(false);
-            firstBox->setVisible(true);
-            firstBox->informContentChanged();
-            lastBox->setVisible(true);
-            lastBox->informContentChanged();
-            centerBox->setVisible(true);
-            centerBox->informContentChanged();
+            if (lowBatteryWarning->visible) {
+                lowBatteryWarning->setVisible(false);
+                firstBox->setVisible(true);
+                firstBox->informContentChanged();
+                lastBox->setVisible(true);
+                lastBox->informContentChanged();
+                centerBox->setVisible(true);
+                centerBox->informContentChanged();
+            }
             break;
         case ScreenViewMode::Warning:
-            firstBox->setVisible(false);
-            lastBox->setVisible(false);
-            centerBox->setVisible(false);
-            lowBatteryWarning->setVisible(true);
-            lowBatteryWarning->informContentChanged();
+            if (!lowBatteryWarning->visible) {
+                firstBox->setVisible(false);
+                lastBox->setVisible(false);
+                centerBox->setVisible(false);
+                lowBatteryWarning->setVisible(true);
+                lowBatteryWarning->informContentChanged();
+            }
             break;
         }
     }


### PR DESCRIPTION
Fix of the issue that underline appeared under
hours value when setting alarm time with knob
down (alarm disabled) after previous
confirmation of the alarm time.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
