### PR TITLE
[BH-1950] Fix incorrect Power Management statistics in the logs

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 * Fixed the backlight blink in pre-wake up
 * Fixed missing tooltip text in Onboarding in French
+* Fixed incorrect Power Management statistics in the logs
 
 ### Added
 * Added custom alarms functionality

--- a/module-sys/SystemManager/PowerManager.cpp
+++ b/module-sys/SystemManager/PowerManager.cpp
@@ -219,12 +219,7 @@ namespace sys
                              ? lowestLevelName
                              : (currentFreq == bsp::CpuFrequencyMHz::Level_6 ? highestLevelName : middleLevelName);
 
-        for (auto &level : cpuFrequencyMonitors) {
-            if (level.GetName() == levelName) {
-                level.IncreaseTicks(ticks - lastCpuFrequencyChangeTimestamp);
-            }
-        }
-
+        UpdateCpuFrequencyMonitor(levelName, ticks - lastCpuFrequencyChangeTimestamp);
         lastCpuFrequencyChangeTimestamp = ticks;
     }
 
@@ -235,6 +230,11 @@ namespace sys
                 level.IncreaseTicks(tickIncrease);
             }
         }
+    }
+
+    void PowerManager::UpdateCpuFrequencyMonitorTimestamp()
+    {
+        lastCpuFrequencyChangeTimestamp = xTaskGetTickCount();
     }
 
     void PowerManager::EnterWfiIfReady()
@@ -254,6 +254,7 @@ namespace sys
             lowPowerControl->EnableSysTick();
             portEXIT_CRITICAL();
             UpdateCpuFrequencyMonitor(WfiName, timeSpentInWFI);
+            UpdateCpuFrequencyMonitorTimestamp();
         }
     }
 

--- a/module-sys/SystemManager/include/SystemManager/PowerManager.hpp
+++ b/module-sys/SystemManager/include/SystemManager/PowerManager.hpp
@@ -76,6 +76,7 @@ namespace sys
         void SetCpuFrequency(bsp::CpuFrequencyMHz freq);
         void UpdateCpuFrequencyMonitor(bsp::CpuFrequencyMHz currentFreq);
         void UpdateCpuFrequencyMonitor(const std::string &name, std::uint32_t tickIncrease);
+        void UpdateCpuFrequencyMonitorTimestamp();
         [[nodiscard]] auto GetMinimumCpuFrequencyRequested() const noexcept -> sentinel::View;
 
         TickType_t lastCpuFrequencyChangeTimestamp{0};


### PR DESCRIPTION
<!-- Please describe your pull request here -->

When the CPU is in WFI mode, the CPU usage statistics should only reflect the WFI range and not the other frequency ranges.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
