### PR TITLE
[BH-1883] Add a low battery notification on home screen with quotes

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -10,6 +10,7 @@
 * Added new clock face with quotes
 * Added a backend for quotes on home screen
 * Added progress bar to update process
+* Added low battery notification on home screen with quotes
 
 ### Changed / Improved
 * Updated FSL drivers from NXP

--- a/products/BellHybrid/apps/common/include/common/layouts/HomeScreenLayoutClassicWithQuotes.hpp
+++ b/products/BellHybrid/apps/common/include/common/layouts/HomeScreenLayoutClassicWithQuotes.hpp
@@ -25,5 +25,6 @@ namespace gui
       private:
         void showQuotes();
         void hideQuotes();
+        void adjustWidgetBox();
     };
 }; // namespace gui

--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassic.cpp
@@ -304,9 +304,17 @@ namespace gui
 
     void HomeScreenLayoutClassic::setBatteryLevelState(const Store::Battery &batteryContext)
     {
+        const bool batteryVisibility = isBatteryVisibilityAllowed(batteryContext);
         battery->update(batteryContext.level, isBatteryCharging(batteryContext.state));
-        battery->setVisible(isBatteryVisibilityAllowed(batteryContext));
+        battery->setVisible(batteryVisibility);
         battery->informContentChanged();
+
+        if (batteryVisibility && (onShowMessage != nullptr)) {
+            onShowMessage();
+        }
+        else if (!batteryVisibility && (onHideMessage != nullptr)) {
+            onHideMessage();
+        }
     }
 
     void HomeScreenLayoutClassic::setTime(std::time_t newTime)
@@ -358,15 +366,16 @@ namespace gui
     }
     auto HomeScreenLayoutClassic::updateUsbStatus(bool isConnected) -> void
     {
+        connectionStatus->show(isConnected);
+        connectionStatus->informContentChanged();
+        adjustConnectionStatusPosition();
+
         if (isConnected && (onShowMessage != nullptr)) {
             onShowMessage();
         }
         else if (!isConnected && (onHideMessage != nullptr)) {
             onHideMessage();
         }
-        connectionStatus->show(isConnected);
-        connectionStatus->informContentChanged();
-        adjustConnectionStatusPosition();
     }
 
     auto HomeScreenLayoutClassic::adjustConnectionStatusPosition() -> void

--- a/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassicWithQuotes.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/HomeScreenLayoutClassicWithQuotes.cpp
@@ -7,11 +7,13 @@
 #include <widgets/text/TextFixedSize.hpp>
 #include <widgets/TimeSetFmtSpinner.hpp>
 #include <widgets/BellConnectionStatus.hpp>
+#include <widgets/BellBattery.hpp>
 
 namespace
 {
     constexpr auto maxTimeBoxHeight{148U};
     constexpr auto textBoxHeight{120U};
+    constexpr auto infoBoxHeight{54U};
 
     constexpr auto imgBoxHeight{52U};
     constexpr auto imgTopMargin{10U};
@@ -30,9 +32,12 @@ namespace gui
         : HomeScreenLayoutClassic(std::move(name))
     {
         buildInterface();
-        onShowMessage = [this]() { hideQuotes(); };
+        onShowMessage = [this]() {
+            hideQuotes();
+            adjustWidgetBox();
+        };
         onHideMessage = [this]() {
-            if (!connectionStatus->isVisible()) {
+            if (!connectionStatus->isVisible() && !battery->visible) {
                 showQuotes();
             }
         };
@@ -61,14 +66,14 @@ namespace gui
         quoteImg->setMargins({0, imgTopMargin, 0, 0});
         quoteImg->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
 
-        /* We do not display information about the battery status at any time
-         * only about the status of the USB connection. */
-        widgetBox->removeWidget(infoBox);
         widgetBox->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
-        infoBox->setVisible(false);
-        /* Add item to body even if it won't fit to avoid manual memory
-         * management for item. */
-        widgetBox->addWidget(infoBox);
+
+        infoBox->setMinimumHeight(infoBoxHeight);
+        infoBox->setMaximumHeight(infoBoxHeight);
+        infoBox->setMargins(Margins(0, 0, 0, 0));
+
+        connectionBox->setMargins(Margins(0, 0, 0, 0));
+        battery->setMargins(Margins(0, 0, 0, 0));
 
         textBox = new VBox(nullptr);
         textBox->setMinimumSize(style::bell_base_layout::last_layout_w, textBoxHeight);
@@ -135,6 +140,13 @@ namespace gui
         authorWithDash.insert(&dash, 0);
         author->setText(authorWithDash);
         quotes->setText(quoteContent);
+    }
+
+    void HomeScreenLayoutClassicWithQuotes::adjustWidgetBox()
+    {
+        infoBox->setVisible(battery->visible);
+        connectionBox->setVisible(connectionStatus->isVisible());
+        widgetBox->informContentChanged();
     }
 
 }; // namespace gui


### PR DESCRIPTION
<!-- Please describe your pull request here -->

Below 20%, instead of quotes, the battery with percentage information about the charge level will appear on the main screen.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
