### PR TITLE
[BH-2090] Fix blink when disabling Power Nap

### DIFF
--- a/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.cpp
+++ b/products/BellHybrid/apps/application-bell-powernap/presenter/PowerNapProgressPresenter.cpp
@@ -82,8 +82,8 @@ namespace app::powernap
             return;
         }
 
+        frontlightModel->lockKeypressTrigger();
         if (frontlightModel->isAlarmLightEnabled()) {
-            frontlightModel->lockKeypressTrigger();
             frontlightModel->startBrightnessFadeIn();
         }
 


### PR DESCRIPTION
Fix of the issue that frontlight would
blink for a second after light clicking
to stop ringing Power Nap.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [ ] Has changelog entry added

<!-- Thanks for your work ♥ -->
