### PR TITLE
[BH-1882] Fix display of "Connected" label on home screen

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -18,6 +18,7 @@
 * Fixed alarm rings when deactivated during snooze
 * Fixed popup about file deletion showing in Relaxation app even if no file was deleted
 * Fixed displaying the menu after deep press on main screen
+* Fixed display of "Connected" label on home screen
 
 ### Added
 * Added setting onboarding year to build date year

--- a/module-apps/apps-common/ApplicationCommon.hpp
+++ b/module-apps/apps-common/ApplicationCommon.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -176,6 +176,8 @@ namespace app
         using OnActionReceived = std::function<ActionResult(manager::actions::ActionParamsPtr &&)>;
 
       protected:
+        std::function<void()> onUsbDisconnected;
+
         virtual sys::MessagePointer handleKBDKeyEvent(sys::Message *msgl);
         virtual sys::MessagePointer handleApplicationSwitch(sys::Message *msgl);
         virtual sys::MessagePointer handleAppClose(sys::Message *msgl);
@@ -194,7 +196,7 @@ namespace app
         sys::MessagePointer handleNetworkAccessTechnologyUpdate(sys::Message *msgl);
         sys::MessagePointer handleInputEvent(sys::Message *msgl);
         sys::MessagePointer handleBatteryStatusChange();
-        sys::MessagePointer handleUSBStatusChange();
+        sys::MessagePointer handleUsbStatusChange();
         sys::MessagePointer handleSimStateUpdateMessage(sys::Message *msgl);
         sys::MessagePointer handleMinuteUpdated(sys::Message *msgl);
         sys::MessagePointer handleAction(sys::Message *msgl);

--- a/products/BellHybrid/apps/application-bell-main/CMakeLists.txt
+++ b/products/BellHybrid/apps/application-bell-main/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(application-bell-main
         windows/BellMainMenuWindow.cpp
 
         models/TemperatureModel.cpp
+        models/UsbStatusModel.cpp
 
         presenters/HomeScreenPresenter.cpp
         presenters/StateController.cpp
@@ -19,6 +20,7 @@ target_sources(application-bell-main
         windows/BellMainMenuWindow.hpp
 
         models/TemperatureModel.hpp
+        models/UsbStatusModel.hpp
 
         presenters/StateController.hpp
 

--- a/products/BellHybrid/apps/application-bell-main/include/application-bell-main/ApplicationBellMain.hpp
+++ b/products/BellHybrid/apps/application-bell-main/include/application-bell-main/ApplicationBellMain.hpp
@@ -53,6 +53,7 @@ namespace app
         std::unique_ptr<home_screen::AbstractTemperatureModel> temperatureModel;
         std::unique_ptr<AbstractUserSessionModel> userSessionModel;
         std::unique_ptr<AbstractBatteryLevelNotificationModel> batteryLevelNotificationModel;
+        std::unique_ptr<AbstractUsbStatusModel> usbStatusModel;
         std::shared_ptr<app::home_screen::HomeScreenPresenter> homeScreenPresenter;
     };
 

--- a/products/BellHybrid/apps/application-bell-main/include/application-bell-main/presenters/HomeScreenPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-main/include/application-bell-main/presenters/HomeScreenPresenter.hpp
@@ -27,6 +27,7 @@ namespace app
     class AbstractBatteryLevelNotificationModel;
     class ApplicationCommon;
     class TemperatureModel;
+    class AbstractUsbStatusModel;
     class AbstractUserSessionModel;
     class ProgressTimerWithSnoozeTimer;
 } // namespace app
@@ -67,7 +68,7 @@ namespace app::home_screen
         virtual void setTemperature(utils::temperature::Temperature newTemp)    = 0;
         virtual void setTextDescription(const UTF8 &desc)                       = 0;
         virtual void setBatteryLevelState(const Store::Battery &batteryContext) = 0;
-        virtual void setUSBStatusConnected()                                    = 0;
+        virtual void updateUsbStatus(bool isConnected)                          = 0;
 
         /// Various
         virtual void setLayout(gui::LayoutGenerator layoutGenerator) = 0;
@@ -103,7 +104,7 @@ namespace app::home_screen
         virtual void switchToBatteryStatus()                                                     = 0;
         virtual void switchToLowBatteryWarning()                                                 = 0;
         virtual UTF8 getGreeting()                                                               = 0;
-        virtual void setUSBStatusConnected()                                                     = 0;
+        virtual void updateUsbStatus()                                                           = 0;
         virtual void handleLowBatteryWarning()                                                   = 0;
         virtual bool isLowBatteryWarningNeeded()                                                 = 0;
         virtual void updateBatteryLevelInterval()                                                = 0;
@@ -122,7 +123,8 @@ namespace app::home_screen
                             AbstractTemperatureModel &temperatureModel,
                             AbstractTimeModel &timeModel,
                             AbstractUserSessionModel &userSessionModel,
-                            AbstractBatteryLevelNotificationModel &batteryLevelNotificationModel);
+                            AbstractBatteryLevelNotificationModel &batteryLevelNotificationModel,
+                            AbstractUsbStatusModel &usbStatusModel);
         virtual ~HomeScreenPresenter();
         HomeScreenPresenter()        = delete;
         HomeScreenPresenter &operator=(const HomeScreenPresenter &oth) = delete;
