### PR TITLE
[BH-2072] Fix power nap volume fade in duration

### DIFF
--- a/module-audio/Audio/AudioCommon.hpp
+++ b/module-audio/Audio/AudioCommon.hpp
@@ -33,7 +33,6 @@ namespace audio
     inline constexpr auto dbPathSeparator{'/'};
 
     inline constexpr std::chrono::seconds defaultMaxFadeDuration{5};
-    inline constexpr std::chrono::seconds alarmMaxFadeDuration{45};
 
     enum class Setting
     {

--- a/products/BellHybrid/alarms/src/actions/PlayAudioActions.cpp
+++ b/products/BellHybrid/alarms/src/actions/PlayAudioActions.cpp
@@ -8,6 +8,11 @@
 #include <db/SystemSettings.hpp>
 #include <Timers/TimerFactory.hpp>
 
+namespace
+{
+    constexpr std::chrono::seconds alarmFadeDuration{45};
+} // namespace
+
 namespace alarms
 {
     PlayAudioAction::PlayAudioAction(sys::Service &service,
@@ -31,7 +36,7 @@ namespace alarms
                                        : audio::Fade::Disable;
 
         auto msg = std::make_shared<service::AudioStartPlaybackRequest>(
-            path, playbackType, playbackMode, audio::FadeParams{fadeInEnabled, audio::alarmMaxFadeDuration});
+            path, playbackType, playbackMode, audio::FadeParams{fadeInEnabled, alarmFadeDuration});
         return service.bus.sendUnicast(std::move(msg), service::audioServiceName);
     }
 

--- a/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.cpp
@@ -14,6 +14,7 @@
 namespace
 {
     constexpr auto powerNapAlarmTimerName = "PowerNapAlarmTimer";
+    constexpr std::chrono::seconds fadeInDuration{45};
 } // namespace
 
 namespace app::powernap
@@ -96,7 +97,7 @@ namespace app::powernap
                         AbstractAudioModel::PlaybackType::Alarm,
                         AbstractAudioModel::PlaybackMode::Single,
                         {},
-                        audio::FadeParams{fadeInActive});
+                        audio::FadeParams{fadeInActive, fadeInDuration});
         napAlarmTimer.start();
         napFinished = true;
     }


### PR DESCRIPTION
<!-- Please describe your pull request here -->

Power nap volume should gradually increase by 0.1 every 300 ms, which gives a time of 45 seconds for a full 15-point scale

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
