### PR TITLE
[BH-2035] Update relaxation paused window

### DIFF
--- a/module-bsp/board/linux/hal/battery_charger/BatteryCharger.cpp
+++ b/module-bsp/board/linux/hal/battery_charger/BatteryCharger.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include <hal/battery_charger/AbstractBatteryCharger.hpp>
@@ -27,7 +27,6 @@ namespace hal::battery
         constexpr auto chargerTypeDcdSDP      = 'l';
         constexpr auto chargerTypeDcdCDP      = ';';
         constexpr auto chargerTypeDcdDCP      = '\'';
-
     } // namespace
 
     class BatteryCharger : public AbstractBatteryCharger

--- a/products/BellHybrid/apps/application-bell-relaxation/data/RelaxationStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/data/RelaxationStyle.hpp
@@ -8,28 +8,22 @@
 namespace gui::relaxationStyle
 {
     inline constexpr auto descriptionFont = style::window::font::verybiglight;
-    inline constexpr auto titleFont       = style::window::font::largelight;
-    inline constexpr auto clockFont       = style::window::font::largelight;
+    inline constexpr auto titleFont       = style::window::font::large;
     inline constexpr auto timerValueFont  = style::window::font::supersizemelight;
     inline constexpr auto volumeValueFont = style::window::font::supersizemelight;
 
     namespace ended
     {
-        inline constexpr auto image_top_margin    = 170U;
-        inline constexpr auto image_bottom_margin = 30U;
+        inline constexpr auto imageMarginTop    = 170U;
+        inline constexpr auto imageMarginBottom = 30U;
     } // namespace ended
 
     namespace title
     {
+        inline constexpr auto loopMarginTop       = 42U;
         inline constexpr auto maxLines            = 2U;
         inline constexpr auto width               = 400U;
     } // namespace title
-
-    namespace text
-    {
-        inline constexpr auto maxLines = title::maxLines;
-        inline constexpr auto minWidth = 300U;
-    } // namespace text
 
     namespace relStyle
     {
@@ -58,9 +52,10 @@ namespace gui::relaxationStyle
         namespace pauseIcon
         {
             inline constexpr auto image     = "big_pause";
-            inline constexpr auto maxSizeX  = 203U;
-            inline constexpr auto maxSizeY  = 203U;
-            inline constexpr auto marginTop = timer::marginTop - (maxSizeY - timer::maxSizeY);
+            inline constexpr auto minSizeX        = 203U;
+            inline constexpr auto loopMinSizeY    = 140U;
+            inline constexpr auto runningMinSizeY = 154U;
+            inline constexpr auto marginTop       = 63U;
         } // namespace pauseIcon
 
         namespace clock
@@ -70,12 +65,26 @@ namespace gui::relaxationStyle
             inline constexpr auto maxSizeY  = 84U;
         } // namespace clock
 
+        namespace loopedDescription
+        {
+            inline constexpr auto marginTop = -8;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 40U;
+            inline constexpr auto font      = style::window::font::big;
+        } // namespace loopedDescription
+
         namespace bottomDescription
         {
-            inline constexpr auto marginTop = 38U;
+            inline constexpr auto loopMarginTop   = 15U;
+            inline constexpr auto pausedMarginTop = 10U;
             inline constexpr auto maxSizeX  = 340U;
             inline constexpr auto maxSizeY  = 80U;
             inline constexpr auto font      = style::window::font::verybig;
         } // namespace bottomDescription
-    }     // namespace relStyle
+
+        namespace battery
+        {
+            inline constexpr auto loopMarginTop = 74U;
+        }
+    } // namespace relStyle
 } // namespace gui::relaxationStyle

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationEndedWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationEndedWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "RelaxationEndedWindow.hpp"
@@ -33,7 +33,7 @@ namespace gui
             new Icon(this, 0, 0, style::window_width, style::window_height, "big_namaste", "", ImageTypeSpecifier::W_G);
         icon->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
         icon->image->setMargins(
-            {0, gui::relaxationStyle::ended::image_top_margin, 0, gui::relaxationStyle::ended::image_bottom_margin});
+            {0, gui::relaxationStyle::ended::imageMarginTop, 0, gui::relaxationStyle::ended::imageMarginBottom});
         icon->text->setFont(style::window::font::verybiglight);
     }
 

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationPausedWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationPausedWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -13,14 +13,13 @@ namespace gui
     class RelaxationPausedWindow : public AppWindow, public app::relaxation::RelaxationPausedContract::View
     {
       public:
-        explicit RelaxationPausedWindow(
-            app::ApplicationCommon *app,
-            std::unique_ptr<app::relaxation::RelaxationPausedContract::Presenter> &&presenter);
+        RelaxationPausedWindow(app::ApplicationCommon *app,
+                               std::unique_ptr<app::relaxation::RelaxationPausedContract::Presenter> &&presenter);
 
       private:
         std::unique_ptr<app::relaxation::RelaxationPausedContract::Presenter> presenter;
 
-        gui::BellStatusClock *time = nullptr;
+        gui::BellStatusClock *clock{nullptr};
 
         void buildInterface() override;
         void setTime(std::time_t newTime) override;
@@ -29,5 +28,4 @@ namespace gui
         bool onInput(const InputEvent &inputEvent) override;
         RefreshModes updateTime() override;
     };
