### PR TITLE
[BH-2100] Fix crash when seeking in large MP3 file

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+* Fixed crash in Relaxation when playing large MP3 file
 
 ### Added
 

--- a/module-audio/Audio/Operation/PlaybackOperation.hpp
+++ b/module-audio/Audio/Operation/PlaybackOperation.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+﻿// Copyright (c) 2017-2025, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/blob/master/LICENSE.md
 
 #pragma once
@@ -19,28 +19,27 @@ namespace audio
     {
       public:
         PlaybackOperation(const std::string &filePath,
-                          const audio::PlaybackType &playbackType,
-                          const audio::PlaybackMode &playbackMode,
+                          const PlaybackType &playbackType,
+                          const PlaybackMode &playbackMode,
                           AudioServiceMessage::Callback callback = nullptr);
 
         ~PlaybackOperation() override;
 
-        audio::RetCode Start(audio::Token token) final;
-        audio::RetCode Stop() final;
-        audio::RetCode Pause() final;
-        audio::RetCode Resume() final;
-        audio::RetCode SendEvent(std::shared_ptr<Event> evt) final;
-        audio::RetCode SwitchProfile(const Profile::Type type) final;
-        audio::RetCode SetOutputVolume(float vol) final;
-        audio::RetCode SetInputGain(float gain) final;
+        RetCode Start(Token token) final;
+        RetCode Stop() final;
+        RetCode Pause() final;
+        RetCode Resume() final;
+        RetCode SendEvent(std::shared_ptr<Event> evt) final;
+        RetCode SwitchProfile(const Profile::Type type) final;
+        RetCode SetOutputVolume(float vol) final;
+        RetCode SetInputGain(float gain) final;
 
         Position GetPosition() final;
-        audio::RetCode SwitchToPriorityProfile(audio::PlaybackType playbackType) final;
+        RetCode SwitchToPriorityProfile(PlaybackType playbackType) final;
 
       private:
         static constexpr auto playbackTimeConstraint = 10ms;
-        static constexpr auto playbackStartPosition  = 0U;
-        audio::PlaybackMode playbackMode             = audio::PlaybackMode::Single;
+        PlaybackMode playbackMode                    = PlaybackMode::Single;
 
         std::unique_ptr<Stream> dataStreamOut;
         std::unique_ptr<Decoder> dec;

--- a/module-audio/Audio/decoder/Decoder.cpp
+++ b/module-audio/Audio/decoder/Decoder.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2025, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/blob/master/LICENSE.md
 
 #include <cstdio>
@@ -42,12 +42,12 @@ namespace audio
         }
     }
 
-    std::unique_ptr<tags::fetcher::Tags> Decoder::fetchTags()
+    auto Decoder::fetchTags() -> std::unique_ptr<tags::fetcher::Tags>
     {
         return std::make_unique<tags::fetcher::Tags>(tags::fetcher::fetchTags(filePath));
     }
 
-    std::unique_ptr<Decoder> Decoder::Create(const std::string &filePath)
+    auto Decoder::Create(const std::string &filePath) -> std::unique_ptr<Decoder>
     {
         const auto extension          = std::filesystem::path(filePath).extension();
         const auto extensionLowercase = utils::stringToLowercase(extension);
@@ -74,10 +74,11 @@ namespace audio
         return dec;
     }
 
-    void Decoder::startDecodingWorker(const DecoderWorker::EndOfFileCallback &endOfFileCallback,
-                                      const DecoderWorker::FileDeletedCallback &fileDeletedCallback)
+    auto Decoder::startDecodingWorker(const DecoderWorker::EndOfFileCallback &endOfFileCallback,
+                                      const DecoderWorker::FileDeletedCallback &fileDeletedCallback) -> void
     {
         assert(_stream != nullptr);
+
         if (audioWorker == nullptr) {
             const auto channelMode = (tags->num_channel == 1) ? DecoderWorker::ChannelMode::ForceStereo
                                                               : DecoderWorker::ChannelMode::NoConversion;
@@ -92,7 +93,7 @@ namespace audio
         }
     }
 