@@ -150,7 +152,7 @@ namespace app::home_screen
         std::uint32_t getBatteryLvl() const override;
         bool isBatteryCharging() const override;
         bool isAlarmActivatedByLatch() const override;
-        void setUSBStatusConnected() override;
+        void updateUsbStatus() override;
 
         void incAlarmMinute() override;
         void decAlarmMinute() override;
@@ -175,6 +177,7 @@ namespace app::home_screen
         AbstractTimeModel &timeModel;
         AbstractUserSessionModel &userSessionModel;
         AbstractBatteryLevelNotificationModel &batteryLevelNotificationModel;
+        AbstractUsbStatusModel &usbStatusModel;
         std::unique_ptr<AbstractController> stateController;
         std::unique_ptr<ProgressTimerWithSnoozeTimer> snoozeTimer;
         std::unique_ptr<std::mt19937> rngEngine;

--- a/products/BellHybrid/apps/application-bell-main/models/UsbStatusModel.cpp
+++ b/products/BellHybrid/apps/application-bell-main/models/UsbStatusModel.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "UsbStatusModel.hpp"
+
+namespace app
+{
+    bool UsbStatusModel::isUsbConnected(const Store::Battery::State &state) const
+    {
+        return ((usbConnected == UsbStatus::Connected) && (state == Store::Battery::State::PluggedNotCharging));
+    }
+
+    void UsbStatusModel::setUsbStatus(UsbStatus status)
+    {
+        usbConnected = status;
+    }
+} // namespace app

--- a/products/BellHybrid/apps/application-bell-main/models/UsbStatusModel.hpp
+++ b/products/BellHybrid/apps/application-bell-main/models/UsbStatusModel.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include <module-utils/EventStore/EventStore.hpp>
+
+namespace app
+{
+    class AbstractUsbStatusModel
+    {
+      public:
+        enum class UsbStatus : bool
+        {
+            Disconnected,
+            Connected
+        };
+
+        virtual ~AbstractUsbStatusModel() noexcept = default;
+
+        virtual bool isUsbConnected(const Store::Battery::State &state) const = 0;
+        virtual void setUsbStatus(UsbStatus status)                           = 0;
+    };
+
+    class UsbStatusModel : public AbstractUsbStatusModel
+    {
+      public:
+        bool isUsbConnected(const Store::Battery::State &state) const override;
+        void setUsbStatus(UsbStatus status) override;
+
+      private:
+        UsbStatus usbConnected{UsbStatus::Disconnected};
+    };
+} // namespace app

--- a/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.cpp
@@ -182,10 +182,10 @@ namespace gui
         return false;
     }
 
-    void BellHomeScreenWindow::setUSBStatusConnected()
+    void BellHomeScreenWindow::updateUsbStatus(bool isConnected)
     {
         if (currentLayout) {
-            currentLayout->setUSBStatusConnected();
+            currentLayout->updateUsbStatus(isConnected);
             application->refreshWindow(gui::RefreshModes::GUI_REFRESH_FAST);
         }
     }

--- a/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-main/windows/BellHomeScreenWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -40,7 +40,7 @@ namespace gui
         void setAlarmTimeFormat(utils::time::Locale::TimeFormat fmt) override;
         void setSnoozeFormat(utils::time::Locale::TimeFormat fmt) override;
         bool updateBatteryStatus() override;
-        void setUSBStatusConnected() override;
+        void updateUsbStatus(bool isConnected) override;
 
         std::shared_ptr<app::home_screen::AbstractPresenter> presenter;
 

--- a/products/BellHybrid/apps/common/include/common/layouts/BaseHomeScreenLayoutProvider.hpp
+++ b/products/BellHybrid/apps/common/include/common/layouts/BaseHomeScreenLayoutProvider.hpp
@@ -50,7 +50,7 @@ namespace gui
         virtual void setViewState(app::home_screen::ViewState state)            = 0;
         virtual void setTextDescription(const UTF8 &desc)                       = 0;
         virtual void setBatteryLevelState(const Store::Battery &batteryContext) = 0;
-        virtual void setUSBStatusConnected()                                    = 0;
+        virtual void updateUsbStatus(bool isConnected)                          = 0;
         virtual void setTime(std::time_t newTime)                               = 0;
         virtual void setAlarmTimeFormat(utils::time::Locale::TimeFormat fmt)    = 0;
         virtual std::time_t getAlarmTime() const                                = 0;

--- a/products/BellHybrid/apps/common/include/common/layouts/HomeScreenLayoutClassic.hpp
+++ b/products/BellHybrid/apps/common/include/common/layouts/HomeScreenLayoutClassic.hpp
@@ -66,7 +66,7 @@ namespace gui
         auto getAlarmTime() const -> std::time_t override;
         auto setAlarmTime(std::time_t newTime) -> void override;
         auto setSnoozeTime(std::time_t newTime) -> void override;
