### PR TITLE
[MOS-1061] Fix screen backlight flash when turning off

### DIFF
--- a/module-bsp/board/rt1051/puretx/board.cpp
+++ b/module-bsp/board/rt1051/puretx/board.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "bsp.hpp"
@@ -36,11 +36,9 @@ namespace bsp
         switch (state) {
         case RebootState::None:
             break;
-        case RebootState::Poweroff:
-            board_shutdown();
-            break;
         case RebootState::Reboot:
-            board_reset();
+        case RebootState::Poweroff:
+            board_reset(); // Reset will result in powering off the CPU if USB is disconnected due to hardware design
             break;
         }
 

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 ### Fixed
-Fixed no response when editing a contact via Center to have the same number as another
+* Fixed no response when editing a contact via Center to have the same number as another.
+* Fixed occasional screen backlight flash when turning off the phone.
 
 ### Added
 


### PR DESCRIPTION
Fix of the issue that screen backlight
would sometimes flash lightly when the
phone is turning off.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
