### PR TITLE
[BH-2078] Fix crash upon receiving invalid timestamp

### DIFF
--- a/products/BellHybrid/services/db/agents/ShuffleQuoteModel.cpp
+++ b/products/BellHybrid/services/db/agents/ShuffleQuoteModel.cpp
@@ -101,9 +101,9 @@ namespace Quotes
             settings->getValue(settings::Quotes::randomQuoteIDUpdateTime, settings::SettingsScope::Global);
 
         try {
-            lastTimestamp = stol(lastTimestampString);
+            lastTimestamp = std::stoll(lastTimestampString);
         }
-        catch (std::invalid_argument &e) {
+        catch (const std::exception &e) {
             LOG_ERROR("Invalid timestamp, set to 0! Cause: %s", e.what());
             lastTimestamp = 0;
         }


### PR DESCRIPTION
Fix of the issue that the device would
crash and never be able to boot up
again after receiving invalid timestamp
(e.g. -1).

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
