### PR TITLE
[BH-2032] Add fade in and fade out support for very short songs

### DIFF
--- a/products/BellHybrid/services/audio/VolumeFade.cpp
+++ b/products/BellHybrid/services/audio/VolumeFade.cpp
@@ -53,6 +53,16 @@ namespace audio
         currentVolume      = minVolume + fadeStep;
         state              = State::FadeIn;
         timestamp          = std::chrono::system_clock::now();
+
+        if (this->fadeParams.playbackDuration.has_value()) {
+            // If the song is shorter than the fade in and out durations, we reduce the target volume value so that both
+            // phases have time to complete
+            const auto maxFadePeriod =
+                std::chrono::duration_cast<std::chrono::milliseconds>(fadeParams.playbackDuration.value()) / 2;
+            const auto maxTargetVolume = (maxFadePeriod.count() * fadeStep) / fadeInterval.count();
+            this->targetVolume         = std::clamp(std::min(targetVolume, maxTargetVolume), minVolume, maxVolume);
+        }
+
         Restart();
         timerHandle.restart(fadeInterval);
     }


### PR DESCRIPTION
<!-- Please describe your pull request here -->

If the song is shorter than the fade in and out durations, we reduce the target volume value so that both phases have time to complete.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
