### PR TITLE
[BH-2036] Fix missing label in the countdown to the start of meditation

### DIFF
--- a/products/BellHybrid/apps/application-bell-meditation-timer/data/MeditationStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/data/MeditationStyle.hpp
@@ -58,7 +58,7 @@ namespace app::meditationStyle
 
         namespace timer
         {
-            inline constexpr auto marginTop = 24U;
+            inline constexpr auto marginTop = 4U;
             inline constexpr auto maxSizeX  = runningStyle::timer::maxSizeX;
             inline constexpr auto maxSizeY  = runningStyle::timer::maxSizeY;
         } // namespace timer
@@ -70,6 +70,14 @@ namespace app::meditationStyle
             inline constexpr auto maxSizeX  = 380U;
             inline constexpr auto maxSizeY  = 102U;
         } // namespace description
+
+        namespace bottomDescription
+        {
+            inline constexpr auto marginTop = runningStyle::bottomDescription::marginTop;
+            inline constexpr auto maxSizeX  = runningStyle::bottomDescription::maxSizeX;
+            inline constexpr auto maxSizeY  = runningStyle::bottomDescription::maxSizeY;
+            inline constexpr auto font      = runningStyle::bottomDescription::font;
+        } // namespace bottomDescription
     }     // namespace countdownStyle
 
     namespace timerStyle

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.cpp
@@ -67,17 +67,29 @@ namespace gui
         description->setMaximumSize(countdownStyle::description::maxSizeX, countdownStyle::description::maxSizeY);
         description->setFont(countdownStyle::description::font);
         description->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
-        description->setMargins(gui::Margins(0, countdownStyle::description::marginTop, 0, 0));
+        description->setMargins(Margins(0, countdownStyle::description::marginTop, 0, 0));
 
-        timer = new gui::TimeMinuteSecondWidget(mainVBox,
-                                                0,
-                                                0,
-                                                countdownStyle::timer::maxSizeX,
-                                                countdownStyle::timer::maxSizeY,
-                                                gui::TimeMinuteSecondWidget::DisplayType::OnlySeconds);
+        timer = new TimeMinuteSecondWidget(mainVBox,
+                                           0,
+                                           0,
+                                           countdownStyle::timer::maxSizeX,
+                                           countdownStyle::timer::maxSizeY,
+                                           TimeMinuteSecondWidget::DisplayType::OnlySeconds);
         timer->setMinimumSize(countdownStyle::timer::maxSizeX, countdownStyle::timer::maxSizeY);
-        timer->setMargins(gui::Margins(0, countdownStyle::timer::marginTop, 0, 0));
+        timer->setMargins(Margins(0, countdownStyle::timer::marginTop, 0, 0));
         timer->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
+
+        bottomDescription = new TextFixedSize(
+            mainVBox, 0, 0, countdownStyle::bottomDescription::maxSizeX, countdownStyle::bottomDescription::maxSizeY);
+        bottomDescription->setMaximumSize(countdownStyle::bottomDescription::maxSizeX,
+                                          countdownStyle::bottomDescription::maxSizeY);
+        bottomDescription->setFont(countdownStyle::bottomDescription::font);
+        bottomDescription->setMargins(Margins(0, 0, 0, 0));
+        bottomDescription->activeItem = false;
+        bottomDescription->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
+        bottomDescription->setRichText(utils::translate("app_bellmain_meditation_timer"));
+        bottomDescription->drawUnderline(false);
+        bottomDescription->setVisible(true);
 
         mainVBox->resizeItems();
     }

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.hpp
@@ -29,10 +29,11 @@ namespace gui
 
       private:
         std::unique_ptr<app::meditation::MeditationCountdownContract::Presenter> presenter;
-        VBox *mainVBox                = nullptr;
-        Arc *progress                 = nullptr;
-        TimeMinuteSecondWidget *timer = nullptr;
-        Text *description             = nullptr;
+        VBox *mainVBox{nullptr};
+        Arc *progress{nullptr};
+        TimeMinuteSecondWidget *timer{nullptr};
+        Text *description{nullptr};
+        TextFixedSize *bottomDescription{nullptr};
 
         void buildLayout();
         void configureTimer();


### PR DESCRIPTION
<!-- Please describe your pull request here -->

The meditation start countdown screen will be consistent with the meditation screen.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