-
 } // namespace gui

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningLoopWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningLoopWindow.hpp
@@ -12,8 +12,8 @@
 
 namespace gui
 {
-    class HBarGraph;
-    class Text;
+    class TextFixedSize;
+
     class RelaxationRunningLoopWindow : public AppWindow, public app::relaxation::RelaxationRunningLoopContract::View
     {
       public:
@@ -25,10 +25,11 @@ namespace gui
         std::unique_ptr<app::relaxation::RelaxationRunningLoopContract::Presenter> presenter;
         std::unique_ptr<RelaxationAudioContext> audioContext;
 
-        gui::Text *title           = nullptr;
-        gui::Text *bottomText      = nullptr;
-        gui::BellStatusClock *time = nullptr;
-        gui::BellBattery *battery  = nullptr;
+        BellStatusClock *clock{nullptr};
+        TextFixedSize *titleText{nullptr};
+        TextFixedSize *loopedText{nullptr};
+        TextFixedSize *relaxationText{nullptr};
+        BellBattery *battery{nullptr};
 
         void buildInterface() override;
         void onBeforeShow(ShowMode mode, SwitchData *data) override;

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.cpp
@@ -43,6 +43,7 @@ namespace gui
     void RelaxationRunningProgressWindow::buildLayout()
     {
         using namespace gui::relaxationStyle;
+
         const auto progressArcRadius = relStyle::progressTime::radius;
         const auto progressArcWidth  = relStyle::progressTime::penWidth;
         const auto arcStartAngle     = -90 - relStyle::progressTime::verticalDeviationDegrees;
@@ -64,6 +65,7 @@ namespace gui
         progress->setMaximum(arcProgressSteps);
 
         mainVBox = new VBox(this, 0, 0, style::window_width, style::window_height);
+        mainVBox->setEdges(rectangle_enums::RectangleEdge::None);
 
         clock = new BellStatusClock(mainVBox);
         clock->setMaximumSize(relStyle::clock::maxSizeX, relStyle::clock::maxSizeY);
@@ -80,22 +82,23 @@ namespace gui
         timer->setMargins(Margins(0, relStyle::timer::marginTop, 0, 0));
         timer->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
 
-        icon = new Icon(mainVBox, 0, 0, 0, 0, {}, {});
-        icon->setMinimumSize(relStyle::pauseIcon::maxSizeX, relStyle::pauseIcon::maxSizeY);
-        icon->setMargins(gui::Margins(0, relStyle::pauseIcon::marginTop, 0, 0));
-        icon->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
-        icon->image->set(relStyle::pauseIcon::image, ImageTypeSpecifier::W_G);
-        icon->setVisible(false);
+        pauseBox = new VBox(mainVBox);
+        pauseBox->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
+        pauseBox->setEdges(RectangleEdge::None);
+        pauseBox->setMargins(Margins(0, relStyle::pauseIcon::marginTop, 0, 0));
+        pauseBox->setMinimumSize(relStyle::pauseIcon::minSizeX, relStyle::pauseIcon::runningMinSizeY);
+        new Image(pauseBox, relStyle::pauseIcon::image, ImageTypeSpecifier::W_G);
+        pauseBox->setVisible(false);
+        pauseBox->resizeItems();
 
-        bottomDescription = new gui::TextFixedSize(
-            mainVBox, 0, 0, relStyle::bottomDescription::maxSizeX, relStyle::bottomDescription::maxSizeY);
+        bottomDescription = new gui::TextFixedSize(mainVBox);
         bottomDescription->setMaximumSize(relStyle::bottomDescription::maxSizeX, relStyle::bottomDescription::maxSizeY);
         bottomDescription->setFont(relStyle::bottomDescription::font);
         bottomDescription->setMargins(gui::Margins(0, 0, 0, 0));
         bottomDescription->activeItem = false;
         bottomDescription->setAlignment(
             gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
-        bottomDescription->setRichText(utils::translate("app_bellmain_relaxation"));
+        bottomDescription->setText(utils::translate("app_bellmain_relaxation"));
         bottomDescription->drawUnderline(false);
         bottomDescription->setVisible(true);
 
@@ -152,14 +155,14 @@ namespace gui
     void RelaxationRunningProgressWindow::onPaused()
     {
         timer->setVisible(false);
-        icon->setVisible(true);
+        pauseBox->setVisible(true);
         mainVBox->resizeItems();
     }
 
     void RelaxationRunningProgressWindow::resume()
     {
         timer->setVisible(true);
-        icon->setVisible(false);
+        pauseBox->setVisible(false);
         mainVBox->resizeItems();
     }
 

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationRunningProgressWindow.hpp
@@ -29,8 +29,8 @@ namespace gui
         VBox *mainVBox{nullptr};
         ArcProgressBar *progress{nullptr};
         TimeMinuteSecondWidget *timer{nullptr};
-        gui::TextFixedSize *bottomDescription{nullptr};
-        Icon *icon{nullptr};
+        TextFixedSize *bottomDescription{nullptr};
+        VBox *pauseBox{nullptr};
         BellStatusClock *clock{nullptr};
 
         void setTime(std::time_t newTime) override;


### PR DESCRIPTION
Updated looped relaxation windows to match
new design.
Fixed issue with misaligned pause button
on timed relaxation windows.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
