### PR TITLE
[BH-2071] Update license URL in migration tool

### DIFF
--- a/tools/db_migration.py
+++ b/tools/db_migration.py
@@ -22,7 +22,7 @@ databases_set = "databases.json"
 env_file = "dbm_env.ini"
 
 license_header = f"-- Copyright (c) 2017-{datetime.date.today().year}, Mudita Sp. z.o.o. All rights reserved.\n" \
-                 "-- For licensing, see https://github.com/mudita/MuditaOS/LICENSE.md\n\n"
+                 "-- For licensing, see https://github.com/mudita/MuditaOS/blob/master/LICENSE.md\n\n"
 
 cli = ArgumentParser()
 subparsers = cli.add_subparsers(dest="subcommand")


### PR DESCRIPTION
Update outdated license URL in migration tool,
which was accidentally missed in commit
https://github.com/mudita/MuditaOS/commit/773f2c7eb156fadb62983d670c1a8a876b2fe8b7.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
