### PR TITLE
[BH-2108] Fix misaligned charging symbol

### DIFF
--- a/harmony_changelog.md
+++ b/harmony_changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+* Fixed misaligned charging symbol on battery state screen
 
 ### Added
 * Added custom quotations feature

--- a/module-gui/gui/widgets/Rect.cpp
+++ b/module-gui/gui/widgets/Rect.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2025, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/blob/master/LICENSE.md
 
 /*
@@ -43,10 +43,12 @@ namespace gui
     {
         borderColor = color;
     }
+
     void Rect::setPenWidth(uint8_t width)
     {
         penWidth = width;
     }
+
     void Rect::setPenFocusWidth(uint8_t width)
     {
         penFocusWidth = width;

--- a/products/BellHybrid/apps/common/include/common/data/BatteryUtils.hpp
+++ b/products/BellHybrid/apps/common/include/common/data/BatteryUtils.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2025, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/blob/master/LICENSE.md
 
 #pragma once
@@ -33,5 +33,4 @@ namespace battery_utils
 
         return {};
     }
-
 } // namespace battery_utils

--- a/products/BellHybrid/apps/common/include/common/windows/BellBatteryStatusWindow.hpp
+++ b/products/BellHybrid/apps/common/include/common/windows/BellBatteryStatusWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, Mudita Sp. z.o.o. All rights reserved.
+// Copyright (c) 2017-2025, Mudita Sp. z.o.o. All rights reserved.
 // For licensing, see https://github.com/mudita/MuditaOS/blob/master/LICENSE.md
 
 #pragma once
@@ -8,7 +8,7 @@
 
 namespace gui
 {
-    class TextFixedSize;
+    class Text;
     class ImageBox;
     class Image;
 
@@ -17,7 +17,7 @@ namespace gui
       public:
         static constexpr auto windowName = "BellBatteryStatusWindow";
 
-        BellBatteryStatusWindow(app::ApplicationCommon *app, const std::string &name = windowName);
+        explicit BellBatteryStatusWindow(app::ApplicationCommon *app, const std::string &name = windowName);
 
       private:
         void buildInterface() override;
@@ -26,13 +26,13 @@ namespace gui
         void onClose(CloseReason reason) override;
 
         BellBaseLayout *body{};
-        TextFixedSize *topDescription{};
+        Text *topDescription{};
 
-        TextFixedSize *bottomDescription{};
+        Text *bottomDescription{};
         ImageBox *chargingIcon{};
 
         HBox *hbox{};
-        ImageBox *center{};
+        ImageBox *batteryImage{};
     };
 
 } // namespace gui


### PR DESCRIPTION
* Fixed misaligned charging symbol on battery popup, shown after holding back button.
* Fixed improper handling of string_view storing battery image name.

<!-- Please describe your pull request here -->

**Your checklist for this pull request**
<!-- Don't delete this - you have to fill it up to be able to merge -->

Make sure that this PR:
- [x] Complies with our guidelines for contributions
- [ ] Has unit tests if possible
- [ ] Has documentation updated
- [x] Has changelog entry added

<!-- Thanks for your work ♥ -->
