### PR TITLE
[BH-1896] Add opening the vertical lists on the currently set sound

### DIFF
--- a/module-db/Tables/MultimediaFilesTable.cpp
+++ b/module-db/Tables/MultimediaFilesTable.cpp
@@ -408,6 +408,9 @@ namespace db::multimedia_files
                                   recordPath + "'";
 
         std::unique_ptr<QueryResult> retQuery = db->query(query.c_str());
+        if ((retQuery == nullptr) || (retQuery->getRowCount() == 0)) {
+            return SortedRecord{.path = recordPath, .offset = 0};
+        }
         return SortedRecord{.path = (*retQuery)[1].getString(), .offset = (*retQuery)[0].getUInt32()};
     }
 } // namespace db::multimedia_files


### PR DESCRIPTION
<!-- Please describe your pull request here -->

Fix displaying vertical list before fileindexer ends

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
