### PR TITLE
[BH-2019] Fix crash after deleting WAV alarm sound

### DIFF
--- a/module-audio/Audio/decoder/DecoderWAV.cpp
+++ b/module-audio/Audio/decoder/DecoderWAV.cpp
@@ -15,6 +15,10 @@ namespace audio
 {
     DecoderWAV::DecoderWAV(const std::string &filePath) : Decoder(filePath), wav(std::make_unique<drwav>())
     {
+        if (fileSize == 0) {
+            return;
+        }
+
         if (drwav_init(wav.get(), drwavRead, drwavSeek, this, nullptr) == DRWAV_FALSE) {
             LOG_ERROR("Unable to init WAV decoder");
             return;


### PR DESCRIPTION
Fix of the issue that the device would crash
when entering alarm sound selection list
after deleting selected file during alarm
ringing, but only when file's format was
WAV.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [ ] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
