### PR TITLE
[MOS-1069] Change A2DP stream volume scale to exponential

### DIFF
--- a/module-bluetooth/Bluetooth/audio/BluetoothAudioDevice.hpp
+++ b/module-bluetooth/Bluetooth/audio/BluetoothAudioDevice.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -6,6 +6,7 @@
 #include <Audio/Endpoint.hpp>
 #include <Audio/AudioDevice.hpp>
 #include <Audio/AudioFormat.hpp>
+#include <Audio/Stream.hpp>
 #include <interface/profiles/A2DP/MediaContext.hpp>
 #include <interface/profiles/AudioProfile.hpp>
 
@@ -16,7 +17,6 @@ extern "C"
 
 namespace bluetooth
 {
-
     class BluetoothAudioDevice : public audio::AudioDevice
     {
       public:
@@ -37,6 +37,8 @@ namespace bluetooth
         auto isInputEnabled() const -> bool;
         auto isOutputEnabled() const -> bool;
         auto fillSbcAudioBuffer() -> int;
+        auto scaleVolume(audio::Stream::Span &dataSpan) const -> void;
+
         float outputVolume;
 
       private:
@@ -95,10 +97,10 @@ namespace bluetooth
         static constexpr auto packetLengthOffset = 2;
         static constexpr auto packetDataOffset   = 3;
 
-        constexpr static auto supportedBitWidth = 16U;
-        constexpr static auto supportedChannels = 1;
+        static constexpr auto supportedBitWidth = 16U;
+        static constexpr auto supportedChannels = 1;
 
-        constexpr static auto allGoodMask = 0x30;
+        static constexpr auto allGoodMask = 0x30;
 
         auto decodeCVSD(audio::AbstractStream::Span dataToDecode) -> audio::AbstractStream::Span;
 
@@ -108,5 +110,4 @@ namespace bluetooth
         btstack_cvsd_plc_state_t cvsdPlcState;
         hci_con_handle_t aclHandle;
     };
-
 } // namespace bluetooth

--- a/module-utils/utility/Utils.hpp
+++ b/module-utils/utility/Utils.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -352,6 +352,16 @@ namespace utils
         return ((((toSwap)&0xff000000) >> 24) | (((toSwap)&0x00ff0000) >> 8) | (((toSwap)&0x0000ff00) << 8) |
                 (((toSwap)&0x000000ff) << 24));
 #endif
+    }
+
+    template <typename T, std::size_t N, typename Generator>
+    [[nodiscard]] inline constexpr std::array<T, N> makeArray(Generator g)
+    {
+        std::array<T, N> array{};
+        for (std::size_t i = 0; i < N; ++i) {
+            array[i] = g(i);
+        }
+        return array;
     }
 
     [[nodiscard]] std::string generateRandomId(std::size_t length) noexcept;

--- a/pure_changelog.md
+++ b/pure_changelog.md
@@ -9,6 +9,7 @@
 
 ### Changed / Improved
 * Increased speed of update process.
+* Changed A2DP volume control scale from linear to exponential.
 
 ## [1.12.0 2024-03-07]
 


### PR DESCRIPTION
Fix of the issue that A2DP stream volume
was controlled using naive approach
with linear scaling instead of
exponential one, what resulted in
highly non-linear volume control
experience.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
