### PR TITLE
[BH-1887] Speed up update process

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -16,6 +16,7 @@
 ### Changed / Improved
 * Updated FSL drivers from NXP
 * Increased battery charger stack size
+* Increased speed of update process
 
 ## [2.5.0 2024-02-09]
 

--- a/module-services/service-desktop/endpoints/update/UpdateHelper.cpp
+++ b/module-services/service-desktop/endpoints/update/UpdateHelper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <service-desktop/Constants.hpp>
@@ -20,11 +20,6 @@
 
 namespace sdesktop::endpoints
 {
-    namespace
-    {
-        constexpr auto chunkSize = 1024 * 128;
-    }
-
     struct UpdatePackageEntries
     {
         explicit UpdatePackageEntries(const json11::Json &json)
@@ -80,11 +75,13 @@ namespace sdesktop::endpoints
             return false;
         }
 
+        constexpr auto chunkSize = 128 * 1024;
+        auto rawDataBuffer       = std::make_unique<char[]>(chunkSize);
+
         MD5 md5;
-        std::vector<std::byte> raw_data(chunkSize);
         std::size_t bytesRead;
-        while ((bytesRead = std::fread(raw_data.data(), 1, chunkSize, fd)) > 0) {
-            md5.add(raw_data.data(), bytesRead);
+        while ((bytesRead = std::fread(rawDataBuffer.get(), sizeof(*rawDataBuffer.get()), chunkSize, fd)) > 0) {
+            md5.add(rawDataBuffer.get(), bytesRead);
         }
 
         std::fclose(fd);

--- a/module-utils/tar/include/tar/tar.hpp
+++ b/module-utils/tar/include/tar/tar.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -21,13 +21,16 @@ namespace tar
         bool is_file() const;
         bool is_directory() const;
 
-        void read(const std::byte *data, std::size_t size) const;
+        void read(std::uint8_t *data, std::size_t size) const;
 
       private:
         explicit entry(const std::filesystem::path &path);
         friend class iterator;
         mutable mtar_t handle{};
         mtar_header_t tar_header;
+
+        static constexpr auto streamBufferSize = 64 * 1024;
+        std::unique_ptr<char[]> streamBuffer;
     };
 
     class iterator

--- a/module-vfs/drivers/src/purefs/fs/filesystem_ext4.cpp
+++ b/module-vfs/drivers/src/purefs/fs/filesystem_ext4.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <memory>
@@ -394,7 +394,7 @@ namespace purefs::fs::drivers
             mnt,
             [](const char *path) {
                 if (ext4_inode_exist(path, EXT4_DE_DIR) == 0) {
-                    LOG_WARN("rmdir syscall instead of unlink is recommended for remove directory");
+                    LOG_WARN("rmdir syscall instead of unlink is recommended to remove directory");
                     return -ext4_dir_rm(path);
                 }
                 else {

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -12,6 +12,7 @@
 ### Changed / Improved
 * Updated share capital in EULA.
 * Updated copy on final onboarding screen.
+* Increased speed of update process.
 
 ## [1.11.0 2023-12-15]
 


### PR DESCRIPTION
* Added stream buffering for reading data 
from tar archive with update.
* Increased size of the buffer used for 
unpacking files from tar archive.
* Changed buffers data type from vectors 
to raw heap-allocated arrays.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