-        auto setUSBStatusConnected() -> void override;
+        auto updateUsbStatus(bool isConnected) -> void override;
 
         auto getSnoozeTimer() -> SnoozeTimer * override;
         auto getLayout() -> Item * override;

--- a/products/BellHybrid/apps/common/include/common/layouts/HomeScreenLayoutVertical.hpp
+++ b/products/BellHybrid/apps/common/include/common/layouts/HomeScreenLayoutVertical.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -44,7 +44,7 @@ namespace gui
         auto setAlarmTimeFormat(utils::time::Locale::TimeFormat fmt) -> void override;
         auto getAlarmTime() const -> std::time_t override;
         auto setAlarmTime(std::time_t newTime) -> void override;
-        auto setUSBStatusConnected() -> void override;
+        auto updateUsbStatus(bool isConnected) -> void override;
 
         auto getSnoozeTimer() -> SnoozeTimer * override;
         auto getLayout() -> Item * override;

--- a/products/BellHybrid/apps/common/include/common/widgets/BellConnectionStatus.hpp
+++ b/products/BellHybrid/apps/common/include/common/widgets/BellConnectionStatus.hpp
@@ -14,8 +14,7 @@ namespace gui
       public:
         BellConnectionStatus(Item *parent);
         void setFont(const UTF8 &fontName);
-        void checkIfConnected(const Store::Battery::State &state);
-        void setConnected();
+        void show(bool visibility);
 
       private:
         Text *statusText = nullptr;

--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
@@ -299,17 +299,8 @@ namespace gui
     void HomeScreenLayoutClassic::setBatteryLevelState(const Store::Battery &batteryContext)
     {
         battery->update(batteryContext.level, isBatteryCharging(batteryContext.state));
-        connectionStatus->checkIfConnected(batteryContext.state);
-
-        if (isBatteryVisibilityAllowed(batteryContext)) {
-            battery->setVisible(true);
-        }
-        else {
-            battery->setVisible(false);
-        }
+        battery->setVisible(isBatteryVisibilityAllowed(batteryContext));
         battery->informContentChanged();
-        connectionStatus->informContentChanged();
-        adjustConnectionStatusPosition();
     }
 
     void HomeScreenLayoutClassic::setTime(std::time_t newTime)
@@ -359,10 +350,11 @@ namespace gui
     {
         return this;
     }
-    auto HomeScreenLayoutClassic::setUSBStatusConnected() -> void
+    auto HomeScreenLayoutClassic::updateUsbStatus(bool isConnected) -> void
     {
-        connectionStatus->setConnected();
+        connectionStatus->show(isConnected);
         connectionStatus->informContentChanged();
+        adjustConnectionStatusPosition();
     }
 
     auto HomeScreenLayoutClassic::adjustConnectionStatusPosition() -> void

--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutVertical.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutVertical.cpp
@@ -162,16 +162,8 @@ namespace gui
     void HomeScreenLayoutVertical::setBatteryLevelState(const Store::Battery &batteryContext)
     {
         battery->update(batteryContext.level, isBatteryCharging(batteryContext.state));
-        connectionStatus->checkIfConnected(batteryContext.state);
-
-        if (isBatteryVisibilityAllowed(batteryContext)) {
-            battery->setVisible(true);
-        }
-        else {
-            battery->setVisible(false);
-        }
+        battery->setVisible(isBatteryVisibilityAllowed(batteryContext));
         battery->informContentChanged();
-        connectionStatus->informContentChanged();
     }
 
     void HomeScreenLayoutVertical::setTime(std::time_t newTime)
@@ -210,9 +202,9 @@ namespace gui
     {
         return this;
     }
-    auto HomeScreenLayoutVertical::setUSBStatusConnected() -> void
+    auto HomeScreenLayoutVertical::updateUsbStatus(bool isConnected) -> void
     {
-        connectionStatus->setConnected();
+        connectionStatus->show(isConnected);
         connectionStatus->informContentChanged();
     }
 

--- a/products/BellHybrid/apps/common/src/widgets/BellConnectionStatus.cpp
+++ b/products/BellHybrid/apps/common/src/widgets/BellConnectionStatus.cpp
@@ -26,7 +26,7 @@ namespace gui
         statusText->activeItem = false;
         statusText->drawUnderline(false);
         statusText->setText(utils::translate(usb_connected_status));
-        statusText->setVisible(true);
+        statusText->setVisible(false);
     }
 
     void BellConnectionStatus::setFont(const UTF8 &fontName)
@@ -34,15 +34,8 @@ namespace gui
         statusText->setFont(fontName);
     }
 
-    void BellConnectionStatus::checkIfConnected(const Store::Battery::State &state)
+    void BellConnectionStatus::show(bool visibility)
     {
-        if (state != Store::Battery::State::PluggedNotCharging) {
-            statusText->setVisible(false);
-        }
-    }
-
-    void BellConnectionStatus::setConnected()
-    {
-        statusText->setVisible(true);
+        statusText->setVisible(visibility);
     }
 } // namespace gui


### PR DESCRIPTION
<!-- Please describe your pull request here -->

The "connected" label did not appear on the home screen if the USB was connected on another screen.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
