### PR TITLE
[BH-2013] Add label with the name of the application on the countdown…

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -10,6 +10,7 @@
 * Added update instruction screen at end of onboarding
 * Added update instruction screen in Settings
 * Added volume setting for focus timer application
+* Added label with the name of the application on the countdown screens
 
 ### Changed / Improved
 * Changed the refresh rate of the progress bar screen

--- a/products/BellHybrid/apps/application-bell-meditation-timer/data/MeditationStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/data/MeditationStyle.hpp
@@ -11,56 +11,64 @@ namespace app::meditationStyle
     {
         namespace progress
         {
-            constexpr inline auto radius                   = 192;
-            constexpr inline auto penWidth                 = 3;
-            constexpr inline auto verticalDeviationDegrees = 38;
+            inline constexpr auto radius                   = 192U;
+            inline constexpr auto penWidth                 = 3U;
+            inline constexpr auto verticalDeviationDegrees = 38U;
         } // namespace progress
 
         namespace timer
         {
-            constexpr inline auto marginTop = 39;
-            constexpr inline auto maxSizeX  = 340;
-            constexpr inline auto maxSizeY  = 198;
+            inline constexpr auto marginTop = 19U;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 198U;
         } // namespace timer
 
         namespace pauseIcon
         {
-            constexpr inline auto image     = "big_pause";
-            constexpr inline auto marginTop = 39;
-            constexpr inline auto maxSizeX  = 203;
-            constexpr inline auto maxSizeY  = 203;
+            inline constexpr auto image     = "big_pause";
+            inline constexpr auto maxSizeX  = 203U;
+            inline constexpr auto maxSizeY  = 203U;
+            inline constexpr auto marginTop = timer::marginTop - (maxSizeY - timer::maxSizeY);
         } // namespace pauseIcon
 
         namespace clock
         {
-            constexpr inline auto marginTop = 17;
-            constexpr inline auto maxSizeX  = 340;
-            constexpr inline auto maxSizeY  = 84;
+            inline constexpr auto marginTop = 17U;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 84U;
         } // namespace clock
+
+        namespace bottomDescription
+        {
+            inline constexpr auto marginTop = 38U;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 80U;
+            inline constexpr auto font      = style::window::font::verybig;
+        } // namespace bottomDescription
     }     // namespace runningStyle
 
     namespace countdownStyle
     {
         namespace progress
         {
-            constexpr inline auto radius                   = runningStyle::progress::radius;
-            constexpr inline auto penWidth                 = 9;
-            constexpr inline auto verticalDeviationDegrees = runningStyle::progress::verticalDeviationDegrees;
+            inline constexpr auto radius                   = runningStyle::progress::radius;
+            inline constexpr auto penWidth                 = 9U;
+            inline constexpr auto verticalDeviationDegrees = runningStyle::progress::verticalDeviationDegrees;
         } // namespace progress
 
         namespace timer
         {
-            constexpr inline auto marginTop = 24;
-            constexpr inline auto maxSizeX  = runningStyle::timer::maxSizeX;
-            constexpr inline auto maxSizeY  = runningStyle::timer::maxSizeY;
+            inline constexpr auto marginTop = 24U;
+            inline constexpr auto maxSizeX  = runningStyle::timer::maxSizeX;
+            inline constexpr auto maxSizeY  = runningStyle::timer::maxSizeY;
         } // namespace timer
 
         namespace description
         {
-            constexpr inline auto font      = style::window::font::large;
-            constexpr inline auto marginTop = 63;
-            constexpr inline auto maxSizeX  = 380;
-            constexpr inline auto maxSizeY  = 102;
+            inline constexpr auto font      = style::window::font::large;
+            inline constexpr auto marginTop = 63U;
+            inline constexpr auto maxSizeX  = 380U;
+            inline constexpr auto maxSizeY  = 102U;
         } // namespace description
     }     // namespace countdownStyle
 
@@ -68,12 +76,12 @@ namespace app::meditationStyle
     {
         namespace text
         {
-            constexpr inline auto font = style::window::font::supersizemelight;
+            inline constexpr auto font = style::window::font::supersizemelight;
         }
 
         namespace minute
         {
-            constexpr inline auto font = style::window::font::largelight;
+            inline constexpr auto font = style::window::font::largelight;
         }
     } // namespace timerStyle
 } // namespace app::meditationStyle

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.cpp
@@ -90,6 +90,19 @@ namespace gui
         icon->image->set(runningStyle::pauseIcon::image, ImageTypeSpecifier::W_G);
         icon->setVisible(false);
 