-    void Decoder::stopDecodingWorker()
+    auto Decoder::stopDecodingWorker() -> void
     {
         if (audioWorker) {
             audioWorker->close();
@@ -100,17 +101,17 @@ namespace audio
         audioWorker = nullptr;
     }
 
-    void Decoder::onDataReceive()
+    auto Decoder::onDataReceive() -> void
     {
         audioWorker->enablePlayback();
     }
 
-    void Decoder::enableInput()
+    auto Decoder::enableInput() -> void
     {
         audioWorker->enablePlayback();
     }
 
-    void Decoder::disableInput()
+    auto Decoder::disableInput() -> void
     {
         audioWorker->disablePlayback();
     }

--- a/module-audio/Audio/decoder/Decoder.hpp
+++ b/module-audio/Audio/decoder/Decoder.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2025, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/blob/master/LICENSE.md
 
 #pragma once
@@ -28,49 +28,52 @@ namespace audio
         explicit Decoder(const std::string &path);
         virtual ~Decoder();
 
-        virtual std::int32_t decode(std::uint32_t samplesToRead, std::int16_t *pcmData) = 0;
+        virtual auto decode(std::uint32_t samplesToRead, std::int16_t *pcmData) -> std::int32_t = 0;
 
         // Range 0 - 1
-        virtual void setPosition(float pos) = 0;
+        virtual auto setPosition(float pos) -> void = 0;
 
-        std::uint32_t getSampleRate()
+        // Rewind to first audio sample
+        virtual auto rewind() -> void = 0;
+
+        [[nodiscard]] auto getSampleRate() const noexcept -> std::uint32_t
         {
             return sampleRate;
         }
 
-        std::uint32_t getChannelCount()
+        [[nodiscard]] auto getChannelCount() const noexcept -> std::uint32_t
         {
             return channelCount;
         }
 
-        float getCurrentPosition()
+        [[nodiscard]] auto getCurrentPosition() const noexcept -> float
         {
             return position;
         }
 
-        void onDataReceive() override;
-        void enableInput() override;
-        void disableInput() override;
+        auto onDataReceive() -> void override;
+        auto enableInput() -> void override;
+        auto disableInput() -> void override;
 
         auto getSourceFormat() -> AudioFormat override;
         auto getSupportedFormats() -> std::vector<AudioFormat> override;
 
         auto getTraits() const -> Endpoint::Traits override;
 
-        void startDecodingWorker(const DecoderWorker::EndOfFileCallback &endOfFileCallback,
-                                 const DecoderWorker::FileDeletedCallback &fileDeletedCallback);
-        void stopDecodingWorker();
+        auto startDecodingWorker(const DecoderWorker::EndOfFileCallback &endOfFileCallback,
+                                 const DecoderWorker::FileDeletedCallback &fileDeletedCallback) -> void;
+        auto stopDecodingWorker() -> void;
 
         // Factory method
-        static std::unique_ptr<Decoder> Create(const std::string &path);
+        static auto Create(const std::string &path) -> std::unique_ptr<Decoder>;
 
       protected:
-        virtual auto getBitWidth() -> unsigned int
+        [[nodiscard]] virtual auto getBitWidth() -> unsigned int
         {
             return bitsPerSample;
         }
 
-        virtual std::unique_ptr<tags::fetcher::Tags> fetchTags();
+        virtual auto fetchTags() -> std::unique_ptr<tags::fetcher::Tags>;
 
         static constexpr Endpoint::Traits decoderCaps = {.usesDMA = false};
 

--- a/module-audio/Audio/decoder/DecoderFLAC.hpp
+++ b/module-audio/Audio/decoder/DecoderFLAC.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2025, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/blob/master/LICENSE.md
 
 #pragma once
@@ -12,18 +12,15 @@ namespace audio
     {
       public:
         explicit DecoderFLAC(const std::string &filePath);
-        ~DecoderFLAC();
+        ~DecoderFLAC() override;
 
-        std::int32_t decode(std::uint32_t samplesToRead, std::int16_t *pcmData) override;
+        auto decode(std::uint32_t samplesToRead, std::int16_t *pcmData) -> std::int32_t override;
 
-        void setPosition(float pos) override;
+        auto setPosition(float pos) -> void override;
+        auto rewind() -> void override;
 
       private:
         drflac *flac = nullptr;
-
-        /* Data encoded in UTF-8 */
-        void parseText(
-            std::uint8_t *in, std::uint32_t taglen, std::uint32_t datalen, std::uint8_t *out, std::uint32_t outlen);
 
         // Callback for when data needs to be read from the client.
         //
@@ -35,7 +32,7 @@ namespace audio
         //
         // A return value of less than bytesToRead indicates the end of the stream. Do _not_ return from this callback
         // until either the entire bytesToRead is filled or you have reached the end of the stream.
-        static std::size_t drflacRead(void *pUserData, void *pBufferOut, std::size_t bytesToRead);
+        static auto drflacRead(void *pUserData, void *pBufferOut, std::size_t bytesToRead) -> std::size_t;
 
         // Callback for when data needs to be seeked.
         //
@@ -48,6 +45,6 @@ namespace audio
         // The offset will never be negative. Whether it is relative to the beginning or current position is
         // determined by the "origin" parameter which will be either drflac_seek_origin_start or
         // drflac_seek_origin_current.
-        static drflac_bool32 drflacSeek(void *pUserData, int offset, drflac_seek_origin origin);
+        static auto drflacSeek(void *pUserData, int offset, drflac_seek_origin origin) -> drflac_bool32;
     };
 } // namespace audio

