### PR TITLE
[BH-2020] Fix double-free in DecoderMP3

### DIFF
--- a/module-audio/Audio/decoder/DecoderMP3.cpp
+++ b/module-audio/Audio/decoder/DecoderMP3.cpp
@@ -49,7 +49,7 @@ namespace
 
 namespace audio
 {
-    DecoderMP3::DecoderMP3(const std::string &filePath) : Decoder(filePath)
+    DecoderMP3::DecoderMP3(const std::string &filePath) : Decoder(filePath), mp3(std::make_unique<drmp3>())
     {
         if (fileSize == 0) {
             return;
@@ -63,10 +63,7 @@ namespace audio
             LOG_INFO("No ID3V2 tag to skip");
         }
 
-        mp3 = std::make_unique<drmp3>();
-
-        drmp3_init(mp3.get(), drmp3Read, drmp3Seek, this, nullptr);
-        if (mp3 == nullptr) {
+        if (drmp3_init(mp3.get(), drmp3Read, drmp3Seek, this, nullptr) == DRMP3_FALSE) {
             LOG_ERROR("Unable to initialize MP3 decoder");
             return;
         }
@@ -80,7 +77,11 @@ namespace audio
 
     DecoderMP3::~DecoderMP3()
     {
+        if (!isInitialized) {
+            return;
+        }
         drmp3_uninit(mp3.get());
+        isInitialized = false;
     }
 
     void DecoderMP3::setPosition(float pos)


### PR DESCRIPTION
Fix of the issue that improper check
of dr_mp3 library initialization
success could result in double-free
of library internals in case
initialization was unsuccessful.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
