### PR TITLE
[BH-1955] Fix incorrect Polish conjugation in Focus Timer

### DIFF
--- a/image/system_a/data/lang/Polski.json
+++ b/image/system_a/data/lang/Polski.json
@@ -40,7 +40,7 @@
     "app_bell_focus_long_break_after": "D\u0142uga przerwa po",
     "app_bell_focus_time_once": "czasie skupienia",
     "app_bell_focus_time_many": "czasach skupienia",
-    "app_bell_focus_summary": "<text>\u015awietnie! <token>$VALUE</token> skupienia<br></br> za tob\u0105.</text>",
+    "app_bell_focus_summary": "<text>\u015awietnie! <token>$VALUE</token> skupienia<br></br> za Tob\u0105.</text>",
     "app_bell_goodbye": "Do widzenia",
     "app_bell_greeting_msg": [
         "<text>Dzie\u0144 dobry!<br />Pobudka</text>"

--- a/products/BellHybrid/apps/application-bell-focus-timer/presenter/FocusTimerPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-focus-timer/presenter/FocusTimerPresenter.cpp
@@ -28,7 +28,7 @@ namespace
             focusTimeLengthString += utils::translate("common_minute_lower");
         }
         else {
-            focusTimeLengthString += utils::language::getCorrectMinutesAccusativeForm(focusMinutes);
+            focusTimeLengthString += utils::language::getCorrectMinutesNumeralForm(focusMinutes);
         }
 
         return focusTimeLengthString;

--- a/products/BellHybrid/apps/common/include/common/widgets/list_items/MinutesWithOff.hpp
+++ b/products/BellHybrid/apps/common/include/common/widgets/list_items/MinutesWithOff.hpp
@@ -22,7 +22,7 @@ namespace app::list_items
         void control_bottom_description(const spinner_type::value_type &value) final
         {
             bottomText->setVisible(value != 0);
-            bottomText->setRichText(utils::language::getCorrectMinutesAccusativeForm(value));
+            bottomText->setRichText(utils::language::getCorrectMinutesNumeralForm(value));
         }
     };
 } // namespace app::list_items


### PR DESCRIPTION
<!-- Please describe your pull request here -->

Fixed incorrect conjugation of word
"minuta" on Focus Timer summary
screen.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
