### PR TITLE
[BH-1921] Fix debug session disconnects on entering WFI

### DIFF
--- a/module-bsp/board/rt1051/bellpx/bsp/lpm/WfiController.cpp
+++ b/module-bsp/board/rt1051/bellpx/bsp/lpm/WfiController.cpp
@@ -92,6 +92,11 @@ namespace bsp
             return ((PMU->REG_2P5 & PMU_REG_2P5_BO_VDD2P5_MASK) != 0);
         }
 
+        bool isDebugSessionActive()
+        {
+            return ((CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) != 0);
+        }
+
         void disableSystick()
         {
             SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
@@ -127,6 +132,11 @@ namespace bsp
             return 0;
         }
         timeSpentInWFI = 0;
+        if (isDebugSessionActive()) {
+            LOG_INFO("WFI disabled - active core debug session detected");
+            blockEnteringWfiMode();
+            return 0;
+        }
         if (isTimerTaskScheduledSoon()) {
             blockEnteringWfiMode();
             return 0;


### PR DESCRIPTION
Fix of the issue that debug session would sometimes 
disconnect when the CPU entered WFI mode due to
core clock being stopped.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