+        bottomDescription = new gui::TextFixedSize(
+            mainVBox, 0, 0, runningStyle::bottomDescription::maxSizeX, runningStyle::bottomDescription::maxSizeY);
+        bottomDescription->setMaximumSize(runningStyle::bottomDescription::maxSizeX,
+                                          runningStyle::bottomDescription::maxSizeY);
+        bottomDescription->setFont(runningStyle::bottomDescription::font);
+        bottomDescription->setMargins(gui::Margins(0, 0, 0, 0));
+        bottomDescription->activeItem = false;
+        bottomDescription->setAlignment(
+            gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
+        bottomDescription->setRichText(utils::translate("app_bellmain_meditation_timer"));
+        bottomDescription->drawUnderline(false);
+        bottomDescription->setVisible(true);
+
         mainVBox->resizeItems();
     }
 

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.hpp
@@ -36,6 +36,7 @@ namespace gui
         VBox *mainVBox{nullptr};
         ArcProgressBar *progress{nullptr};
         TimeMinuteSecondWidget *timer{nullptr};
+        gui::TextFixedSize *bottomDescription{nullptr};
         Icon *icon{nullptr};
         gui::BellStatusClock *clock{nullptr};
 

--- a/products/BellHybrid/apps/application-bell-powernap/data/PowerNapStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/data/PowerNapStyle.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -13,40 +13,48 @@ namespace gui::powerNapStyle
     {
         namespace progress
         {
-            inline constexpr auto radius                   = 192;
-            inline constexpr auto penWidth                 = 3;
-            inline constexpr auto verticalDeviationDegrees = 38;
+            inline constexpr auto radius                   = 192U;
+            inline constexpr auto penWidth                 = 3U;
+            inline constexpr auto verticalDeviationDegrees = 38U;
         } // namespace progress
 
         namespace timer
         {
-            inline constexpr auto marginTop = 41;
+            inline constexpr auto marginTop = 19U;
             inline constexpr auto font      = style::window::font::supersizeme;
-            inline constexpr auto maxSizeX  = 340;
-            inline constexpr auto maxSizeY  = 198;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 198U;
         } // namespace timer
 
         namespace pauseIcon
         {
             inline constexpr auto image     = "big_pause";
-            inline constexpr auto marginTop = 39;
-            inline constexpr auto maxSizeX  = 203;
-            inline constexpr auto maxSizeY  = 203;
+            inline constexpr auto maxSizeX  = 203U;
+            inline constexpr auto maxSizeY  = 203U;
+            inline constexpr auto marginTop = timer::marginTop - (maxSizeY - timer::maxSizeY);
         } // namespace pauseIcon
 
         namespace ringIcon
         {
             inline constexpr auto image     = "big_bell_ringing";
-            inline constexpr auto marginTop = 39;
-            inline constexpr auto maxSizeX  = 210;
-            inline constexpr auto maxSizeY  = 203;
+            inline constexpr auto maxSizeX  = 210U;
+            inline constexpr auto maxSizeY  = 203U;
+            inline constexpr auto marginTop = timer::marginTop - (maxSizeY - timer::maxSizeY);
         } // namespace ringIcon
 
         namespace clock
         {
-            inline constexpr auto marginTop = 17;
-            inline constexpr auto maxSizeX  = 340;
-            inline constexpr auto maxSizeY  = 84;
+            inline constexpr auto marginTop = 17U;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 84U;
         } // namespace clock
+
+        namespace bottomDescription
+        {
+            inline constexpr auto marginTop = 38U;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 80U;
+            inline constexpr auto font      = style::window::font::verybig;
+        } // namespace bottomDescription
     }
 } // namespace gui::powerNapStyle

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
@@ -91,6 +91,19 @@ namespace gui
         iconRing->image->set(progressStyle::ringIcon::image, ImageTypeSpecifier::W_G);
         iconRing->setVisible(false);
 
