### PR TITLE
[BH-2067] Fix volume change during relaxation pause

### DIFF
--- a/products/BellHybrid/services/audio/ServiceAudio.cpp
+++ b/products/BellHybrid/services/audio/ServiceAudio.cpp
@@ -400,7 +400,7 @@ namespace service
     {
         auto retCode = audio::RetCode::InvokedInIncorrectState;
 
-        if (!volumeFade->IsActive()) {
+        if (volumeFade->IsActive()) {
             volumeFade->Resume();
         }
 

--- a/products/BellHybrid/services/audio/VolumeFade.cpp
+++ b/products/BellHybrid/services/audio/VolumeFade.cpp
@@ -101,7 +101,7 @@ namespace audio
             if (setVolumeCallback != nullptr) {
                 setVolumeCallback(currentVolume);
             }
-            if (IsActive()) {
+            if (timerHandle.isActive()) {
                 RestartWaitingTimer();
             }
         }
@@ -120,7 +120,7 @@ namespace audio
 
     bool VolumeFade::IsActive()
     {
-        return timerHandle.isActive();
+        return phase != Phase::Idle;
     }
 
     bool VolumeFade::IsFadePhaseActive()


### PR DESCRIPTION
<!-- Please describe your pull request here -->

When the user changed the volume during pause, the fade out started at the wrong level.

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
