### PR TITLE
[BH-2000] Change order of entries in Settings

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -13,6 +13,7 @@
 ### Changed / Improved
 * Changed the refresh rate of the progress bar screen
 * Extended range of supported chargers.
+* Changed order of options in Settings menu.
 
 ## [2.7.0 2024-05-20]
 

--- a/products/BellHybrid/apps/application-bell-settings/windows/BellSettingsWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/windows/BellSettingsWindow.cpp
@@ -65,12 +65,12 @@ namespace gui
         addWinSettings(
             utils::translate("app_bell_settings_language"), gui::window::name::bellSettingsLanguage, defaultCallback);
         addWinSettings(
+            utils::translate("app_bell_settings_frontlight"), gui::BellSettingsFrontlightWindow::name, defaultCallback);
+        addWinSettings(
             utils::translate("app_bell_settings_shortcuts"), window::name::bellSettingsShortcuts, defaultCallback);
         addWinSettings(utils::translate("app_bell_update_instruction_title"),
                        window::name::bellSettingsUpdateInstruction,
                        defaultCallback);
-        addWinSettings(
-            utils::translate("app_bell_settings_frontlight"), gui::BellSettingsFrontlightWindow::name, defaultCallback);
         addWinSettings(utils::translate("app_bell_settings_about"), gui::AboutYourBellWindow::name, defaultCallback);
         addWinSettings(
             utils::translate("app_bell_settings_turn_off"), BellTurnOffOptionWindow::defaultName, defaultCallback);


### PR DESCRIPTION
Changed order of entries in Settings menu, so
that they're grouped in logical categories.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
