### PR TITLE
[BH-2024] Fix lack of alarm directory after updating software

### DIFF
--- a/scripts/lua/products/BellHybrid/scripts/update.lua
+++ b/scripts/lua/products/BellHybrid/scripts/update.lua
@@ -74,6 +74,16 @@ local function create_directories()
     lfs.mkdir(target_dir .. "/log")
     lfs.mkdir(target_dir .. "/crash_dumps")
     lfs.mkdir(target_dir .. "/var")
+
+    if not helpers.exists(paths.user_alarm_dir) then
+        print("Creating 'alarm' directory")
+        lfs.mkdir(paths.user_alarm_dir)
+    end
+
+    if not helpers.exists(paths.user_relaxation_dir) then
+        print("Creating 'relaxation' directory")
+        lfs.mkdir(paths.user_relaxation_dir)
+    end
 end
 
 local function migrate_db()


### PR DESCRIPTION
The alarm directory is created while updating the software.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
