### PR TITLE
[BH-2064] Change message shown after removing alarm file

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+* Fixed message shown when entering alarm sound list after deleting selected alarm file
 
 ### Added
 * Added label with the name of the application on the countdown screens

--- a/module-audio/Audio/AudioCommon.hpp
+++ b/module-audio/Audio/AudioCommon.hpp
@@ -74,7 +74,7 @@ namespace audio
         Snooze,
         FocusTimer,
         Bedtime,
-        Last = Bedtime,
+        Last = Bedtime
     };
 
     enum class VolumeChangeRequestSource
@@ -141,7 +141,7 @@ namespace audio
         CallLoudspeakerOff,
     };
 
-    constexpr auto hwStateUpdateMaxEvent = magic_enum::enum_index(EventType::BluetoothA2DPDeviceState);
+    inline constexpr auto hwStateUpdateMaxEvent = magic_enum::enum_index(EventType::BluetoothA2DPDeviceState);
 
     class Event
     {
@@ -158,12 +158,12 @@ namespace audio
 
         virtual ~Event() = default;
 
-        EventType getType() const noexcept
+        [[nodiscard]] EventType getType() const noexcept
         {
             return eventType;
         }
 
-        DeviceState getDeviceState() const noexcept
+        [[nodiscard]] DeviceState getDeviceState() const noexcept
         {
             return deviceState;
         }
@@ -181,14 +181,14 @@ namespace audio
             auto hwUpdateEventIdx = magic_enum::enum_integer(stateChangeEvent->getType());
             if (hwUpdateEventIdx <= hwStateUpdateMaxEvent) {
                 audioSinkState.set(hwUpdateEventIdx,
-                                   stateChangeEvent->getDeviceState() == Event::DeviceState::Connected ? true : false);
+                                   stateChangeEvent->getDeviceState() == Event::DeviceState::Connected);
             }
         }
 
