### PR TITLE
[BH-2065] Fix race condition between CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 
 if (${ENABLE_TESTS})
     enable_testing()
-    add_custom_target(check ${CMAKE_CTEST_COMMAND} -V DEPENDS create_test_product_databases)
+    add_custom_target(check ${CMAKE_CTEST_COMMAND} -V)
     add_subdirectory(test)
     include(PureCoverage)
 endif ()

--- a/cmake/modules/Assets.cmake
+++ b/cmake/modules/Assets.cmake
@@ -28,8 +28,8 @@ function(add_assets_target)
             ${_ASSETS_SYSTEM_DEST_DIR}
 
         # Create 'golden copy' of DBs
-        COMMAND mkdir -p ${_ASSETS_SYSTEM_DEST_DIR}/db/factory
-        COMMAND rsync -qlptgoDu
+        # 'v' flag intentionally left for debugging purposes, can be removed if you're sure it's no longer needed
+        COMMAND rsync -vlptgoDu
             ${_ASSETS_SYSTEM_DEST_DIR}/db/*
             ${_ASSETS_SYSTEM_DEST_DIR}/db/factory
 

--- a/cmake/modules/DownloadAsset.cmake
+++ b/cmake/modules/DownloadAsset.cmake
@@ -17,8 +17,6 @@ function(download_asset_release asset_name_in asset_name_out asset_repo asset_ve
     )
 
     add_custom_target(${asset_name_out}-target DEPENDS ${asset_repo})
-
-#    multicomp_install(PROGRAMS ${CMAKE_BINARY_DIR}/${asset_repo} DESTINATION "./" COMPONENTS Standalone Update)
 endfunction()
 
 function(download_asset_release_json

--- a/cmake/modules/Utils.cmake
+++ b/cmake/modules/Utils.cmake
@@ -1,17 +1,3 @@
-# An equivalent of install() which allows to declare multiple components using
-# a custom 'COMPONENTS' clause. This clause must be the last on the
-# argument list. The original 'COMPONENT' from install() clause must not appear
-# on the argument list.  
-function(multicomp_install)
-    list(FIND ARGN "COMPONENTS" CLAUSE_INDEX)
-    list(SUBLIST ARGN 0 ${CLAUSE_INDEX} INSTALL_ARGN)
-    math(EXPR COMPS_INDEX "${CLAUSE_INDEX}+1")
-    list(SUBLIST ARGN ${COMPS_INDEX} ${ARGC} COMPONENTS)
-    foreach(COMP IN LISTS COMPONENTS)
-        install(${INSTALL_ARGN} COMPONENT ${COMP})
-    endforeach()
-endfunction()
-
 macro(print_var VARIABLE)
     if(${VARIABLE})
         message(STATUS "${Green}${VARIABLE}: '${Orange}${${VARIABLE}}${ColourReset}'")

--- a/image/CMakeLists.txt
+++ b/image/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SYSTEM_DEST_DIR ${SYSROOT_PATH}/system_a)
 set(USER_DEST_DIR ${SYSROOT_PATH}/user)
 
 set(ASSETS_DEPENDENCIES "json-common-target")
+list(APPEND ASSETS_DEPENDENCIES "create_product_databases")
 
 if (${ASSETS_TYPE} STREQUAL "Proprietary")
     list(APPEND ASSETS_DEPENDENCIES "json-proprietary-target")

--- a/products/BellHybrid/CMakeLists.txt
+++ b/products/BellHybrid/CMakeLists.txt
@@ -105,7 +105,6 @@ if (${PROJECT_TARGET} STREQUAL "TARGET_RT1051")
         SYSROOT sysroot
         DEPENDS
             install_scripts
-            create_product_databases
             create_user_directories
             assets
             recovery.bin-target
@@ -121,7 +120,6 @@ else()
         LUTS ""
         DEPENDS
             install_scripts
-            create_product_databases
             remove_var_directory
             create_user_directories
             assets

--- a/products/PurePhone/CMakeLists.txt
+++ b/products/PurePhone/CMakeLists.txt
@@ -121,7 +121,6 @@ if (${PROJECT_TARGET} STREQUAL "TARGET_RT1051")
         SYSROOT sysroot
         DEPENDS
             install_scripts
-            create_product_databases
             create_user_directories
             assets
             recovery.bin-target
@@ -136,7 +135,6 @@ else()
         SYSROOT sysroot
         DEPENDS
             install_scripts
-            create_product_databases
             remove_var_directory
             create_user_directories
             assets

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,7 +46,7 @@ download_asset_json(json-test-proprietary-target
                     ${MUDITA_CACHE_DIR}
     )
 
-set(ASSETS_DEPENDENCIES "")
+set(ASSETS_DEPENDENCIES "create_test_product_databases")
 
 if (${ASSETS_TYPE} STREQUAL "Proprietary")
     list(APPEND ASSETS_DEPENDENCIES "json-test-proprietary-target")


### PR DESCRIPTION
* Fix for the issue that resulted in race
condition between target creating and
populating databases and the one copying
created databases to required directories.
The issue was caused by lack of dependency
between those targets, what allowed CMake
engine to parallelize them. As a result,
databases were copied before their creation
has been finished, what resulted in weird
discrepancies in databases content and
occasional rsync errors.

* Removed unused multicomp_install
function.

* Refactored DB tests readContent
helper.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