+        bottomDescription = new gui::TextFixedSize(
+            mainVBox, 0, 0, progressStyle::bottomDescription::maxSizeX, progressStyle::bottomDescription::maxSizeY);
+        bottomDescription->setMaximumSize(progressStyle::bottomDescription::maxSizeX,
+                                          progressStyle::bottomDescription::maxSizeY);
+        bottomDescription->setFont(progressStyle::bottomDescription::font);
+        bottomDescription->setMargins(gui::Margins(0, 0, 0, 0));
+        bottomDescription->activeItem = false;
+        bottomDescription->setAlignment(
+            gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
+        bottomDescription->setRichText(utils::translate("app_bellmain_power_nap"));
+        bottomDescription->drawUnderline(false);
+        bottomDescription->setVisible(true);
+
         mainVBox->resizeItems();
     }
 

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.hpp
@@ -35,6 +35,7 @@ namespace gui
         VBox *mainVBox{nullptr};
         ArcProgressBar *progress{nullptr};
         TimeMinuteSecondWidget *timer{nullptr};
+        gui::TextFixedSize *bottomDescription{nullptr};
         BellStatusClock *clock{nullptr};
         Icon *iconPause{nullptr};
         Icon *iconRing{nullptr};

--- a/products/BellHybrid/apps/application-bell-relaxation/data/RelaxationStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/data/RelaxationStyle.hpp
@@ -49,7 +49,7 @@ namespace gui::relaxationStyle
 
         namespace timer
         {
-            inline constexpr auto marginTop = 41U;
+            inline constexpr auto marginTop = 19U;
             inline constexpr auto font      = style::window::font::supersizeme;
             inline constexpr auto maxSizeX  = 340U;
             inline constexpr auto maxSizeY  = 198U;
@@ -58,9 +58,9 @@ namespace gui::relaxationStyle
         namespace pauseIcon
         {
             inline constexpr auto image     = "big_pause";
-            inline constexpr auto marginTop = 39U;
             inline constexpr auto maxSizeX  = 203U;
             inline constexpr auto maxSizeY  = 203U;
+            inline constexpr auto marginTop = timer::marginTop - (maxSizeY - timer::maxSizeY);
         } // namespace pauseIcon
 
         namespace clock
@@ -69,5 +69,13 @@ namespace gui::relaxationStyle
             inline constexpr auto maxSizeX  = 340U;
             inline constexpr auto maxSizeY  = 84U;
         } // namespace clock
+
+        namespace bottomDescription
+        {
+            inline constexpr auto marginTop = 38U;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 80U;
+            inline constexpr auto font      = style::window::font::verybig;
+        } // namespace bottomDescription
     }     // namespace relStyle
 } // namespace gui::relaxationStyle

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.cpp
@@ -87,6 +87,18 @@ namespace gui
         icon->image->set(relStyle::pauseIcon::image, ImageTypeSpecifier::W_G);
         icon->setVisible(false);
 
+        bottomDescription = new gui::TextFixedSize(
+            mainVBox, 0, 0, relStyle::bottomDescription::maxSizeX, relStyle::bottomDescription::maxSizeY);
+        bottomDescription->setMaximumSize(relStyle::bottomDescription::maxSizeX, relStyle::bottomDescription::maxSizeY);
+        bottomDescription->setFont(relStyle::bottomDescription::font);
+        bottomDescription->setMargins(gui::Margins(0, 0, 0, 0));
+        bottomDescription->activeItem = false;
+        bottomDescription->setAlignment(
+            gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
+        bottomDescription->setRichText(utils::translate("app_bellmain_relaxation"));
+        bottomDescription->drawUnderline(false);
+        bottomDescription->setVisible(true);
+
         mainVBox->resizeItems();
     }
 

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.hpp
@@ -29,6 +29,7 @@ namespace gui
         VBox *mainVBox{nullptr};
         ArcProgressBar *progress{nullptr};
         TimeMinuteSecondWidget *timer{nullptr};
+        gui::TextFixedSize *bottomDescription{nullptr};
         Icon *icon{nullptr};
         BellStatusClock *clock{nullptr};
 


### PR DESCRIPTION
… screens

<!-- Please describe your pull request here -->

Harmony's UI will be consistent so that on each screen showing the elapsed time on a timer (Meditation, Relaxation and Focus Timer, Power nap) will have words indicating which feature is active. This is how it is done with the focus timer and has been added to other timers as well.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
