### PR TITLE
[BH-1971] Changing the refresh rate of the progress bar screen

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -17,6 +17,7 @@
 * Updated the countdown timer in Meditation app according to the new design
 * Updated the countdown timer in Power nap app according to the new design
 * Updated the countdown timer in Relaxation app according to the new design
+* Changed the refresh rate of the progress bar screen
 
 ## [2.6.1 2024-04-02]
 

--- a/module-apps/application-meditation/widgets/MeditationTimer.cpp
+++ b/module-apps/application-meditation/widgets/MeditationTimer.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MeditationTimer.hpp"
@@ -14,7 +14,7 @@
 namespace
 {
     inline constexpr auto meditationTimerName = "MeditationTimer";
-    inline constexpr std::chrono::seconds timerTick{1};
+    inline constexpr std::chrono::seconds initialInterval{1};
 } // namespace
 namespace gui
 {
@@ -56,7 +56,7 @@ namespace gui
         text->setEditMode(EditMode::Browse);
 
         timer = std::make_unique<app::ProgressTimerWithBarGraphAndCounter>(
-            application, *this, meditationTimerName, timerTick);
+            application, *this, meditationTimerName, initialInterval);
         timer->attach(progressBar);
         timer->attach(text);
         timer->registerOnIntervalCallback(std::bind(&MeditationTimer::playSound, this));

--- a/module-apps/apps-common/widgets/AbstractProgressTime.hpp
+++ b/module-apps/apps-common/widgets/AbstractProgressTime.hpp
@@ -8,11 +8,11 @@
 
 namespace gui
 {
-
     class AbstractProgressTime
     {
       public:
         virtual ~AbstractProgressTime()                = default;
         virtual void updateTime(std::uint32_t seconds) = 0;
+        virtual std::chrono::seconds getRefreshTime()  = 0;
     };
 } // namespace gui

--- a/module-apps/apps-common/widgets/ProgressTimer.cpp
+++ b/module-apps/apps-common/widgets/ProgressTimer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "ProgressTimer.hpp"
@@ -51,6 +51,14 @@ namespace app
         };
         timerTask            = app::GuiTimerFactory::createPeriodicTimer(app, &parent, name, baseTickInterval);
         timerTask.start();
+    }
+
+    void ProgressTimer::updateInterval(std::chrono::milliseconds newInterval)
+    {
+        if (baseTickInterval != newInterval) {
+            baseTickInterval = newInterval;
+            timerTask.restart(newInterval);
+        }
     }
 
     auto ProgressTimer::onTimerTimeout(sys::Timer &task) -> bool

--- a/module-apps/apps-common/widgets/ProgressTimer.hpp
+++ b/module-apps/apps-common/widgets/ProgressTimer.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 #pragma once
 
@@ -54,6 +54,7 @@ namespace app
         utils::time::Duration::DisplayedFormat displayFormat;
 
         void startTimer();
+        void updateInterval(std::chrono::milliseconds newInterval);
 
         [[nodiscard]] auto onTimerTimeout(sys::Timer &timerTask) -> bool;
         [[nodiscard]] auto isFinished() const noexcept -> bool;

--- a/module-apps/apps-common/widgets/ProgressTimerWithBarGraphAndCounter.cpp
+++ b/module-apps/apps-common/widgets/ProgressTimerWithBarGraphAndCounter.cpp
@@ -21,6 +21,7 @@ namespace app
         updateProgress();
         updateTimeWidget();
         ProgressTimer::update();
+        updateInterval(timeWidget->getRefreshTime());
     }
 
     void ProgressTimerWithBarGraphAndCounter::updateText()

--- a/module-apps/apps-common/widgets/TimeMinuteSecondWidget.hpp
+++ b/module-apps/apps-common/widgets/TimeMinuteSecondWidget.hpp
@@ -27,12 +27,14 @@ namespace gui
                                DisplayType type = DisplayType::OnlyMinutes);
 
         void updateTime(std::uint32_t sec) override;
+        std::chrono::seconds getRefreshTime() override;
         void buildInterface(std::uint32_t w, std::uint32_t h);
         void setText(std::uint32_t value);
 
       private:
         DisplayType displayType;
         std::optional<std::uint32_t> totalSeconds;
+        std::uint32_t secondsLeft{0};
 
         static constexpr auto maxDigits{3U};
         VBox *mainBox{nullptr};

--- a/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusTimerWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusTimerWindow.cpp
@@ -13,7 +13,7 @@
 namespace
 {
     constexpr auto progressTimerName{"FocusProgressTimer"};
-    constexpr auto progressTimerPeriod{std::chrono::seconds{1}};
+    constexpr auto initialInterval{std::chrono::seconds{1}};
     constexpr auto progressMode{app::ProgressCountdownMode::Increasing};
 } // namespace
 
