### PR TITLE
[BH-2025] Add alarm handling in What`s new application

### DIFF
--- a/products/BellHybrid/apps/application-bell-whats-new/ApplicationWhatsNew.cpp
+++ b/products/BellHybrid/apps/application-bell-whats-new/ApplicationWhatsNew.cpp
@@ -31,6 +31,14 @@ namespace app
         cpuSentinel->BlockWfiMode(false);
     }
 
+    sys::MessagePointer ApplicationWhatsNew::handleAppClose(sys::Message *msgl)
+    {
+        if (featuresModel != nullptr) {
+            featuresModel->setCurrentOsVersion();
+        }
+        return ApplicationCommon::handleAppClose(msgl);
+    }
+
     sys::ReturnCodes ApplicationWhatsNew::InitHandler()
     {
         auto ret = Application::InitHandler();

--- a/products/BellHybrid/apps/application-bell-whats-new/include/application-bell-whats-new/ApplicationWhatsNew.hpp
+++ b/products/BellHybrid/apps/application-bell-whats-new/include/application-bell-whats-new/ApplicationWhatsNew.hpp
@@ -36,6 +36,7 @@ namespace app
         void createUserInterface() override;
         void destroyUserInterface() override
         {}
+        sys::MessagePointer handleAppClose(sys::Message *msgl) override;
 
         sys::MessagePointer DataReceivedHandler(sys::DataMessage *msgl, sys::ResponseMessage *resp) override;
 


### PR DESCRIPTION
<!-- Please describe your pull request here -->

When the alarm rings during the What`s new application, the system handles the alarm and closes the current application. After the alarm ends, we go to the main application without showing any more new features.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