--- a/module-audio/Audio/decoder/DecoderMP3.cpp
+++ b/module-audio/Audio/decoder/DecoderMP3.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2025, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/blob/master/LICENSE.md
 
 #define MINIMP3_IMPLEMENTATION
@@ -25,7 +25,7 @@ namespace audio
 
         const auto decoderStatus = mp3dec_ex_open_cb(dec.get(), dec->io, MP3D_SEEK_TO_SAMPLE | MP3D_DO_NOT_SCAN);
         if (decoderStatus != 0) {
-            LOG_ERROR("Failed to open minimp3, error: %d", decoderStatus);
+            LOG_ERROR("Failed to open minimp3, error %d", decoderStatus);
             return;
         }
 
@@ -45,22 +45,36 @@ namespace audio
         isInitialized = false;
     }
 
-    void DecoderMP3::setPosition(float pos)
+    auto DecoderMP3::setPosition(float pos) -> void
     {
         if (!isInitialized) {
             LOG_ERROR("MP3 decoder not initialized");
             return;
         }
-        mp3dec_ex_seek(dec.get(), pos);
+
+        const auto sampleToSeek = static_cast<std::uint64_t>(dec->samples * pos);
+        const auto frameToSeek  = sampleToSeek / channelCount;
+        const auto status       = mp3dec_ex_seek(dec.get(), sampleToSeek);
+        if (status != 0) {
+            LOG_ERROR(
+                "Failed to seek to frame %" PRIu64 " in file '%s', error %d!", frameToSeek, filePath.c_str(), status);
+        }
+
+        position = frameToSeek / static_cast<float>(sampleRate);
     }
 
