### PR TITLE
[BH-2062] Fix alarm volume fade in duration

### DIFF
--- a/module-audio/Audio/AudioCommon.hpp
+++ b/module-audio/Audio/AudioCommon.hpp
@@ -21,17 +21,19 @@ namespace audio
 
 namespace audio
 {
-    inline constexpr Volume defaultVolumeStep = 1;
+    inline constexpr Volume defaultVolumeStep{1};
 
-    inline constexpr Volume maxVolume = 10;
-    inline constexpr Volume minVolume = 0;
+    inline constexpr Volume maxVolume{10};
+    inline constexpr Volume minVolume{0};
 
-    inline constexpr Gain maxGain = 100;
-    inline constexpr Gain minGain = 0;
+    inline constexpr Gain maxGain{100};
+    inline constexpr Gain minGain{0};
 
+    inline constexpr auto audioDbPrefix{"audio"};
+    inline constexpr auto dbPathSeparator{'/'};
 
-    inline constexpr auto audioDbPrefix   = "audio";
-    inline constexpr auto dbPathSeparator = '/';
+    inline constexpr std::chrono::seconds defaultMaxFadeDuration{5};
+    inline constexpr std::chrono::seconds alarmMaxFadeDuration{45};
 
     enum class Setting
     {
@@ -87,7 +89,8 @@ namespace audio
     struct FadeParams
     {
         Fade mode;
-        std::optional<std::chrono::seconds> playbackDuration = std::nullopt;
+        std::chrono::seconds maxFadeDuration{defaultMaxFadeDuration};
+        std::optional<std::chrono::seconds> playbackDuration{std::nullopt};
     };
 
     enum class VolumeUpdateType
@@ -294,8 +297,8 @@ namespace audio
             return *this;
         }
 
-        constexpr static TokenType tokenUninitialized = -1;
-        constexpr static TokenType tokenBad           = -2;
+        constexpr static TokenType tokenUninitialized{-1};
+        constexpr static TokenType tokenBad{-2};
 
         TokenType t;
         friend class ::audio::AudioMux;

--- a/products/BellHybrid/alarms/src/actions/PlayAudioActions.cpp
+++ b/products/BellHybrid/alarms/src/actions/PlayAudioActions.cpp
@@ -29,8 +29,8 @@ namespace alarms
                                        ? audio::Fade::In
                                        : audio::Fade::Disable;
 
-        auto msg =
-            std::make_shared<service::AudioStartPlaybackRequest>(path, playbackType, audio::FadeParams{fadeInEnabled});
+        auto msg = std::make_shared<service::AudioStartPlaybackRequest>(
+            path, playbackType, audio::FadeParams{fadeInEnabled, audio::alarmMaxFadeDuration});
         return service.bus.sendUnicast(std::move(msg), service::audioServiceName);
     }
 

--- a/products/BellHybrid/services/audio/include/audio/VolumeFade.hpp
+++ b/products/BellHybrid/services/audio/include/audio/VolumeFade.hpp
@@ -37,15 +37,18 @@ namespace audio
         float minVolume;
         float maxVolume;
         float currentVolume;
+        std::chrono::milliseconds fadeInterval;
         SetCallback setVolumeCallback;
         Phase phase{Phase::Idle};
         std::chrono::time_point<std::chrono::system_clock> timestamp;
 
         void PerformNextFadeStep();
-        void RestartTimer();
+        void RestartWaitingTimer();
         void TurnUpVolume();
         void TurnDownVolume();
         void SetTargetVolume(float volume);
         bool IsFadePhaseActive();
+        std::chrono::milliseconds calculateFadeInterval(std::chrono::seconds maxDuration);
+        std::chrono::milliseconds calculateWaitingTimerPeriod(std::chrono::seconds timeElapsed);
     };
 } // namespace audio


### PR DESCRIPTION
<!-- Please describe your pull request here -->

The alarm volume should gradually increase by 0.1 every 300 ms, which gives a time of 45 seconds for a full 15-point scale

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
