### PR TITLE
[BH-1913] Fix debug mode

### DIFF
--- a/module-bsp/board/rt1051/bellpx/board/pin_mux.h
+++ b/module-bsp/board/rt1051/bellpx/board/pin_mux.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 /*
@@ -97,6 +97,7 @@ extern "C"
 #define PINMUX_EMMC_CMD   IOMUXC_GPIO_SD_B1_05_USDHC2_CMD
 #define PINMUX_EMMC_RESET IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B
 
+    void PINMUX_InitEMMC(void);
     void emmc_pin_config(uint32_t freq);
 
 //#define PINMUX_AUDIOCODEC_SAIx_MCLK      IOMUXC_GPIO_AD_B0_10_SAI2_MCLK

--- a/module-bsp/board/rt1051/bellpx/pin_mux.c
+++ b/module-bsp/board/rt1051/bellpx/pin_mux.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 /*
@@ -298,6 +298,7 @@ void PINMUX_InitBootPins(void)
     PINMUX_InitDEBUG_UART();
     PINMUX_InitAudioCodec();
     PINMUX_InitEINK();
+    PINMUX_InitEMMC();
     PINMUX_InitBatteryCharger();
     PINMUX_InitEinkFrontlight();
     PINMUX_InitButtons();
@@ -1228,6 +1229,124 @@ void PINMUX_InitTempSensorPwr(void)
 
                         PAD_CONFIG_SLEW_RATE_SLOW | PAD_CONFIG_DRIVER_DISABLED | PAD_CONFIG_SPEED_SLOW_50MHz |
                             PAD_CONFIG_PULL_KEEPER_ENABLED | PAD_CONFIG_SELECT_PULL | PAD_CONFIG_PULL_DOWN_100kOhm);
+}
+
+void PINMUX_InitEMMC(void)
+{
+    CLOCK_EnableClock(kCLOCK_Iomuxc); /* iomuxc clock (iomuxc_clk_enable): 0x03u */
+
+    IOMUXC_SetPinMux(PINMUX_EMMC_CMD,   /* GPIO_SD_B0_00 is configured as USDHC1_CMD */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_CLK,   /* GPIO_SD_B0_01 is configured as USDHC1_CLK */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA0, /* GPIO_SD_B0_02 is configured as USDHC1_DATA0 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA1, /* GPIO_SD_B0_03 is configured as USDHC1_DATA1 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA2, /* GPIO_SD_B0_04 is configured as USDHC1_DATA2 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA3, /* GPIO_SD_B0_05 is configured as USDHC1_DATA3 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA4, /* GPIO_SD_B0_02 is configured as USDHC1_DATA0 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA5, /* GPIO_SD_B0_03 is configured as USDHC1_DATA1 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA6, /* GPIO_SD_B0_04 is configured as USDHC1_DATA2 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA7, /* GPIO_SD_B0_05 is configured as USDHC1_DATA3 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+
+    IOMUXC_SetPinConfig(PINMUX_EMMC_CMD,   /* GPIO_SD_B0_00 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_CLK,   /* GPIO_SD_B0_01 PAD functional properties : */
+                        0x014089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Disabled
+                                        Pull / Keep Select Field: Keeper
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA0, /* GPIO_SD_B0_02 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA1, /* GPIO_SD_B0_03 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA2, /* GPIO_SD_B0_04 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA3, /* GPIO_SD_B0_05 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA4, /* GPIO_SD_B0_02 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA5, /* GPIO_SD_B0_03 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA6, /* GPIO_SD_B0_04 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA7, /* GPIO_SD_B0_05 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
 }
 
 /***********************************************************************************************************************

--- a/module-bsp/board/rt1051/puretx/board/pin_mux.h
+++ b/module-bsp/board/rt1051/puretx/board/pin_mux.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 /*
@@ -97,6 +97,7 @@ extern "C"
 #define PINMUX_EMMC_CMD   IOMUXC_GPIO_SD_B1_05_USDHC2_CMD
 #define PINMUX_EMMC_RESET IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B
 
+    void PINMUX_InitEMMC(void);
     void emmc_pin_config(uint32_t freq);
 
 #define PINMUX_AUDIOCODEC_SAIx_MCLK      IOMUXC_GPIO_AD_B0_10_SAI2_MCLK

--- a/module-bsp/board/rt1051/puretx/pin_mux.c
+++ b/module-bsp/board/rt1051/puretx/pin_mux.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 /*
@@ -300,6 +300,7 @@ void PINMUX_InitBootPins(void)
     PINMUX_InitKeyboard();
     PINMUX_InitAudioCodec();
     PINMUX_InitEINK();
+    PINMUX_InitEMMC();
     PINMUX_InitBluetoothPins();
     PINMUX_InitCellular();
     PINMUX_InitLEDDRIVER();
@@ -1447,6 +1448,124 @@ void PINMUX_InitLightSensor(void)
     IOMUXC_SetPinConfig(PINMUX_LIGHT_SENSOR_IRQ_PIN,
                         PAD_CONFIG_SLEW_RATE_SLOW | PAD_CONFIG_DRIVER_DISABLED | PAD_CONFIG_SPEED_SLOW_50MHz |
                             PAD_CONFIG_PULL_KEEPER_ENABLED | PAD_CONFIG_SELECT_PULL | PAD_CONFIG_PULL_UP_22kOhm);
+}
+
+void PINMUX_InitEMMC(void)
+{
+    CLOCK_EnableClock(kCLOCK_Iomuxc); /* iomuxc clock (iomuxc_clk_enable): 0x03u */
+
+    IOMUXC_SetPinMux(PINMUX_EMMC_CMD,   /* GPIO_SD_B0_00 is configured as USDHC1_CMD */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_CLK,   /* GPIO_SD_B0_01 is configured as USDHC1_CLK */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA0, /* GPIO_SD_B0_02 is configured as USDHC1_DATA0 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA1, /* GPIO_SD_B0_03 is configured as USDHC1_DATA1 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA2, /* GPIO_SD_B0_04 is configured as USDHC1_DATA2 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA3, /* GPIO_SD_B0_05 is configured as USDHC1_DATA3 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA4, /* GPIO_SD_B0_02 is configured as USDHC1_DATA0 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA5, /* GPIO_SD_B0_03 is configured as USDHC1_DATA1 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA6, /* GPIO_SD_B0_04 is configured as USDHC1_DATA2 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(PINMUX_EMMC_DATA7, /* GPIO_SD_B0_05 is configured as USDHC1_DATA3 */
+                     0U);               /* Software Input On Field: Input Path is determined by functionality */
+
+    IOMUXC_SetPinConfig(PINMUX_EMMC_CMD,   /* GPIO_SD_B0_00 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_CLK,   /* GPIO_SD_B0_01 PAD functional properties : */
+                        0x014089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Disabled
+                                        Pull / Keep Select Field: Keeper
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA0, /* GPIO_SD_B0_02 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA1, /* GPIO_SD_B0_03 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA2, /* GPIO_SD_B0_04 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA3, /* GPIO_SD_B0_05 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA4, /* GPIO_SD_B0_02 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA5, /* GPIO_SD_B0_03 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA6, /* GPIO_SD_B0_04 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
+    IOMUXC_SetPinConfig(PINMUX_EMMC_DATA7, /* GPIO_SD_B0_05 PAD functional properties : */
+                        0x017089u);        /* Slew Rate Field: Fast Slew Rate
+                                        Drive Strength Field: R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)
+                                        Speed Field: medium(100MHz)
+                                        Open Drain Enable Field: Open Drain Disabled
+                                        Pull / Keep Enable Field: Pull/Keeper Enabled
+                                        Pull / Keep Select Field: Pull
+                                        Pull Up / Down Config. Field: 47K Ohm Pull Up
+                                        Hyst. Enable Field: Hysteresis Enabled */
 }
 
 /***********************************************************************************************************************

--- a/products/BellHybrid/BinaryAssetsVersions.cmake
+++ b/products/BellHybrid/BinaryAssetsVersions.cmake
@@ -1,7 +1,7 @@
 # This file sets versions of downloaded binaries for release packaging purposes
 
 if (NOT DEFINED ECOBOOT_BIN_VERSION)
-    set(ECOBOOT_BIN_VERSION 2.0.9 CACHE STRING "bootloader binary version to download from bootloader release page")
+    set(ECOBOOT_BIN_VERSION 2.0.10 CACHE STRING "bootloader binary version to download from bootloader release page")
 endif()
 
 if (NOT DEFINED RECOVERY_BIN_VERSION)


### PR DESCRIPTION
Add init eMMC pins to make sure that the pins
are configured in debug mode. If we run a debug mode the 1st bootloader is not run so the pins may have incorrect config.
Added config also for Pure.
Bump ecoboot version with this same fix.

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
