### PR TITLE
[BH-1842] Fix dependabot alerts

### DIFF
--- a/docker/assets/requirements.txt
+++ b/docker/assets/requirements.txt
@@ -8,10 +8,9 @@ iniconfig==1.1.1
 inotify==0.2.10
 packaging==20.4
 pluggy==0.13.1
-py<=1.11.0
 pyparsing==2.4.7
 pyserial==3.5
-pytest==6.1.2
+pytest>=7.2.0
 six==1.15.0
 toml==0.10.2
 tqdm==4.62.2

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,10 +2,9 @@ attrs==20.3.0
 iniconfig==1.1.1
 packaging==20.4
 pluggy==0.13.1
-py==1.10.0
 pyparsing==2.4.7
 pyserial==3.5
-pytest==6.1.2
+pytest>=7.2.0
 six==1.15.0
 toml==0.10.2
 inotify==0.2.10


### PR DESCRIPTION
GitHub's Dependabot suggests stopping using the py library and switch to a new pytest version which does not depend on py anymore. 

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
