### PR TITLE
[BH-2026] Add mechanism for getting previously OS version

### DIFF
--- a/module-utils/utility/CMakeLists.txt
+++ b/module-utils/utility/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(utility
     PRIVATE
         Utils.cpp
         Anonymize.cpp
+        Version.cpp
 
     PUBLIC
         integer.hpp
@@ -14,6 +15,7 @@ target_sources(utility
         Utils.hpp
         Units.hpp
         Anonymize.hpp
+        Version.hpp
 )
 
 target_include_directories(utility
@@ -28,6 +30,8 @@ target_link_libraries(utility
 
     PRIVATE
         hash-library::hash-library
+        json::json
+        purefs-paths
 )
 
 if (${ENABLE_TESTS})

--- a/module-utils/utility/Version.cpp
+++ b/module-utils/utility/Version.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#include "Version.hpp"
+
+#include <module-utils/i18n/JSONLoader.hpp>
+#include <log/log.hpp>
+
+namespace utils
+{
+
+    std::optional<std::string> getPreviousVersionFromFile(const std::filesystem::path &path)
+    {
+        const auto &load = utils::JSONLoader(path);
+        if (not load.has_value()) {
+            LOG_ERROR("Cannot parse %s to json", path.c_str());
+            return {};
+        }
+        const auto &json = load.value();
+        return json["prevOsVersion"].string_value();
+    }
+
+} // namespace utils

--- a/module-utils/utility/Version.hpp
+++ b/module-utils/utility/Version.hpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
+
+#pragma once
+#include <purefs/filesystem_paths.hpp>
+
+#include <string>
+#include <optional>
+
+namespace utils
+{
+    inline constexpr auto defaultPreviousVersion = "0.00.0";
+    std::optional<std::string> getPreviousVersionFromFile(const std::filesystem::path &path);
+} // namespace utils

--- a/products/BellHybrid/apps/application-bell-whats-new/models/WhatsNewFeaturesModel.cpp
+++ b/products/BellHybrid/apps/application-bell-whats-new/models/WhatsNewFeaturesModel.cpp
@@ -7,6 +7,8 @@
 #include <db/WhatsNewMessages.hpp>
 #include <service-db/Settings.hpp>
 #include <service-db/agents/settings/SystemSettings.hpp>
+#include <service-desktop/Constants.hpp>
+#include <module-utils/utility/Version.hpp>
 #include <product/version.hpp>
 #include <Utils.hpp>
 
@@ -52,9 +54,14 @@ namespace app::whatsnew::models
     WhatsNewFeaturesModel::WhatsNewFeaturesModel(app::ApplicationCommon *app, settings::Settings *settings)
         : settings{settings}
     {
-        const auto &lastVersion =
-            this->settings->getValue(settings::SystemProperties::osCurrentVersion, settings::SettingsScope::Global);
-        const auto &version = getVersionNumber(lastVersion);
+        auto previousVersion =
+            settings->getValue(settings::SystemProperties::osCurrentVersion, settings::SettingsScope::Global);
+        if (previousVersion == utils::defaultPreviousVersion) {
+            previousVersion = utils::getPreviousVersionFromFile(purefs::dir::getTemporaryPath() /
+                                                                sdesktop::paths::recoveryStatusFilename)
+                                  .value_or(utils::defaultPreviousVersion);
+        }
+        const auto &version = getVersionNumber(previousVersion);
         if (!version.has_value()) {
             LOG_ERROR("Failed to parse last version string!");
             return;

--- a/products/BellHybrid/services/appmgr/ApplicationManager.cpp
+++ b/products/BellHybrid/services/appmgr/ApplicationManager.cpp
@@ -13,9 +13,11 @@
 #include <service-evtmgr/BatteryMessages.hpp>
 #include <service-db/agents/settings/SystemSettings.hpp>
 #include <service-appmgr/Controller.hpp>
+#include <service-desktop/Constants.hpp>
 #include <popups/ChargingNotificationPopupRequestParams.hpp>
 #include <popups/ChargingDoneNotificationPopupRequestParams.hpp>
 #include <product/version.hpp>
+#include <module-utils/utility/Version.hpp>
 
 namespace app::manager
 {
@@ -127,8 +129,16 @@ namespace app::manager
 
     auto ApplicationManager::isWhatsNewAvailable() -> bool
     {
-        const auto &lastVersionNumber =
+        auto previousVersion =
             settings->getValue(settings::SystemProperties::osCurrentVersion, settings::SettingsScope::Global);
-        return lastVersionNumber != VERSION;
+        if (previousVersion == utils::defaultPreviousVersion) {
+            const auto version = utils::getPreviousVersionFromFile(purefs::dir::getTemporaryPath() /
+                                                                   sdesktop::paths::recoveryStatusFilename);
+            if (not version.has_value()) {
+                return true; // If we cannot get the version, display all What's New
+            }
+            previousVersion = version.value();
+        }
+        return previousVersion != VERSION;
     }
 } // namespace app::manager

--- a/scripts/lua/products/BellHybrid/scripts/entry.lua
+++ b/scripts/lua/products/BellHybrid/scripts/entry.lua
@@ -35,11 +35,18 @@ local function print_boot_reason()
     print(string.format("Boot reason: %s", rec.sys.boot_reason_str()))
 end
 
+local function get_os_version()
+    if helpers.exists(paths.version_file) then
+        return helpers.get_os_version(paths.version_file)
+    end
+    return "0.00.0"
+end
+
 local function generate_report_file(boot_reason_str, success, message)
     local file_path = paths.temp_dir .. "/recovery_status.json"
     local body = string.format(
-        "{\"version\": \"%s\",\"branch\": \"%s\",\"revision\": \"%s\",\"operation\": \"%s\",\"successful\": %s,\"message\": \"%s\"}",
-        rec.version(), rec.branch(), rec.revision(), boot_reason_str, tostring(success), message)
+        "{\"version\": \"%s\",\"branch\": \"%s\",\"revision\": \"%s\",\"operation\": \"%s\",\"successful\": %s,\"prevOsVersion\": \"%s\",\"message\": \"%s\"}",
+        rec.version(), rec.branch(), rec.revision(), boot_reason_str, tostring(success), get_os_version(), message)
     local fd = assert(io.open(file_path, 'w'))
     fd:write(body)
     fd:close()


### PR DESCRIPTION
This task relates to the What’s new feature that needs to know which version of MuditaOS was installed before the update. Normally What’s new uses a database to get the previous  version, but after the first run this field will be empty. To bypass this issue the PureRecovery needs to save the previous version in recovery_status.json that is generated after the update process.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
