### PR TITLE
[BH-2038] Remove redundant frames around screen

### DIFF
--- a/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusMainWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusMainWindow.cpp
@@ -30,11 +30,11 @@ namespace app::focus
 
     std::list<Option> FocusMainWindow::settingsOptionsList()
     {
-        using ActivatedCallback = std::function<bool(gui::Item &)>;
+        using ActivatedCallback = std::function<bool(Item &)>;
         using Callback          = std::function<ActivatedCallback(const std::string &window)>;
 
         auto defaultCallback = [this](const std::string &window) {
-            return [window, this](gui::Item &) {
+            return [window, this](Item &) {
                 if (window.empty()) {
                     return false;
                 }
@@ -50,7 +50,7 @@ namespace app::focus
                 }
                 application->switchWindow(window);
             };
-            return [window, this](gui::Item &) {
+            return [window, this](Item &) {
                 const auto batteryState = presenter->getBatteryState();
                 const auto soc          = batteryState.level;
                 const auto isCharging   = presenter->isBatteryCharging(batteryState.state);
@@ -69,12 +69,12 @@ namespace app::focus
             };
         };
 
-        std::list<gui::Option> settingsOptionList;
+        std::list<Option> settingsOptionList;
         auto addWinSettings = [&](const UTF8 &name, const std::string &window, Callback &&callback) {
-            settingsOptionList.emplace_back(std::make_unique<gui::option::OptionBellMenu>(
+            settingsOptionList.emplace_back(std::make_unique<option::OptionBellMenu>(
                 name,
                 callback(window),
-                [=](gui::Item &item) {
+                [=](Item &item) {
                     // put focus change callback here
                     return true;
                 },

--- a/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusSettingsWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusSettingsWindow.cpp
@@ -12,6 +12,7 @@
 namespace app::focus
 {
     using namespace gui;
+
     SettingsWindow::SettingsWindow(app::ApplicationCommon *app,
                                    std::unique_ptr<SettingsContract::Presenter> presenter,
                                    const std::string &name)
@@ -35,7 +36,7 @@ namespace app::focus
         header->setTitleVisibility(false);
         navBar->setVisible(false);
 
-        sideListView = new gui::SideListView(
+        sideListView = new SideListView(
             this, 0U, 0U, this->getWidth(), this->getHeight(), presenter->getPagesProvider(), PageBarType::None);
         sideListView->setEdges(RectangleEdge::None);
 
@@ -44,13 +45,13 @@ namespace app::focus
         presenter->loadData();
     }
 
-    void SettingsWindow::onBeforeShow(gui::ShowMode mode, gui::SwitchData *data)
+    void SettingsWindow::onBeforeShow(ShowMode mode, SwitchData *data)
     {
         AppWindow::onBeforeShow(mode, data);
         setFocusItem(sideListView);
     }
 
-    bool SettingsWindow::onInput(const gui::InputEvent &inputEvent)
+    bool SettingsWindow::onInput(const InputEvent &inputEvent)
     {
         if (sideListView->onInput(inputEvent)) {
             return true;

--- a/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusSettingsWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusSettingsWindow.hpp
@@ -32,7 +32,7 @@ namespace app::focus
       private:
         void switchToExitWindow();
 
-        gui::SideListView *sideListView{};
+        gui::SideListView *sideListView{nullptr};
         std::unique_ptr<SettingsContract::Presenter> presenter;
         bool isSaveNeeded{false};
     };

--- a/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusTimerWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusTimerWindow.cpp
@@ -5,10 +5,12 @@
 #include <data/FocusTimerStyle.hpp>
 
 #include <Application.hpp>
-#include <apps-common/widgets/BellBaseLayout.hpp>
-#include <apps-common/ApplicationCommon.hpp>
+
+#include <gui/widgets/Icon.hpp>
+#include <common/widgets/BellStatusClock.hpp>
+#include <apps-common/widgets/BarGraph.hpp>
+#include <apps-common/widgets/TimeMinuteSecondWidget.hpp>
 #include <apps-common/widgets/ProgressTimerWithBarGraphAndCounter.hpp>
-#include <module-gui/gui/input/InputEvent.hpp>
 
 namespace
 {
@@ -19,6 +21,8 @@ namespace
 
 namespace app::focus
 {
+    using namespace gui;
+
     FocusTimerWindow::FocusTimerWindow(app::ApplicationCommon *app,
                                        std::unique_ptr<FocusTimerContract::Presenter> &&windowPresenter,
                                        const std::string &name)
@@ -50,60 +54,60 @@ namespace app::focus
         const auto arcSweepAngle    = 360 - (2 * runningStyle::progress::verticalDeviationDegrees);
         const auto arcProgressSteps = 1000;
 
-        gui::Arc::ShapeParams arcParams;
-        arcParams.setCenterPoint(gui::Point(getWidth() / 2, getHeight() / 2))
+        Arc::ShapeParams arcParams;
+        arcParams.setCenterPoint(Point(getWidth() / 2, getHeight() / 2))
             .setRadius(progressArcRadius)
             .setStartAngle(arcStartAngle)
             .setSweepAngle(arcSweepAngle)
             .setPenWidth(progressArcWidth)
-            .setBorderColor(gui::ColorFullBlack);
+            .setBorderColor(ColorFullBlack);
 
-        progress = new gui::ArcProgressBar(this,
-                                           arcParams,
-                                           gui::ArcProgressBar::ProgressDirection::CounterClockwise,
-                                           gui::ArcProgressBar::ProgressChange::DecrementFromFull);
+        progress = new ArcProgressBar(this,
+                                      arcParams,
+                                      ArcProgressBar::ProgressDirection::CounterClockwise,
+                                      ArcProgressBar::ProgressChange::DecrementFromFull);
         progress->setMaximum(arcProgressSteps);
 
-        mainVBox = new gui::VBox(this, 0, 0, style::window_width, style::window_height);
+        mainVBox = new VBox(this, 0, 0, style::window_width, style::window_height);
+        mainVBox->setEdges(RectangleEdge::None);
 
-        clock = new gui::BellStatusClock(mainVBox);
+        clock = new BellStatusClock(mainVBox);
         clock->setMaximumSize(runningStyle::clock::maxSizeX, runningStyle::clock::maxSizeY);
-        clock->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center));
-        clock->setMargins(gui::Margins(0, runningStyle::clock::marginTop, 0, 0));
+        clock->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
+        clock->setMargins(Margins(0, runningStyle::clock::marginTop, 0, 0));
 
-        timer = new gui::TimeMinuteSecondWidget(mainVBox,
-                                                0,
-                                                0,
-                                                runningStyle::timer::maxSizeX,
-                                                runningStyle::timer::maxSizeY,
-                                                gui::TimeMinuteSecondWidget::DisplayType::MinutesThenSeconds);
+        timer = new TimeMinuteSecondWidget(mainVBox,
+                                           0,
+                                           0,
+                                           runningStyle::timer::maxSizeX,
+                                           runningStyle::timer::maxSizeY,
+                                           TimeMinuteSecondWidget::DisplayType::MinutesThenSeconds);
         timer->setMinimumSize(runningStyle::timer::maxSizeX, runningStyle::timer::maxSizeY);
-        timer->setMargins(gui::Margins(0, runningStyle::timer::marginTop, 0, 0));
-        timer->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center));
+        timer->setMargins(Margins(0, runningStyle::timer::marginTop, 0, 0));
+        timer->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
 
-        iconPause = new gui::Icon(mainVBox, 0, 0, 0, 0, {}, {});
+        iconPause = new Icon(mainVBox, 0, 0, 0, 0, {}, {});
         iconPause->setMinimumSize(runningStyle::pauseIcon::maxSizeX, runningStyle::pauseIcon::maxSizeY);
-        iconPause->setMargins(gui::Margins(0, runningStyle::pauseIcon::marginTop, 0, 0));
-        iconPause->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
-        iconPause->image->set(runningStyle::pauseIcon::image, gui::ImageTypeSpecifier::W_G);
+        iconPause->setMargins(Margins(0, runningStyle::pauseIcon::marginTop, 0, 0));
+        iconPause->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
+        iconPause->image->set(runningStyle::pauseIcon::image, ImageTypeSpecifier::W_G);
         iconPause->setVisible(false);
 
-        iconRing = new gui::Icon(mainVBox, 0, 0, 0, 0, {}, {});
+        iconRing = new Icon(mainVBox, 0, 0, 0, 0, {}, {});
         iconRing->setMinimumSize(runningStyle::ringIcon::maxSizeX, runningStyle::ringIcon::maxSizeY);
-        iconRing->setMargins(gui::Margins(0, runningStyle::ringIcon::marginTop, 0, 0));
-        iconRing->setAlignment(gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
-        iconRing->image->set(runningStyle::ringIcon::image, gui::ImageTypeSpecifier::W_G);
+        iconRing->setMargins(Margins(0, runningStyle::ringIcon::marginTop, 0, 0));
+        iconRing->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
+        iconRing->image->set(runningStyle::ringIcon::image, ImageTypeSpecifier::W_G);
         iconRing->setVisible(false);
 
-        bottomDescription = new gui::TextFixedSize(
+        bottomDescription = new TextFixedSize(
             mainVBox, 0, 0, runningStyle::bottomDescription::maxSizeX, runningStyle::bottomDescription::maxSizeY);
         bottomDescription->setMaximumSize(runningStyle::bottomDescription::maxSizeX,
                                           runningStyle::bottomDescription::maxSizeY);
         bottomDescription->setFont(runningStyle::bottomDescription::font);
-        bottomDescription->setMargins(gui::Margins(0, 0, 0, 0));
+        bottomDescription->setMargins(Margins(0, 0, 0, 0));
         bottomDescription->activeItem = false;
-        bottomDescription->setAlignment(
-            gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
+        bottomDescription->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
         bottomDescription->setRichText(utils::translate("app_bell_focus_time"));
         bottomDescription->drawUnderline(false);
         bottomDescription->setVisible(true);
@@ -111,20 +115,20 @@ namespace app::focus
         mainVBox->resizeItems();
     }
 
-    void FocusTimerWindow::onBeforeShow(gui::ShowMode mode, gui::SwitchData *data)
+    void FocusTimerWindow::onBeforeShow(ShowMode mode, SwitchData *data)
     {
         AppWindow::onBeforeShow(mode, data);
         presenter->onBeforeShow();
         updateTime();
-        if (mode == gui::ShowMode::GUI_SHOW_INIT) {
+        if (mode == ShowMode::GUI_SHOW_INIT) {
             presenter->playGong();
             presenter->start();
         }
     }
 
-    bool FocusTimerWindow::onInput(const gui::InputEvent &inputEvent)
+    bool FocusTimerWindow::onInput(const InputEvent &inputEvent)
     {
-        if (inputEvent.isShortRelease(gui::KeyCode::KEY_ENTER)) {
+        if (inputEvent.isShortRelease(KeyCode::KEY_ENTER)) {
             if (presenter->isAllSessionsFinished()) {
                 presenter->finish();
             }
@@ -136,7 +140,7 @@ namespace app::focus
             }
             return true;
         }
-        if (inputEvent.isShortRelease(gui::KeyCode::KEY_RF)) {
+        if (inputEvent.isShortRelease(KeyCode::KEY_RF)) {
             static_cast<app::Application *>(application)->resumeIdleTimer();
             presenter->abandon();
             return true;
@@ -244,11 +248,11 @@ namespace app::focus
         clock->setTimeFormat(fmt);
     }
 
-    gui::RefreshModes FocusTimerWindow::updateTime()
+    RefreshModes FocusTimerWindow::updateTime()
     {
         if (presenter != nullptr) {
             presenter->handleUpdateTimeEvent();
         }
-        return gui::RefreshModes::GUI_REFRESH_FAST;
+        return RefreshModes::GUI_REFRESH_FAST;
     }
 } // namespace app::focus

--- a/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusTimerWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusTimerWindow.hpp
@@ -6,25 +6,30 @@
 #include "data/FocusCommon.hpp"
 #include "presenter/FocusTimerPresenter.hpp"
 
-#include <Text.hpp>
-#include <apps-common/widgets/BarGraph.hpp>
-#include <apps-common/widgets/TimeMinuteSecondWidget.hpp>
-#include <common/widgets/BellStatusClock.hpp>
-#include <gui/widgets/Icon.hpp>
 #include <apps-common/windows/AppWindow.hpp>
+
+namespace gui
+{
+    class ArcProgressBar;
+    class TimeMinuteSecondWidget;
+    class Icon;
+    class BellStatusClock;
+} // namespace gui
 
 namespace app::focus
 {
-    class FocusTimerWindow : public gui::AppWindow, public FocusTimerContract::View
+    using namespace gui;
+
+    class FocusTimerWindow : public AppWindow, public FocusTimerContract::View
     {
       public:
         FocusTimerWindow(app::ApplicationCommon *app,
                          std::unique_ptr<FocusTimerContract::Presenter> &&windowPresenter,
                          const std::string &name = window::name::timer);
 
-        void onBeforeShow(gui::ShowMode mode, gui::SwitchData *data) override;
+        void onBeforeShow(ShowMode mode, SwitchData *data) override;
         void buildInterface() override;
-        bool onInput(const gui::InputEvent &inputEvent) override;
+        bool onInput(const InputEvent &inputEvent) override;
         void showFocusSessionCountdown() override;
         void showShortBreakCountdown() override;
         void showLongBreakCountdown() override;
@@ -36,17 +41,17 @@ namespace app::focus
 
       private:
         std::unique_ptr<FocusTimerContract::Presenter> presenter;
-        gui::VBox *mainVBox{nullptr};
-        gui::ArcProgressBar *progress{nullptr};
-        gui::TimeMinuteSecondWidget *timer{nullptr};
-        gui::TextFixedSize *bottomDescription{nullptr};
-        gui::Icon *iconPause{nullptr};
-        gui::Icon *iconRing{nullptr};
-        gui::BellStatusClock *clock{nullptr};
+        VBox *mainVBox{nullptr};
+        ArcProgressBar *progress{nullptr};
+        TimeMinuteSecondWidget *timer{nullptr};
+        TextFixedSize *bottomDescription{nullptr};
+        Icon *iconPause{nullptr};
+        Icon *iconRing{nullptr};
+        BellStatusClock *clock{nullptr};
 
         void setTime(std::time_t newTime) override;
         void setTimeFormat(utils::time::Locale::TimeFormat fmt) override;
-        gui::RefreshModes updateTime() override;
+        RefreshModes updateTime() override;
 
         void buildLayout();
         void configureTimer();

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.cpp
@@ -1,15 +1,17 @@
 // Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
-#include <Arc.hpp>
-
 #include "MeditationTimer.hpp"
 #include "MeditationCommon.hpp"
 #include "MeditationCountdownWindow.hpp"
 #include "MeditationStyle.hpp"
 
-#include <keymap/KeyMap.hpp>
+#include <Arc.hpp>
+#include <Text.hpp>
+#include <apps-common/widgets/TimeMinuteSecondWidget.hpp>
 #include <apps-common/widgets/ProgressTimerWithBarGraphAndCounter.hpp>
+
+#include <keymap/KeyMap.hpp>
 
 namespace
 {
@@ -61,6 +63,7 @@ namespace gui
         progress = new Arc(this, arcParams);
 
         mainVBox = new VBox(this, 0, 0, style::window_width, style::window_height);
+        mainVBox->setEdges(RectangleEdge::None);
 
         description = new Text(mainVBox, 0, 0, 0, 0);
         description->setText(utils::translate("app_meditation_countdown_desc"));

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationCountdownWindow.hpp
@@ -3,17 +3,16 @@
 
 #pragma once
 
+#include "MeditationCountdownPresenter.hpp"
+
 #include <Application.hpp>
 #include <AppWindow.hpp>
 #include <InputEvent.hpp>
-#include <Text.hpp>
-#include <apps-common/widgets/TimeMinuteSecondWidget.hpp>
-
-#include "MeditationCountdownPresenter.hpp"
 
 namespace gui
 {
     class Arc;
+    class TimeMinuteSecondWidget;
 
     class MeditationCountdownWindow : public AppWindow, public app::meditation::MeditationCountdownContract::View
     {
@@ -22,7 +21,6 @@ namespace gui
             app::ApplicationCommon *app,
             std::unique_ptr<app::meditation::MeditationCountdownContract::Presenter> &&windowPresenter);
 
-        // virtual methods
         void onBeforeShow(ShowMode mode, SwitchData *data) override;
         bool onInput(const InputEvent &inputEvent) override;
         void buildInterface() override;

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationMainWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationMainWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MeditationMainWindow.hpp"
@@ -14,8 +14,9 @@
 namespace app::meditation
 {
     using namespace gui;
+
     MeditationMainWindow::MeditationMainWindow(app::ApplicationCommon *app)
-        : BellOptionWindow(app, gui::name::window::main_window)
+        : BellOptionWindow(app, name::window::main_window)
     {
         addOptions(settingsOptionsList());
         setListTitle(utils::translate("app_bell_meditation_timer"));
@@ -23,11 +24,11 @@ namespace app::meditation
 
     std::list<Option> MeditationMainWindow::settingsOptionsList()
     {
-        using ActivatedCallback = std::function<bool(gui::Item &)>;
+        using ActivatedCallback = std::function<bool(Item &)>;
         using Callback          = std::function<ActivatedCallback(const std::string &window)>;
 
         auto defaultCallback = [this](const std::string &window) {
-            return [window, this](gui::Item &) {
+            return [window, this](Item &) {
                 if (window.empty()) {
                     return false;
                 }
@@ -36,12 +37,12 @@ namespace app::meditation
             };
         };
 
-        std::list<gui::Option> settingsOptionList;
+        std::list<Option> settingsOptionList;
         auto addWinSettings = [&](const UTF8 &name, const std::string &window, Callback &&callback) {
-            settingsOptionList.emplace_back(std::make_unique<gui::option::OptionBellMenu>(
+            settingsOptionList.emplace_back(std::make_unique<option::OptionBellMenu>(
                 name,
                 callback(window),
-                [=](gui::Item &item) {
+                [=](Item &item) {
                     // put focus change callback here
                     return true;
                 },

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationMainWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationMainWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -11,10 +11,10 @@ namespace app::meditation
     {
       public:
         static constexpr auto defaultName = gui::name::window::main_window;
+
         explicit MeditationMainWindow(app::ApplicationCommon *app);
 
       private:
         std::list<gui::Option> settingsOptionsList();
     };
-
 } // namespace app::meditation

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.cpp
@@ -6,11 +6,11 @@
 #include "MeditationRunningWindow.hpp"
 #include "MeditationStyle.hpp"
 
-#include <apps-common/widgets/BellBaseLayout.hpp>
-#include <apps-common/widgets/ProgressTimerWithBarGraphAndCounter.hpp>
-#include <apps-common/widgets/BarGraph.hpp>
-#include <common/widgets/BellStatusClock.hpp>
 #include <gui/widgets/Icon.hpp>
+#include <common/widgets/BellStatusClock.hpp>
+#include <apps-common/widgets/BarGraph.hpp>
+#include <apps-common/widgets/TimeMinuteSecondWidget.hpp>
+#include <apps-common/widgets/ProgressTimerWithBarGraphAndCounter.hpp>
 
 namespace
 {
@@ -67,38 +67,38 @@ namespace gui
         progress->setMaximum(arcProgressSteps);
 
         mainVBox = new VBox(this, 0, 0, style::window_width, style::window_height);
+        mainVBox->setEdges(RectangleEdge::None);
 
         clock = new BellStatusClock(mainVBox);
         clock->setMaximumSize(runningStyle::clock::maxSizeX, runningStyle::clock::maxSizeY);
         clock->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
-        clock->setMargins(gui::Margins(0, runningStyle::clock::marginTop, 0, 0));
+        clock->setMargins(Margins(0, runningStyle::clock::marginTop, 0, 0));
 
-        timer = new gui::TimeMinuteSecondWidget(mainVBox,
-                                                0,
-                                                0,
-                                                runningStyle::timer::maxSizeX,
-                                                runningStyle::timer::maxSizeY,
-                                                gui::TimeMinuteSecondWidget::DisplayType::OnlyMinutes);
+        timer = new TimeMinuteSecondWidget(mainVBox,
+                                           0,
+                                           0,
+                                           runningStyle::timer::maxSizeX,
+                                           runningStyle::timer::maxSizeY,
+                                           TimeMinuteSecondWidget::DisplayType::OnlyMinutes);
         timer->setMinimumSize(runningStyle::timer::maxSizeX, runningStyle::timer::maxSizeY);
-        timer->setMargins(gui::Margins(0, runningStyle::timer::marginTop, 0, 0));
+        timer->setMargins(Margins(0, runningStyle::timer::marginTop, 0, 0));
         timer->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
 
         icon = new Icon(mainVBox, 0, 0, 0, 0, {}, {});
         icon->setMinimumSize(runningStyle::pauseIcon::maxSizeX, runningStyle::pauseIcon::maxSizeY);
-        icon->setMargins(gui::Margins(0, runningStyle::pauseIcon::marginTop, 0, 0));
+        icon->setMargins(Margins(0, runningStyle::pauseIcon::marginTop, 0, 0));
         icon->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
         icon->image->set(runningStyle::pauseIcon::image, ImageTypeSpecifier::W_G);
         icon->setVisible(false);
 
-        bottomDescription = new gui::TextFixedSize(
+        bottomDescription = new TextFixedSize(
             mainVBox, 0, 0, runningStyle::bottomDescription::maxSizeX, runningStyle::bottomDescription::maxSizeY);
         bottomDescription->setMaximumSize(runningStyle::bottomDescription::maxSizeX,
                                           runningStyle::bottomDescription::maxSizeY);
         bottomDescription->setFont(runningStyle::bottomDescription::font);
-        bottomDescription->setMargins(gui::Margins(0, 0, 0, 0));
+        bottomDescription->setMargins(Margins(0, 0, 0, 0));
         bottomDescription->activeItem = false;
-        bottomDescription->setAlignment(
-            gui::Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Top));
+        bottomDescription->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
         bottomDescription->setRichText(utils::translate("app_bellmain_meditation_timer"));
         bottomDescription->drawUnderline(false);
         bottomDescription->setVisible(true);
@@ -120,7 +120,7 @@ namespace gui
 
     bool MeditationRunningWindow::onInput(const InputEvent &inputEvent)
     {
-        if (inputEvent.isShortRelease(gui::KeyCode::KEY_ENTER)) {
+        if (inputEvent.isShortRelease(KeyCode::KEY_ENTER)) {
             if (presenter->isTimerStopped()) {
                 presenter->resume();
             }
@@ -129,7 +129,7 @@ namespace gui
             }
             return true;
         }
-        if (inputEvent.isShortRelease(gui::KeyCode::KEY_RF)) {
+        if (inputEvent.isShortRelease(KeyCode::KEY_RF)) {
             static_cast<app::Application *>(application)->resumeIdleTimer();
             presenter->abandon();
             return true;

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.hpp
@@ -3,18 +3,17 @@
 
 #pragma once
 
+#include "MeditationProgressPresenter.hpp"
+
 #include <Application.hpp>
 #include <AppWindow.hpp>
-#include <apps-common/widgets/TimeMinuteSecondWidget.hpp>
-
-#include "MeditationProgressPresenter.hpp"
 
 namespace gui
 {
     class ArcProgressBar;
     class BellStatusClock;
     class Icon;
-    class TimeFixedWidget;
+    class TimeMinuteSecondWidget;
 
     class MeditationRunningWindow : public AppWindow, public app::meditation::MeditationProgressContract::View
     {
@@ -36,9 +35,9 @@ namespace gui
         VBox *mainVBox{nullptr};
         ArcProgressBar *progress{nullptr};
         TimeMinuteSecondWidget *timer{nullptr};
-        gui::TextFixedSize *bottomDescription{nullptr};
+        TextFixedSize *bottomDescription{nullptr};
         Icon *icon{nullptr};
-        gui::BellStatusClock *clock{nullptr};
+        BellStatusClock *clock{nullptr};
 
         void setTime(std::time_t newTime) override;
         void setTimeFormat(utils::time::Locale::TimeFormat fmt) override;

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationTimerWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationTimerWindow.cpp
@@ -6,9 +6,12 @@
 #include "MeditationStyle.hpp"
 #include "MeditationTimerWindow.hpp"
 
+#include <widgets/BellBaseLayout.hpp>
+
 namespace app::meditation
 {
     using namespace gui;
+
     MeditationTimerWindow::MeditationTimerWindow(
         app::ApplicationCommon *app,
         std::unique_ptr<app::meditation::MeditationTimerContract::Presenter> &&windowPresenter)
@@ -33,15 +36,15 @@ namespace app::meditation
         auto topMessage = new TextFixedSize(body->firstBox);
         topMessage->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::outer_layouts_h);
         topMessage->setFont(style::window::font::largelight);
-        topMessage->setEdges(gui::RectangleEdge::None);
+        topMessage->setEdges(RectangleEdge::None);
         topMessage->activeItem = false;
-        topMessage->setAlignment(Alignment(gui::Alignment::Horizontal::Center, gui::Alignment::Vertical::Center));
+        topMessage->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
         topMessage->setText(utils::translate("app_bell_meditation_timer"));
         topMessage->drawUnderline(false);
 
         spinner = new U8IntegerSpinner(
             U8IntegerSpinner::range{presenter->getMinValue(), presenter->getMaxValue(), presenter->getStepValue()},
-            gui::Boundaries::Fixed);
+            Boundaries::Fixed);
         spinner->onValueChanged = [this](const auto val) { this->onValueChanged(val); };
         spinner->setMaximumSize(style::bell_base_layout::w, style::bell_base_layout::h);
         spinner->setFont(timerStyle::text::font);
@@ -67,13 +70,13 @@ namespace app::meditation
         body->resize();
     }
 
-    bool MeditationTimerWindow::onInput(const gui::InputEvent &inputEvent)
+    bool MeditationTimerWindow::onInput(const InputEvent &inputEvent)
     {
         if (spinner->onInput(inputEvent)) {
             return true;
         }
 
-        if (inputEvent.isShortRelease(gui::KeyCode::KEY_ENTER)) {
+        if (inputEvent.isShortRelease(KeyCode::KEY_ENTER)) {
             presenter->activate(spinner->value());
             return true;
         }

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationTimerWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationTimerWindow.hpp
@@ -1,37 +1,43 @@
-// Copyright (c) 2017-2021, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
-#include <apps-common/widgets/spinners/Spinners.hpp>
-#include <widgets/BellBaseLayout.hpp>
+#include "MeditationTimerPresenter.hpp"
 
 #include <Application.hpp>
 #include <AppWindow.hpp>
 #include <InputEvent.hpp>
 
-#include "MeditationTimerPresenter.hpp"
+#include <apps-common/widgets/spinners/Spinners.hpp>
+
+namespace gui
+{
+    class BellBaseLayout;
+}
 
 namespace app::meditation
 {
-    class MeditationTimerWindow : public gui::AppWindow, public app::meditation::MeditationTimerContract::View
+    using namespace gui;
+
+    class MeditationTimerWindow : public AppWindow, public app::meditation::MeditationTimerContract::View
     {
       public:
         static constexpr auto name = "MeditationTimerWindow";
+
         explicit MeditationTimerWindow(
             app::ApplicationCommon *app,
             std::unique_ptr<app::meditation::MeditationTimerContract::Presenter> &&windowPresenter);
 
-        // virtual methods
         void buildInterface() override;
-        bool onInput(const gui::InputEvent &inputEvent) override;
+        bool onInput(const InputEvent &inputEvent) override;
 
-        void onValueChanged(const std::uint32_t currentValue);
+        void onValueChanged(std::uint32_t currentValue);
 
       private:
         std::unique_ptr<app::meditation::MeditationTimerContract::Presenter> presenter;
-        gui::BellBaseLayout *body{};
-        gui::U8IntegerSpinner *spinner{};
-        gui::Label *bottomDescription{};
+        BellBaseLayout *body{nullptr};
+        U8IntegerSpinner *spinner{nullptr};
+        Label *bottomDescription{nullptr};
     };
 } // namespace app::meditation

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/SettingsWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/SettingsWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "MeditationMainWindow.hpp"
@@ -13,6 +13,7 @@
 namespace app::meditation
 {
     using namespace gui;
+
     SettingsWindow::SettingsWindow(app::ApplicationCommon *app,
                                    std::unique_ptr<app::meditation::contract::Presenter> presenter)
         : AppWindow(app, name), presenter{std::move(presenter)}
@@ -35,8 +36,8 @@ namespace app::meditation
         header->setTitleVisibility(false);
         navBar->setVisible(false);
 
-        sideListView = new gui::SideListView(
-            this, 0U, 0U, this->getWidth(), this->getHeight(), presenter->getPagesProvider(), PageBarType::None);
+        sideListView =
+            new SideListView(this, 0U, 0U, getWidth(), getHeight(), presenter->getPagesProvider(), PageBarType::None);
         sideListView->setEdges(RectangleEdge::None);
 
         sideListView->rebuildList(listview::RebuildType::Full);
@@ -44,13 +45,13 @@ namespace app::meditation
         presenter->loadData();
     }
 
-    void SettingsWindow::onBeforeShow(gui::ShowMode mode, gui::SwitchData *data)
+    void SettingsWindow::onBeforeShow(ShowMode mode, SwitchData *data)
     {
         AppWindow::onBeforeShow(mode, data);
         setFocusItem(sideListView);
     }
 
-    bool SettingsWindow::onInput(const gui::InputEvent &inputEvent)
+    bool SettingsWindow::onInput(const InputEvent &inputEvent)
     {
         if (sideListView->onInput(inputEvent)) {
             return true;

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/SettingsWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/SettingsWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -14,22 +14,25 @@ namespace gui
 
 namespace app::meditation
 {
-    class SettingsWindow : public gui::AppWindow, public app::meditation::contract::View
+    using namespace gui;
+
+    class SettingsWindow : public AppWindow, public app::meditation::contract::View
     {
       public:
         static constexpr auto name = "MeditationSettingsWindow";
+
         SettingsWindow(app::ApplicationCommon *app, std::unique_ptr<app::meditation::contract::Presenter> presenter);
 
         void buildInterface() override;
-        void onBeforeShow(gui::ShowMode mode, gui::SwitchData *data) override;
+        void onBeforeShow(ShowMode mode, SwitchData *data) override;
         void onClose(CloseReason reason) override;
-        bool onInput(const gui::InputEvent &inputEvent) override;
+        bool onInput(const InputEvent &inputEvent) override;
         void rebuild() override;
 
       private:
         void switchToExitWindow();
 
-        gui::SideListView *sideListView{};
+        SideListView *sideListView{nullptr};
         std::unique_ptr<app::meditation::contract::Presenter> presenter;
         bool isSaveNeeded{false};
     };

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/StatisticsWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/StatisticsWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "StatisticsWindow.hpp"
@@ -17,7 +17,7 @@ namespace app::meditation
         InputEvent newEvent{inputEvent};
 
         if (inputEvent.is(KeyCode::KEY_UP)) {
-            newEvent.setKeyCode(gui::KeyCode::KEY_ENTER);
+            newEvent.setKeyCode(KeyCode::KEY_ENTER);
         }
 
         if (inputEvent.is(KeyCode::KEY_DOWN)) {
@@ -27,7 +27,7 @@ namespace app::meditation
         return newEvent;
     }
 
-    bool filterInputEvents(const gui::InputEvent &inputEvent)
+    bool filterInputEvents(const InputEvent &inputEvent)
     {
         return inputEvent.isShortRelease(KeyCode::KEY_ENTER);
     }
@@ -53,22 +53,22 @@ namespace app::meditation
         header->setTitleVisibility(false);
         navBar->setVisible(false);
 
-        sideListView = new gui::SideListView(
-            this, 0U, 0U, this->getWidth(), this->getHeight(), presenter->getPagesProvider(), PageBarType::None);
+        sideListView =
+            new SideListView(this, 0U, 0U, getWidth(), getHeight(), presenter->getPagesProvider(), PageBarType::None);
         sideListView->setEdges(RectangleEdge::None);
-        sideListView->setBoundaries(gui::Boundaries::Continuous);
+        sideListView->setBoundaries(Boundaries::Continuous);
 
         sideListView->rebuildList(listview::RebuildType::Full);
 
         setFocusItem(sideListView);
     }
 
-    void StatisticsWindow::onBeforeShow(gui::ShowMode mode, gui::SwitchData *data)
+    void StatisticsWindow::onBeforeShow(ShowMode mode, SwitchData *data)
     {
         setFocusItem(sideListView);
     }
 
-    bool StatisticsWindow::onInput(const gui::InputEvent &inputEvent)
+    bool StatisticsWindow::onInput(const InputEvent &inputEvent)
     {
         if (filterInputEvents(inputEvent)) {
             return true;

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/StatisticsWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/StatisticsWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
@@ -14,21 +14,24 @@ namespace gui
 
 namespace app::meditation
 {
-    class StatisticsWindow : public gui::AppWindow, public app::meditation::contract::View
+    using namespace gui;
+
+    class StatisticsWindow : public AppWindow, public app::meditation::contract::View
     {
       public:
         static constexpr auto name = "MeditationStatisticsWindow";
+
         StatisticsWindow(app::ApplicationCommon *app,
                          std::unique_ptr<app::meditation::contract::StatisticsPresenter> presenter);
 
         void buildInterface() override;
-        void onBeforeShow(gui::ShowMode mode, gui::SwitchData *data) override;
+        void onBeforeShow(ShowMode mode, SwitchData *data) override;
         void onClose(CloseReason reason) override;
-        bool onInput(const gui::InputEvent &inputEvent) override;
+        bool onInput(const InputEvent &inputEvent) override;
         void rebuild() override;
 
       private:
-        gui::SideListView *sideListView{};
+        SideListView *sideListView{nullptr};
         std::unique_ptr<app::meditation::contract::StatisticsPresenter> presenter;
     };
 } // namespace app::meditation

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapMainWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapMainWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PowerNapMainWindow.hpp"
@@ -11,7 +11,7 @@ namespace gui
     PowerNapMainWindow::PowerNapMainWindow(
         app::ApplicationCommon *app,
         std::unique_ptr<app::powernap::PowerNapMainWindowContract::Presenter> &&windowPresenter)
-        : AppWindow(app, gui::name::window::main_window), windowPresenter{std::move(windowPresenter)}
+        : AppWindow(app, name::window::main_window), windowPresenter{std::move(windowPresenter)}
     {
         this->windowPresenter->attach(this);
         buildInterface();
@@ -22,14 +22,15 @@ namespace gui
         AppWindow::buildInterface();
         statusBar->setVisible(false);
 
-        sideListView = new gui::SideListView(
+        sideListView = new SideListView(
             this, 0, 0, style::window_width, style::window_height, windowPresenter->getNapTimeProvider());
+        sideListView->setEdges(rectangle_enums::RectangleEdge::None);
         windowPresenter->loadNapTimeList();
         sideListView->rebuildList(listview::RebuildType::Full);
         setFocusItem(sideListView);
     }
 
-    bool PowerNapMainWindow::onInput(const gui::InputEvent &inputEvent)
+    bool PowerNapMainWindow::onInput(const InputEvent &inputEvent)
     {
         if (sideListView->onInput(inputEvent)) {
             return true;

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.cpp
@@ -61,6 +61,7 @@ namespace gui
         progress->setMaximum(arcProgressSteps);
 
         mainVBox = new VBox(this, 0, 0, style::window_width, style::window_height);
+        mainVBox->setEdges(RectangleEdge::None);
 
         clock = new BellStatusClock(mainVBox);
         clock->setMaximumSize(progressStyle::clock::maxSizeX, progressStyle::clock::maxSizeY);

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapSessionEndedWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapSessionEndedWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "PowerNapSessionEndedWindow.hpp"
@@ -24,7 +24,9 @@ namespace gui
     void PowerNapSessionEndedWindow::buildLayout()
     {
         statusBar->setVisible(false);
+
         auto body = new VBox(this, 0, 0, style::window_width, style::window_height);
+        body->setEdges(RectangleEdge::None);
         body->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
 
         auto icon =

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationPausedWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationPausedWindow.cpp
@@ -32,7 +32,7 @@ namespace gui
         statusBar->setVisible(false);
 
         auto mainVBox = new VBox(this, 0, 0, style::window_width, style::window_height);
-        mainVBox->setEdges(rectangle_enums::RectangleEdge::None);
+        mainVBox->setEdges(RectangleEdge::None);
 
         clock = new BellStatusClock(mainVBox);
         clock->setMaximumSize(relStyle::clock::maxSizeX, relStyle::clock::maxSizeY);

--- a/products/BellHybrid/apps/common/include/common/windows/ShortcutsWindow.hpp
+++ b/products/BellHybrid/apps/common/include/common/windows/ShortcutsWindow.hpp
@@ -1,32 +1,30 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #pragma once
 
 #include "ShortcutsWindowContract.hpp"
-#include <ApplicationCommon.hpp>
 #include <AppWindow.hpp>
 #include <apps-common/widgets/spinners/Spinners.hpp>
 
 namespace gui
 {
     class SideListView;
+
     class ShortcutsWindow : public AppWindow, public ShortcutsWindowContract::View
     {
-        std::unique_ptr<ShortcutsWindowContract::Presenter> presenter;
-        SideListView *sideListView = nullptr;
-        WidgetSpinner *spinner     = nullptr;
-
-        bool onInput(const gui::InputEvent &inputEvent) override;
-        void buildInterface() override;
-
-        void onValueChanged(const std::uint32_t currentValue);
-
       public:
         ShortcutsWindow(app::ApplicationCommon *app,
                         std::unique_ptr<ShortcutsWindowContract::Presenter> &&presenter,
                         const std::string &name);
 
-        bool isOneOfTwoLastShortcuts() const;
+        [[nodiscard]] bool isOneOfTwoLastShortcuts() const;
+
+      private:
+        std::unique_ptr<ShortcutsWindowContract::Presenter> presenter;
+        WidgetSpinner *spinner{nullptr};
+
+        bool onInput(const InputEvent &inputEvent) override;
+        void buildInterface() override;
     };
 } // namespace gui

--- a/products/BellHybrid/apps/common/src/layouts/ShortcutsLayoutClassic.cpp
+++ b/products/BellHybrid/apps/common/src/layouts/ShortcutsLayoutClassic.cpp
@@ -32,7 +32,6 @@ namespace
             constexpr auto height = 146U;
             constexpr auto width  = 448U;
         } // namespace text
-
     } // namespace container
 } // namespace
 
@@ -52,6 +51,7 @@ namespace gui
     void ShortcutsLayoutClassic::buildInterface()
     {
         setAlignment(Alignment::Horizontal::Center);
+        setEdges(RectangleEdge::None);
 
         auto containerThreeBox = new HThreeBox<HBox, HBox, HBox>(this);
         containerThreeBox->setMinimumSize(container::width, container::image::height);
@@ -121,4 +121,4 @@ namespace gui
     {
         return this;
     }
-}; // namespace gui
+} // namespace gui

--- a/products/BellHybrid/apps/common/src/windows/ShortcutsWindow.cpp
+++ b/products/BellHybrid/apps/common/src/windows/ShortcutsWindow.cpp
@@ -1,8 +1,9 @@
-// Copyright (c) 2017-2023, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md
 
 #include "windows/ShortcutsWindow.hpp"
 
+#include <ApplicationCommon.hpp>
 #include <Style.hpp>
 #include <SideListView.hpp>
 #include <gui/input/InputEvent.hpp>
@@ -34,9 +35,7 @@ namespace gui
         auto selectedLayout = presenter->getFirstLayout();
         spinner->setCurrentValue(selectedLayout);
 
-        spinner->onValueChanged = [this](const auto &) {
-            getApplication()->render(gui::RefreshModes::GUI_REFRESH_DEEP);
-        };
+        spinner->onValueChanged = [this](const auto &) { getApplication()->render(RefreshModes::GUI_REFRESH_DEEP); };
 
         setFocusItem(spinner);
     }
@@ -47,7 +46,7 @@ namespace gui
         return presenter->isOneOfTwoLastLayouts(currentLayout);
     }
 
-    bool ShortcutsWindow::onInput(const gui::InputEvent &inputEvent)
+    bool ShortcutsWindow::onInput(const InputEvent &inputEvent)
     {
         if (spinner->onInput(inputEvent)) {
             return true;
@@ -59,5 +58,4 @@ namespace gui
 
         return AppWindow::onInput(inputEvent);
     }
-
 } // namespace gui


### PR DESCRIPTION
* Removed frames that were drawn around 
the entire screen, as they're not present in
the design and are not even visible,
as the very edge of the display is
covered by the casing.
* Cleanups.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
