### PR TITLE
[MOS-1063] Fix device freeze after onboarding in Spanish

### DIFF
--- a/module-apps/application-onboarding/windows/UpdateDialogWindow.cpp
+++ b/module-apps/application-onboarding/windows/UpdateDialogWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "UpdateDialogWindow.hpp"
@@ -7,7 +7,6 @@
 #include <Style.hpp>
 
 #include <application-onboarding/ApplicationOnBoarding.hpp>
-#include <service-appmgr/Controller.hpp>
 #include <product/version.hpp>
 
 namespace app::onBoarding

--- a/module-gui/gui/core/RawFont.cpp
+++ b/module-gui/gui/core/RawFont.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "RawFont.hpp"
@@ -86,7 +86,7 @@ namespace gui
         return gui::Status::GUI_SUCCESS;
     }
 
-    int32_t RawFont::getKerning(std::uint32_t id1, std::uint32_t id2) const
+    std::int32_t RawFont::getKerning(std::uint32_t id1, std::uint32_t id2) const
     {
         if (id2 == none_char_id) {
             return 0;
@@ -111,28 +111,27 @@ namespace gui
         return kern->amount;
     }
 
-    std::uint32_t RawFont::getCharCountInSpace(const UTF8 &str, const std::uint32_t space) const
+    std::uint32_t RawFont::getCharCountInSpace(const UTF8 &str, const std::uint32_t availableSpace) const
     {
-        std::uint32_t availableSpace = space;
-        std::uint32_t textSpace      = 0;
         std::uint32_t count          = 0;
-        std::uint32_t current        = 0;
-        std::uint32_t previous       = none_char_id;
+        std::uint32_t usedSpace      = 0;
+        auto previousChar            = none_char_id;
 
-        for (std::uint32_t i = 0; i < str.length(); ++i, ++count) {
-            current = str[i];
-            textSpace += getCharPixelWidth(current, previous);
-            if (availableSpace < textSpace) {
-                return count - 1;
+        while (count < str.length()) {
+            const auto currentChar = str[count];
+            usedSpace += getCharPixelWidth(currentChar, previousChar);
+            if (availableSpace < usedSpace) {
+                return ((count > 0) ? (count - 1) : 0);
             }
-            previous = current;
+            previousChar = currentChar;
+            ++count;
         }
         return count;
     }
 
     FontGlyph *RawFont::getGlyph(std::uint32_t glyph_id) const
     {
-        auto glyph = this->findGlyph(glyph_id);
+        auto glyph = findGlyph(glyph_id);
         if (glyph != nullptr) {
             return glyph;
         }
@@ -286,4 +285,4 @@ namespace gui
             fallback_font = fallback;
         }
     }
-} /* namespace gui */
+} // namespace gui

--- a/module-gui/gui/core/RawFont.hpp
+++ b/module-gui/gui/core/RawFont.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -27,7 +27,7 @@ namespace gui
 
         gui::Status load(uint8_t *data);
 
-        static const std::uint32_t none_char_id = std::numeric_limits<const std::uint32_t>().max();
+        static constexpr auto none_char_id = std::numeric_limits<std::uint32_t>().max();
         // structure holding detailed information about font
         FontInfo info;
         // number of glyphs in the font
@@ -53,14 +53,14 @@ namespace gui
          * @param id2 Code of the second character - if none_char_id then return 0
          * @return Value of the kerning or 0 if pair was not found.
          */
-        int32_t getKerning(std::uint32_t id1, std::uint32_t id2) const;
+        std::int32_t getKerning(std::uint32_t id1, std::uint32_t id2) const;
         /**
          * @brief Method calculates how many chars will fit specified width using current font.
          * @param str UTF8 string that will be used to calculate how many chars can fit provided space.
-         * @param space Number of pixels in width availabale to calculate how many chars will fit.
+         * @param space Number of pixels in width available to calculate how many chars will fit.
          * @return number of chars that can fit provided space;
          */
