### PR TITLE
[BH-2079] Fix outdated forum link

### DIFF
--- a/image/system_a/data/lang/Deutsch.json
+++ b/image/system_a/data/lang/Deutsch.json
@@ -175,7 +175,7 @@
     "app_bell_welcome_charge_message": "<text>Charge Harmony<br/>und leicht dr\u00fccken</text>",
     "app_bell_welcome_message": "<text>Mudita Harmony<br/>ist ausgeschaltet</text>",
     "app_bell_whatsnew_continue": "Weiter",
-    "app_bell_whatsnew_end_screen_text": "<text>Teile uns deine Meinung zu<br/>diesem Update mit auf<br/><b>mudita.com/forum</b></text>",
+    "app_bell_whatsnew_end_screen_text": "<text>Teile uns deine Meinung zu<br/>diesem Update mit auf<br/><b>forum.mudita.com</b></text>",
     "app_bell_whatsnew_skip": "\u00dcberspr.",
     "app_bell_whatsnew_title": "Neues",
     "app_bell_whatsnew_version": "<text>OS-Version: <token>$VERSION</token></text>",

--- a/image/system_a/data/lang/English.json
+++ b/image/system_a/data/lang/English.json
@@ -177,7 +177,7 @@
     "app_bell_welcome_charge_message": "<text>Charge Harmony<br/>and press light click</text>",
     "app_bell_welcome_message": "<text>Mudita Harmony<br/>is switched OFF</text>",
     "app_bell_whatsnew_continue": "Continue",
-    "app_bell_whatsnew_end_screen_text": "<text>We'd love to hear your<br/>feedback about this update at<br/><b>mudita.com/forum</b></text>",
+    "app_bell_whatsnew_end_screen_text": "<text>We'd love to hear your<br/>feedback about this update at<br/><b>forum.mudita.com</b></text>",
     "app_bell_whatsnew_skip": "Skip",
     "app_bell_whatsnew_title": "What's New",
     "app_bell_whatsnew_version": "<text>OS version: <token>$VERSION</token></text>",

--- a/image/system_a/data/lang/Espanol.json
+++ b/image/system_a/data/lang/Espanol.json
@@ -174,7 +174,7 @@
     "app_bell_welcome_charge_message": "<text>Carga tu Harmony<br/>y pulsa levemente</text>",
     "app_bell_welcome_message": "<text>Mudita Harmony<br/>est\u00e1 apagado</text>",
     "app_bell_whatsnew_continue": "Continuar",
-    "app_bell_whatsnew_end_screen_text": "<text>Esperamos vuestros comentarios sobre esta actualizaci\u00f3n en<br/><b>mudita.com/forum</b></text>",
+    "app_bell_whatsnew_end_screen_text": "<text>Esperamos vuestros comentarios sobre esta actualizaci\u00f3n en<br/><b>forum.mudita.com</b></text>",
     "app_bell_whatsnew_skip": "Omitir",
     "app_bell_whatsnew_title": "Novedades",
     "app_bell_whatsnew_version": "<text>Versi\u00f3n del SO: <token>$VERSION</token></text>",

--- a/image/system_a/data/lang/Francais.json
+++ b/image/system_a/data/lang/Francais.json
@@ -176,7 +176,7 @@
     "app_bell_welcome_charge_message": "<text>Rechargez Harmony<br/>et appuyez l\u00e9g\u00e8rement</text>",
     "app_bell_welcome_message": "<text>Mudita Harmony<br/>est d\u00e9sactiv\u00e9</text>",
     "app_bell_whatsnew_continue": "Continuer",
-    "app_bell_whatsnew_end_screen_text": "<text>Envoyez-nous vos retours concernant la mise \u00e0 jour ici<br/><b>mudita.com/forum</b></text>",
+    "app_bell_whatsnew_end_screen_text": "<text>Envoyez-nous vos retours concernant la mise \u00e0 jour ici<br/><b>forum.mudita.com</b></text>",
     "app_bell_whatsnew_skip": "Passer",
     "app_bell_whatsnew_title": "Nouveaut\u00e9s",
     "app_bell_whatsnew_version": "<text>Version du syst\u00e8me: <token>$VERSION</token></text>",

--- a/image/system_a/data/lang/Polski.json
+++ b/image/system_a/data/lang/Polski.json
@@ -175,7 +175,7 @@
     "app_bell_welcome_charge_message": "<text>Na\u0142aduj Harmony<br/>i kliknij lekko</text>",
     "app_bell_welcome_message": "<text>Mudita Harmony<br/>jest wy\u0142\u0105czony</text>",
     "app_bell_whatsnew_continue": "Kontynuuj",
-    "app_bell_whatsnew_end_screen_text": "<text>Zach\u0119camy do podzielenia si\u0119<br/>opini\u0105 o tej wersji na<br/><b>mudita.com/forum</b></text>",
+    "app_bell_whatsnew_end_screen_text": "<text>Zach\u0119camy do podzielenia si\u0119<br/>opini\u0105 o tej wersji na<br/><b>forum.mudita.com</b></text>",
     "app_bell_whatsnew_skip": "Pomi\u0144",
     "app_bell_whatsnew_title": "Nowo\u015bci",
     "app_bell_whatsnew_version": "<text>Wersja OS: <token>$VERSION</token></text>",


### PR DESCRIPTION
Fix of the issue that link to
Mudita Forum displayed at the
end of What's New would lead
to 404 page.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
