### PR TITLE
[BH-2029] Add volume control during fade in and fade out

### DIFF
--- a/products/BellHybrid/services/audio/ServiceAudio.cpp
+++ b/products/BellHybrid/services/audio/ServiceAudio.cpp
@@ -331,7 +331,10 @@ namespace service
         const auto clampedValue = std::clamp(utils::getNumericValue<float>(value), minVolumeToSet, maxVolumeToSet);
         auto retCode            = audio::RetCode::Success;
 
-        if (const auto activeInput = audioMux.GetActiveInput(); activeInput.has_value()) {
+        if (volumeFade->IsActive()) {
+            volumeFade->SetVolume(clampedValue);
+        }
+        else if (const auto activeInput = audioMux.GetActiveInput(); activeInput.has_value()) {
             if (activeInput.value() != nullptr) {
                 retCode = activeInput.value()->audio->SetOutputVolume(clampedValue);
             }

--- a/products/BellHybrid/services/audio/include/audio/VolumeFade.hpp
+++ b/products/BellHybrid/services/audio/include/audio/VolumeFade.hpp
@@ -19,13 +19,15 @@ namespace audio
         void Start(float targetVolume, float minVolume, float maxVolume, audio::FadeParams fadeParams);
         void Restart();
         void Stop();
+        void SetVolume(float volume);
         bool IsActive();
 
       private:
-        enum class State
+        enum class Phase
         {
-            Disable,
+            Idle,
             FadeIn,
+            Wait,
             FadeOut
         };
 
@@ -36,12 +38,15 @@ namespace audio
         float maxVolume;
         float currentVolume;
         SetCallback setVolumeCallback;
-        State state{State::Disable};
+        Phase phase{Phase::Idle};
         std::chrono::time_point<std::chrono::system_clock> timestamp;
 
         void PerformNextFadeStep();
+        void RestartTimer();
         void TurnUpVolume();
         void TurnDownVolume();
+        void SetTargetVolume(float volume);
+        bool IsFadePhaseActive();
     };
 
 } // namespace audio


### PR DESCRIPTION
<!-- Please describe your pull request here -->

During the fade in or fade out phase, when the user turns the encoder to set the volume, the fade in or fade out phase continues and the target volume is set to the one requested by the user

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
