### PR TITLE
[BH-1885] Increase stack size for battery charger task

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -13,6 +13,7 @@
 
 ### Changed / Improved
 * Updated FSL drivers from NXP
+* Increased battery charger stack size
 
 ## [2.5.0 2024-02-09]
 

--- a/module-bsp/board/rt1051/bellpx/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/rt1051/bellpx/hal/battery_charger/BatteryCharger.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BatteryChargerIRQ.hpp"
@@ -97,6 +97,7 @@ namespace hal::battery
         xTimerHandle reinit_timer;
         xQueueHandle notification_channel;
         inline static std::unique_ptr<BatteryWorkerQueue> worker_queue;
+        static constexpr auto workerStackSize = 1024 + 512;
 
         std::shared_ptr<drivers::DriverI2C> i2c;
         std::shared_ptr<drivers::DriverGPIO> charger_gpio_chgok;
@@ -132,7 +133,7 @@ namespace hal::battery
         });
 
         worker_queue = std::make_unique<BatteryWorkerQueue>(
-            "battery_charger", [this](const auto &msg) { handleIrqEvents(msg); }, 1024);
+            "battery_charger", [this](const auto &msg) { handleIrqEvents(msg); }, workerStackSize);
 
         pollFuelGauge();
 

--- a/module-bsp/bsp/battery_charger/battery_charger.hpp
+++ b/module-bsp/bsp/battery_charger/battery_charger.hpp
@@ -1,6 +1,11 @@
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
 #pragma once
 
-namespace bsp::battery_charger {
+namespace bsp::battery_charger
+{
     int getAvgCurrent();
     int getCurrentMeasurement();
-}
+} // namespace bsp::battery_charger
+


### PR DESCRIPTION
The battery charger worker had only ~10% free
stack size so it was a possibility to stack overflow. 
After increasing the stack by 512 bytes the worker has ~40% free stack space.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