-    std::int32_t DecoderMP3::decode(std::uint32_t samplesToRead, std::int16_t *pcmData)
+    auto DecoderMP3::rewind() -> void
+    {
+        setPosition(0.0f);
+    }
+
+    auto DecoderMP3::decode(std::uint32_t samplesToRead, std::int16_t *pcmData) -> std::int32_t
     {
         const auto samplesRead = mp3dec_ex_read(dec.get(), reinterpret_cast<mp3d_sample_t *>(pcmData), samplesToRead);
         if (samplesRead > 0) {
             /* Calculate frame duration in seconds */
-            const auto samplesPerChannel = static_cast<float>(samplesRead) / static_cast<float>(channelCount);
-            position += samplesPerChannel / static_cast<float>(sampleRate);
+            const auto framesRead = static_cast<float>(samplesRead) / static_cast<float>(channelCount);
+            position += framesRead / static_cast<float>(sampleRate);
         }
         else if (!fileExists(fd)) {
             /* Unfortunately this second check of file existence is needed
@@ -72,9 +86,9 @@ namespace audio
         return samplesRead;
     }
 
-    std::size_t DecoderMP3::mp3Read(void *pBufferOut, std::size_t bytesToRead, void *pUserData)
+    auto DecoderMP3::mp3Read(void *pBufferOut, std::size_t bytesToRead, void *pUserData) -> std::size_t
     {
-        const auto decoderContext = reinterpret_cast<DecoderMP3 *>(pUserData);
+        const auto decoderContext = static_cast<DecoderMP3 *>(pUserData);
 
         /* Check if the file exists - std::fread happily returns bytesToRead if
          * requested to read from deleted file, what causes decoding library
@@ -85,9 +99,9 @@ namespace audio
         return std::fread(pBufferOut, 1, bytesToRead, decoderContext->fd);
     }
 
-    int DecoderMP3::mp3Seek(std::uint64_t offset, void *pUserData)
+    auto DecoderMP3::mp3Seek(std::uint64_t offset, void *pUserData) -> int
     {
-        const auto decoderContext = reinterpret_cast<DecoderMP3 *>(pUserData);
+        const auto decoderContext = static_cast<DecoderMP3 *>(pUserData);
         return std::fseek(decoderContext->fd, offset, SEEK_SET);
     }
 } // namespace audio

--- a/module-audio/Audio/decoder/DecoderMP3.hpp
+++ b/module-audio/Audio/decoder/DecoderMP3.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2025, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/blob/master/LICENSE.md
 
 #pragma once
@@ -12,11 +12,12 @@ namespace audio
     {
       public:
         explicit DecoderMP3(const std::string &filePath);
-        ~DecoderMP3();
+        ~DecoderMP3() override;
 
-        std::int32_t decode(std::uint32_t samplesToRead, std::int16_t *pcmData) override;
+        auto decode(std::uint32_t samplesToRead, std::int16_t *pcmData) -> std::int32_t override;
 
-        void setPosition(float pos) override;
+        auto setPosition(float pos) -> void override;
+        auto rewind() -> void override;
 
       private:
         std::unique_ptr<mp3dec_ex_t> dec;
@@ -32,7 +33,7 @@ namespace audio
         //
         // A return value of less than bytesToRead indicates the end of the stream. Do _not_ return from this callback
         // until either the entire bytesToRead is filled or you have reached the end of the stream.
-        static std::size_t mp3Read(void *pBufferOut, std::size_t bytesToRead, void *pUserData);
+        static auto mp3Read(void *pBufferOut, std::size_t bytesToRead, void *pUserData) -> std::size_t;
 
         // Callback for when data needs to be seeked.
         //
@@ -42,6 +43,6 @@ namespace audio
         // Returns whether the seek was successful.
         //
         // The offset will never be negative. It relates to the beginning position.
-        static int mp3Seek(std::uint64_t offset, void *pUserData);
+        static auto mp3Seek(std::uint64_t offset, void *pUserData) -> int;
     };
 } // namespace audio

--- a/module-audio/Audio/decoder/DecoderWAV.hpp
+++ b/module-audio/Audio/decoder/DecoderWAV.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2025, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/blob/master/LICENSE.md
 
 #pragma once
@@ -12,11 +12,12 @@ namespace audio
     {
       public:
         explicit DecoderWAV(const std::string &filePath);
-        ~DecoderWAV();
+        ~DecoderWAV() override;
 
-        std::int32_t decode(std::uint32_t samplesToRead, std::int16_t *pcmData) override;
+        auto decode(std::uint32_t samplesToRead, std::int16_t *pcmData) -> std::int32_t override;
 
-        void setPosition(float pos) override;
+        auto setPosition(float pos) -> void override;
+        auto rewind() -> void override;
 
       private:
         std::unique_ptr<drwav> wav;
@@ -31,7 +32,7 @@ namespace audio
         //
         // A return value of less than bytesToRead indicates the end of the stream. Do _not_ return from this callback
         // until either the entire bytesToRead is filled or you have reached the end of the stream.
-        static std::size_t drwavRead(void *pUserData, void *pBufferOut, std::size_t bytesToRead);
+        static auto drwavRead(void *pUserData, void *pBufferOut, std::size_t bytesToRead) -> std::size_t;
 
         // Callback for when data needs to be seeked.
         //
@@ -44,6 +45,6 @@ namespace audio
         // The offset will never be negative. Whether it is relative to the beginning or current position is
         // determined by the "origin" parameter which will be either drwav_seek_origin_start or
         // drwav_seek_origin_current.
-        static drwav_bool32 drwavSeek(void *pUserData, int offset, drwav_seek_origin origin);
+        static auto drwavSeek(void *pUserData, int offset, drwav_seek_origin origin) -> drwav_bool32;
     };
 } // namespace audio


### PR DESCRIPTION
* Fix of the issue that seeking in large MP3 file would 
cause OOM error when creating MP3 indexes. This 
caused OS crash when looping large MP3 file in 
Relaxation.
* Minor cleanups.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
