### PR TITLE
[BH-2042] Fix misaligned pause and bell icons

### DIFF
--- a/products/BellHybrid/apps/application-bell-focus-timer/data/FocusTimerStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-focus-timer/data/FocusTimerStyle.hpp
@@ -12,48 +12,48 @@ namespace app::focusTimerStyle
     {
         namespace progress
         {
-            inline constexpr auto radius                   = 192u;
-            inline constexpr auto penWidth                 = 3u;
-            inline constexpr auto verticalDeviationDegrees = 38u;
+            inline constexpr auto radius                   = 192U;
+            inline constexpr auto penWidth                 = 3U;
+            inline constexpr auto verticalDeviationDegrees = 38U;
         } // namespace progress
 
         namespace timer
         {
             inline constexpr auto font      = style::window::font::supersizeme;
-            inline constexpr auto maxSizeX  = 340u;
-            inline constexpr auto maxSizeY  = 198u;
-            inline constexpr auto marginTop = 19u;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 198U;
+            inline constexpr auto marginTop = 19U;
         } // namespace timer
 
         namespace pauseIcon
         {
             inline constexpr auto image     = "big_pause";
-            inline constexpr auto maxSizeX  = 203u;
-            inline constexpr auto maxSizeY  = 203u;
-            inline constexpr auto marginTop = timer::marginTop - (maxSizeY - timer::maxSizeY);
+            inline constexpr auto minSizeX  = 203U;
+            inline constexpr auto minSizeY  = 154U;
+            inline constexpr auto marginTop = 63U;
         } // namespace pauseIcon
 
         namespace ringIcon
         {
             inline constexpr auto image     = "big_bell_ringing";
-            inline constexpr auto maxSizeX  = 220u;
-            inline constexpr auto maxSizeY  = 203u;
-            inline constexpr auto marginTop = timer::marginTop - (maxSizeY - timer::maxSizeY);
+            inline constexpr auto minSizeX  = 210U;
+            inline constexpr auto minSizeY  = 154U;
+            inline constexpr auto marginTop = 63U;
         } // namespace ringIcon
 
         namespace bottomDescription
         {
-            inline constexpr auto marginTop = 38u;
-            inline constexpr auto maxSizeX  = 340u;
-            inline constexpr auto maxSizeY  = 80u;
+            inline constexpr auto marginTop = 38U;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 80U;
             inline constexpr auto font      = style::window::font::verybig;
         } // namespace bottomDescription
 
         namespace clock
         {
-            inline constexpr auto marginTop = 17u;
-            inline constexpr auto maxSizeX  = 340u;
-            inline constexpr auto maxSizeY  = 84u;
+            inline constexpr auto marginTop = 17U;
+            inline constexpr auto maxSizeX  = 340U;
+            inline constexpr auto maxSizeY  = 84U;
         } // namespace clock
     }     // namespace runningStyle
 

--- a/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusTimerWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusTimerWindow.cpp
@@ -6,7 +6,6 @@
 
 #include <Application.hpp>
 
-#include <gui/widgets/Icon.hpp>
 #include <common/widgets/BellStatusClock.hpp>
 #include <apps-common/widgets/BarGraph.hpp>
 #include <apps-common/widgets/TimeMinuteSecondWidget.hpp>
@@ -86,19 +85,23 @@ namespace app::focus
         timer->setMargins(Margins(0, runningStyle::timer::marginTop, 0, 0));
         timer->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
 
-        iconPause = new Icon(mainVBox, 0, 0, 0, 0, {}, {});
-        iconPause->setMinimumSize(runningStyle::pauseIcon::maxSizeX, runningStyle::pauseIcon::maxSizeY);
-        iconPause->setMargins(Margins(0, runningStyle::pauseIcon::marginTop, 0, 0));
-        iconPause->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
-        iconPause->image->set(runningStyle::pauseIcon::image, ImageTypeSpecifier::W_G);
-        iconPause->setVisible(false);
+        pauseBox = new VBox(mainVBox);
+        pauseBox->setMinimumSize(runningStyle::pauseIcon::minSizeX, runningStyle::pauseIcon::minSizeY);
+        pauseBox->setMargins(Margins(0, runningStyle::pauseIcon::marginTop, 0, 0));
+        pauseBox->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
+        pauseBox->setEdges(RectangleEdge::None);
+        new Image(pauseBox, runningStyle::pauseIcon::image, ImageTypeSpecifier::W_G);
+        pauseBox->setVisible(false);
+        pauseBox->resizeItems();
 
