### PR TITLE
[BH-000] Workaround for CI/CD issue

### DIFF
--- a/cmake/modules/Assets.cmake
+++ b/cmake/modules/Assets.cmake
@@ -30,6 +30,7 @@ function(add_assets_target)
         # Create 'golden copy' of DBs
         COMMAND mkdir -p ${_ASSETS_SYSTEM_DEST_DIR}/db/factory
         COMMAND rsync -qlptgoDu
+            --exclude '*.db-journal'
             ${_ASSETS_SYSTEM_DEST_DIR}/db/*
             ${_ASSETS_SYSTEM_DEST_DIR}/db/factory
 


### PR DESCRIPTION
Workaround for an issue that arised after
Jenkins has been migrated to new machine.
Because of some reason build would fail
on rsync'ing non-existent '.db-journal'
files - locally the same rsync works
perfectly fine.
These files are not needed anyway,
so temporary exclude them from
rsync.
This should be reverted after CI/CD
is fixed.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