-        std::vector<std::shared_ptr<Event>> getUpdateEvents() const
+        [[nodiscard]] std::vector<std::shared_ptr<Event>> getUpdateEvents() const
         {
             std::vector<std::shared_ptr<Event>> updateEvents;
-            for (size_t i = 0; i <= hwStateUpdateMaxEvent; i++) {
+            for (auto i = 0; i <= hwStateUpdateMaxEvent; i++) {
                 auto isConnected =
                     audioSinkState.test(i) ? Event::DeviceState::Connected : Event::DeviceState::Disconnected;
                 auto updateEvt = magic_enum::enum_cast<EventType>(i);
@@ -197,7 +197,7 @@ namespace audio
             return updateEvents;
         }
 
-        bool isConnected(EventType deviceUpdateEvent) const
+        [[nodiscard]] bool isConnected(EventType deviceUpdateEvent) const
         {
             return audioSinkState.test(magic_enum::enum_integer(deviceUpdateEvent));
         }
@@ -231,22 +231,22 @@ namespace audio
 
     struct AudioInitException : public std::runtime_error
     {
-      protected:
-        audio::RetCode errorCode = audio::RetCode::Failed;
-
       public:
-        AudioInitException(const char *message, audio::RetCode errorCode) : runtime_error(message)
+        AudioInitException(const char *message, audio::RetCode errorCode) : runtime_error(message), errorCode{errorCode}
         {}
 
-        audio::RetCode getErrorCode() const noexcept
+        [[nodiscard]] audio::RetCode getErrorCode() const noexcept
         {
             return errorCode;
         }
+
+      protected:
+        audio::RetCode errorCode = audio::RetCode::Failed;
     };
 
     class Token
     {
-        using TokenType = int16_t;
+        using TokenType = std::int16_t;
 
       public:
         explicit Token(TokenType initValue = tokenUninitialized) : t(initValue)
@@ -266,7 +266,7 @@ namespace audio
          * Valid token is one connected with existing sequence of operations
          * @return True if valid, false otherwise
          */
-        bool IsValid() const
+        [[nodiscard]] bool IsValid() const
         {
             return t > tokenUninitialized;
         }
@@ -274,7 +274,7 @@ namespace audio
          * Bad token cannot be used anymore
          * @return True if token is flagged bad
          */
-        bool IsBad() const
+        [[nodiscard]] bool IsBad() const
         {
             return t == tokenBad;
         }
@@ -282,7 +282,7 @@ namespace audio
          * Uninitialized token can be used but it is not connected to any sequence of operations
          * @return True if token is flagged uninitialized
          */
-        bool IsUninitialized() const
+        [[nodiscard]] bool IsUninitialized() const
         {
             return t == tokenUninitialized;
         }
@@ -303,8 +303,8 @@ namespace audio
             return *this;
         }
 
-        constexpr static TokenType tokenUninitialized{-1};
-        constexpr static TokenType tokenBad{-2};
+        static constexpr TokenType tokenUninitialized{-1};
+        static constexpr TokenType tokenBad{-2};
 
         TokenType t;
         friend class ::audio::AudioMux;
@@ -322,7 +322,8 @@ namespace AudioServiceMessage
       public:
         explicit EndOfFile(audio::Token &token) : token(token)
         {}
-        const audio::Token &GetToken() const
+
+        [[nodiscard]] const audio::Token &GetToken() const
         {
             return token;
         }
@@ -336,7 +337,8 @@ namespace AudioServiceMessage
       public:
         explicit FileDeleted(audio::Token &token) : token(token)
         {}
-        const audio::Token &GetToken() const
+
+        [[nodiscard]] const audio::Token &GetToken() const
         {
             return token;
         }
@@ -350,7 +352,8 @@ namespace AudioServiceMessage
       public:
         explicit FileSystemNoSpace(audio::Token &token) : token(token)
         {}
-        const audio::Token &GetToken() const
+
+        [[nodiscard]] const audio::Token &GetToken() const
         {
             return token;
         }
@@ -380,12 +383,12 @@ namespace AudioServiceMessage
             : device(std::move(device)), type(type)
         {}
 
-        auto getDevice() const noexcept -> std::shared_ptr<audio::AudioDevice>
+        [[nodiscard]] auto getDevice() const noexcept -> std::shared_ptr<audio::AudioDevice>
         {
             return device;
         }
 
-        auto getDeviceType() const noexcept -> audio::AudioDevice::Type
+        [[nodiscard]] auto getDeviceType() const noexcept -> audio::AudioDevice::Type
         {
             return type;
         }

--- a/module-audio/Audio/Operation/PlaybackOperation.cpp
+++ b/module-audio/Audio/Operation/PlaybackOperation.cpp
@@ -216,7 +216,7 @@ namespace audio
         // check if audio device supports Decoder's profile
         if (auto format = dec->getSourceFormat(); !audioDevice->isFormatSupportedBySink(format)) {
             LOG_ERROR("Format unsupported by the audio device: %s", format.toString().c_str());
-            return RetCode::Failed;
+            return RetCode::InvalidFormat;
         }
 
         // store profile

--- a/module-audio/Audio/Operation/PlaybackOperation.hpp
+++ b/module-audio/Audio/Operation/PlaybackOperation.hpp
@@ -23,7 +23,7 @@ namespace audio
                           const audio::PlaybackMode &playbackMode,
                           AudioServiceMessage::Callback callback = nullptr);
 
-        virtual ~PlaybackOperation();
+        ~PlaybackOperation() override;
 
         audio::RetCode Start(audio::Token token) final;
         audio::RetCode Stop() final;

--- a/products/BellHybrid/apps/application-bell-relaxation/presenter/RelaxationMainWindowPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/presenter/RelaxationMainWindowPresenter.hpp
@@ -10,9 +10,9 @@ namespace app::music
 {
     class AbstractSongsRepository;
 }
+
 namespace app::relaxation
 {
-
     class RelaxationMainWindowContract
     {
       public:
@@ -22,7 +22,6 @@ namespace app::relaxation
             virtual ~View() = default;
 
             virtual void updateViewState()                                                             = 0;
-            virtual void handleError()                                                                 = 0;
         };
 
         class Presenter : public BasePresenter<RelaxationMainWindowContract::View>
@@ -38,15 +37,15 @@ namespace app::relaxation
 
     class RelaxationMainWindowPresenter : public RelaxationMainWindowContract::Presenter
     {
+      public:
+        explicit RelaxationMainWindowPresenter(std::unique_ptr<SongsModel> songsModel);
+
       private:
-        std::shared_ptr<SongsModel> songsModel;
         void createData(SongsModel::OnActivateCallback activateCallback) override;
         void updateViewState() override;
         void updateRecordsCount() override;
         std::shared_ptr<SongsModel> getSongsModel() override;
 
-      public:
-        explicit RelaxationMainWindowPresenter(std::unique_ptr<SongsModel> songsModel);
+        std::shared_ptr<SongsModel> songsModel;
     };
-
 } // namespace app::relaxation

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationMainWindow.cpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationMainWindow.cpp
@@ -8,8 +8,6 @@
 #include <ApplicationBellRelaxation.hpp>
 #include <common/options/BellOptionsNavigation.hpp>
 #include <common/options/OptionBellMenu.hpp>
-#include <common/BellCommonNames.hpp>
-#include <popups/data/AudioErrorParams.hpp>
 #include <i18n/i18n.hpp>
 
 namespace gui
@@ -57,12 +55,6 @@ namespace gui
         auto audioContext = std::make_unique<RelaxationAudioContext>(selectedSound);
         auto switchData   = std::make_unique<RelaxationSwitchData>(std::move(audioContext));
         application->switchWindow(gui::window::name::relaxationTimerSelect, std::move(switchData));
-    }
-
-    void RelaxationMainWindow::handleError()
-    {
-        auto switchData = std::make_unique<AudioErrorParams>(AudioErrorType::FilesLimitExceeded);
-        application->switchWindow(gui::window::name::audioErrorWindow, std::move(switchData));
     }
 
     void RelaxationMainWindow::updateViewState()