@@ -227,7 +227,7 @@ namespace app::focus
     void FocusTimerWindow::configureTimer()
     {
         auto progressTimer = std::make_unique<app::ProgressTimerWithBarGraphAndCounter>(
-            application, *this, progressTimerName, progressTimerPeriod, progressMode);
+            application, *this, progressTimerName, initialInterval, progressMode);
         progressTimer->attach(progress);
         progressTimer->attach(timer);
         presenter->setTimer(std::move(progressTimer));

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.cpp
@@ -14,7 +14,7 @@
 namespace
 {
     constexpr auto meditationCountdownTimerName{"MeditationCountdownTimer"};
-    constexpr std::chrono::seconds meditationCountdownTimerPeriod{1};
+    constexpr std::chrono::seconds initialInterval{1};
     constexpr auto meditationCountdownMode{app::ProgressCountdownMode::Increasing};
     constexpr auto leftBoxSize{1};
 } // namespace
@@ -110,7 +110,7 @@ namespace gui
     void MeditationCountdownWindow::configureTimer()
     {
         auto progressTimer = std::make_unique<app::ProgressTimerWithBarGraphAndCounter>(
-            application, *this, meditationCountdownTimerName, meditationCountdownTimerPeriod, meditationCountdownMode);
+            application, *this, meditationCountdownTimerName, initialInterval, meditationCountdownMode);
         progressTimer->attach(timer);
         presenter->setTimer(std::move(progressTimer));
     }

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.cpp
@@ -15,7 +15,7 @@
 namespace
 {
     constexpr auto meditationProgressTimerName{"MeditationProgressTimer"};
-    constexpr std::chrono::seconds meditationProgressTimerPeriod{1};
+    constexpr std::chrono::seconds initialInterval{1};
     constexpr auto meditationProgressMode{app::ProgressCountdownMode::Increasing};
 } // namespace
 
@@ -152,7 +152,7 @@ namespace gui
     void MeditationRunningWindow::configureTimer()
     {
         auto progressTimer = std::make_unique<app::ProgressTimerWithBarGraphAndCounter>(
-            application, *this, meditationProgressTimerName, meditationProgressTimerPeriod, meditationProgressMode);
+            application, *this, meditationProgressTimerName, initialInterval, meditationProgressMode);
         progressTimer->attach(progress);
         progressTimer->attach(timer);
         presenter->setTimer(std::move(progressTimer));

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
@@ -11,7 +11,7 @@
 namespace
 {
     constexpr auto powerNapTimerName{"PowerNapTimer"};
-    constexpr auto powerNapTimerPeriod{std::chrono::seconds{1}};
+    constexpr auto initialInterval{std::chrono::seconds{1}};
 } // namespace
 
 namespace gui
@@ -97,7 +97,7 @@ namespace gui
     void PowerNapProgressWindow::configureTimer()
     {
         auto progressTimer = std::make_unique<app::ProgressTimerWithBarGraphAndCounter>(
-            application, *this, powerNapTimerName, powerNapTimerPeriod, app::ProgressCountdownMode::Increasing);
+            application, *this, powerNapTimerName, initialInterval, app::ProgressCountdownMode::Increasing);
         progressTimer->attach(progress);
         progressTimer->attach(timer);
         presenter->setTimer(std::move(progressTimer));

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.cpp
@@ -13,7 +13,7 @@
 namespace
 {
     constexpr auto relaxationProgressTimerName{"RelaxationProgressTimer"};
-    constexpr std::chrono::seconds relaxationProgressTimerPeriod{1};
+    constexpr std::chrono::seconds initialInterval{1};
     constexpr auto relaxationProgressMode{app::ProgressCountdownMode::Increasing};
 } // namespace
 
@@ -154,7 +154,7 @@ namespace gui
     void RelaxationRunningProgressWindow::configureTimer()
     {
         auto progressTimer = std::make_unique<app::ProgressTimerWithBarGraphAndCounter>(
-            application, *this, relaxationProgressTimerName, relaxationProgressTimerPeriod, relaxationProgressMode);
+            application, *this, relaxationProgressTimerName, initialInterval, relaxationProgressMode);
         progressTimer->attach(progress);
         progressTimer->attach(timer);
         presenter->setTimer(std::move(progressTimer));

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationVolumeWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationVolumeWindow.cpp
@@ -7,7 +7,6 @@
 
 #include <popups/data/PopupData.hpp>
 #include <apps-common/widgets/BellBaseLayout.hpp>
-#include <apps-common/widgets/ProgressTimerWithBarGraphAndCounter.hpp>
 
 namespace gui
 {

--- a/products/BellHybrid/apps/common/include/common/widgets/list_items/details.hpp
+++ b/products/BellHybrid/apps/common/include/common/widgets/list_items/details.hpp
@@ -8,7 +8,6 @@
 #include <common/data/StyleCommon.hpp>
 
 #include <apps-common/widgets/spinners/Spinners.hpp>
-#include <apps-common/widgets/ProgressTimerWithBarGraphAndCounter.hpp>
 #include <apps-common/widgets/BarGraph.hpp>
 #include "common/data/ListItemBarStyle.hpp"
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

The longer the time countdown on the progress bar, the less frequently the screen is refreshed, which results in less power consumption when running the Meditation, Relaxation, Power Nap and Focus Timer applications.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
