### PR TITLE
[BH-2019] Fix alarm sounds list after selected file deletion

### DIFF
--- a/products/BellHybrid/apps/application-bell-settings/presenter/alarm_settings/AlarmSettingsPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/presenter/alarm_settings/AlarmSettingsPresenter.cpp
@@ -113,6 +113,9 @@ namespace app::bell_settings
 
     auto AlarmSettingsPresenter::handleAudioError(const UTF8 &path, gui::AudioErrorType errorType) -> void
     {
+        if (audioErrorModel == nullptr) {
+            return;
+        }
         const bool validPath = !audioErrorModel->isPathOnErrorList(path);
         if (validPath) {
             audioErrorModel->addPathToErrorList(path, errorType);
@@ -122,6 +125,9 @@ namespace app::bell_settings
 
     auto AlarmSettingsPresenter::validatePath(const UTF8 &path) const -> bool
     {
+        if (audioErrorModel == nullptr) {
+            return true;
+        }
         const auto errorType = audioErrorModel->getErrorType(path);
         if (errorType.has_value()) {
             showAudioError(errorType.value());

--- a/products/BellHybrid/apps/application-bell-settings/widgets/SongsListViewItem.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/widgets/SongsListViewItem.cpp
@@ -58,13 +58,14 @@ namespace gui
             list->rebuildList(listview::RebuildType::InPlace);
             return false;
         };
-        auto onListItemFocusAcquire = [this](const db::multimedia_files::MultimediaFilesRecord &record) {
+        auto onListItemFocusAcquire = [this, songsModel](const db::multimedia_files::MultimediaFilesRecord &record) {
             const auto &recordPath = record.fileInfo.path;
 
             /* Suppress initial calls of this function while the list is being
-             * loaded, only handle those caused by knob rotation. */
+             * loaded, only handle those caused by knob rotation. If currently
+             * selected file's missing, just assume the list is already loaded. */
             if (!listLoadingDone) {
-                if (recordPath == value()) {
+                if ((recordPath == value()) || !songsModel->fileExists(value())) {
                     listLoadingDone = true;
                 }
             }

--- a/products/BellHybrid/apps/common/include/common/models/SongsModel.hpp
+++ b/products/BellHybrid/apps/common/include/common/models/SongsModel.hpp
@@ -54,9 +54,10 @@ namespace app
         auto updateRecordsCount() -> void;
         auto nextRecordExists(gui::Order order) -> bool;
 
-        auto updateCurrentlyChosenRecordPath(const std::string &path) -> void;
         auto getLabelsFilesCount() -> std::vector<std::pair<std::string, std::uint32_t>>;
+        auto updateCurrentlyChosenRecordPath(const std::string &path) -> void;
         [[nodiscard]] auto getCurrentlyChosenRecordPath() const -> std::string;
+        [[nodiscard]] auto fileExists(const std::string &path) -> bool;
 
       private:
         auto onMusicListRetrieved(const std::vector<db::multimedia_files::MultimediaFilesRecord> &records,

--- a/products/BellHybrid/apps/common/src/AudioModel.cpp
+++ b/products/BellHybrid/apps/common/src/AudioModel.cpp
@@ -40,16 +40,17 @@ namespace
 
     auto SendAudioRequest(sys::Service *serv, std::shared_ptr<service::AudioMessage> msg)
     {
-        auto msgType = static_cast<int>(msg->type);
         auto ret     = serv->bus.sendUnicastSync(msg, service::audioServiceName, sys::BusProxy::defaultTimeout);
         if (ret.first == sys::ReturnCodes::Success) {
             if (auto resp = std::dynamic_pointer_cast<service::AudioResponseMessage>(ret.second)) {
                 return resp;
             }
-            LOG_ERROR("Message type [%d] - not AudioResponseMessage", msgType);
+            LOG_ERROR("Message type '%s' - not AudioResponseMessage", magic_enum::enum_name(msg->type).data());
             return std::make_shared<service::AudioResponseMessage>(audio::RetCode::Failed);
         }
-        LOG_ERROR("Command %d Failed with %d error", msgType, static_cast<int>(ret.first));
+        LOG_ERROR("Command '%s' failed with error '%s'",
+                  magic_enum::enum_name(msg->type).data(),
+                  magic_enum::enum_name(ret.first).data());
         return std::make_shared<service::AudioResponseMessage>(audio::RetCode::Failed);
     }
 } // namespace

--- a/products/BellHybrid/apps/common/src/models/SongsModel.cpp
+++ b/products/BellHybrid/apps/common/src/models/SongsModel.cpp
@@ -133,4 +133,10 @@ namespace app
     {
         return currentlyChosenRecordPath;
     }
+
+    auto SongsModel::fileExists(const std::string &path) -> bool
+    {
+        std::error_code ec;
+        return std::filesystem::exists(path, ec);
+    }
 } // namespace app


### PR DESCRIPTION
Fix of the issue that removing custom
alarm file while the alarm was ringing
would result in "Unsupported media file"
popup being shown for any file on
alarm sound selection list.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