--- a/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationMainWindow.hpp
+++ b/products/BellHybrid/apps/application-bell-relaxation/windows/RelaxationMainWindow.hpp
@@ -22,7 +22,6 @@ namespace gui
         gui::ListViewWithLabels *songList{nullptr};
 
         void buildInterface() override;
-        void handleError() override;
         void rebuild() override;
         void updateViewState() override;
         void activate(const db::multimedia_files::MultimediaFilesRecord &selectedSound);

--- a/products/BellHybrid/apps/application-bell-settings/presenter/alarm_settings/AlarmSettingsPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-settings/presenter/alarm_settings/AlarmSettingsPresenter.cpp
@@ -15,11 +15,18 @@ namespace app::bell_settings
         : app{app}, provider{std::move(provider)}, settingsModel{std::move(settingsModel)}, audioModel{audioModel},
           frontlight{std::move(frontlight)}, audioErrorModel{std::move(audioErrorModel)}
     {
-
         auto playSound = [this](const UTF8 &val) {
             auto onStartCallback = [this, val](audio::RetCode retCode) {
-                if (retCode != audio::RetCode::Success) {
+                switch (retCode) {
+                case audio::RetCode::Success:
+                    break;
+                case audio::RetCode::FileDoesntExist:
+                    handleAudioError(val, gui::AudioErrorType::FileDeleted);
+                    break;
+                case audio::RetCode::InvalidFormat:
+                default: // Maybe one day each error will get its own UI message...
                     handleAudioError(val, gui::AudioErrorType::UnsupportedMediaType);
+                    break;
                 }
             };
 
@@ -90,23 +97,23 @@ namespace app::bell_settings
         return provider;
     }
 
-    void AlarmSettingsPresenter::eraseProviderData()
+    auto AlarmSettingsPresenter::eraseProviderData() -> void
     {
         provider->clearData();
     }
 
-    void AlarmSettingsPresenter::stopSound()
+    auto AlarmSettingsPresenter::stopSound() -> void
     {
         this->audioModel.stopPlayedByThis({});
     }
 
-    void AlarmSettingsPresenter::exitWithSave()
+    auto AlarmSettingsPresenter::exitWithSave() -> void
     {
         saveData();
         eraseProviderData();
     }
 
-    void AlarmSettingsPresenter::exitWithRollback()
+    auto AlarmSettingsPresenter::exitWithRollback() -> void
     {
         this->stopSound();
         settingsModel->getAlarmVolume().restoreDefault();


### PR DESCRIPTION
* Changed the message that is shown 
when entering alarm sound selection list
after file selected as an alarm has been 
deleted via Center.
* Fixed bug with audio exception error code 
not being set at all.
* Removed unused logic handling file limit 
error message, as there is no longer fixed 
tracks limit.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
