### PR TITLE
[BH-2037] Fix text parsing on factory reset screen

### DIFF
--- a/products/BellHybrid/apps/common/src/options/BellOptionWithDescriptionWindow.cpp
+++ b/products/BellHybrid/apps/common/src/options/BellOptionWithDescriptionWindow.cpp
@@ -94,7 +94,7 @@ namespace gui
             descriptionBody->setRichText(title, std::move(tokenMap.value()));
         }
         else {
-            descriptionBody->setText(title);
+            descriptionBody->setRichText(title);
         }
 
         body->centerBox->setMargins(gui::Margins{0, top_center_margin, 0, 0});


### PR DESCRIPTION
Fix of a regression introduced by c6192fd9,
resulting in BellOptionWithDescriptionWindow
not parsing rich text in case no token map
is provided.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
