### PR TITLE
[BH-2081] Fix crash for MP3s with missing Xing frame

### DIFF
--- a/module-audio/Audio/decoder/DecoderMP3.cpp
+++ b/module-audio/Audio/decoder/DecoderMP3.cpp
@@ -23,8 +23,9 @@ namespace audio
         io->seek_data = this;
         dec->io       = io.get();
 
-        if (mp3dec_ex_open_cb(dec.get(), dec->io, MP3D_SEEK_TO_SAMPLE)) {
-            LOG_ERROR("Failed to open minimp3");
+        const auto decoderStatus = mp3dec_ex_open_cb(dec.get(), dec->io, MP3D_SEEK_TO_SAMPLE | MP3D_DO_NOT_SCAN);
+        if (decoderStatus != 0) {
+            LOG_ERROR("Failed to open minimp3, error: %d", decoderStatus);
             return;
         }
 


### PR DESCRIPTION
Fix of the issue that playing large MP3
files with missing Xing frame would
result in crash due to minimp3
trying to compute metadata by analyzing
the entire file and running out of
heap memory.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
