### PR TITLE
[BH-1944] Changing the rounding method for minutes in relaxation

### DIFF
--- a/module-apps/apps-common/widgets/TimeMinuteSecondWidget.hpp
+++ b/module-apps/apps-common/widgets/TimeMinuteSecondWidget.hpp
@@ -32,6 +32,7 @@ namespace gui
 
       private:
         DisplayType displayType;
+        std::optional<std::uint32_t> totalSeconds;
 
         static constexpr auto maxDigits{3U};
         VBox *mainBox{nullptr};

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.cpp
@@ -75,7 +75,7 @@ namespace gui
                                            0,
                                            relStyle::timer::maxSizeX,
                                            relStyle::timer::maxSizeY,
-                                           TimeMinuteSecondWidget::DisplayType::OnlyMinutes);
+                                           TimeMinuteSecondWidget::DisplayType::MinutesThenSeconds);
         timer->setMinimumSize(relStyle::timer::maxSizeX, relStyle::timer::maxSizeY);
         timer->setMargins(Margins(0, relStyle::timer::marginTop, 0, 0));
         timer->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));


### PR DESCRIPTION
<!-- Please describe your pull request here -->

Only at startup, when the number of seconds is less than 30, the minutes are rounded down, otherwise they are rounded up

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
