### PR TITLE
[BH-2002] Fix crash when connected with broken USB cable

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -12,8 +12,9 @@
 
 ### Changed / Improved
 * Changed the refresh rate of the progress bar screen
-* Extended range of supported chargers.
-* Changed order of options in Settings menu.
+* Extended range of supported chargers
+* Changed order of options in Settings menu
+* Improved device stability with low quality USB cables
 
 ## [2.7.0 2024-05-20]
 

--- a/module-services/service-desktop/WorkerDesktop.cpp
+++ b/module-services/service-desktop/WorkerDesktop.cpp
@@ -41,7 +41,7 @@ bool WorkerDesktop::init(std::list<sys::WorkerQueueInfo> queues)
     receiveQueue = Worker::getQueueHandleByName(sdesktop::cdcReceiveQueueName);
     sdesktop::endpoints::sender::setSendQueueHandle(Worker::getQueueHandleByName(sdesktop::cdcSendQueueName));
 
-    cpuSentinel                  = std::make_shared<sys::CpuSentinel>("WorkerDesktop", ownerService);
+    cpuSentinel                  = std::make_shared<sys::CpuSentinel>(cpuSentinelName, ownerService);
     auto sentinelRegistrationMsg = std::make_shared<sys::SentinelRegistrationMessage>(cpuSentinel);
     ownerService->bus.sendUnicast(std::move(sentinelRegistrationMsg), service::name::system_manager);
 
@@ -79,8 +79,8 @@ void WorkerDesktop::closeWorker()
     close();
 
     cpuSentinel->ReleaseMinimumFrequency();
-    auto sentinelRemoveMsg = std::make_shared<sys::SentinelRemovalMessage>("WorkerDesktop");
-    auto result            = ownerService->bus.sendUnicastSync(sentinelRemoveMsg, service::name::system_manager, 1000);
+    auto sentinelRemoveMsg = std::make_shared<sys::SentinelRemovalMessage>(cpuSentinelName);
+    auto result = ownerService->bus.sendUnicastSync(std::move(sentinelRemoveMsg), service::name::system_manager, 1000);
     if (result.first != sys::ReturnCodes::Success) {
         LOG_ERROR("Sentinel %s could not be removed!", cpuSentinel->GetName().c_str());
     }

--- a/module-services/service-desktop/WorkerDesktop.hpp
+++ b/module-services/service-desktop/WorkerDesktop.hpp
@@ -62,6 +62,8 @@ class WorkerDesktop : public sys::Worker
     sys::Service *ownerService = nullptr;
     sdesktop::endpoints::StateMachine parser;
 
+    static constexpr auto cpuSentinelName = "WorkerDesktop";
     std::shared_ptr<sys::CpuSentinel> cpuSentinel;
+
     std::function<void()> messageProcessedCallback;
 };

--- a/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
+++ b/module-services/service-desktop/include/service-desktop/ServiceDesktop.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -71,17 +71,17 @@ class ServiceDesktop : public sys::Service
     std::unique_ptr<WorkerDesktop> desktopWorker;
     Sync::OperationStatus syncStatus;
 
-    sys::ReturnCodes InitHandler() override;
-    sys::ReturnCodes DeinitHandler() override;
-    sys::ReturnCodes SwitchPowerModeHandler(sys::ServicePowerMode mode) override;
-    sys::MessagePointer DataReceivedHandler(sys::DataMessage *msg, sys::ResponseMessage *resp) override;
+    auto InitHandler() -> sys::ReturnCodes override;
+    auto DeinitHandler() -> sys::ReturnCodes override;
+    auto SwitchPowerModeHandler(sys::ServicePowerMode mode) -> sys::ReturnCodes override;
+    auto DataReceivedHandler(sys::DataMessage *msg, sys::ResponseMessage *resp) -> sys::MessagePointer override;
 
-    void prepareSyncData();
-    const Sync::OperationStatus getSyncStatus()
+    auto prepareSyncData() -> void;
+    auto getSyncStatus() const -> Sync::OperationStatus
     {
         return syncStatus;
     }
-    const sdesktop::USBSecurityModel *getSecurity()
+    auto getSecurity() const -> const sdesktop::USBSecurityModel *
     {
         return usbSecurityModel.get();
     }
@@ -93,7 +93,7 @@ class ServiceDesktop : public sys::Service
     auto getDeviceToken() -> std::string;
 
     auto getNotificationEntries() const -> std::vector<Outbox::NotificationEntry>;
-    void removeNotificationEntries(const std::vector<std::uint32_t> &);
+    auto removeNotificationEntries(const std::vector<std::uint32_t> &uidsOfNotificationsToBeRemoved) -> void;
     auto getMtpPath() const noexcept -> std::filesystem::path;
     auto getOnboardingState() const -> sdesktop::endpoints::OnboardingState;
 
@@ -103,24 +103,24 @@ class ServiceDesktop : public sys::Service
     std::unique_ptr<sdesktop::bluetooth::BluetoothMessagesHandler> btMsgHandler;
     OutboxNotifications outboxNotifications;
     sys::TimerHandle connectionActiveTimer;
-    static constexpr unsigned int DefaultLogFlushTimeoutInMs = 1000U;
+    static constexpr unsigned int defaultLogFlushTimeoutMs   = 1000U;
     bool initialized                                         = false;
     bool isPlugEventUnhandled                                = false;
     bool isUsbConfigured                                     = false;
     std::filesystem::path mtpRootPath;
 
-    void generateDeviceUniqueId();
+    auto generateDeviceUniqueId() -> void;
     auto getDeviceUniqueId() const -> std::string;
-    void setDeviceUniqueId(const std::string &token);
+    auto setDeviceUniqueId(const std::string &token) -> void;
 
     auto usbWorkerInit() -> sys::ReturnCodes;
     auto usbWorkerDeinit() -> sys::ReturnCodes;
 
-    void restartConnectionActiveTimer();
+    auto restartConnectionActiveTimer() -> void;
 
-    void checkChargingCondition();
+    auto checkChargingCondition() -> void;
 
-    void cleanFileSystemEndpointUndeliveredTransfers();
+    auto cleanFileSystemEndpointUndeliveredTransfers() -> void;
 
     template <typename T>
     auto connectHandler() -> bool


### PR DESCRIPTION
Fixes of the issues that would cause device crash 
when connected with broken USB cable:
* fixed memory leaks in VCOM init and deinit 
functions;
* guarded accessing desktopWorker object in 
message handlers, as messages are 
asynchronous and might arrive after worker has
already been destroyed. Not the cleanest solution, 
but does the trick.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
