### PR TITLE
[BH-2073] Fix invalid accusative form in Meditation

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Fixed message shown when entering alarm sound list after deleting selected alarm file
+* Fixed invalid accusative form in meditation summary in Polish
 
 ### Added
 * Added label with the name of the application on the countdown screens

--- a/products/BellHybrid/apps/application-bell-meditation-timer/presenter/MeditationProgressPresenter.hpp
+++ b/products/BellHybrid/apps/application-bell-meditation-timer/presenter/MeditationProgressPresenter.hpp
@@ -6,6 +6,7 @@
 #include <apps-common/ApplicationCommon.hpp>
 #include <apps-common/BasePresenter.hpp>
 #include <apps-common/widgets/TimerWithCallbacks.hpp>
+#include <common/windows/BellFinishedWindow.hpp>
 #include <time/time_locale.hpp>
 
 #include <memory>
@@ -103,5 +104,6 @@ namespace app::meditation
         void onIntervalReached();
 
         void addMeditationEntry(std::chrono::minutes elapsed);
+        void onMeditationEnd(gui::BellFinishedWindowData::ExitBehaviour exitBehaviour);
     };
 } // namespace app::meditation


### PR DESCRIPTION
Fix of the issue that abandoning meditation
by clicking back will result in displaying
meditation session summary with invalid
accusative form in Polish.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
