### PR TITLE
[BH-1884] Fix biwin memory errors

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+* Fixed BIWIN eMMC memory errors
 
 ### Added
 * Added new 32px and 170px fonts

--- a/module-platform/rt1051/src/disk_emmc.cpp
+++ b/module-platform/rt1051/src/disk_emmc.cpp
@@ -42,7 +42,7 @@ namespace purefs::blkdev
 #endif
         mmcCard->busWidth                   = kMMC_DataBusWidth8bit;
         mmcCard->busTiming                  = kMMC_HighSpeed200Timing;
-        mmcCard->enablePreDefinedBlockCount = true;
+        mmcCard->enablePreDefinedBlockCount = false; // BIWIN eMMC doesn't work stable when this flag is true
         mmcCard->host->hostController.base  = USDHC2;
         mmcCard->host->hostController.sourceClock_Hz =
             CLOCK_GetFreq(kCLOCK_SysPllPfd2Clk) / (CLOCK_GetDiv(kCLOCK_Usdhc2Div) + 1U);

--- a/products/BellHybrid/BinaryAssetsVersions.cmake
+++ b/products/BellHybrid/BinaryAssetsVersions.cmake
@@ -1,9 +1,9 @@
 # This file sets versions of downloaded binaries for release packaging purposes
 
 if( NOT DEFINED ECOBOOT_BIN_VERSION)
-    set(ECOBOOT_BIN_VERSION 2.0.7 CACHE STRING "bootloader binary version to download from bootloader release page")
+    set(ECOBOOT_BIN_VERSION 2.0.8 CACHE STRING "bootloader binary version to download from bootloader release page")
 endif()
 
 if (NOT DEFINED RECOVERY_BIN_VERSION)
-    set(RECOVERY_BIN_VERSION 1.0.3 CACHE STRING "recovery binary version to download from recovery release page")
+    set(RECOVERY_BIN_VERSION 1.0.4 CACHE STRING "recovery binary version to download from recovery release page")
 endif()


### PR DESCRIPTION
The BIWIN eMMC memory
doesn't work stable when enablePreDefinedBlockCount flag is enabled.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
