### PR TITLE
[BH-1930] Fix no volume update in DB in Relaxation

### DIFF
--- a/module-apps/apps-common/popups/WindowWithTimer.hpp
+++ b/module-apps/apps-common/popups/WindowWithTimer.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -8,26 +8,32 @@
 
 namespace gui
 {
-    inline constexpr auto defautTimeout   = std::chrono::seconds{3};
-    inline constexpr auto noTimeoutChange = std::chrono::seconds::zero();
     class WindowWithTimer : public gui::AppWindow
     {
-      private:
-        sys::TimerHandle popupTimer;
-        std::chrono::milliseconds timeout;
-
       public:
-        explicit WindowWithTimer(app::ApplicationCommon *app,
-                                 const std::string &name,
-                                 const std::chrono::milliseconds timeout = defautTimeout);
-        void destroyInterface() override;
+        static constexpr auto defaultTimeout  = std::chrono::seconds{3};
+        static constexpr auto noTimeoutChange = std::chrono::seconds::zero();
+
+        WindowWithTimer(app::ApplicationCommon *app,
+                        const std::string &name,
+                        std::chrono::milliseconds timeout = defaultTimeout);
         ~WindowWithTimer() override;
+
+        void destroyInterface() override;
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
         void onClose(CloseReason reason) override;
         bool onInput(const gui::InputEvent &inputEvent) override;
 
+        /// Called before automatic switch to previous window at window's timer timeout.
+        void setWindowTimerActionCallback(std::function<void()> &&callback);
+
       protected:
         void detachTimerIfExists();
-        void resetTimer(const std::chrono::seconds newTimeout = noTimeoutChange);
+        void resetTimer(std::chrono::seconds newTimeout = noTimeoutChange);
+
+      private:
+        sys::TimerHandle popupTimer;
+        std::chrono::milliseconds timeout;
+        std::function<void()> windowTimerActionCallback;
     };
 } // namespace gui

--- a/module-apps/apps-common/widgets/BellBaseLayout.hpp
+++ b/module-apps/apps-common/widgets/BellBaseLayout.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -52,5 +52,4 @@ namespace gui
 
         void addSideArrows();
     };
-
 } /* namespace gui */

--- a/module-apps/apps-common/windows/AppWindow.hpp
+++ b/module-apps/apps-common/windows/AppWindow.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -121,5 +121,4 @@ namespace gui
 
         void startInputModeRestoreTimer(const std::function<void()> &inputModeRestoreFunction = nullptr);
     };
-
 } /* namespace gui */

--- a/module-gui/gui/widgets/Item.hpp
+++ b/module-gui/gui/widgets/Item.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -192,7 +192,7 @@ namespace gui
         /// @param newDim : new bounding box dimensions (item size & position)
         /// @note TODO should be fixed so that api would be consistent
         virtual bool onDimensionChanged(const BoundingBox &oldDim, const BoundingBox &newDim);
-        /// called on Timer event in application, triggeres timerCallback
+        /// called on Timer event in application, triggers timerCallback
         /// @param : timer timer element which triggered this action
         virtual bool onTimer(sys::Timer &timer);
 

--- a/module-gui/gui/widgets/Window.hpp
+++ b/module-gui/gui/widgets/Window.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -96,5 +96,4 @@ namespace gui
             return false;
         }
     };
-
 } /* namespace gui */

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationVolumeWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationVolumeWindow.cpp
@@ -5,8 +5,8 @@
 #include <data/RelaxationStyle.hpp>
 #include <ApplicationBellRelaxation.hpp>
 
-#include <apps-common/widgets/BellBaseLayout.hpp>
 #include <popups/data/PopupData.hpp>
+#include <apps-common/widgets/BellBaseLayout.hpp>
 #include <apps-common/widgets/ProgressTimerWithBarGraphAndCounter.hpp>
 
 namespace gui
@@ -73,6 +73,8 @@ namespace gui
 
         setFocusItem(body);
         body->resize();
+
+        setWindowTimerActionCallback([this]() { presenter->saveVolume(spinner->value()); });
     }
 
     bool RelaxationVolumeWindow::onInput(const InputEvent &inputEvent)
@@ -90,11 +92,5 @@ namespace gui
         progress->setValue(selectedValue);
         body->setMinMaxArrowsVisibility(selectedValue == data.min, selectedValue == data.max);
         return ret;
-    }
-
-    void RelaxationVolumeWindow::onClose(CloseReason reason)
-    {
-        presenter->saveVolume(spinner->value());
-        WindowWithTimer::onClose(reason);
     }
 } // namespace gui

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationVolumeWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationVolumeWindow.hpp
@@ -7,12 +7,13 @@
 
 #include <apps-common/popups/WindowWithTimer.hpp>
 #include <apps-common/widgets/spinners/Spinners.hpp>
-#include <common/models/AbstractAudioModel.hpp>
 #include <apps-common/widgets/BarGraph.hpp>
+#include <common/models/AbstractAudioModel.hpp>
 
 namespace gui
 {
     class BellBaseLayout;
+
     class RelaxationVolumeWindow : public WindowWithTimer
     {
       public:
@@ -28,6 +29,5 @@ namespace gui
 
         void buildInterface() override;
         bool onInput(const gui::InputEvent &inputEvent) override;
-        void onClose(CloseReason reason) override;
     };
 } // namespace gui


### PR DESCRIPTION
Fix of the issue that autoclose of volume
window in Relaxation would result in not
updating current volume value in database.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