-        iconRing = new Icon(mainVBox, 0, 0, 0, 0, {}, {});
-        iconRing->setMinimumSize(runningStyle::ringIcon::maxSizeX, runningStyle::ringIcon::maxSizeY);
-        iconRing->setMargins(Margins(0, runningStyle::ringIcon::marginTop, 0, 0));
-        iconRing->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
-        iconRing->image->set(runningStyle::ringIcon::image, ImageTypeSpecifier::W_G);
-        iconRing->setVisible(false);
+        ringBox = new VBox(mainVBox);
+        ringBox->setMinimumSize(runningStyle::ringIcon::minSizeX, runningStyle::ringIcon::minSizeY);
+        ringBox->setMargins(Margins(0, runningStyle::ringIcon::marginTop, 0, 0));
+        ringBox->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
+        ringBox->setEdges(RectangleEdge::None);
+        new Image(ringBox, runningStyle::ringIcon::image, ImageTypeSpecifier::W_G);
+        ringBox->setVisible(false);
+        ringBox->resizeItems();
 
         bottomDescription = new TextFixedSize(
             mainVBox, 0, 0, runningStyle::bottomDescription::maxSizeX, runningStyle::bottomDescription::maxSizeY);
@@ -152,8 +155,8 @@ namespace app::focus
     void FocusTimerWindow::showEndOfAllSessionsInfo()
     {
         timer->setVisible(false);
-        iconPause->setVisible(false);
-        iconRing->setVisible(true);
+        pauseBox->setVisible(false);
+        ringBox->setVisible(true);
         bottomDescription->setVisible(true);
         bottomDescription->setText(utils::translate("app_bell_focus_well_done"));
         mainVBox->resizeItems();
@@ -163,8 +166,8 @@ namespace app::focus
     void FocusTimerWindow::showFocusSessionCountdown()
     {
         timer->setVisible(true);
-        iconPause->setVisible(false);
-        iconRing->setVisible(false);
+        pauseBox->setVisible(false);
+        ringBox->setVisible(false);
         bottomDescription->setVisible(true);
         bottomDescription->setText(utils::translate("app_bell_focus_time"));
         mainVBox->resizeItems();
@@ -173,8 +176,8 @@ namespace app::focus
     void FocusTimerWindow::showTimeForBreakInfo()
     {
         timer->setVisible(false);
-        iconPause->setVisible(false);
-        iconRing->setVisible(true);
+        pauseBox->setVisible(false);
+        ringBox->setVisible(true);
         bottomDescription->setVisible(true);
         bottomDescription->setText(utils::translate("app_bell_focus_time_for_break"));
         mainVBox->resizeItems();
@@ -184,8 +187,8 @@ namespace app::focus
     void FocusTimerWindow::showShortBreakCountdown()
     {
         timer->setVisible(true);
-        iconPause->setVisible(false);
-        iconRing->setVisible(false);
+        pauseBox->setVisible(false);
+        ringBox->setVisible(false);
         bottomDescription->setVisible(true);
         bottomDescription->setText(utils::translate("app_bell_focus_short_break"));
         mainVBox->resizeItems();
@@ -194,8 +197,8 @@ namespace app::focus
     void FocusTimerWindow::showLongBreakCountdown()
     {
         timer->setVisible(true);
-        iconPause->setVisible(false);
-        iconRing->setVisible(false);
+        pauseBox->setVisible(false);
+        ringBox->setVisible(false);
         bottomDescription->setVisible(true);
         bottomDescription->setText(utils::translate("app_bell_focus_long_break"));
         mainVBox->resizeItems();
@@ -204,8 +207,8 @@ namespace app::focus
     void FocusTimerWindow::showTimeForFocusInfo()
     {
         timer->setVisible(false);
-        iconPause->setVisible(false);
-        iconRing->setVisible(true);
+        pauseBox->setVisible(false);
+        ringBox->setVisible(true);
         bottomDescription->setVisible(true);
         bottomDescription->setText(utils::translate("app_bell_focus_time_for_focus"));
         mainVBox->resizeItems();
@@ -215,16 +218,16 @@ namespace app::focus
     void FocusTimerWindow::pause()
     {
         timer->setVisible(false);
-        iconPause->setVisible(true);
-        iconRing->setVisible(false);
+        pauseBox->setVisible(true);
+        ringBox->setVisible(false);
         mainVBox->resizeItems();
     }
 
     void FocusTimerWindow::resume()
     {
         timer->setVisible(true);
-        iconPause->setVisible(false);
-        iconRing->setVisible(false);
+        pauseBox->setVisible(false);
+        ringBox->setVisible(false);
         mainVBox->resizeItems();
     }
 

--- a/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusTimerWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-focus-timer/windows/FocusTimerWindow.hpp
@@ -41,13 +41,14 @@ namespace app::focus
 
       private:
         std::unique_ptr<FocusTimerContract::Presenter> presenter;
+
         VBox *mainVBox{nullptr};
+        BellStatusClock *clock{nullptr};
         ArcProgressBar *progress{nullptr};
+        VBox *pauseBox{nullptr};
+        VBox *ringBox{nullptr};
         TimeMinuteSecondWidget *timer{nullptr};
         TextFixedSize *bottomDescription{nullptr};
-        Icon *iconPause{nullptr};
-        Icon *iconRing{nullptr};
-        BellStatusClock *clock{nullptr};
 
         void setTime(std::time_t newTime) override;
         void setTimeFormat(utils::time::Locale::TimeFormat fmt) override;

--- a/products/BellHybrid/apps/application-bell-meditation-timer/data/MeditationStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/data/MeditationStyle.hpp
@@ -26,9 +26,9 @@ namespace app::meditationStyle
         namespace pauseIcon
         {
             inline constexpr auto image     = "big_pause";
-            inline constexpr auto maxSizeX  = 203U;
-            inline constexpr auto maxSizeY  = 203U;
-            inline constexpr auto marginTop = timer::marginTop - (maxSizeY - timer::maxSizeY);
+            inline constexpr auto minSizeX  = 203U;
+            inline constexpr auto minSizeY  = 154U;
+            inline constexpr auto marginTop = 63U;
         } // namespace pauseIcon
 
         namespace clock

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.cpp
@@ -84,12 +84,14 @@ namespace gui
         timer->setMargins(Margins(0, runningStyle::timer::marginTop, 0, 0));
         timer->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
 
-        icon = new Icon(mainVBox, 0, 0, 0, 0, {}, {});
-        icon->setMinimumSize(runningStyle::pauseIcon::maxSizeX, runningStyle::pauseIcon::maxSizeY);
-        icon->setMargins(Margins(0, runningStyle::pauseIcon::marginTop, 0, 0));
-        icon->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
-        icon->image->set(runningStyle::pauseIcon::image, ImageTypeSpecifier::W_G);
-        icon->setVisible(false);
+        pauseBox = new VBox(mainVBox);
+        pauseBox->setMinimumSize(runningStyle::pauseIcon::minSizeX, runningStyle::pauseIcon::minSizeY);
+        pauseBox->setMargins(Margins(0, runningStyle::pauseIcon::marginTop, 0, 0));
+        pauseBox->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Center));
+        pauseBox->setEdges(RectangleEdge::None);
+        new Image(pauseBox, runningStyle::pauseIcon::image, ImageTypeSpecifier::W_G);
+        pauseBox->setVisible(false);
+        pauseBox->resizeItems();
 
         bottomDescription = new TextFixedSize(
             mainVBox, 0, 0, runningStyle::bottomDescription::maxSizeX, runningStyle::bottomDescription::maxSizeY);
@@ -99,7 +101,7 @@ namespace gui
         bottomDescription->setMargins(Margins(0, 0, 0, 0));
         bottomDescription->activeItem = false;
         bottomDescription->setAlignment(Alignment(Alignment::Horizontal::Center, Alignment::Vertical::Top));
-        bottomDescription->setRichText(utils::translate("app_bellmain_meditation_timer"));
+        bottomDescription->setText(utils::translate("app_bellmain_meditation_timer"));
         bottomDescription->drawUnderline(false);
         bottomDescription->setVisible(true);
 
@@ -151,14 +153,14 @@ namespace gui
     void MeditationRunningWindow::pause()
     {
         timer->setVisible(false);
-        icon->setVisible(true);
+        pauseBox->setVisible(true);
         mainVBox->resizeItems();
     }
 
     void MeditationRunningWindow::resume()
     {
         timer->setVisible(true);
-        icon->setVisible(false);
+        pauseBox->setVisible(false);
         mainVBox->resizeItems();
     }
 

--- a/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/windows/MeditationRunningWindow.hpp
@@ -12,7 +12,6 @@ namespace gui
 {
     class ArcProgressBar;
     class BellStatusClock;
-    class Icon;
     class TimeMinuteSecondWidget;
 
     class MeditationRunningWindow : public AppWindow, public app::meditation::MeditationProgressContract::View
@@ -32,12 +31,13 @@ namespace gui
 
       private:
         std::unique_ptr<app::meditation::MeditationProgressContract::Presenter> presenter;
+
         VBox *mainVBox{nullptr};
+        BellStatusClock *clock{nullptr};
         ArcProgressBar *progress{nullptr};
+        VBox *pauseBox{nullptr};
         TimeMinuteSecondWidget *timer{nullptr};
         TextFixedSize *bottomDescription{nullptr};
-        Icon *icon{nullptr};
-        BellStatusClock *clock{nullptr};
 
         void setTime(std::time_t newTime) override;
         void setTimeFormat(utils::time::Locale::TimeFormat fmt) override;

--- a/products/BellHybrid/apps/application-bell-powernap/data/PowerNapStyle.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/data/PowerNapStyle.hpp
@@ -29,17 +29,17 @@ namespace gui::powerNapStyle
         namespace pauseIcon
         {
             inline constexpr auto image     = "big_pause";
-            inline constexpr auto maxSizeX  = 203U;
-            inline constexpr auto maxSizeY  = 203U;
-            inline constexpr auto marginTop = timer::marginTop - (maxSizeY - timer::maxSizeY);
+            inline constexpr auto minSizeX  = 203U;
+            inline constexpr auto minSizeY  = 154U;
+            inline constexpr auto marginTop = 63U;
         } // namespace pauseIcon
 
         namespace ringIcon
         {
             inline constexpr auto image     = "big_bell_ringing";
-            inline constexpr auto maxSizeX  = 210U;
-            inline constexpr auto maxSizeY  = 203U;
-            inline constexpr auto marginTop = timer::marginTop - (maxSizeY - timer::maxSizeY);
+            inline constexpr auto minSizeX  = 210U;
+            inline constexpr auto minSizeY  = 154U;
+            inline constexpr auto marginTop = 63U;
         } // namespace ringIcon
 
         namespace clock

--- a/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.hpp
@@ -87,8 +87,6 @@ namespace app::powernap
         auto onBeforeShow() -> void override;
 
       private:
-        static constexpr auto endWindowTimeout = std::chrono::seconds{5};
-
         app::ApplicationCommon *app{};
         settings::Settings *settings{};
         AbstractAudioModel &audioModel;

--- a/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-powernap/windows/PowerNapProgressWindow.hpp
@@ -4,18 +4,16 @@
 #pragma once
 
 #include "presenter/PowerNapProgressPresenter.hpp"
-#include <apps-common/widgets/BarGraph.hpp>
-#include <apps-common/widgets/TimeMinuteSecondWidget.hpp>
-#include <common/widgets/BellStatusClock.hpp>
-#include <gui/widgets/Icon.hpp>
+
 #include <AppWindow.hpp>
-#include <Application.hpp>
-#include <InputEvent.hpp>
-#include <Text.hpp>
 
 namespace gui
 {
     class Text;
+    class ArcProgressBar;
+    class TimeMinuteSecondWidget;
+    class BellStatusClock;
+
     class PowerNapProgressWindow : public AppWindow, public app::powernap::PowerNapProgressContract::View
     {
       public:
@@ -32,13 +30,14 @@ namespace gui
 
       private:
         std::shared_ptr<app::powernap::PowerNapProgressContract::Presenter> presenter;
+
         VBox *mainVBox{nullptr};
-        ArcProgressBar *progress{nullptr};
-        TimeMinuteSecondWidget *timer{nullptr};
-        gui::TextFixedSize *bottomDescription{nullptr};
         BellStatusClock *clock{nullptr};
-        Icon *iconPause{nullptr};
-        Icon *iconRing{nullptr};
+        ArcProgressBar *progress{nullptr};
+        VBox *pauseBox{nullptr};
+        VBox *ringBox{nullptr};
+        TimeMinuteSecondWidget *timer{nullptr};
+        TextFixedSize *bottomDescription{nullptr};
 
         void setTime(std::time_t newTime) override;
         void setTimeFormat(utils::time::Locale::TimeFormat fmt) override;


### PR DESCRIPTION
Fix of the issue that pause and bell
icons were misaligned in Power Nap,
Meditation and Focus Timer after
introduction of BH-2013.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
