### PR TITLE
[BH-2067] Fix fade in for relaxation after pausing a song

### DIFF
--- a/products/BellHybrid/services/audio/ServiceAudio.cpp
+++ b/products/BellHybrid/services/audio/ServiceAudio.cpp
@@ -378,6 +378,11 @@ namespace service
     auto Audio::handlePause() -> std::unique_ptr<AudioResponseMessage>
     {
         auto retCode = audio::RetCode::InvokedInIncorrectState;
+
+        if (volumeFade->IsActive()) {
+            volumeFade->Pause();
+        }
+
         if (const auto activeInput = audioMux.GetActiveInput(); activeInput) {
             auto playbackType = (*activeInput)->audio->GetCurrentOperationPlaybackType();
             if (isResumable(playbackType)) {
@@ -394,6 +399,11 @@ namespace service
     auto Audio::handleResume() -> std::unique_ptr<AudioResponseMessage>
     {
         auto retCode = audio::RetCode::InvokedInIncorrectState;
+
+        if (!volumeFade->IsActive()) {
+            volumeFade->Resume();
+        }
+
         if (const auto activeInput = audioMux.GetActiveInput();
             activeInput && activeInput.value()->audio->GetCurrentOperationState() == audio::Operation::State::Paused) {
             retCode = activeInput.value()->audio->Resume();

--- a/products/BellHybrid/services/audio/include/audio/VolumeFade.hpp
+++ b/products/BellHybrid/services/audio/include/audio/VolumeFade.hpp
@@ -19,6 +19,8 @@ namespace audio
         void Start(float targetVolume, float minVolume, float maxVolume, audio::FadeParams fadeParams);
         void Restart();
         void Stop();
+        void Pause();
+        void Resume();
         void SetVolume(float volume);
         bool IsActive();
 
@@ -41,6 +43,7 @@ namespace audio
         SetCallback setVolumeCallback;
         Phase phase{Phase::Idle};
         std::chrono::time_point<std::chrono::system_clock> timestamp;
+        std::chrono::milliseconds timeElapsed;
 
         void PerformNextFadeStep();
         void RestartWaitingTimer();


### PR DESCRIPTION
<!-- Please describe your pull request here -->

When we stopped the song at the beginning of the relaxation, it had no effect to fade in that was still running in the background, meaning that when we resumed playback, we had a sudden increase in volume.
Additionally, after pausing and resuming relaxation, the fade out appeared too quickly.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
