### PR TITLE
[BH-1935] Fix the backlight in pre-wake up

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -3,12 +3,13 @@
 ## Unreleased
 
 ### Fixed
+* Fixed the backlight blink in pre-wake up
 
 ### Added
 * Added custom alarms functionality
 
 ### Changed / Improved
-* Updated button handling during pre wake up
+* Updated button handling during pre-wake up
 
 ## [2.6.1 2024-04-02]
 

--- a/module-services/service-evtmgr/screen-light-control/ScreenLightControlParameters.hpp
+++ b/module-services/service-evtmgr/screen-light-control/ScreenLightControlParameters.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -34,8 +34,8 @@ namespace screen_light_control
         setManualModeBrightness,    ///< Set screen brightness in manual mode control
         setAutomaticModeParameters, ///< Set parameters for automatic mode of screen frontlight
         fadeOut,                    ///< Set light fade out in automatic mode
-        ignoreKeypress,             ///< Enter state that ignores keypress turnon
-        stopIgnoringKeypress,       ///< Leave state that ignores keypress turon
+        ignoreKeypress,             ///< Enter state that ignores keypress
+        stopIgnoringKeypress,       ///< Leave state that ignores keypress
     };
 
     struct ManualModeParameters

--- a/products/BellHybrid/alarms/BellAlarmHandler.cpp
+++ b/products/BellHybrid/alarms/BellAlarmHandler.cpp
@@ -1,10 +1,11 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "BellAlarmHandler.hpp"
 #include "src/actions/PlayAudioActions.hpp"
 #include "src/actions/NotifyGUIAction.hpp"
 #include "src/actions/FrontlightAction.hpp"
+#include "src/actions/IgnoreKeysAction.hpp"
 #include "src/actions/NotifyGUIBedtimeReminderAction.hpp"
 
 namespace alarms
@@ -52,6 +53,7 @@ namespace alarms
     {
         Actions actions;
         actions.emplace_back(factory::createPreWakeUpChimeAction(*service));
+        actions.emplace_back(std::make_unique<IgnoreKeysAction>(*service));
         return actions;
     }
 

--- a/products/BellHybrid/alarms/CMakeLists.txt
+++ b/products/BellHybrid/alarms/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(alarms
         src/actions/NotifyGUIAction.cpp
         src/actions/NotifyGUIBedtimeReminderAction.cpp
         src/actions/FrontlightAction.cpp
+        src/actions/IgnoreKeysAction.cpp
 
         include/AbstractAlarmAction.hpp
         include/BellAlarmHandler.hpp
@@ -15,6 +16,7 @@ target_sources(alarms
         src/actions/PlayAudioActions.hpp
         src/actions/FrontlightAction.hpp
         src/actions/NotifyGUIAction.hpp
+        src/actions/IgnoreKeysAction.hpp
         src/actions/NotifyGUIBedtimeReminderAction.hpp
     PUBLIC
         include/popups/AlarmActivatedPopupRequestParams.hpp

--- a/products/BellHybrid/alarms/src/actions/FrontlightAction.cpp
+++ b/products/BellHybrid/alarms/src/actions/FrontlightAction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "FrontlightAction.hpp"
@@ -144,6 +144,11 @@ namespace alarms
                                             screen_light_control::Action::stopIgnoringKeypress),
                                         service::name::evt_manager);
             }
+            break;
+        case SettingsDependency::Prewakeup:
+            service.bus.sendUnicast(
+                std::make_shared<sevm::ScreenLightControlMessage>(screen_light_control::Action::stopIgnoringKeypress),
+                service::name::evt_manager);
             break;
         default:
             break;

--- a/products/BellHybrid/alarms/src/actions/IgnoreKeysAction.cpp
+++ b/products/BellHybrid/alarms/src/actions/IgnoreKeysAction.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "IgnoreKeysAction.hpp"
+
+#include <service-evtmgr/ServiceEventManagerName.hpp>
+#include <service-evtmgr/ScreenLightControlMessage.hpp>
+
+namespace alarms
+{
+    IgnoreKeysAction::IgnoreKeysAction(sys::Service &service) : service{service}
+    {}
+    bool IgnoreKeysAction::execute()
+    {
+        return service.bus.sendUnicast(
+            std::make_shared<sevm::ScreenLightControlMessage>(screen_light_control::Action::ignoreKeypress),
+            service::name::evt_manager);
+    }
+    bool IgnoreKeysAction::turnOff()
+    {
+        return true;
+    }
+} // namespace alarms

--- a/products/BellHybrid/alarms/src/actions/IgnoreKeysAction.hpp
+++ b/products/BellHybrid/alarms/src/actions/IgnoreKeysAction.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+
+#include "AbstractAlarmAction.hpp"
+
+#include <Service/Service.hpp>
+
+namespace alarms
+{
+    class IgnoreKeysAction : public AbstractAlarmAction
+    {
+      public:
+        explicit IgnoreKeysAction(sys::Service &service);
+        bool execute() override;
+        bool turnOff() override;
+
+      private:
+        sys::Service &service;
+    };
+
+} // namespace alarms


### PR DESCRIPTION
If the chime is before the backlight we need to ignore keys. Otherwise, the back button will run the backlight.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