-        std::uint32_t getCharCountInSpace(const UTF8 &str, const std::uint32_t space) const;
+        std::uint32_t getCharCountInSpace(const UTF8 &str, const std::uint32_t availableSpace) const;
         /**
          * @brief Calculates how many pixels will occupy selected part of the string.
          * @param str String used as a source of text.
@@ -85,11 +85,13 @@ namespace gui
          * @brief Returns number of pixels occupied by the character vertically.
          */
         std::uint32_t getCharPixelHeight(std::uint32_t charCode);
+
+        void setFallbackFont(RawFont *font);
+
         const std::string getName()
         {
             return info.face;
         }
-        void setFallbackFont(RawFont *font);
 
       private:
         std::map<std::uint32_t, std::unique_ptr<FontGlyph>> glyphs;
@@ -108,4 +110,4 @@ namespace gui
         /// if code is not found - nullptr is returned
         FontGlyph *findGlyphFallback(std::uint32_t id) const;
     };
-} /* namespace gui */
+} // namespace gui

--- a/module-gui/gui/widgets/text/core/lines/MultiTextLine.cpp
+++ b/module-gui/gui/widgets/text/core/lines/MultiTextLine.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MultiTextLine.hpp"
@@ -6,10 +6,10 @@
 namespace gui
 {
     /// Note - line breaking could be done here with different TextLines to return
-    /// or via different block types (i.e. numeric block tyle could be not "breakable"
+    /// or via different block types (i.e. numeric block type could be not "breakable")
     MultiTextLine::MultiTextLine(BlockCursor &localCursor, unsigned int maxWidth) : TextLine(maxWidth)
     {
-        do {
+        while (true) {
             if (!localCursor) { // cursor is faulty
                 lineEnd = true;
                 return;
@@ -29,7 +29,7 @@ namespace gui
                 continue;
             }
 
-            auto textFormat = localCursor->getFormat();
+            const auto textFormat = localCursor->getFormat();
             if (textFormat->getFont() == nullptr) {
                 lineEnd = true;
                 return;
@@ -41,7 +41,7 @@ namespace gui
                 return;
             }
 
-            auto signsCountToShow = calculateSignsToShow(localCursor, text, maxWidth - widthUsed);
+            const auto signsCountToShow = calculateSignsToShow(localCursor, text, maxWidth - widthUsed);
 
             // we can show nothing - this is the end of this line
             if (signsCountToShow == 0) {
@@ -57,7 +57,7 @@ namespace gui
             }
 
             // create item for show and update Line data
-            auto item = buildUITextPart(textToPrint(signsCountToShow, text), textFormat);
+            const auto item = buildUITextPart(textToPrint(signsCountToShow, text), textFormat);
             shownLetterCount += signsCountToShow;
             widthUsed += item->widgetArea.w;
             heightUsed = std::max(heightUsed, item->widgetArea.h);
@@ -82,8 +82,7 @@ namespace gui
                 end = TextBlock::End::None;
                 return;
             }
-
-        } while (true);
+        }
     }
 
     unsigned int MultiTextLine::calculateSignsToShow(BlockCursor &localCursor, UTF8 &text, unsigned int space)
@@ -91,7 +90,7 @@ namespace gui
         auto signsCountToShow = localCursor->getFormat()->getFont()->getCharCountInSpace(text, space);
 
         // additional one sign to detect potential space as last character in line
-        auto searchSubstring = text.substr(0, signsCountToShow + 1);
+        const auto searchSubstring = text.substr(0, signsCountToShow + 1);
 
         auto newlinePos = searchSubstring.findLast("\n", signsCountToShow);
         auto spacePos   = searchSubstring.findLast(" ", signsCountToShow);
@@ -117,7 +116,7 @@ namespace gui
 
             breakLineDashAddition = false;
         }
-        // if sings still left in text add dash sign
+        // if signs still left in text add dash sign
         else if (signsCountToShow != 0 && signsCountToShow < text.length()) {
             // decrease character shown count by one to fit dash
             signsCountToShow      = signsCountToShow - 1;

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 * Fixed no response when editing a contact via Center to have the same number as another.
 * Fixed occasional screen backlight flash when turning off the phone.
+* Fixed device freeze after finishing onboarding in Spanish.
 
 ### Added
 


### PR DESCRIPTION
Fix of the issue that Pure would freeze
before displaying the last onboarding
screen if the language set during
onboarding was Spanish.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
